### PR TITLE
Remove excess padding when nav is 'desktop'

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -115,6 +115,11 @@ $tweakpoints: (
     padding-right: map-get($container-padding, 'medium');
   }
 
+  @include respond-to('header-medium') {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   .enhanced & {
     display: none;
     background: color('white');


### PR DESCRIPTION
## What is this PR trying to achieve?

Getting rid of excess padding that was causing the nav to break when squished in the 'desktop' configuration.

## What does it look like?

Before:
![screen shot 2016-12-14 at 11 17 08](https://cloud.githubusercontent.com/assets/1394592/21180039/f6f382e0-c1ee-11e6-8a3a-2efb2d300a95.png)

After:
![screen shot 2016-12-14 at 11 17 28](https://cloud.githubusercontent.com/assets/1394592/21180040/fbc343be-c1ee-11e6-88a5-cb9fc6bfa4a9.png)
