### PR TITLE
Fix opening hours/article page description in Cardigan

### DIFF
--- a/server/views/components/footer/index.njk
+++ b/server/views/components/footer/index.njk
@@ -1,10 +1,10 @@
 <div class="footer row row--dark-black">
   <div class="container">
     <div class="grid">
-      <div class="grid__cell grid__cell--s4 grid__cell--m8 grid__cell--l3">
+      <div class="grid__cell grid__cell--s4 grid__cell--m4 grid__cell--l3">
         {% component "footer-nav", {navLinks: navLinks} %}
       </div>
-      <div class="grid__cell grid__cell--s4 grid__cell--m8 grid__cell--l3">
+      <div class="grid__cell grid__cell--s4 grid__cell--m4 grid__cell--l3">
         <h3 class="footer__heading">Finding us:</h3>
         {% component "find-us" %}
       </div>

--- a/server/views/templates/article.config.yml
+++ b/server/views/templates/article.config.yml
@@ -1,8 +1,11 @@
 name: Article
 handle: article-template
 context:
-  author: "@author"
-  headline: AIDS Posters
+  pageConfig:
+    inSection: explore
+  article:
+    author: "@author"
+    headline: AIDS Posters
   mainMedia:
   - mediaType: image
     weighting: leading

--- a/server/views/templates/templates.config.yml
+++ b/server/views/templates/templates.config.yml
@@ -1,5 +1,6 @@
 preview: null
 context:
+  pageConfig:
+    openingHours: "@opening-hours.places"
   footerNav: "@footer-nav"
-  openingHours: "@opening-hours"
   footerSocial: "@footer-social"


### PR DESCRIPTION
## What is this PR trying to achieve?

Getting opening hours and misc article data to display in Cardigan (after updates to the app).

Also slipped in a realignment of the footer map at the awkward intermediate breakpoint after a chat with @Norvard.