### PR TITLE
Nest figcaption within grid__cell to correct underline

### DIFF
--- a/server/views/components/figure/index.njk
+++ b/server/views/components/figure/index.njk
@@ -20,10 +20,12 @@
   {% endif %}
     <div class="{{ 'container' if full }}">
       <div class="grid">
-        <figcaption class="figure__caption grid__cell {% for size in captionSizes %}grid__cell--{{ size }}{% endfor %} {% for shift in captionShifts %}grid__cell--shift-{{ shift }} {% endfor %}">
-          {% icon icon %}
-          {{ caption }}
-        </figcaption>
+        <div class="grid__cell {% for size in captionSizes %}grid__cell--{{ size }}{% endfor %} {% for shift in captionShifts %}grid__cell--shift-{{ shift }} {% endfor %}">
+          <figcaption class="figure__caption">
+            {% icon icon %}
+            {{ caption }}
+          </figcaption>
+        </div>
       </div>
     </div>
 </figure>


### PR DESCRIPTION
## What is this PR trying to achieve?

Fixing the border-bottom of the figure so that it isn't shifted over to the left (as a result of negative margin on the `grid`). Done by nesting the `figure__caption` element within the `grid__cell`.

## What does it look like?

Before (underline shunted over to the left):
![screen shot 2016-12-05 at 18 05 29](https://cloud.githubusercontent.com/assets/1394592/20896506/05d77e72-bb16-11e6-982d-ea33049f56aa.png)

After:
![screen shot 2016-12-05 at 18 05 01](https://cloud.githubusercontent.com/assets/1394592/20896510/0c40ba6c-bb16-11e6-8063-256c15aee714.png)

