### PR TITLE
Use British 'colour' spelling for class name

### DIFF
--- a/client/js/styleguide/palette.js
+++ b/client/js/styleguide/palette.js
@@ -26,7 +26,7 @@
   pairArray.forEach((pair) => {
     palette_element.innerHTML += `
     <div class="styleguide__hex" style="background: ${pair.hex};">
-      <span class="styleguide__colour">${pair.name}: <code class="styleguide__hex-code">${pair.hex}</code></span>
+      <span class="styleguide__color">${pair.name}: <code class="styleguide__hex-code">${pair.hex}</code></span>
     </div>`
   })
 })()

--- a/client/scss/styleguide/_styleguide.scss
+++ b/client/scss/styleguide/_styleguide.scss
@@ -218,7 +218,7 @@ html,
   float: left;
 }
 
-.styleguide__colour {
+.styleguide__color {
   position: absolute;
   font-size: $font-xsmall;
   top: 5px;

--- a/client/scss/styleguide/_styleguide.scss
+++ b/client/scss/styleguide/_styleguide.scss
@@ -218,7 +218,7 @@ html,
   float: left;
 }
 
-.styleguide__color {
+.styleguide__colour {
   position: absolute;
   font-size: $font-xsmall;
   top: 5px;


### PR DESCRIPTION
Fixes the result of a heavy handed find-and-replace colour -> color