### PR TITLE
Prevent margin collapse on row--lead

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -6,6 +6,8 @@
 
 .row--lead {
   position: relative;
+  overflow: hidden;
+  margin-bottom: 1rem;
 
   &:before {
     position: absolute;

--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -6,7 +6,6 @@
 
 .row--lead {
   position: relative;
-  overflow: hidden;
   margin-bottom: 1rem;
 
   &:before {

--- a/server/views/components/header/index.njk
+++ b/server/views/components/header/index.njk
@@ -1,5 +1,5 @@
-<div class="header js-header-burger">
-  <div class="header__upper">
+<div class="header grid js-header-burger">
+  <div class="header__upper grid__cell">
     <div class="header__inner container">
       <div class="header__burger">
         <button id="header-burger-trigger"


### PR DESCRIPTION
Unwanted [collapsing margins](http://reference.sitepoint.com/css/collapsingmargins) are causing the lead row to overlap the nav. This PR ensures the rows are flush.

Before (grey 'starter block' line overlapping nav):
![screen shot 2016-12-05 at 09 48 55](https://cloud.githubusercontent.com/assets/1394592/20880583/c5cc3a6a-bad0-11e6-9e87-f03d8b565aee.png)

After:
![screen shot 2016-12-05 at 09 48 22](https://cloud.githubusercontent.com/assets/1394592/20880600/d122ca6e-bad0-11e6-90f7-5235aa863688.png)
