### PR TITLE
check that terraform remote state is configured before release

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 1 ]; then
-    echo "⚡ Usage: deploy <CONTAINER_TAG>"
+    echo "⚡ Usage: deploy.sh <CONTAINER_TAG>"
     exit 1
 fi
 
 CONTAINER_TAG=$1
 
 pushd terraform
-terraform get
-terraform remote pull
-terraform apply \
-    -var "container_tag=$CONTAINER_TAG"
+    terraform get
+    terraform remote pull
 
+    REMOTE_PULL_CODE=$?
+
+    if [ $REMOTE_PULL_CODE == 1 ]; then
+        echo "ERROR: Please run ./setup.sh <BUILD_BUCKET> first before trying to deploy."
+        echo "⚡ Top tip: You can get this from your .tfvars file."
+        exit 1
+    fi
+
+    terraform apply \
+        -var "container_tag=$CONTAINER_TAG"
 popd

--- a/infra/setup.sh
+++ b/infra/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 1 ]; then
+    echo "⚡ Usage: setup.sh <BUILD_BUCKET>"
+    exit 1
+fi
+
+# TODO: grab this from tfvars?
+BUILD_BUCKET=$1
+
+pushd terraform
+    terraform remote config \
+        -backend=s3 \
+        -backend-config="bucket=$BUILD_BUCKET" \
+        -backend-config="key=build-state/terraform.tfstate" \
+        -backend-config="region=eu-west-1"
+popd

--- a/infra/terraform/templates/cloudfront.tf
+++ b/infra/terraform/templates/cloudfront.tf
@@ -6,6 +6,7 @@ resource "aws_cloudfront_distribution" "cardigan" {
 
   enabled             = true
   default_root_object = "index.html"
+  is_ipv6_enabled     = true
 
   aliases = ["cardigan.wellcomecollection.org"]
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Making deploys more reliable.
If the remote state and your state aren't configured there is a risk of killing the entire stack.

This is not good.

But this is the danger of using our stack deployment to do app deployment.

What might be nice is to have your stack deployed, and somehow only update the ECS task definition... I will have a think about this.

