### PR TITLE
Add close search functionality

### DIFF
--- a/client/js/components/header/search.js
+++ b/client/js/components/header/search.js
@@ -3,6 +3,7 @@ import { KEYS } from './../../util';
 
 const headerSearch = (el) => {
   const headerSearchInput = el.querySelector('.js-header-input');
+  const closeSearchButton = el.querySelector('.js-header-close-search');
   const searchToggle = showHide({
     el: el,
     activeClass: 'header__form--is-active'
@@ -48,6 +49,17 @@ const headerSearch = (el) => {
       if (keyCode !== KEYS.TAB) return;
       if (shiftKey) return;
 
+      searchToggle.setActive(false);
+    });
+
+    // Close search if clicked anywhere outside of search element
+    document.addEventListener('click', (event) => {
+      if (el.contains(event.target)) return;
+
+      searchToggle.setActive(false);
+    });
+
+    closeSearchButton.addEventListener('click', () => {
       searchToggle.setActive(false);
     });
   };

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -245,6 +245,14 @@ $tweakpoints: (
   display: flex;
 }
 
+.header__search-button {
+  position: relative;
+
+  .header__form--is-active & {
+    right: 30px;
+  }
+}
+
 .header__button-text {
   .header__form--is-active & {
     @include visuallyhidden();
@@ -252,6 +260,21 @@ $tweakpoints: (
 
   @include respond-between('small', 'header-medium') {
     @include visuallyhidden();
+  }
+}
+
+.header__close-search {
+  display: none;
+  position: absolute;
+  top: 1rem;
+
+  .icon {
+    width: 1em;
+    height: 1em;
+  }
+
+  .header__form--is-active & {
+    display: flex;
   }
 }
 

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -278,6 +278,10 @@ $tweakpoints: (
   }
 }
 
+.header__close-text {
+  @include visuallyhidden();
+}
+
 .header__list {
   @include plain-list();
   @include font('WB7');

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -278,10 +278,6 @@ $tweakpoints: (
   }
 }
 
-.header__close-text {
-  @include visuallyhidden();
-}
-
 .header__list {
   @include plain-list();
   @include font('WB7');

--- a/server/views/components/header/index.njk
+++ b/server/views/components/header/index.njk
@@ -42,7 +42,7 @@
               {% icon 'actions/search', null, ['header__search-button'] %}
               <span class="header__button-text">Search</span>
           </button>
-          <span role="button" class="header__close-search js-header-close-search">{% icon 'actions/cross-big' %}</span>
+          <span role="button" class="header__close-search js-header-close-search">{% icon 'actions/cross-big', 'Close' %}</span>
         </form>
       </div>
     </div>

--- a/server/views/components/header/index.njk
+++ b/server/views/components/header/index.njk
@@ -39,10 +39,10 @@
           </div>
           <button class="header__button js-show-hide-trigger">
             <span class="header__button-inner">
-              {% icon 'actions/search' %}
-              <span class="header__button-text">Search</search>
-            </span>
+              {% icon 'actions/search', null, ['header__search-button'] %}
+              <span class="header__button-text">Search</span>
           </button>
+          <span role="button" class="header__close-search js-header-close-search">{% icon 'actions/cross-big' %}</span>
         </form>
       </div>
     </div>

--- a/server/views/components/header/index.njk
+++ b/server/views/components/header/index.njk
@@ -42,7 +42,10 @@
               {% icon 'actions/search', null, ['header__search-button'] %}
               <span class="header__button-text">Search</span>
           </button>
-          <span role="button" class="header__close-search js-header-close-search">{% icon 'actions/cross-big', 'Close' %}</span>
+          <span role="button" aria-controls="header-input" class="header__close-search js-header-close-search">
+            <span class="header__close-text">Close search box</span>
+            {% icon 'actions/cross-big' %}
+          </span>
         </form>
       </div>
     </div>

--- a/server/views/components/header/index.njk
+++ b/server/views/components/header/index.njk
@@ -43,8 +43,7 @@
               <span class="header__button-text">Search</span>
           </button>
           <span role="button" aria-controls="header-input" class="header__close-search js-header-close-search">
-            <span class="header__close-text">Close search box</span>
-            {% icon 'actions/cross-big' %}
+            {% icon 'actions/cross-big', 'Close search box' %}
           </span>
         </form>
       </div>


### PR DESCRIPTION
## What is this PR trying to achieve?

Enabling close of the search input either by clicking the (added) cross, or by clicking anywhere on the page that isn't the search form. Fixes #157.

## What does it look like?

![screen shot 2016-12-08 at 17 46 58](https://cloud.githubusercontent.com/assets/1394592/21020997/a1a07b6a-bd6e-11e6-8666-cbd5a7d627ce.png)
