### PR TITLE
Add articleAuthor block

### DIFF
--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -1,5 +1,8 @@
 {% extends "templates/article.njk" %}
 
+{% block articleAuthor %}
+{% endblock %}
+
 {% block articleBody %}
   <div class="grid__cell grid__cell--l6 grid__cell--shift-l1  grid__cell--m8">
     {% for bodyPart in articleBody | parseBody %}

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -18,15 +18,19 @@
 
 <div class="row row--cream">
   <div class="container">
-    <div class="grid">
-      <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
-        {% component 'author', {
-          name: author.name,
-          twitterHandle: author.twitterHandle,
-          image: author.image
-        } %}
+
+    {% block articleAuthor %}
+      <div class="grid">
+        <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+          {% component 'author', {
+            name: author.name,
+            twitterHandle: author.twitterHandle,
+            image: author.image
+          } %}
+        </div>
       </div>
-    </div>
+    {% endblock %}
+
     {% block articleBody %}
       <div class="body-content">
         {% for bodyPart in bodyParts %}


### PR DESCRIPTION
## What is this PR trying to achieve?

Adds a nunjucks block for the article author to allow for the disparity in content between the current and future content types.

## What does it look like?

It gets rid of the broken author component displaying above the body copy on e.g. https://next.wellcomecollection.org/articles/aids-posters-0 –

![screen shot 2016-12-22 at 14 47 29](https://cloud.githubusercontent.com/assets/1394592/21429207/b28b124a-c855-11e6-90c4-62dbb26601fb.png)
