### PR TITLE
Fix page-description icon

### DIFF
--- a/client/scss/components/_page_description.scss
+++ b/client/scss/components/_page_description.scss
@@ -34,12 +34,12 @@
   display: flex;
   align-items: center;
   color: color('accessible-grey-1');
-}
 
-.page-description__icon {
-  margin-right: 0.5em;
-  width: 1.3em;
-  height: 1.3em;
+  .icon {
+    margin-right: 0.5em;
+    width: 1.3em;
+    height: 1.3em;
+  }
 }
 
 .page-description__use {

--- a/server/views/components/page-description/index.config.yml
+++ b/server/views/components/page-description/index.config.yml
@@ -11,15 +11,15 @@ variants:
     intro: States of Mind
     title: 'Inspired: Alchemists and housewives around a long table'
     outro: September 9th 2016
-    icon: Clock
+    icon: other/clock
 - name: hn
   label: B (library item)
   notes: Library item title.
   context:
     modifiers:
     - b
-    intro: 
+    intro:
     title: On the Origin of Species by Means of Natural Selection, or the Preservation
       of Favoured Races in the Struggle for Life
-    outro: 
-    icon: 
+    outro:
+    icon:

--- a/server/views/components/page-description/index.njk
+++ b/server/views/components/page-description/index.njk
@@ -3,7 +3,7 @@
   <h1 class="page-description__title">{{ title }}</h1>
   <span class="page-description__outro">
     {% if icon %}
-      {% component 'icon', {icon: icon, blockClass: 'page-description'} %}
+      {% icon icon %}
     {% endif %}
     {{ outro }}
   </span>


### PR DESCRIPTION
## What is this PR trying to achieve?

Fixing the page description outro/icon. This was needed after we moved to using an `icon` block from a `component` block.