### PR TITLE
Modularise gulp

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ popd
 
 pushd client
 npm install
-npm run compile
+npm run build
 popd
 
 mkdir -p build

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -96,9 +96,6 @@ gulp.task('js:lint', () => {
     .pipe(eslint.failAfterError());
 });
 
-gulp.task('js', ['js:lint', 'js:compile']);
-gulp.task('scss', ['scss:lint', 'scss:compile']);
-
 gulp.task('browsersync', () => {
   browserSync.init({
     open: false,
@@ -107,10 +104,14 @@ gulp.task('browsersync', () => {
 });
 
 gulp.task('watch', () => {
-  gulp.watch(sources.scss.all, ['scss', 'scss:lint']);
-  gulp.watch(sources.js.all, ['js', 'js:lint']);
+  gulp.watch(sources.scss.all, ['scss:compile']);
+  gulp.watch(sources.js.all, ['js:compile']);
   gulp.watch(sources.images.icons.all, ['svgstore']);
 });
 
-gulp.task('compile', ['scss', 'js', 'svgstore']);
+gulp.task('js', ['js:lint', 'js:compile']);
+gulp.task('scss', ['scss:lint', 'scss:compile']);
+gulp.task('lint', ['scss:lint', 'js:lint'])
+gulp.task('compile', ['scss:compile', 'js:compile', 'svgstore']);
+gulp.task('build', ['scss', 'js']);
 gulp.task('dev', ['compile', 'browsersync', 'watch']);

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "webpack-stream": "^3.2.0"
   },
   "scripts": {
+    "build": "gulp build", 
     "compile": "gulp compile",
     "compile:dev": "gulp dev --dev",
     "test": "exit 0",

--- a/client/package.json
+++ b/client/package.json
@@ -43,6 +43,6 @@
     "compile": "gulp compile",
     "compile:dev": "gulp dev --dev",
     "test": "exit 0",
-    "prepush": "gulp scss:lint && gulp js:lint"
+    "prepush": "gulp lint"
   }
 }


### PR DESCRIPTION
Having the `lint`ing running on `watch` was riving me insane as I write a lot of pseudo code etc.
If you'd like lint, we could add a `npm run dev:linted` as this is modular enough to do that.