### PR TITLE
Add symlink to .stylelintrc

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,1 @@
+client/.stylelintrc

--- a/client/.stylelintrc
+++ b/client/.stylelintrc
@@ -30,7 +30,7 @@
     ],
     "property-no-unknown": true,
     "scss/selector-no-redundant-nesting-selector": true,
-    "scss/at-import-partial-extension-blacklist": ['scss'],
+    "scss/at-import-partial-extension-blacklist": ["scss"],
     "scss/at-extend-no-missing-placeholder": true,
     "scss/at-import-no-partial-leading-underscore": true,
     "plugin/selector-bem-pattern": {


### PR DESCRIPTION
This adds a symlink from the root of the repo to the .stylelintrc in the client directory so that IDEs can pick up on it from the root