### PR TITLE
Wp images

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -15,6 +15,20 @@ export const article = async(ctx, next) => {
   }
 };
 
+export const wpArticle = async(ctx, next) => {
+    const id = ctx.params.id;
+    // TODO: This should be discoverable - not hard-coded
+    const uri = `https://public-api.wordpress.com/rest/v1.1/sites/blog.wellcomecollection.org/posts/slug:${id}`;
+    const response = await request(uri);
+    const valid = response.type === 'application/json' && response.status === 200;
+
+    if (valid) {
+        return ctx.render('pages/article', Article.fromWpApi(response.body));
+    } else {
+        return next();
+    }
+};
+
 export const explore = (ctx) => ctx.render('pages/explore');
 export const favicon = (ctx) => ctx.body = '';
 export const healthcheck = (ctx) => ctx.body = 'ok';

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -1,3 +1,5 @@
+import {getWpFeaturedImage} from './media';
+
 export default class Article {
   constructor(headline, articleBody, mainImage, associatedMedia) {
     this.headline = headline;
@@ -9,6 +11,11 @@ export default class Article {
 
   static fromDrupalApi(json) {
     return new Article(json.headline, json.articleBody, json.mainImage, json.associatedMedia);
+  }
+
+  static fromWpApi(json) {
+      const mainImage = getWpFeaturedImage(json.featured_image, json.attachments);
+      return new Article(json.title, json.content, mainImage, [mainImage]);
   }
 }
 

--- a/server/model/image.js
+++ b/server/model/image.js
@@ -1,0 +1,11 @@
+import {Record} from 'immutable';
+
+export const Image = Record({
+  contentUrl: null,
+  caption: null,
+  author: null,
+  width: 0,
+  height: 0,
+  copyrightHolder: null,
+  fileFormat: null
+});

--- a/server/model/media.js
+++ b/server/model/media.js
@@ -34,7 +34,6 @@ export default class Media {
 export function getWpFeaturedImage(uri, images) {
   const i = findWpFeaturedImage(uri, images);
   // I wish we had options ;_;
-  console.info(convertWpImageToMedia(i));
   return i ? convertWpImageToMedia(i) : null;
 }
 

--- a/server/model/media.js
+++ b/server/model/media.js
@@ -1,0 +1,56 @@
+// TODO: This model needs to match Schema.org
+// TODO: Maybe ImmutableJs Records?
+export default class Media {
+  // We use destructuring here as pseudo named arguments functionality
+  constructor({
+    mediaType,
+    uri,
+    mimetype,
+    weighting,
+    altText,
+    filesize,
+    title,
+    author,
+    caption,
+    credit,
+    copyright,
+    dimensions
+  }) {
+    this.mediaType = mediaType;
+    this.uri = uri;
+    this.mimetype = mimetype;
+    this.altText = altText;
+    this.filesize = filesize;
+    this.title = title;
+    this.author = author;
+    this.caption = caption;
+    this.credit = credit;
+    this.copyright = copyright;
+    this.dimensions = dimensions;
+    this.weighting = weighting;
+  }
+}
+
+export function getWpFeaturedImage(uri, images) {
+  const i = findWpFeaturedImage(uri, images);
+  // I wish we had options ;_;
+  console.info(convertWpImageToMedia(i));
+  return i ? convertWpImageToMedia(i) : null;
+}
+
+function findWpFeaturedImage(uri, images) {
+  const imagesArr = Object.keys(images).map(k => images[k]);
+  return imagesArr.find(i => i.URL === uri);
+}
+
+function convertWpImageToMedia(wpImage) {
+  return new Media({
+    mediaType: 'image',
+    weighting: 'leading',
+    uri: wpImage.URL,
+    mimetype: wpImage.mime_type,
+    caption: wpImage.caption,
+    altText: wpImage.alt,
+    dimensions: { width: wpImage.width, height: wpImage.height }
+  });
+}

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,11 +1,12 @@
 import Router from 'koa-router';
-import {article, explore, healthcheck, favicon} from '../controllers';
+import {article, wpArticle, explore, healthcheck, favicon} from '../controllers';
 
 const r = new Router();
 
 r.get('/healthcheck', healthcheck);
 r.get('/favicon.ico', favicon);
 r.get('/explore', explore);
+r.get('/articles/wp/:id', wpArticle);
 r.get('/:id*', article);
 
 export const router = r.middleware();

--- a/server/test/util/body-parser.js
+++ b/server/test/util/body-parser.js
@@ -1,26 +1,46 @@
 import test from 'ava';
+import parse from 'parse5';
 import exploreApiResp from '../mocks/explore-api.json';
+
 import {
-    getFragment,
-    explodeIntoBodyParts,
-    removeEmptyTextNodes
+  getFragment,
+  explodeIntoBodyParts,
+  removeEmptyTextNodes,
+  getImageFromWpNode
 } from '../../util/body-parser';
 
+const wpImageNode = parse.parseFragment(`
+<div data-shortcode="caption" id="attachment_12033" style="width: 810px" class="wp-caption alignnone">
+    <img data-attachment-id="12033" data-permalink="http://blog.wellcomecollection.org/2016/12/22/christmas-part-the-second/v0040154-a-family-sit-around-a-table-eating-their-christmas-meal-and/" data-orig-file="https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg?w=800&amp;h=521" data-orig-size="800,521" data-comments-opened="1" data-image-meta="{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;Wellcome Library, London&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;V0040154 A family sit around a table eating their Christmas meal and\\nCredit: Wellcome Library, London. Wellcome Images\\nimages@wellcome.ac.uk\\nhttp:\\/\\/wellcomeimages.org\\nA family sit around a table eating their Christmas meal and greet the arrival of the plum pudding which is being carried in on a large tray. Reproduction after Cecil Aldin.\\nBy: Cecil AldinPublished:  - \\n\\nCopyrighted work available under Creative Commons Attribution only licence CC BY 4.0 http:\\/\\/creativecommons.org\\/licenses\\/by\\/4.0\\/&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;Copyrighted work available under Creative Commons Attribution only licence CC BY 4.0 http:\\/\\/creativecommons.org\\/licenses\\/by\\/4.0\\/&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;V0040154 A family sit around a table eating their Christmas meal and&quot;,&quot;orientation&quot;:&quot;0&quot;}" data-image-title="V0040154 A family sit around a table eating their Christmas meal and" data-image-description="<p>The typical canon-ball shaped plum pudding pictured as the grand finale of the British Christmas feast.</p>\n" data-medium-file="https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg?w=800&amp;h=521?w=300" data-large-file="https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg?w=800&amp;h=521?w=800" class="alignnone size-full
+[1] wp-image-12033" src="https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg?w=800&amp;h=521" alt="The typical canon-ball shaped plum pudding pictured as the grand finale of the British Christmas feast." width="800" height="521" srcset="https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg 800w, https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg?w=150&amp;h=98 150w, https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg?w=300&amp;h=195 300w, https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg?w=768&amp;h=500 768w" sizes="(max-width: 800px) 100vw, 800px">
+    <p class="wp-caption-text">The typical canon-ball shaped plum pudding pictured as the grand finale of the British Christmas feast.</p>
+</div>
+`.trim()).childNodes[0];
 
 test.beforeEach(t => {
-    const fragment = getFragment(exploreApiResp.articleBody);
-    t.context.fragment = fragment;
-});
-
-test('removeEmptyTextNodes', t => {
-    const parsedBody = explodeIntoBodyParts(t.context.fragment);
-    t.true(Array.isArray(parsedBody));
+  const fragment = getFragment(exploreApiResp.articleBody);
+  t.context.fragment = fragment;
 });
 
 test('explodeIntoBodyParts', t => {
-    const uncleanNodes = t.context.fragment.childNodes;
-    const cleanNodes = removeEmptyTextNodes(t.context.fragment.childNodes);
+  const parsedBody = explodeIntoBodyParts(t.context.fragment.childNodes);
+  t.true(Array.isArray(parsedBody));
+});
 
-    t.is(uncleanNodes.length, 18);
-    t.is(cleanNodes.length, 9);
+test('removeEmptyTextNodes', t => {
+  const uncleanNodes = t.context.fragment.childNodes;
+  const cleanNodes = removeEmptyTextNodes(t.context.fragment.childNodes);
+
+  t.is(uncleanNodes.length, 18);
+  t.is(cleanNodes.length, 9);
+});
+
+test('getImageFromWpNode', t => {
+  const i = getImageFromWpNode(wpImageNode);
+  t.is(i.width, 800);
+  t.is(i.height, 521);
+  t.is(
+    i.caption,
+    'The typical canon-ball shaped plum pudding pictured as the grand finale of the British Christmas feast.'
+  );
 });

--- a/server/test/util/body-parser.js
+++ b/server/test/util/body-parser.js
@@ -37,6 +37,7 @@ test('removeEmptyTextNodes', t => {
 
 test('getImageFromWpNode', t => {
   const i = getImageFromWpNode(wpImageNode);
+  t.is(i.contentUrl, 'https://wellcomecollection.files.wordpress.com/2016/12/865c27bde0241fe5fc47cfb40826.jpg');
   t.is(i.width, 800);
   t.is(i.height, 521);
   t.is(

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -1,4 +1,5 @@
 import parse from 'parse5';
+import url from 'url';
 import {Image} from '../model/image';
 
 const treeAdapter = parse.treeAdapters.default;
@@ -20,7 +21,8 @@ export function explodeIntoBodyParts(nodes) {
 
     return {
       nodeName: node.nodeName,
-      value: parse.serialize(frag)
+      value: node.value,
+      html: parse.serialize(frag)
     };
   });
 
@@ -49,10 +51,13 @@ function cleanWpImages(nodes) {
 
 export function getImageFromWpNode(node) {
   const img = node.childNodes.find(node => node.nodeName === 'img');
+  const urlObj = url.parse(getAttrVal(img.attrs, 'data-orig-file'));
+  const contentUrl = `https://${urlObj.hostname}${urlObj.pathname}`;
   const caption = getAttrVal(img.attrs, 'data-image-description').replace(/<\/?p>/g, '').trim();
   const [width, height] = getAttrVal(img.attrs, 'data-orig-size').split(',');
 
   return new Image({
+    contentUrl,
     caption,
     width: parseInt(width, 10),
     height: parseInt(height, 10)

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -3,7 +3,16 @@
 {% block articleBody %}
   <div class="grid__cell grid__cell--l6 grid__cell--shift-l1  grid__cell--m8">
     {% for bodyPart in articleBody | parseBody %}
-      {{bodyPart.value | safe}}
+      {% if bodyPart.nodeName === 'img' %}
+          {% component 'figure', {
+            type: 'picture',
+            sources: [{src: bodyPart.value.contentUrl, size: bodyPart.value.width}],
+            caption: bodyPart.value.caption,
+            icon: 'other/picture'
+          } %}
+      {%  else %}
+        {{bodyPart.html | safe}}
+      {% endif %}
     {% endfor %}
   </div>
 {% endblock %}

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -22,7 +22,7 @@
       <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
         {% component 'author', {
           name: author.name,
-          twitterHandle: author.twitterHandle,
+            twitterHandle: author.twitterHandle,
           image: author.image
         } %}
       </div>


### PR DESCRIPTION
## What is this PR trying to achieve?
We need to turn the images into cleansed, usable nodes, in the markup that we want.
We can then start to decide how this might apply in the sticky images.

## Notes
I would like to start using the model types as extensively as possible. Having a type means that we have a contract with what we expect. Things like `sources` etc will be able to be created within the figure elements itself if we have all the relevant metadata.

It will also allow us to have consistency with the API once they land, and then use content model generators such as swagger.

I'm not sold on the `nodeName`, `value`, `html` model, but I think this is going to be passed of the the API anyhow.

## What does it look like?
![wp-images-type](https://cloud.githubusercontent.com/assets/31692/21681554/9beba7dc-d347-11e6-9c65-97437a327bc4.png)

