### PR TITLE
separate articles and artefacts

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -1,26 +1,18 @@
-import request from 'superagent';
-import Article from '../model/article';
 import {PageConfig} from '../model/page-config';
 import {getPosts, getArticle} from '../services/wordpress';
+import {getArtefact} from '../services/artefacts';
 
-export const article = async(ctx, next) => {
+export const artefact = async(ctx, next) => {
   const id = ctx.params.id;
-  // TODO: This should be discoverable - not hard-coded
-  const uri = `https://wellcomecollection.org/api/v0/${id}`;
-  const response = await request(uri);
-  const valid = response.type === 'application/json' && response.status === 200;
+  const artefact = await getArtefact(id);
 
-  if (valid) {
-    return ctx.render('pages/article', {
-      pageConfig: new PageConfig({inSection: 'explore'}),
-      article: Article.fromDrupalApi(response.body)
-    });
-  } else {
-    return next();
-  }
+  return artefact ? ctx.render('pages/article', {
+    pageConfig: new PageConfig({inSection: 'explore'}),
+    article: artefact
+  }) : next();
 };
 
-export const wpArticle = async(ctx, next) => {
+export const article = async(ctx, next) => {
     const id = ctx.params.id;
     const article = await getArticle(id);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,5 +1,5 @@
 import Router from 'koa-router';
-import {index, article, wpArticle, explore, healthcheck, favicon} from '../controllers';
+import {index, article, artefact, explore, healthcheck, favicon} from '../controllers';
 
 const r = new Router();
 
@@ -7,7 +7,7 @@ r.get('/', index);
 r.get('/healthcheck', healthcheck);
 r.get('/favicon.ico', favicon);
 r.get('/explore', explore);
-r.get('/articles/wp/:id', wpArticle);
-r.get('/:id*', article);
+r.get('/articles/:id', article);
+r.get('/artefacts/:id*', artefact);
 
 export const router = r.middleware();

--- a/server/services/artefacts.js
+++ b/server/services/artefacts.js
@@ -1,0 +1,13 @@
+import request from 'superagent';
+import Article from '../model/article';
+const baseUri = 'https://wellcomecollection.org/api/v0';
+
+export async function getArtefact(id) {
+  const uri = `${baseUri}/${id}`;
+  const response = await request(uri);
+  const valid = response.type === 'application/json' && response.status === 200;
+
+  if (valid) {
+    return Article.fromDrupalApi(response.body);
+  }
+}

--- a/server/services/artefacts.js
+++ b/server/services/artefacts.js
@@ -3,7 +3,7 @@ import Article from '../model/article';
 const baseUri = 'https://wellcomecollection.org/api/v0';
 
 export async function getArtefact(id) {
-  const uri = `${baseUri}/${id}`;
+  const uri = `${baseUri}/articles/${id}`;
   const response = await request(uri);
   const valid = response.type === 'application/json' && response.status === 200;
 

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -17,7 +17,7 @@
           <ul>
               {% for post in wpPosts %}
                 <li>
-                  <a href="/articles/wp/{{ post.slug }}">{{ post.title }}</a>
+                  <a href="/articles/{{ post.slug }}">{{ post.title }}</a>
                 </li>
               {% endfor %}
           </ul>
@@ -25,16 +25,16 @@
           <h1>From the Collection explore section</h1>
           <ul>
             <li>
-              <a href="/articles/john-thomsons-china">John Thomson's China (article)</a>
+              <a href="/artefacts/john-thomsons-china">John Thomson's China (article)</a>
             </li>
             <li>
-              <a href="/articles/fly-sugar-crystals">A fly on sugar crystals (audio)</a>
+              <a href="/artefacts/fly-sugar-crystals">A fly on sugar crystals (audio)</a>
             </li>
             <li>
-              <a href="/articles/david-cotterrell-afghanistan">David Cotterrell on Afghanistan (video)</a>
+              <a href="/artefacts/david-cotterrell-afghanistan">David Cotterrell on Afghanistan (video)</a>
             </li>
             <li>
-              <a href="/articles/aids-posters-0">AIDS Posters (image gallery)</a>
+              <a href="/artefacts/aids-posters-0">AIDS Posters (image gallery)</a>
             </li>
           </ul>
 


### PR DESCRIPTION
## What is this PR trying to achieve?
As it seems we're heading as using WordPress content as article truth (for the time being).

Eventually most things will be migrated to `/articles`, and I assume we will deprecate the `/artefacts` URL.