### PR TITLE
Pa11y

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@
 
 - [ ] Tests?
 - [ ] Docs?
-- [ ] A11y?
+- [ ] A11y testing - if this PR affects a user interface component, have you run pa11y against the component and fixed/verified all errors, warnings and notices?

--- a/server/README.md
+++ b/server/README.md
@@ -18,3 +18,19 @@ npm run dev
 npm install
 npm run start
 ```
+
+## Accessibility testing
+
+```bash
+npm run test:accessibility <url> 
+```
+
+The test outputs 3 message types:
+
+- **error** clear-cut guideline violations that must be fixed
+- **warnings** items it identifies that require human verification to determine if guidelines are breached
+- **notices** items the system can't detect that require human verification to determine if guidelines are breached
+
+It is important to resolve/verify all 3 types in order to achieve standards compliance.
+Additional guidance on manually checking warnings and can be found here:
+https://github.com/wellcometrust/developer-docs/blob/master/front-end/accessibility/Webpage_Accessibility_Audit_Procedure.md 

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "start:watch": "nodemon app.pack.js -e js,njk",
     "test": "ava",
     "test:watch": "ava --watch",
+    "test:accessibility": "pa11y",
     "compile": "webpack",
     "compile:watch": "webpack --watch",
     "optimise:svg": "node ./optimise-svgs.js",
@@ -42,7 +43,8 @@
   },
   "devDependencies": {
     "concurrently": "^3.1.0",
-    "nodemon": "^1.10.2"
+    "nodemon": "^1.10.2",
+    "pa11y": "^4.2.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
## What is this PR trying to achieve?

- Added [pa11y](https://github.com/pa11y/pa11y) module to enable local automated accessibility testing 
- Added directions about making use of [pa11y](https://github.com/pa11y/pa11y) in pull request template and README

## What does it look like?

<img width="904" alt="pa11y" src="https://cloud.githubusercontent.com/assets/6051896/21191358/c52762ee-c21c-11e6-8602-6c613d0e1fb2.png">

From the server folder you can run an accessibility test against a local URL with the following command:

`npm run test:accessibility <url>`

The test outputs 3 message types:

- **error** clear-cut guideline violations that must be fixed
- **warnings** items it identifies that require human verification to determine if guidelines are breached
- **notices** items the system can't detect that require human verification to determine if guidelines are breached

It is important to resolve/verify all 3 types in order to achieve standards compliance.

[Additional guidance on manually checking accessibility](https://github.com/wellcometrust/developer-docs/blob/master/front-end/accessibility/Webpage_Accessibility_Audit_Procedure.md)
