### PR TITLE
Make with-marks modifier

### DIFF
--- a/client/scss/components/_blockquote.scss
+++ b/client/scss/components/_blockquote.scss
@@ -24,27 +24,29 @@
     margin-top: 0;
   }
 
-  &:before,
-  &:after {
-    // stylelint-disable sh-waqar/declaration-use-variable
-    // Decorative quotes – not defined as part of the typography styles
-    font-family: $helvetica-neue-medium-base;
-    font-size: 6rem;
-    // stylelint-enable sh-waqar/declaration-use-variable
-    line-height: 1;
-    display: block;
-    color: color('turquoise');
-    height: 3rem;
-  }
+  &.blockquote--with-marks {
+    &:before,
+    &:after {
+      // stylelint-disable sh-waqar/declaration-use-variable
+      // Decorative quotes – not defined as part of the typography styles
+      font-family: $helvetica-neue-medium-base;
+      font-size: 6rem;
+      // stylelint-enable sh-waqar/declaration-use-variable
+      line-height: 1;
+      display: block;
+      color: color('turquoise');
+      height: 3rem;
+    }
 
-  &:before {
-    content: '\201c';
-    margin-bottom: 1rem;
-  }
+    &:before {
+      content: '\201c';
+      margin-bottom: 1rem;
+    }
 
-  &:after {
-    content: '\201d';
-    margin-top: 0.5rem;
+    &:after {
+      content: '\201d';
+      margin-top: 0.5rem;
+    }
   }
 }
 

--- a/server/views/components/blockquote/index.config.json
+++ b/server/views/components/blockquote/index.config.json
@@ -1,21 +1,25 @@
 {
   "handle": "blockquote",
-  "name": "Blockquote",
   "context": {
     "body": "<p>It was a large room, heavily outfitted with the usual badly ventilated furnaces, rows of bubbling crucibles, and one stuffed alligator. Things floated in jars. The air smelled of a limited life expectancy.</p>",
     "footer": "<footer class='blockquote__footer'>Emily Dickinson, <cite class='blockquote__cite'>I felt a funeral in my brain</cite></footer>"
   },
   "notes": "For pull quotes. Suited for more serious articles",
   "variants": [{
+    "name": "default",
+    "context": {
+      "modifiers": ["with-marks"]
+    }
+  },{
     "name": "Wellcome Bold",
     "context": {
-      "modifier": "wb"
+      "modifiers": ["with-marks", "wb"]
     },
     "notes": "For pull quotes. Suited for more informal articles"
   }, {
     "name": "Leterra",
     "context": {
-      "modifier": "lr"
+      "modifiers": ["lr"]
     },
     "notes": "For text references"
   }]

--- a/server/views/components/blockquote/index.njk
+++ b/server/views/components/blockquote/index.njk
@@ -1,4 +1,4 @@
-<blockquote class="blockquote {% if modifier %}blockquote--{{ modifier }}{% endif %}">
+<blockquote class="blockquote {% for modifier in modifiers %}blockquote--{{ modifier }} {% endfor %}">
   {{ body }}
   {{ footer }}
 </blockquote>


### PR DESCRIPTION
## What is this PR trying to achieve?

In a design review, we agreed to remove the big quote marks from the monospace `blockquote` variant. This PR adds a `--with-marks` modifier to the blockquote component to enable this. #122

## What does it look like?

Before:
![screen shot 2016-12-05 at 13 44 25](https://cloud.githubusercontent.com/assets/1394592/20887162/6d5acb96-baf1-11e6-9190-78c0e5e9cf7e.png)

After:
![screen shot 2016-12-05 at 13 44 32](https://cloud.githubusercontent.com/assets/1394592/20887175/76ecdc12-baf1-11e6-9b89-a8788cb39cda.png)


