### PR TITLE
Grid shift

### DIFF
--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -75,6 +75,10 @@
       flex-basis: ($i / $columns) * 100%;
       max-width: ($i / $columns) * 100%;
     }
+
+    .grid__cell--shift-#{$key}#{$i} {
+      margin-left: ($i / $columns) * 100%;
+    }
   }
 }
 

--- a/server/views/article/index.njk
+++ b/server/views/article/index.njk
@@ -31,7 +31,7 @@
 <div class="row row--cream">
   <div class="container body-content">
     <div class="grid grid--spaced">
-      <div class="grid__cell grid__cell--l7  grid__cell--m8">
+      <div class="grid__cell grid__cell--l7 grid__cell--shift-l1  grid__cell--m8">
         {% for bodyPart in articleBody | parseBody %}
           {{bodyPart.value | safe}}
         {% endfor %}

--- a/server/views/grid/aligning/README.md
+++ b/server/views/grid/aligning/README.md
@@ -1,3 +1,5 @@
 Applying a class of either `grid--start`, `grid--center` or `grid--end` to the containing `grid` div will determine how grid cells are aligned horizontally.
 
 Applying a class of `grid--spaced` to the containing `grid` element will space out its child `grid__cell`s (useful for when e.g. there is an empty column of space between to content columns, rather than having to include an empty element for spacing).
+
+Applying a class of `grid__cell--shift-{viewport}{columns}` adds left margin of `{columns}` width to the given cell at the `{viewport}` breakpoint.

--- a/server/views/grid/aligning/aligning.njk
+++ b/server/views/grid/aligning/aligning.njk
@@ -25,3 +25,12 @@
     {% include "views/grid/_placeholder/placeholder.njk" %}
   </div>
 </div>
+
+<div class="grid">
+  <div class="grid__cell grid__cell--l5 grid__cell--shift-l1 grid__cell--m3 grid__cell--shift-m1 grid__cell--s1 grid__cell--shift-s1">
+    {% include "views/grid/_placeholder/placeholder.njk" %}
+  </div>
+  <div class="grid__cell grid__cell--l5 grid__cell--shift-l1 grid__cell--m3 grid__cell--shift-m1 grid__cell--s1 grid__cell--shift-s1">
+    {% include "views/grid/_placeholder/placeholder.njk" %}
+  </div>
+</div>


### PR DESCRIPTION
Grid containers in the visual designs can be shifted over to enable the creation of empty columns. This allows for any number of empty columns to be created at each breakpoint.

Before (no shift in copy):
![screen shot 2016-11-30 at 12 54 51](https://cloud.githubusercontent.com/assets/1394592/20753100/a3f8da10-b6fc-11e6-9efc-72fb15efeb1c.png)

After (copy shifted one-column to the right):
![screen shot 2016-11-30 at 12 54 26](https://cloud.githubusercontent.com/assets/1394592/20753104/a91207c4-b6fc-11e6-9573-381a6a0623e2.png)
