### PR TITLE
Allow ECS to go 200 over capacity

### DIFF
--- a/infra/terraform/templates/ecs.tf
+++ b/infra/terraform/templates/ecs.tf
@@ -13,6 +13,7 @@ resource "aws_ecs_service" "wellcomecollection" {
   task_definition = "${aws_ecs_task_definition.wellcomecollection.arn}"
   desired_count = 2
   deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent = 200
   iam_role = "${aws_iam_role.ecs_service_role.arn}"
 
   load_balancer {

--- a/infra/terraform/templates/iam.tf
+++ b/infra/terraform/templates/iam.tf
@@ -51,6 +51,8 @@ data "aws_iam_policy_document" "ecs_service_policy" {
       "elasticloadbalancing:Describe*",
       "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
       "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+      "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:RegisterTargets",
       "ec2:Describe*",
       "ec2:AuthorizeSecurityGroupIngress"
     ]

--- a/infra/terraform/templates/launch.tf
+++ b/infra/terraform/templates/launch.tf
@@ -59,3 +59,8 @@ resource "aws_autoscaling_group" "wellcomecollection_ecs_asg" {
   vpc_zone_identifier       = ["${aws_subnet.public_a.id}", "${aws_subnet.public_b.id}"]
   target_group_arns         = ["${aws_alb_target_group.wellcomecollection.id}"]
 }
+
+output "ami_id" {
+  value = "${data.aws_ami.ecs_optimized.id}"
+}
+

--- a/infra/terraform/wellcomecollection.tf
+++ b/infra/terraform/wellcomecollection.tf
@@ -18,3 +18,8 @@ module "wellcomecollection" {
   container_tag                = "${var.container_tag}"
   build_state_bucket           = "${var.build_state_bucket}"
 }
+
+output "ami_id" {
+  value = "${module.wellcomecollection.ami_id}"
+}
+


### PR DESCRIPTION
This allows us to have 3 tasks running to be able to start the new ones up.