### PR TITLE
Fix link to principles on the Cardigan home page

### DIFF
--- a/server/views/docs/index.md
+++ b/server/views/docs/index.md
@@ -2,7 +2,7 @@
 title: Cardigan
 ---
 
-Welcome to Cardigan, a living repository of Wellcome Collection's [principles](/docs/principles)
+Welcome to Cardigan, a living repository of Wellcome Collection's [principles](/docs/principles.html)
 and patterns.
 
 ## Useful links

--- a/server/views/docs/principles.md
+++ b/server/views/docs/principles.md
@@ -47,6 +47,7 @@ In terms of implementation, it dictates a strategy for the use of media queries.
 [back to top](#index)
 
 
+<a name="pl"></a>
 ## Pattern Library
 
 **The site will contain a living pattern library**


### PR DESCRIPTION
This link was added in #234, but visiting that page on the live site (https://cardigan.wellcomecollection.org/docs/principles) gives a server error.  Changing to `principles.html` seems to work.

## What is this PR trying to achieve?

Fix a broken link on Cardigan.

## Have the following been considered/are they needed?

Docs and A11y testing not needed.

Tests: it’s theoretically possible to test for broken links in CI (which might have caught this). Serve the website locally, then run a crawler that follows every link it can find and looks for pages that throw an error. In practice, not sure if it’s worth spending the time (and the incurred CI delays) to actually do so.