### PR TITLE
Change 'articles' to 'article' in URL

### DIFF
--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -4,16 +4,16 @@
 <h1>Explore</h1>
 <ul>
   <li>
-    <a href="/articles/john-thomsons-china">John Thomson's China (article)</a>
+    <a href="/article/john-thomsons-china">John Thomson's China (article)</a>
   </li>
   <li>
-    <a href="/articles/fly-sugar-crystals">A fly on sugar crystals (audio)</a>
+    <a href="/article/fly-sugar-crystals">A fly on sugar crystals (audio)</a>
   </li>
   <li>
-    <a href="/articles/david-cotterrell-afghanistan">David Cotterrell on Afghanistan (video)</a>
+    <a href="/article/david-cotterrell-afghanistan">David Cotterrell on Afghanistan (video)</a>
   </li>
   <li>
-    <a href="/articles/aids-posters-0">AIDS Posters (image gallery)</a>
+    <a href="/article/aids-posters-0">AIDS Posters (image gallery)</a>
   </li>
 </ul>
 {% endblock %}


### PR DESCRIPTION
## What is this PR trying to achieve?

The Explore page has broken links (containing 'articles' instead of 'article'). This fixes those links.

