### PR TITLE
Figure

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -23,6 +23,7 @@
 // Components
 @import 'components/block_description';
 @import 'components/blockquote';
+@import 'components/figure';
 @import 'components/grid_placeholder';
 @import 'components/header';
 @import 'components/page_description';

--- a/client/scss/components/_figure.scss
+++ b/client/scss/components/_figure.scss
@@ -1,0 +1,34 @@
+//* @define figure
+
+.figure {
+  @include bleed(map-get($gutter-width, 'small'));
+
+  @include respond-to('medium') {
+    @include bleed(map-get($gutter-width, 'medium'));
+  }
+
+  @include respond-to('large') {
+    @include bleed(map-get($gutter-width, 'large'));
+  }
+}
+
+.figure__image {
+  width: 100%;
+  margin-bottom: 0.7rem;
+}
+
+.figure__caption {
+  @include font('LR2');
+  display: flex;
+  color: color('accessible-grey-2');
+  padding-bottom: 1rem;
+  border-bottom: 1px solid color('keyline-grey');
+}
+
+.figure__icon {
+  width: 1.3em;
+  height: 1.3em;
+  min-width: 1.3em;
+  stroke: color('currentColor');
+  margin-right: 0.8em;
+}

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -109,3 +109,11 @@
     }
   }
 }
+
+// Allow an element to be horizontally stretched outwith its container
+@mixin bleed($amount) {
+  margin-left: -$amount;
+  margin-right: -$amount;
+  padding-left: $amount;
+  padding-right: $amount;
+}

--- a/server/views/components/figure/index.config.json
+++ b/server/views/components/figure/index.config.json
@@ -1,0 +1,32 @@
+{
+  "handle": "figure",
+  "name": "Figure",
+  "context": {
+    "sources": [{
+      "src": "http://fillmurray.com/1200/800",
+      "media": "1200"
+    }, {
+      "src": "http://fillmurray.com/600/400",
+      "media": "600"
+    }, {
+      "src": "http://fillmurray.com/300/200",
+      "media": "300"
+    }],
+    "caption": "Bill Murray. He don't need no money."
+  },
+  "variants": [{
+    "name": "default",
+    "label": "Picture",
+    "context": {
+      "type": "picture",
+      "icon": "Picture"
+    }
+  }, {
+    "name": "image",
+    "label": "Image",
+    "context": {
+      "type": "image",
+      "icon": "Picture"
+    }
+  }]
+}

--- a/server/views/components/figure/index.config.json
+++ b/server/views/components/figure/index.config.json
@@ -3,16 +3,16 @@
   "name": "Figure",
   "context": {
     "sources": [{
-      "src": "http://fillmurray.com/1200/800",
-      "media": "1200"
+      "src": "http://placehold.it/1200x800",
+      "size": "1200"
     }, {
-      "src": "http://fillmurray.com/600/400",
-      "media": "600"
+      "src": "http://placehold.it/600x400",
+      "size": "600"
     }, {
-      "src": "http://fillmurray.com/300/200",
-      "media": "300"
+      "src": "http://placehold.it/300x200",
+      "size": "300"
     }],
-    "caption": "Bill Murray. He don't need no money."
+    "caption": "Aspernatur neque debitis atque saepe magni praesentium eos."
   },
   "variants": [{
     "name": "default",

--- a/server/views/components/figure/index.njk
+++ b/server/views/components/figure/index.njk
@@ -1,0 +1,25 @@
+<figure class="figure figure--{{type}}">
+  {% if type === 'picture' %}
+    <picture class="figure__picture">
+      {%- for source in sources %}
+        <source media="(min-width: {{ source.media }}px)"
+          srcset="{{ source.src }}">
+      {%- endfor %}
+      <img class="figure__image"
+        src="{{ sources[(sources | length) - 1].src }}"
+        alt="{{ caption }}" />
+    </picture>
+  {% elif type === 'image' %}
+    <img class="figure__image"
+      src="{{ sources[(sources | length) - 1].src }}"
+      srcset="{%- for source in sources %}
+        {{ source.src }} {{ source.media }}w
+        {%- if (source !== (sources | last)) %}, {%- endif %}
+      {%- endfor %}"
+      alt="{{ caption }}" />
+  {% endif %}
+  <figcaption class="figure__caption">
+    {% component 'icon', {icon: icon, extraClasses: ['figure__icon']} %}{% endcomponent %}
+    {{ caption }}
+  </figcaption>
+</figure>

--- a/server/views/components/figure/index.njk
+++ b/server/views/components/figure/index.njk
@@ -2,7 +2,7 @@
   {% if type === 'picture' %}
     <picture class="figure__picture">
       {%- for source in sources %}
-        <source media="(min-width: {{ source.media }}px)"
+        <source media="(min-width: {{ source.size }}px)"
           srcset="{{ source.src }}">
       {%- endfor %}
       <img class="figure__image"
@@ -13,7 +13,7 @@
     <img class="figure__image"
       src="{{ sources[(sources | length) - 1].src }}"
       srcset="{%- for source in sources %}
-        {{ source.src }} {{ source.media }}w
+        {{ source.src }} {{ source.size }}w
         {%- if (source !== (sources | last)) %}, {%- endif %}
       {%- endfor %}"
       alt="{{ caption }}" />


### PR DESCRIPTION
Styles and markup for figures (with captions).

Initially I've added a conditional `type` to allow for specification of the image element – either `img` or `picture`, depending on the level of art-direction required.

I have kept the media-queries basic for the time-being (`min-width` for the `picture` case, and `w` for the `img` case).

I imagine we'll have to add picturefill (not done here) to support any IE before Edge.

![screen shot 2016-11-25 at 11 21 59](https://cloud.githubusercontent.com/assets/1394592/20623826/70c12912-b301-11e6-8412-44d1678420d4.png)
