### PR TITLE
add fractal run script

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "pm2 start babel-entry.js --name 'wellcomecollection.org'",
     "test": "exit 0",
-    "watch": "nodemon babel-entry.js -e njk,js"
+    "watch": "nodemon babel-entry.js -e njk,js",
+    "fractal": "fractal start —sync --port 3002"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We can come up with a logic for what is on what port.
For now, I don't install global npm modules, so this is better than "./node_modules/.bin/fractal".