### PR TITLE
Apply the grey lead-in bar style to the row rather than the page-desc…

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -1,7 +1,36 @@
 //* @define row
 
-.row {
-  &.row--cream {
-    background: color('cream');
+.row--cream {
+  background: color('cream');
+}
+
+.row--lead {
+  position: relative;
+
+  &:before {
+    position: absolute;
+    content: '';
+    background: color('keyline-grey');
+    top: 0;
+    bottom: 0;
+    left: 0;
+  }
+
+  &.row--lead--s:before {
+    @include respond-to('small') {
+      width: map-get($container-padding, 'small');
+    }
+  }
+
+  &.row--lead--m:before {
+    @include respond-to('medium') {
+      width: map-get($container-padding, 'medium');
+    }
+  }
+
+  &.row--lead--l:before {
+    @include respond-to('large') {
+      width: map-get($container-padding, 'large');
+    }
   }
 }

--- a/client/scss/components/_page_description.scss
+++ b/client/scss/components/_page_description.scss
@@ -1,23 +1,6 @@
 //* @define page-description;
 
 .page-description {
-  &.page-description--a {
-    @include respond-to('large') {
-      position: relative;
-      padding: 1.8rem 0 1.5rem span-columns('large', 1.5);
-
-      &:before {
-        content: '';
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: span-columns('large', 0.5);
-        background: color('keyline-grey');
-      }
-    }
-  }
-
   &.page-description--b {
     padding-bottom: 1.2rem;
     border-bottom: 1px solid color('keyline-grey');

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -115,11 +115,11 @@
 }
 
 // Allow an element to be horizontally stretched outwith its container
-@mixin bleed($amount, $use-padding: false) {
+@mixin bleed($amount, $with-padding: false) {
   margin-left: -$amount;
   margin-right: -$amount;
 
-  @if ($use-padding) {
+  @if ($with-padding) {
     padding-left: $amount;
     padding-right: $amount;
   }

--- a/server/views/article/index.njk
+++ b/server/views/article/index.njk
@@ -1,8 +1,14 @@
 {% extends "layout/default.njk" %}
 
 {% block body %}
-<div class="container">
-  {% component 'page-description', {title: headline, modifiers: ['a']} %}{% endcomponent %}
+<div class="row row--lead row--lead--l">
+  <div class="container">
+    <div class="grid">
+      <div class="grid__cell grid__cell--shift-l1">
+        {% component 'page-description', {title: headline, modifiers: ['a']} %}{% endcomponent %}
+      </div>
+    </div>
+  </div>
 </div>
 {% for media in mainMedia %}
   {% if media.weighting == 'leading' %}


### PR DESCRIPTION
The 'starter block' grey bar was previously attached to the page-description component. This precluded it from being used with other types of content (which is a requirement).

It also meant the location of the bar was tied to the page-description itself, whereas it should be attached flush to the left of the viewport.

There is likely still alignment work to be done with this bar (should it finish in line with the baseline of the heading text?) but I felt that that might have been premature optimisation.

![screen shot 2016-11-30 at 16 52 50](https://cloud.githubusercontent.com/assets/1394592/20762213/8f921854-b71d-11e6-94fa-8bb4aa0942b9.png)
