### PR TITLE
Ecs allow dynamic ports

### DIFF
--- a/infra/TODO.md
+++ b/infra/TODO.md
@@ -4,7 +4,6 @@
 * Better AZN
 * Review VPC strategy
 * What do we do about concurrent deploys? Queue?
-* Move from ELB to ALB
 * Figure out domain name
 * Get HTTPs setup on ALB
 * Health checks

--- a/infra/app.js
+++ b/infra/app.js
@@ -1,6 +1,7 @@
 import inquirer from 'inquirer';
-import {exec} from 'child_process';
 import {listTags} from './docker';
+import deployTag from './deploy';
+import {error, success, info} from './console';
 
 async function deploy() {
   const tags = await listTags();
@@ -14,25 +15,14 @@ async function deploy() {
 
   const {tag} = await inquirer.prompt(tagsQ);
 
-  const deployStart = Date.now();
-  console.info(`Deploying build: ${tag} of wellcomecollection.org to prod…`);
-
-  exec(`./deploy.sh ${tag}`, (err, stdout, stderr) => {
-    if (err) {
-      console.info('\n');
-      console.error('\x1b[33m', 'Airbag error: Application not deployed.', '\x1b[0m');
-      console.error(err);
-    }
-    if (stderr) {
-      console.info('\n');
-      console.error('\x1b[33m', 'Terraform error: Application not deployed, there was a Terraform error.', '\x1b[0m');
-      console.error(stderr);
-    }
-    if (!(err || stderr)) {
-      const deployedIn = Date.now() - deployStart;
-      console.info('\x1b[32m', `Deployed build: ${tag} of wellcomecollection.org to prod in ${deployedIn/1000} seconds`, '\x1b[0m');
-    }
-  });
+  info(`Deploying build: ${tag} of wellcomecollection.org to prod…`);
+  const deployInfo = await deployTag(tag);
+  success(`Deployed service: ${tag} of wellcomecollection.org to prod in ${deployInfo.deployedIn/1000} seconds`);
 }
 
-deploy();
+try {
+  deploy();
+} catch(e) {
+  error('Airbag exploded: Application not deployed.');
+  error(e);
+}

--- a/infra/console.js
+++ b/infra/console.js
@@ -1,0 +1,15 @@
+const def = '\x1b[0m';
+const red = '\x1b[33m';
+const green = '\x1b[32m';
+
+export function error(m) {
+  console.info(red, m, def);
+}
+
+export function success(m) {
+  console.info(green, m, def);
+}
+
+export function info(m) {
+  console.info(def, m, def);
+}

--- a/infra/console.js
+++ b/infra/console.js
@@ -3,7 +3,7 @@ const red = '\x1b[33m';
 const green = '\x1b[32m';
 
 export function error(m) {
-  console.info(red, m, def);
+  console.error(red, m, def);
 }
 
 export function success(m) {

--- a/infra/deploy.js
+++ b/infra/deploy.js
@@ -1,0 +1,29 @@
+import {exec} from 'child_process';
+
+export default function deployTag(tag) {
+  return new Promise((resolve, reject) => {
+    const deployStart = Date.now();
+    exec(`./deploy.sh ${tag}`, (error, stdout, stderr) => {
+      if (error) {
+        reject({
+          error,
+          message: 'Airbag error: Application not deployed.'
+        });
+      }
+      if (stderr) {
+        reject({
+          error: stderr,
+          message: 'Terraform error: Application not deployed, there was a Terraform error.'
+        });
+      }
+      if (!(error || stderr)) {
+        const deployedIn = Date.now() - deployStart;
+        resolve({
+          message: `Deployed service: ${tag} of wellcomecollection.org to prod in ${deployedIn/1000} seconds`,
+          deployedIn
+        });
+      }
+    });
+  });
+}
+

--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -8,7 +8,7 @@
     "portMappings": [
       {
         "containerPort": 3000,
-        "hostPort": 3000,
+        "hostPort": 0,
         "protocol": "tcp"
       }
     ],

--- a/infra/terraform/templates/alb.tf
+++ b/infra/terraform/templates/alb.tf
@@ -9,20 +9,21 @@ resource "aws_alb" "wellcomecollection_alb" {
   security_groups = [
     "${aws_security_group.https.id}",
     "${aws_security_group.http.id}",
-    "${aws_security_group.node_app_port.id}"
+    "${aws_security_group.node_app_port.id}",
+    "${aws_security_group.docker.id}"
   ]
 }
 
 resource "aws_alb_target_group" "wellcomecollection" {
   name     = "wellcomecollection"
-  port     = 3000
+  port     = 80
   protocol = "HTTP"
   vpc_id   = "${aws_vpc.wellcomecollection.id}"
 
   health_check {
-    healthy_threshold   = 2
-    unhealthy_threshold = 10
-    timeout             = 20
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    timeout             = 5
     protocol            = "HTTP"
     path                = "/healthcheck"
     interval            = 30

--- a/infra/terraform/templates/launch.tf
+++ b/infra/terraform/templates/launch.tf
@@ -39,7 +39,8 @@ resource "aws_launch_configuration" "wellcomecollection_ecs" {
     "${aws_security_group.ssh_in.id}",
     "${aws_security_group.http.id}",
     "${aws_security_group.https.id}",
-    "${aws_security_group.node_app_port.id}"
+    "${aws_security_group.node_app_port.id}",
+    "${aws_security_group.docker.id}"
   ]
   user_data = <<EOF
 #!/bin/bash

--- a/infra/terraform/templates/launch.tf
+++ b/infra/terraform/templates/launch.tf
@@ -56,6 +56,7 @@ resource "aws_autoscaling_group" "wellcomecollection_ecs_asg" {
   desired_capacity = 2
   min_size         = 2
   max_size         = 4
+  health_check_type         = "EC2"
   launch_configuration      = "${aws_launch_configuration.wellcomecollection_ecs.id}"
   vpc_zone_identifier       = ["${aws_subnet.public_a.id}", "${aws_subnet.public_b.id}"]
   target_group_arns         = ["${aws_alb_target_group.wellcomecollection.id}"]

--- a/infra/terraform/templates/sg.tf
+++ b/infra/terraform/templates/sg.tf
@@ -18,6 +18,26 @@ resource "aws_security_group" "http" {
   }
 }
 
+resource "aws_security_group" "docker" {
+  name = "docker"
+  description = "Allow all docker ports"
+  vpc_id = "${aws_vpc.wellcomecollection.id}"
+
+  # HTTP
+  ingress {
+    from_port = 32768
+    to_port = 61000
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port = 32768
+    to_port = 61000
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 
 resource "aws_security_group" "https" {
   name = "allow-http-s"


### PR DESCRIPTION
We now allow for dynamic `hostPorts` on the container hosts. 
This moves deployment from 10+ minutes to about 1 minute.

Before we were having to drain one task, which seems to take ages, restart it, and then do that again for each host as having a hard-coded port means you can only run that service once on the host.

🚤 🐎 