### PR TITLE
Add row background colour option and spaced grids

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -10,6 +10,7 @@
 @import 'base/fonts';
 @import 'base/layout';
 @import 'base/container';
+@import 'base/row';
 @import 'base/typography';
 @import 'base/icon-sprite';
 

--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -1,0 +1,7 @@
+//* @define row
+
+.row {
+  &.row--cream {
+    background: color('cream');
+  }
+}

--- a/client/scss/grids/_grid_alignment.scss
+++ b/client/scss/grids/_grid_alignment.scss
@@ -10,3 +10,7 @@
 .grid--end {
   justify-content: flex-end;
 }
+
+.grid--spaced {
+  justify-content: space-between;
+}

--- a/server/views/grid/aligning/README.md
+++ b/server/views/grid/aligning/README.md
@@ -1,1 +1,3 @@
 Applying a class of either `grid--start`, `grid--center` or `grid--end` to the containing `grid` div will determine how grid cells are aligned horizontally.
+
+Applying a class of `grid--spaced` to the containing `grid` element will space out its child `grid__cell`s (useful for when e.g. there is an empty column of space between to content columns, rather than having to include an empty element for spacing).

--- a/server/views/grid/aligning/aligning.njk
+++ b/server/views/grid/aligning/aligning.njk
@@ -15,3 +15,13 @@
     {% include "views/grid/_placeholder/placeholder.njk" %}
   </div>
 </div>
+
+<div class="grid grid--spaced">
+  <div class="grid__cell grid__cell--s1 grid__cell--m3 grid__cell--l5">
+    {% include "views/grid/_placeholder/placeholder.njk" %}
+  </div>
+
+  <div class="grid__cell grid__cell--s1 grid__cell--m3 grid__cell--l5">
+    {% include "views/grid/_placeholder/placeholder.njk" %}
+  </div>
+</div>


### PR DESCRIPTION
1. The designs call for full-bleed background colours (e.g. cream on the article pages). The `row` class added here is designed to wrap an e.g. `container` to add background to the whole page around that container.

2. The `grid--spaced` class added here adds `justify-content: space-between` to `grid__cell`s to distribute them evenly on the line. This is useful for when there are two `grid__cell`s on a row that have one or more empty columns between them.