### PR TITLE
Nest 'grid' instead of applying to 'container'

### DIFF
--- a/server/views/components/figure/index.njk
+++ b/server/views/components/figure/index.njk
@@ -18,10 +18,12 @@
       {%- endfor %}"
       alt="{{ caption }}" />
   {% endif %}
-    <div class="{{ 'container' if full }} grid">
-      <figcaption class="figure__caption grid__cell {% for size in captionSizes %}grid__cell--{{ size }}{% endfor %} {% for shift in captionShifts %}grid__cell--shift-{{ shift }} {% endfor %}">
-        {% icon icon %}
-        {{ caption }}
-      </figcaption>
+    <div class="{{ 'container' if full }}">
+      <div class="grid">
+        <figcaption class="figure__caption grid__cell {% for size in captionSizes %}grid__cell--{{ size }}{% endfor %} {% for shift in captionShifts %}grid__cell--shift-{{ shift }} {% endfor %}">
+          {% icon icon %}
+          {{ caption }}
+        </figcaption>
+      </div>
     </div>
 </figure>


### PR DESCRIPTION
## What is this PR trying to achieve?

The figure caption will become misaligned with body content at wider screen widths, because the negative left margin applied to the `grid` class overrides the `margin: 0 auto;` of the `container` class.

Nesting the `grid` within the `container` solves this. 

## What does it look like?

Before:
![screen shot 2016-12-05 at 14 51 27](https://cloud.githubusercontent.com/assets/1394592/20889496/27829ce8-bafb-11e6-977f-4bb9dffa9bb4.png)

After:
![screen shot 2016-12-05 at 14 52 07](https://cloud.githubusercontent.com/assets/1394592/20889500/2be1cd2c-bafb-11e6-9d82-d3b4efe6f7e9.png)

