### PR TITLE
Allow for alignment of figcaption content

### DIFF
--- a/server/views/article/index.njk
+++ b/server/views/article/index.njk
@@ -10,10 +10,12 @@
     {% if media.mediaType == 'image' %}
       {% component 'figure', {
         type: 'image',
-        icon: 'Picture',
+        icon: 'picture',
         full: true,
         sources: [{size: 1000, src: media.uri}],
-        caption: media.altText
+        caption: media.altText,
+        captionSizes: ['l7'],
+        captionShifts: ['l1']
       } %}{% endcomponent %}
     {% endif %}
 

--- a/server/views/components/figure/index.njk
+++ b/server/views/components/figure/index.njk
@@ -18,10 +18,10 @@
       {%- endfor %}"
       alt="{{ caption }}" />
   {% endif %}
-    {% if full %}<div class="container">{% endif %}
-      <figcaption class="figure__caption">
+    <div class="{{ 'container' if full }} grid">
+      <figcaption class="figure__caption grid__cell {% for size in captionSizes %}grid__cell--{{ size }}{% endfor %} {% for shift in captionShifts %}grid__cell--shift-{{ shift }} {% endfor %}">
         {% component 'icon', {icon: icon, blockClass: 'figure'} %}{% endcomponent %}
         {{ caption }}
       </figcaption>
-    {% if full %}</div>{% endif %}
+    </div>
 </figure>

--- a/server/views/components/icon/index.njk
+++ b/server/views/components/icon/index.njk
@@ -1,4 +1,4 @@
 <svg class="icon {{ blockClass }}__icon {{ extraClasses }}"{% if title %} role="img"{% else %} aria-hidden="true"{% endif %}>
   {% if title %}<title>{{title}}</title>{% endif %}
-  <use class="icon__use" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{icon}}"></use>
+  <use class="icon__use {{ blockClass }}__use" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#{{icon}}"></use>
 </svg>


### PR DESCRIPTION
The caption content within the e.g. hero image should align with any content that follows it.

Because it lives in a separate grid, it needs the option to accept grid size/shift classes.

Before:
![screen shot 2016-11-30 at 17 50 40](https://cloud.githubusercontent.com/assets/1394592/20764505/5d4ca6d0-b726-11e6-9797-f3e06e691e4c.png)

After:
![screen shot 2016-11-30 at 17 50 02](https://cloud.githubusercontent.com/assets/1394592/20764509/6607a5b8-b726-11e6-898f-f7a141a25663.png)
