### PR TITLE
add deploy infra

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,11 @@
+# IntelliJ
+.idea/
+*.iml
+.DS_Store
+
+
+# Terraform
+.terraform
+*.tfvars
+*.tfstate
+*.tfstate.backup

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,10 @@
+# Deploy
+
+You'll need to be sure to get setup with you `tfvars` from a friendly developer near you.
+Once that's done run:
+
+    ./airbag.sh <BUILD_STATE_BUCKET>
+    
+You'll be asked for a build number - get that from [cirleci](https://circleci.com/gh/wellcometrust/wellcomecollection.org).
+
+That should deploy your changes once all the LBs and instances are reporting healthy.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,6 +1,6 @@
 # Deploy
 
-You'll need to be sure to get setup with you `tfvars` from a friendly developer near you.
+To get deploying, you'll need to get some `tfvars` from a friendly developer near you.
 Once that's done run:
 
     ./airbag.sh <BUILD_STATE_BUCKET>

--- a/infra/TODO.md
+++ b/infra/TODO.md
@@ -1,0 +1,10 @@
+# TODO
+
+* Tag AWS resources with stage, project...
+* Better AZN
+* A VPC strategy
+* Sync node version with circleci (make explicit)
+* Use roles instead of loads of policies
+* Only allow valid builds 
+* Pump AMI ref into Terraform vars from Packer. 
+* Make airbag target the asg and instances only

--- a/infra/airbag.sh
+++ b/infra/airbag.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 1 ]; then
+    echo "⚡ Usage: deploy <STATE_BUCKET>"
+    exit 1
+fi
+
+STATE_BUCKET=$1
+
+pushd terraform
+
+terraform remote config \
+    -backend=s3 \
+    -backend-config="bucket=$STATE_BUCKET" \
+    -backend-config="key=build-state/terraform.tfstate" \
+    -backend-config="region=eu-west-1"
+
+terraform get
+terraform apply
+# potentially terraform apply \
+#   --target=wellcomecollection.aws_autoscaling_group.wellcomecollection_asg
+#   --target=wellcomecollection.aws_launch_configuration.wellcomecollection
+
+popd

--- a/infra/packer/node6.json
+++ b/infra/packer/node6.json
@@ -1,0 +1,26 @@
+{
+  "variables": {
+    "build_bucket": "",
+    "build_number": ""
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "region": "eu-west-1",
+    "source_ami": "ami-1b4f0a68",
+    "instance_type": "t2.micro",
+    "ssh_username": "ubuntu",
+    "ami_name": "wellcome-web-platform-node6"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": [
+      "sleep 30",
+      "sudo apt-get update",
+      "curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -",
+      "sudo apt-get -y install -y nodejs",
+      "sudo apt-get -y install awscli"
+    ]
+  }]
+}

--- a/infra/terraform/launch-script.tpl
+++ b/infra/terraform/launch-script.tpl
@@ -1,0 +1,8 @@
+#!/bin/bash
+cd /home/ubuntu
+aws s3 cp s3://${build_bucket}/builds/${build_branch}/${build_number}.tar ./app.tar
+mkdir -p app
+tar -xvf app.tar -C app
+cd app/server
+
+npm run start

--- a/infra/terraform/templates/elb.tf
+++ b/infra/terraform/templates/elb.tf
@@ -1,0 +1,31 @@
+resource "aws_elb" "wellcomecollection" {
+  name                  = "${var.project_name}"
+  subnets               = ["${aws_subnet.public.id}"]
+  security_groups       = [
+    "${aws_security_group.http.id}",
+    "${aws_security_group.https.id}",
+    "${aws_security_group.node_app_port.id}"
+  ]
+
+  listener {
+    instance_port       = 3000
+    instance_protocol   = "http"
+    lb_port             = 3000
+    lb_protocol         = "http"
+  }
+
+  listener {
+    instance_port       = 3000
+    instance_protocol   = "http"
+    lb_port             = 80
+    lb_protocol         = "http"
+  }
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 10
+    timeout             = 20
+    target              = "HTTP:3000/healthcheck"
+    interval            = 30
+  }
+}

--- a/infra/terraform/templates/iam.tf
+++ b/infra/terraform/templates/iam.tf
@@ -1,0 +1,34 @@
+resource "aws_iam_role" "wellcomecollection_instance" {
+  name = "wellcomecollection-instance"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {"Service": "ec2.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "get_builds" {
+  name = "get-builds"
+  role = "${aws_iam_role.wellcomecollection_instance.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${var.build_bucket}/builds/*"
+    }
+  ]
+}
+EOF
+}

--- a/infra/terraform/templates/launch.tf
+++ b/infra/terraform/templates/launch.tf
@@ -1,0 +1,54 @@
+data "template_file" "launch_script" {
+  template = "${var.launch_template}"
+
+  vars {
+    build_number = "${var.build_number}",
+    build_bucket = "${var.build_bucket}",
+    build_branch = "${var.build_branch}",
+    project_name = "${var.project_name}"
+  }
+}
+
+resource "aws_key_pair" "wellcomecollection" {
+  key_name   = "${var.wellcomecollection_key_name}"
+  public_key = "${file(var.wellcomecollection_key_path)}"
+}
+
+resource "aws_launch_configuration" "wellcomecollection" {
+  lifecycle { create_before_destroy = true }
+
+  key_name               = "${aws_key_pair.wellcomecollection.id}"
+  image_id               = "${var.aws_node_ami}"
+  instance_type          = "t2.micro"
+  iam_instance_profile   = "${aws_iam_instance_profile.wellcomecollection.id}"
+  user_data              = "${data.template_file.launch_script.rendered}"
+  security_groups        = [
+    "${aws_security_group.ssh_in.id}",
+    "${aws_security_group.http.id}",
+    "${aws_security_group.https.id}",
+    "${aws_security_group.node_app_port.id}"
+  ]
+
+  connection { user = "ubuntu" }
+}
+
+resource "aws_iam_instance_profile" "wellcomecollection" {
+  name = "${var.project_name}-app"
+  roles = ["${aws_iam_role.wellcomecollection_instance.name}"]
+}
+
+resource "aws_autoscaling_group" "wellcomecollection_asg" {
+  lifecycle { create_before_destroy = true }
+
+  // We use the dynamis name from the ALC to ensure recreation
+  name                      = "${var.project_name}-asg-${aws_launch_configuration.wellcomecollection.name}"
+  max_size                  = 2
+  min_size                  = 1
+  wait_for_elb_capacity     = 1
+  desired_capacity          = 1
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  launch_configuration      = "${aws_launch_configuration.wellcomecollection.id}"
+  load_balancers            = ["${aws_elb.wellcomecollection.id}"]
+  vpc_zone_identifier       = ["${aws_subnet.public.id}"]
+}

--- a/infra/terraform/templates/provider.tf
+++ b/infra/terraform/templates/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "${var.aws_region}"
+}

--- a/infra/terraform/templates/sg.tf
+++ b/infra/terraform/templates/sg.tf
@@ -1,0 +1,75 @@
+resource "aws_security_group" "http" {
+  name = "allow-http"
+  description = "Allow http/s traffic"
+  vpc_id = "${aws_vpc.wellcomecollection.id}"
+
+  # HTTP
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+resource "aws_security_group" "https" {
+  name = "allow-http-s"
+  description = "Allow http/s traffic"
+  vpc_id = "${aws_vpc.wellcomecollection.id}"
+
+  # HTTPS
+  ingress {
+    from_port = 443
+    to_port = 443
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+resource "aws_security_group" "node_app_port" {
+  name = "allow-3000"
+  description = "Allow http/s traffic"
+  vpc_id = "${aws_vpc.wellcomecollection.id}"
+
+  # Our apps run on port 3000
+  ingress {
+    from_port = 3000
+    to_port = 3000
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port = 3000
+    to_port = 3000
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ssh_in" {
+  name        = "ssh-in"
+  description = "Used to allow SSH access"
+  vpc_id      = "${aws_vpc.wellcomecollection.id}"
+
+  # HTTP SSH from anywhere
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/infra/terraform/templates/state.tf
+++ b/infra/terraform/templates/state.tf
@@ -1,0 +1,9 @@
+data "terraform_remote_state" "wellcomecollection" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.build_bucket}"
+    key = "build-state/terraform.tfstate"
+    region = "eu-west-1"
+  }
+}

--- a/infra/terraform/templates/vars.tf
+++ b/infra/terraform/templates/vars.tf
@@ -1,0 +1,12 @@
+variable "project_name" {}
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "aws_availability_zones" {}
+variable "wellcomecollection_key_name" {}
+variable "wellcomecollection_key_path" {}
+variable "aws_region" {}
+variable "aws_node_ami" {}
+variable "build_bucket" {}
+variable "build_number" {}
+variable "build_branch" {}
+variable "launch_template" {}

--- a/infra/terraform/templates/vpc.tf
+++ b/infra/terraform/templates/vpc.tf
@@ -1,0 +1,46 @@
+resource "aws_vpc" "wellcomecollection" {
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
+
+  tags {
+    Name = "wellcomecollection"
+  }
+}
+
+resource "aws_internet_gateway" "wellcomecollection" {
+  vpc_id = "${aws_vpc.wellcomecollection.id}"
+
+  tags {
+    Name = "wellcomecollection-igw"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = "${aws_vpc.wellcomecollection.id}"
+
+  tags {
+    Name = "wellcomecollection-public"
+  }
+}
+
+resource "aws_route" "public_internet_gateway" {
+  route_table_id         = "${aws_route_table.public.id}"
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = "${aws_internet_gateway.wellcomecollection.id}"
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = "${aws_vpc.wellcomecollection.id}"
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "eu-west-1a"
+  map_public_ip_on_launch = true
+
+  tags {
+    Name = "wellcomecollection-public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = "${element(aws_subnet.public.*.id, count.index)}"
+  route_table_id = "${aws_route_table.public.id}"
+}

--- a/infra/terraform/wellcomecollection.tf
+++ b/infra/terraform/wellcomecollection.tf
@@ -1,0 +1,23 @@
+variable "aws_access_key" {}
+variable "aws_secret_key" {}
+variable "wellcomecollection_key_path" {}
+variable "wellcomecollection_key_name" {}
+variable "build_number" {}
+variable "build_bucket" {}
+variable "build_branch" {}
+
+module "wellcomecollection" {
+  source                       = "templates/"
+  project_name                 = "wellcomecollection"
+  launch_template              = "${file("launch-script.tpl")}"
+  aws_region                   = "eu-west-1"
+  aws_availability_zones       = "eu-west-1a"
+  aws_node_ami                 = "ami-ffaad08c"
+  aws_access_key               = "${var.aws_access_key}"
+  aws_secret_key               = "${var.aws_secret_key}"
+  wellcomecollection_key_path  = "${var.wellcomecollection_key_path}"
+  wellcomecollection_key_name  = "${var.wellcomecollection_key_name}"
+  build_number                 = "${var.build_number}"
+  build_bucket                 = "${var.build_bucket}"
+  build_branch                 = "${var.build_branch}"
+}


### PR DESCRIPTION
Adding the deploy infra to wellcomecollections.org.
We can now deploy artifacts created by circle.

The instructions are in the [README](https://github.com/wellcometrust/wellcomecollection.org/blob/3a35283f7e27df3011d2940418530f5e1d60ff63/infra/README.md).

There is still a bit [to do](https://github.com/wellcometrust/wellcomecollection.org/blob/3a35283f7e27df3011d2940418530f5e1d60ff63/infra/TODO.md) (not an exhaustive list) - but for now we have a ELB with content serving, so great.

