### PR TITLE
Prevent search box from over-stretching

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -152,6 +152,7 @@ $tweakpoints: (
   display: inline-block;
   position: static;
   width: auto;
+  z-index: 1;
 
   .enhanced & {
     display: none;
@@ -161,6 +162,7 @@ $tweakpoints: (
     bottom: 0;
     margin-right: -1rem;
     width: calc(100vw - 6.4rem);
+    max-width: 72rem;
 
     @include respond-to('medium') {
       width: calc(100vw - 8rem);
@@ -207,6 +209,7 @@ $tweakpoints: (
   background: color('transparent');
   transition: color 200ms ease;
   position: relative;
+  z-index: 1;
 
   .enhanced & {
     padding: 1rem 0 1rem 1.5rem;


### PR DESCRIPTION
## What is this PR trying to achieve?

Stopping the search box from overlapping the Wellcome logo with the addition of `max-width`

## What does it look like?

Before:
![screen shot 2016-12-13 at 09 35 28](https://cloud.githubusercontent.com/assets/1394592/21134880/a9bb06ce-c117-11e6-9334-1d12da3cc643.png)

After:
![screen shot 2016-12-13 at 09 35 44](https://cloud.githubusercontent.com/assets/1394592/21134886/afff5bac-c117-11e6-8ff8-0a0f4dcb741c.png)

Additionally, I had to bump a couple of z-index values because the work to cover the new-site banner meant the navigation was no longer being covered by the search input when opened.
