### PR TITLE
use less than all the CPU units

### DIFF
--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -2,7 +2,7 @@
   {
     "name": "wellcomecollection",
     "image": "wellcome/wellcomecollection:${container_tag}",
-    "cpu": 1024,
+    "cpu": 256,
     "memory": 768,
     "essential": true,
     "portMappings": [


### PR DESCRIPTION
This is not the long term solution - adding machines with more cores is (1024CPU units / core).