### PR TITLE
Update partials path for SVG sprite generation

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -31,7 +31,7 @@ const sources = {
     icons: {
       all: 'images/icons/*.svg',
       srcPath: 'images/icons/svg-sprite.njk',
-      distPath: '../server/views/partials'
+      distPath: '../server/views/_partials'
     }
   }
 };


### PR DESCRIPTION
Points the SVG creation gulp task to the correct directory (now `_partials`, previously just `partials`).