### PR TITLE
Cutting the mustard

### DIFF
--- a/client/.stylelintrc
+++ b/client/.stylelintrc
@@ -41,7 +41,7 @@
       "ignoreSelectors": [
         ".*\\.icon*",
         ".*\\.is-.*",
-        ".*\\.no-js.*",
+        ".*\\.enhanced.*",
         ".*\\.lt-ie.*"
       ]
     },

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -15,20 +15,24 @@ $tweakpoints: (
 }
 
 .header__inner {
-  display: flex;
   padding-bottom: 0.8rem;
-  align-items: center;
+
+  .enhanced & {
+    display: flex;
+    align-items: center;
+  }
 }
 
 .header__burger {
+  display: none;
   flex: 1;
 
-  .no-js & {
-    display: none;
-  }
+  .enhanced & {
+    display: block;
 
-  @include respond-to('header-medium') {
-    display: none;
+    @include respond-to('header-medium') {
+      display: none;
+    }
   }
 }
 
@@ -101,9 +105,9 @@ $tweakpoints: (
 }
 
 .header__nav {
-  display: none;
+  display: block;
   margin-top: 0.5rem;
-  position: absolute;
+  position: static;
   top: 100%;
   left: map-get($container-padding, 'small');
   right: map-get($container-padding, 'small');
@@ -113,23 +117,31 @@ $tweakpoints: (
     right: map-get($container-padding, 'medium');
   }
 
-  .no-js &,
-  .header--is-burger-open & {
-    display: block;
+  .enhanced & {
+    display: none;
+    position: absolute;
+
+    @include respond-to('header-medium') {
+      position: static;
+      display: block;
+      margin-top: 0;
+    }
   }
 
-  @include respond-to('header-medium') {
-    position: static;
+  .header--is-burger-open & {
     display: block;
-    margin-top: 0;
   }
 }
 
 .header__search {
-  flex: 1;
-  display: flex;
-  justify-content: flex-end;
+  margin-top: 1rem;
 
+  .enhanced & {
+    margin-top: 0;
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+  }
 }
 
 .header__form {
@@ -137,34 +149,34 @@ $tweakpoints: (
 }
 
 .header__input-wrap {
-  position: absolute;
-  right: 100%;
-  margin-right: -1rem;
-  top: 0;
-  bottom: 0;
-  width: calc(100vw - 6.4rem);
-  display: none;
+  display: inline-block;
+  position: static;
+  width: auto;
 
-  .no-js &,
+  .enhanced & {
+    display: none;
+    position: absolute;
+    right: 100%;
+    top: 0;
+    bottom: 0;
+    margin-right: -1rem;
+    width: calc(100vw - 6.4rem);
+
+    @include respond-to('medium') {
+      width: calc(100vw - 8rem);
+    }
+
+    @include respond-to('header-medium') {
+      width: calc(100vw - 16.4rem);
+    }
+
+    @include respond-to('large') {
+      width: calc(100vw - 19rem);
+    }
+  }
+
   .header__form--is-active & {
     display: block;
-  }
-
-  @include respond-to('medium') {
-    width: calc(100vw - 8rem);
-  }
-
-  @include respond-to('header-medium') {
-    width: calc(100vw - 16.4rem);
-  }
-
-  @include respond-to('large') {
-    width: calc(100vw - 19rem);
-  }
-
-  .no-js & {
-    position: static;
-    width: auto;
   }
 }
 
@@ -173,11 +185,13 @@ $tweakpoints: (
 }
 
 .header__input {
-  @include font('HNL2');
-  width: 100%;
-  border: 0;
-  border-bottom: 1px solid color('keyline-grey');
-  padding: 0.5rem 0;
+  .enhanced & {
+    @include font('HNL2');
+    width: 100%;
+    border: 0;
+    border-bottom: 1px solid color('keyline-grey');
+    padding: 0.5rem 0;
+  }
 
   &:focus {
     outline: 0;
@@ -186,27 +200,34 @@ $tweakpoints: (
 
 .header__button {
   @include font('WB7');
+  cursor: pointer;
   align-items: center;
-  padding: 1rem 0 1rem 1.5rem;
   appearance: none;
   border: 0;
   background: color('transparent');
   transition: color 200ms ease;
   position: relative;
 
-  .header__form--is-active & {
+  .enhanced & {
+    padding: 1rem 0 1rem 1.5rem;
+
+    @include respond-to('header-medium') {
+      border-left: 1px solid color('keyline-grey');
+    }
+  }
+
+  .enhanced .header__form--is-active & {
     padding-left: 0;
     border-left: 0;
   }
 
   &:hover,
   &:focus {
-    outline: 0;
     color: color('action-green-1');
-  }
 
-  @include respond-to('header-medium') {
-    border-left: 1px solid color('keyline-grey');
+    .enhanced & {
+      outline: 0;
+    }
   }
 
   .icon {
@@ -242,7 +263,10 @@ $tweakpoints: (
 .header__list {
   @include plain-list();
   @include font('WB7');
-  margin-left: -0.3rem;
+
+  .enhanced & {
+    margin-left: -0.3rem;
+  }
 
   @include respond-to('header-medium') {
     display: flex;
@@ -296,4 +320,3 @@ $tweakpoints: (
     }
   }
 }
-

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -25,8 +25,6 @@
       {% block body %}
       {% endblock %}
     </div>
-    
-    <script src="{{ '/assets/js/app.js' }}"></script>
     {% include "partials/analytics.njk" %}
   </body>
 </html>

--- a/server/views/layout/preview-no-container.njk
+++ b/server/views/layout/preview-no-container.njk
@@ -1,6 +1,5 @@
 {% include "views/partials/html_top.njk" %}
 <body>
   {{ yield }}
-  <script src="{{ '/assets/js/app.js' | path }}"></script>
 </body>
 </html>

--- a/server/views/layout/preview.njk
+++ b/server/views/layout/preview.njk
@@ -3,6 +3,5 @@
   <div class="container styleguide__container">
     {{ yield }}
   </div>
-  <script src="{{ '/assets/js/app.js' | path }}"></script>
 </body>
 </html>

--- a/server/views/partials/js-head.njk
+++ b/server/views/partials/js-head.njk
@@ -20,14 +20,12 @@
       var HNM = new FontFaceObserver('Helvetica Neue Medium Web');
       var LR = new FontFaceObserver('Lettera Regular Web');
 
-      function addClass() {
-        if (!rootElement.classList.contains(enhancedClass)) {
-          rootElement.className += ' ' + enhancedClass;
-        }
+      function addEnhancedClass() {
+        rootElement.classList.add(enhancedClass);
       }
 
-      function removeClass() {
-        rootElement.className = rootElement.className.replace(enhancedClass, ' ');
+      function removeEnhancedClass() {
+        rootElement.classList.remove(enhancedClass);
       }
 
       function loadJS(src) {
@@ -40,25 +38,25 @@
       };
 
       if (sessionStorage.fontsLoaded) {
-        rootElement.className += ' font-stage-1 font-stage-2';
+        rootElement.classList.add('font-stage-1','font-stage-2');
       } else {
         WBSubset.load().then(function() {
-          rootElement.className += ' font-stage-1';
+          rootElement.classList.add('font-stage-1');
           Promise.all([WB.load(), HNL.load(), HNM.load(), LR.load()]).then(() => {
-            rootElement.className += ' font-stage-2';
+            rootElement.classList.add('font-stage-2');
             sessionStorage.fontsLoaded = true;
           });
         });
       }
 
-      addClass();
+      addEnhancedClass();
 
       var script = loadJS(enhancedScriptPath);
-      var fallback = setTimeout(removeClass, 8000);
+      var fallback = setTimeout(removeEnhancedClass, 8000);
 
       script.onload = function() {
         clearTimeout(fallback);
-        addClass();
+        addEnhancedClass();
       };
     }
   })();

--- a/server/views/partials/js-head.njk
+++ b/server/views/partials/js-head.njk
@@ -1,30 +1,65 @@
 <script>
-  // FontFaceObserver https://github.com/bramstein/fontfaceobserver
-  (function(){function l(a,b){document.addEventListener?a.addEventListener("scroll",b,!1):a.attachEvent("scroll",b)}function m(a){document.body?a():document.addEventListener?document.addEventListener("DOMContentLoaded",function c(){document.removeEventListener("DOMContentLoaded",c);a()}):document.attachEvent("onreadystatechange",function k(){if("interactive"==document.readyState||"complete"==document.readyState)document.detachEvent("onreadystatechange",k),a()})};function r(a){this.a=document.createElement("div");this.a.setAttribute("aria-hidden","true");this.a.appendChild(document.createTextNode(a));this.b=document.createElement("span");this.c=document.createElement("span");this.h=document.createElement("span");this.f=document.createElement("span");this.g=-1;this.b.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.c.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";
-  this.f.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.h.style.cssText="display:inline-block;width:200%;height:200%;font-size:16px;max-width:none;";this.b.appendChild(this.h);this.c.appendChild(this.f);this.a.appendChild(this.b);this.a.appendChild(this.c)}
-  function x(a,b){a.a.style.cssText="max-width:none;min-width:20px;min-height:20px;display:inline-block;overflow:hidden;position:absolute;width:auto;margin:0;padding:0;top:-999px;left:-999px;white-space:nowrap;font:"+b+";"}function y(a){var b=a.a.offsetWidth,c=b+100;a.f.style.width=c+"px";a.c.scrollLeft=c;a.b.scrollLeft=a.b.scrollWidth+100;return a.g!==b?(a.g=b,!0):!1}function z(a,b){function c(){var a=k;y(a)&&null!==a.a.parentNode&&b(a.g)}var k=a;l(a.b,c);l(a.c,c);y(a)};function A(a,b){var c=b||{};this.family=a;this.style=c.style||"normal";this.weight=c.weight||"normal";this.stretch=c.stretch||"normal"}var B=null,D=null,E=null;function H(){if(null===D){var a=document.createElement("div");try{a.style.font="condensed 100px sans-serif"}catch(b){}D=""!==a.style.font}return D}function I(a,b){return[a.style,a.weight,H()?a.stretch:"","100px",b].join(" ")}
-  A.prototype.load=function(a,b){var c=this,k=a||"BESbswy",q=0,C=b||3E3,F=(new Date).getTime();return new Promise(function(a,b){null===E&&(E=!!document.fonts);if(E){var J=new Promise(function(a,b){function e(){(new Date).getTime()-F>=C?b():document.fonts.load(I(c,'"'+c.family+'"'),k).then(function(c){1<=c.length?a():setTimeout(e,25)},function(){b()})}e()}),K=new Promise(function(a,c){q=setTimeout(c,C)});Promise.race([K,J]).then(function(){clearTimeout(q);a(c)},function(){b(c)})}else m(function(){function t(){var b;
-  if(b=-1!=f&&-1!=g||-1!=f&&-1!=h||-1!=g&&-1!=h)(b=f!=g&&f!=h&&g!=h)||(null===B&&(b=/AppleWebKit\/([0-9]+)(?:\.([0-9]+))/.exec(window.navigator.userAgent),B=!!b&&(536>parseInt(b[1],10)||536===parseInt(b[1],10)&&11>=parseInt(b[2],10))),b=B&&(f==u&&g==u&&h==u||f==v&&g==v&&h==v||f==w&&g==w&&h==w)),b=!b;b&&(null!==d.parentNode&&d.parentNode.removeChild(d),clearTimeout(q),a(c))}function G(){if((new Date).getTime()-F>=C)null!==d.parentNode&&d.parentNode.removeChild(d),b(c);else{var a=document.hidden;if(!0===
-  a||void 0===a)f=e.a.offsetWidth,g=n.a.offsetWidth,h=p.a.offsetWidth,t();q=setTimeout(G,50)}}var e=new r(k),n=new r(k),p=new r(k),f=-1,g=-1,h=-1,u=-1,v=-1,w=-1,d=document.createElement("div");d.dir="ltr";x(e,I(c,"sans-serif"));x(n,I(c,"serif"));x(p,I(c,"monospace"));d.appendChild(e.a);d.appendChild(n.a);d.appendChild(p.a);document.body.appendChild(d);u=e.a.offsetWidth;v=n.a.offsetWidth;w=p.a.offsetWidth;G();z(e,function(a){f=a;t()});x(e,I(c,'"'+c.family+'",sans-serif'));z(n,function(a){g=a;t()});x(n,
-  I(c,'"'+c.family+'",serif'));z(p,function(a){h=a;t()});x(p,I(c,'"'+c.family+'",monospace'))})})};"undefined"!==typeof module?module.exports=A:(window.FontFaceObserver=A,window.FontFaceObserver.prototype.load=A.prototype.load);}());
+  (function() {
+    if ('visibilityState' in document) {
+      // FontFaceObserver https://github.com/bramstein/fontfaceobserver
+      (function(){function l(a,b){document.addEventListener?a.addEventListener("scroll",b,!1):a.attachEvent("scroll",b)}function m(a){document.body?a():document.addEventListener?document.addEventListener("DOMContentLoaded",function c(){document.removeEventListener("DOMContentLoaded",c);a()}):document.attachEvent("onreadystatechange",function k(){if("interactive"==document.readyState||"complete"==document.readyState)document.detachEvent("onreadystatechange",k),a()})};function r(a){this.a=document.createElement("div");this.a.setAttribute("aria-hidden","true");this.a.appendChild(document.createTextNode(a));this.b=document.createElement("span");this.c=document.createElement("span");this.h=document.createElement("span");this.f=document.createElement("span");this.g=-1;this.b.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.c.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";
+      this.f.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.h.style.cssText="display:inline-block;width:200%;height:200%;font-size:16px;max-width:none;";this.b.appendChild(this.h);this.c.appendChild(this.f);this.a.appendChild(this.b);this.a.appendChild(this.c)}
+      function x(a,b){a.a.style.cssText="max-width:none;min-width:20px;min-height:20px;display:inline-block;overflow:hidden;position:absolute;width:auto;margin:0;padding:0;top:-999px;left:-999px;white-space:nowrap;font:"+b+";"}function y(a){var b=a.a.offsetWidth,c=b+100;a.f.style.width=c+"px";a.c.scrollLeft=c;a.b.scrollLeft=a.b.scrollWidth+100;return a.g!==b?(a.g=b,!0):!1}function z(a,b){function c(){var a=k;y(a)&&null!==a.a.parentNode&&b(a.g)}var k=a;l(a.b,c);l(a.c,c);y(a)};function A(a,b){var c=b||{};this.family=a;this.style=c.style||"normal";this.weight=c.weight||"normal";this.stretch=c.stretch||"normal"}var B=null,D=null,E=null;function H(){if(null===D){var a=document.createElement("div");try{a.style.font="condensed 100px sans-serif"}catch(b){}D=""!==a.style.font}return D}function I(a,b){return[a.style,a.weight,H()?a.stretch:"","100px",b].join(" ")}
+      A.prototype.load=function(a,b){var c=this,k=a||"BESbswy",q=0,C=b||3E3,F=(new Date).getTime();return new Promise(function(a,b){null===E&&(E=!!document.fonts);if(E){var J=new Promise(function(a,b){function e(){(new Date).getTime()-F>=C?b():document.fonts.load(I(c,'"'+c.family+'"'),k).then(function(c){1<=c.length?a():setTimeout(e,25)},function(){b()})}e()}),K=new Promise(function(a,c){q=setTimeout(c,C)});Promise.race([K,J]).then(function(){clearTimeout(q);a(c)},function(){b(c)})}else m(function(){function t(){var b;
+      if(b=-1!=f&&-1!=g||-1!=f&&-1!=h||-1!=g&&-1!=h)(b=f!=g&&f!=h&&g!=h)||(null===B&&(b=/AppleWebKit\/([0-9]+)(?:\.([0-9]+))/.exec(window.navigator.userAgent),B=!!b&&(536>parseInt(b[1],10)||536===parseInt(b[1],10)&&11>=parseInt(b[2],10))),b=B&&(f==u&&g==u&&h==u||f==v&&g==v&&h==v||f==w&&g==w&&h==w)),b=!b;b&&(null!==d.parentNode&&d.parentNode.removeChild(d),clearTimeout(q),a(c))}function G(){if((new Date).getTime()-F>=C)null!==d.parentNode&&d.parentNode.removeChild(d),b(c);else{var a=document.hidden;if(!0===
+      a||void 0===a)f=e.a.offsetWidth,g=n.a.offsetWidth,h=p.a.offsetWidth,t();q=setTimeout(G,50)}}var e=new r(k),n=new r(k),p=new r(k),f=-1,g=-1,h=-1,u=-1,v=-1,w=-1,d=document.createElement("div");d.dir="ltr";x(e,I(c,"sans-serif"));x(n,I(c,"serif"));x(p,I(c,"monospace"));d.appendChild(e.a);d.appendChild(n.a);d.appendChild(p.a);document.body.appendChild(d);u=e.a.offsetWidth;v=n.a.offsetWidth;w=p.a.offsetWidth;G();z(e,function(a){f=a;t()});x(e,I(c,'"'+c.family+'",sans-serif'));z(n,function(a){g=a;t()});x(n,
+      I(c,'"'+c.family+'",serif'));z(p,function(a){h=a;t()});x(p,I(c,'"'+c.family+'",monospace'))})})};"undefined"!==typeof module?module.exports=A:(window.FontFaceObserver=A,window.FontFaceObserver.prototype.load=A.prototype.load);}());
 
-  (function(window){
-    var WBSubset = new FontFaceObserver('Wellcome Bold Web Subset', {weight: 'bold'});
-    var WB = new FontFaceObserver('Wellcome Bold Web', {weight: 'bold'});
-    var HNL = new FontFaceObserver('Helvetica Neue Light Web');
-    var HNM = new FontFaceObserver('Helvetica Neue Medium Web');
-    var LR = new FontFaceObserver('Lettera Regular Web');
-    var rootElement = document.documentElement;
-    if (sessionStorage.fontsLoaded) {
-      rootElement.className += ' font-stage-1 font-stage-2';
-    } else {
-      WBSubset.load().then(function() {
-        rootElement.className += ' font-stage-1';
-        Promise.all([WB.load(), HNL.load(), HNM.load(), LR.load()]).then(() => {
-          rootElement.className += ' font-stage-2';
-          sessionStorage.fontsLoaded = true;
+      var rootElement = document.documentElement;
+      var enhancedClass = 'enhanced';
+      var enhancedScriptPath = '/assets/js/app.js';
+
+      var WBSubset = new FontFaceObserver('Wellcome Bold Web Subset', {weight: 'bold'});
+      var WB = new FontFaceObserver('Wellcome Bold Web', {weight: 'bold'});
+      var HNL = new FontFaceObserver('Helvetica Neue Light Web');
+      var HNM = new FontFaceObserver('Helvetica Neue Medium Web');
+      var LR = new FontFaceObserver('Lettera Regular Web');
+
+      function addClass() {
+        if (!rootElement.classList.contains(enhancedClass)) {
+          rootElement.className += ' ' + enhancedClass;
+        }
+      }
+
+      function removeClass() {
+        rootElement.className = rootElement.className.replace(enhancedClass, ' ');
+      }
+
+      function loadJS(src) {
+        var ref = window.document.getElementsByTagName('script')[ 0 ];
+        var script = window.document.createElement('script');
+        script.src = src;
+        script.async = true;
+        ref.parentNode.insertBefore(script, ref);
+        return script;
+      };
+
+      if (sessionStorage.fontsLoaded) {
+        rootElement.className += ' font-stage-1 font-stage-2';
+      } else {
+        WBSubset.load().then(function() {
+          rootElement.className += ' font-stage-1';
+          Promise.all([WB.load(), HNL.load(), HNM.load(), LR.load()]).then(() => {
+            rootElement.className += ' font-stage-2';
+            sessionStorage.fontsLoaded = true;
+          });
         });
-      });
+      }
+
+      addClass();
+
+      var script = loadJS(enhancedScriptPath);
+      var fallback = setTimeout(removeClass, 8000);
+
+      script.onload = function() {
+        clearTimeout(fallback);
+        addClass();
+      };
     }
   })();
 </script>


### PR DESCRIPTION
## What is this PR trying to achieve?

- Help us to ensure we provide a functional experience if javascript fails to load or is unavailable.
- Help us to ensure we provide a functional experience to users of older browsers.

### How
- Only loading the app.js and fonts in browsers deemed capable.
- Applying a class to the html element when the app.js has successfully loaded, which can then be utilised in the CSS to apply 'enhanced' styles.

## What does it look like?

Previously if  javascript was unavailable functionality such as the navigation was hidden behind a non functional button

![before](https://cloud.githubusercontent.com/assets/6051896/20895411/4437570a-bb11-11e6-8b5b-8ee38b5c6121.png)

Now it is visible

![after](https://cloud.githubusercontent.com/assets/6051896/20895430/5461d56a-bb11-11e6-9e0a-c62555f4edf1.png)

Previously the app.js and fonts were being called by all browsers, regardless of their capabilities, now this only happens if they are deemed capable. The cut off at the moment is Internet Explorer < 10 and Android browsers based on WebKit.