### PR TITLE
Use correct (turquoise)  quote colour; add grey borders

### DIFF
--- a/client/scss/components/_blockquote.scss
+++ b/client/scss/components/_blockquote.scss
@@ -4,6 +4,13 @@
   @include font('HNM2');
   text-align: center;
 
+  @include respond-to('large') {
+    border-left: 5px solid color('keyline-grey');
+    border-right: 5px solid color('keyline-grey');
+    padding-left: span-columns('large', 1, true);
+    padding-right: span-columns('large', 1, true);
+  }
+
   &.blockquote--wb {
     @include font('WB5');
   }
@@ -26,7 +33,7 @@
     // stylelint-enable sh-waqar/declaration-use-variable
     line-height: 1;
     display: block;
-    color: color('action-green-1');
+    color: color('turquoise');
     height: 3rem;
   }
 

--- a/client/scss/utilities/_functions.scss
+++ b/client/scss/utilities/_functions.scss
@@ -33,14 +33,8 @@
 @function span-columns($viewport-size, $number, $no-final-gutter: false) {
   $columns-at-size: map-get($total-columns, $viewport-size);
   $gutter-at-size: map-get($gutter-width, $viewport-size);
-  $total-gutter: null;
-
-  @if ($no-final-gutter) {
-    $total-gutter: ($number - 1) * $gutter-at-size;
-  } @else {
-    $total-gutter: $number * $gutter-at-size;
-  }
-
+  $multiplier: if($no-final-gutter, $number - 1, $number);
+  $total-gutter: $multiplier * $gutter-at-size;
   $percent-width: (100% / $columns-at-size) * $number;
 
   @return calc(#{$percent-width} + #{$total-gutter});

--- a/client/scss/utilities/_functions.scss
+++ b/client/scss/utilities/_functions.scss
@@ -30,10 +30,17 @@
 }
 
 // Get the width of a number of columns at a given viewport width
-@function span-columns($viewport-size, $number) {
+@function span-columns($viewport-size, $number, $no-final-gutter: false) {
   $columns-at-size: map-get($total-columns, $viewport-size);
   $gutter-at-size: map-get($gutter-width, $viewport-size);
-  $total-gutter: $number * $gutter-at-size;
+  $total-gutter: null;
+
+  @if ($no-final-gutter) {
+    $total-gutter: ($number - 1) * $gutter-at-size;
+  } @else {
+    $total-gutter: $number * $gutter-at-size;
+  }
+
   $percent-width: (100% / $columns-at-size) * $number;
 
   @return calc(#{$percent-width} + #{$total-gutter});


### PR DESCRIPTION
I hadn't realised that the grey borders around the blockquotes in the C&T styleguide were part of the blockquote design. Spotted them in the article page design and added them here.

Also updated the quote colour from green to turquoise after colour picking (not much difference to my colour-blind eyes).

![screen shot 2016-11-25 at 11 08 56](https://cloud.githubusercontent.com/assets/1394592/20623470/a33e8e72-b2ff-11e6-9fd6-f42b306c35c7.png)
