### PR TITLE
add video to article

### DIFF
--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -1,7 +1,9 @@
 import parseBody from './parse-body';
+import youtubeEmbedUrl from './youtube-embed-url';
 
 // We could do this automatically with `fs`, but that's unnecessary I/O
 // And doesn't allow us to exclude some.
 module.exports = new Map([
+  ['youtubeEmbedUrl', youtubeEmbedUrl],
   ['parseBody', parseBody]
 ]);

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -4,9 +4,19 @@ export default class Article {
     this.articleBody = articleBody;
     this.mainImage = mainImage;
     this.associatedMedia = associatedMedia;
+    this.mainMedia = getMainMedia(associatedMedia);
   }
 
   static fromDrupalApi(json) {
     return new Article(json.headline, json.articleBody, json.mainImage, json.associatedMedia);
   }
+}
+
+function getMainMedia(associatedMedia) {
+  // This is to make sure we don't serve the main image and the main video
+  const video = associatedMedia.find(m => m.weighting === 'leading' && m.mediaType === 'video');
+  const image = associatedMedia.find(m => m.weighting === 'leading' && m.mediaType === 'image');
+  const audio = associatedMedia.find(m => m.weighting === 'leading' && m.mediaType === 'audio');
+
+  return [(video || image), audio];
 }

--- a/server/views/article/index.njk
+++ b/server/views/article/index.njk
@@ -3,15 +3,23 @@
 {% block body %}
 <h1>{{ headline }}</h1>
 
-{% for media in associatedMedia %}
-  {% if media.mediaType == 'image' and media.weighting == 'leading' %}
-    <picture>
-      <img src="{{media.uri}}" alt="{{media.altText}}" title="{{media.title}}" />
-    </picture>
-  {% endif %}
+{% for media in mainMedia %}
+  {% if media.weighting == 'leading' %}
 
-  {% if media.mediaType == 'audio' and media.weighting == 'leading' %}
-    <audio controls="controls" src="{{media.uri}}"></audio>
+    {% if media.mediaType == 'image' %}
+      <picture>
+        <img src="{{media.uri}}" alt="{{media.altText}}" title="{{media.title}}" />
+      </picture>
+    {% endif %}
+
+    {% if media.mediaType == 'audio' %}
+      <audio controls="controls" src="{{media.uri}}"></audio>
+    {% endif %}
+
+    {% if media.mediaType == 'video' %}
+      <iframe width="640" height="360" src="{{media.uri | youtubeEmbedUrl}}" frameborder="0"></iframe>
+    {% endif %}
+
   {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
We can show the video now.

It also makes sure that we don't show the image with the video, as that's completely overkill (although we could probably use the image as a fallback).

![video](https://cloud.githubusercontent.com/assets/31692/20355022/d8d53c6e-ac17-11e6-9d75-27c173dca34d.png)