### PR TITLE
Add charcoal to palette config

### DIFF
--- a/server/views/global/palette.config.yml
+++ b/server/views/global/palette.config.yml
@@ -33,3 +33,5 @@ context:
     hex: "#8f8f8f"
   - name: keyline-grey
     hex: "#e5e5e5"
+  - name: charcoal
+    hex: "#323232"


### PR DESCRIPTION
## What is this PR trying to achieve?

Adding 'charcoal' (#323232) the the palette config so the Cardigan palette is in sync with the Sass variables.