### PR TITLE
Add body-content type styles

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -23,6 +23,7 @@
 // Components
 @import 'components/block_description';
 @import 'components/blockquote';
+@import 'components/body_content';
 @import 'components/figure';
 @import 'components/grid_placeholder';
 @import 'components/header';

--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -1,0 +1,38 @@
+.body-content {
+  h2 {
+    @include font('WB5');
+  }
+
+  ul {
+    @include plain-list();
+
+    li {
+      list-style: none;
+
+      &:before {
+        content: '';
+        width: 0.35em;
+        height: 0.35em;
+        display: inline-block;
+        vertical-align: middle;
+        border-radius: 0.1em;
+        background: color('currentColor');
+        margin-right: 0.4em;
+      }
+    }
+  }
+
+  *::selection {
+    background: transparentize(color('turquoise'), 0.7);
+  }
+
+  a:link {
+    text-decoration: none;
+    box-shadow: inset 0 -0.1em 0 0 color('action-green-1');
+
+    &:hover,
+    &:focus {
+      box-shadow: inset 0 -0.2em 0 0 color('action-green-1');
+    }
+  }
+}

--- a/server/views/components/body-content/index.config.json
+++ b/server/views/components/body-content/index.config.json
@@ -1,0 +1,7 @@
+{
+  "handle": "body-content",
+  "name": "Body content",
+  "context": {
+    "body": "<h2>This is a heading two</h2><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit <a href='0'>this is a link</a>. Magnam nostrum adipisci voluptas eius asperiores fugiat alias nihil eaque, <em>something with emphasis</em> and <strong>something strong</strong> optio eos itaque porro laudantium illum corporis sed inventore ipsam, pariatur excepturi.</p><p>Repellat doloribus, here's a list</p><ul><li>item</li><li>item</li><li>item</li><li>item</li><li>item</li><li>item</li></ul>"
+  }
+}

--- a/server/views/components/body-content/index.njk
+++ b/server/views/components/body-content/index.njk
@@ -1,0 +1,3 @@
+<div class="body-content">
+  {{ body }}
+</div>


### PR DESCRIPTION
Adding some `h2`, `ul`, `a` and `::selection` styles for content contained within a `class="body-content"` block. This should allow styling of e.g. article content elements without requiring us to class every element during parsing.

The styles I've added so far are based on type styles from the visual designs, but I imagine there will likely be other elements that we want to have default styling.

Do we think e.g. `table`s should belong in here, or would we specifically add classes to them during the parsing stage? Any other obvious omissions.