### PR TITLE
Unbreak font component

### DIFF
--- a/server/views/components/font-example/index.njk
+++ b/server/views/components/font-example/index.njk
@@ -1,14 +1,14 @@
 <div class="styleguide__font">
-  <h2 class="styleguide__font__name">{{ font.font__name }}</h2>
-  <p class="styleguide__font__example--{{ font.font__name }}">{{ font.font__example }}</p>
+  <h2 class="styleguide__font__name">{{ font__name }}</h2>
+  <p class="styleguide__font__example--{{ font__name }}">{{ font__example }}</p>
   <dl class="styleguide__font__properties">
     <dt class="styleguide__font__property">Font-size:</dt>
-    <dd class="styleguide__font__value">{{ font.font__size }}</dd>
+    <dd class="styleguide__font__value">{{ font__size }}</dd>
     <dt class="styleguide__font__property">Letter-spacing:</dt>
-    <dd class="styleguide__font__value">{{ font.letter__spacing }}</dd>
+    <dd class="styleguide__font__value">{{ letter__spacing }}</dd>
     <dt class="styleguide__font__property">Line-height:</dt>
-    <dd class="styleguide__font__value">{{ font.line__height }}</dd>
+    <dd class="styleguide__font__value">{{ line__height }}</dd>
   </dl>
   <h2 class="styleguide__font__usage-title">Usage:</h2>
-  <p class="styleguide__font__usage-text">{{ font.usage__text}}</p>
+  <p class="styleguide__font__usage-text">{{ usage__text}}</p>
 </div>


### PR DESCRIPTION
The data for the font-example component didn't exist (presumably after a refactor). Removed the `font.` prefix to make it work again.