### PR TITLE
Vertical image gallery: dark

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -35,6 +35,7 @@
 @import 'components/footer_social';
 @import 'components/header';
 @import 'components/iframed-video';
+@import 'components/image-gallery';
 @import 'components/new-site-notice';
 @import 'components/opening_hours';
 @import 'components/page_description';

--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -9,6 +9,10 @@
   background: color('dark-black');
 }
 
+.row--black {
+  background: color('black');
+}
+
 .row--cream {
   background: color('cream');
 }

--- a/client/scss/components/_image-gallery.scss
+++ b/client/scss/components/_image-gallery.scss
@@ -1,0 +1,3 @@
+.image-gallery {
+  color: color('accessible-grey-2');
+}

--- a/server/model/image-gallery.js
+++ b/server/model/image-gallery.js
@@ -1,0 +1,6 @@
+import {Record} from 'immutable';
+
+export const ImageGallery = Record({
+  name: null,
+  items: []
+});

--- a/server/test/util/body-parser.js
+++ b/server/test/util/body-parser.js
@@ -8,7 +8,8 @@ import {
   removeEmptyTextNodes,
   convertDomNode,
   convertWpImage,
-  convertWpVideo
+  convertWpVideo,
+  findWpImageGallery
 } from '../../util/body-parser';
 import {domNodeHtml, wpImageNodeHtml, wpVideoNodeHtml} from '../mocks/dom-nodes';
 
@@ -50,6 +51,8 @@ test('convertWpVideo', t => {
   );
 });
 
-test('wp', t => {
-  const b = bodyParser(wpApiResp.content);
+test('findWpImageGallery', t => {
+  const bodyParts = bodyParser(wpApiResp.content);
+  const wpImageGalleries = bodyParts.filter(part => part.type === 'imageGallery');
+  t.is(wpImageGalleries.length, 1);
 });

--- a/server/views/components/image-gallery/index.config.njk
+++ b/server/views/components/image-gallery/index.config.njk
@@ -1,8 +1,0 @@
-handle: image-gallery
-label: Image gallery
-context:
-  items:
-    - description: This is an image
-    - description: This is another image
-    - description: And another
-    - description: Yet again another

--- a/server/views/components/image-gallery/index.config.njk
+++ b/server/views/components/image-gallery/index.config.njk
@@ -1,0 +1,8 @@
+handle: image-gallery
+label: Image gallery
+context:
+  items:
+    - description: This is an image
+    - description: This is another image
+    - description: And another
+    - description: Yet again another

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,0 +1,12 @@
+<div class="image-gallery">
+{% for item in imageGallery.items %}
+  <div class="image-gallery__item">
+    {% component 'figure', {
+      type: 'picture',
+      sources: [{src: item.contentUrl, size: item.width}],
+      caption: item.caption,
+      icon: 'other/picture'
+    } %}
+  </div>
+{% endfor %}
+</div>

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,12 +1,13 @@
 <div class="image-gallery">
-{% for item in imageGallery.items %}
-  <div class="image-gallery__item">
-    {% component 'figure', {
-      type: 'picture',
-      sources: [{src: item.contentUrl, size: item.width}],
-      caption: item.caption,
-      icon: 'other/picture'
-    } %}
-  </div>
-{% endfor %}
+  <h2>{{ imageGallery.name or 'Image gallery' }}</h2>
+  {% for item in imageGallery.items %}
+    <div class="image-gallery__item">
+      {% component 'figure', {
+        type: 'picture',
+        sources: [{src: item.contentUrl, size: item.width}],
+        caption: item.caption,
+        icon: 'other/picture'
+      } %}
+    </div>
+  {% endfor %}
 </div>

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,7 +1,0 @@
-<ul class="image-gallery">
-  {% for item in items %}
-  <li class="image-gallery__item">
-      {% item.description %}
-  </li>
-  {% endfor %}
-</ul>

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,0 +1,7 @@
+<ul class="image-gallery">
+  {% for item in items %}
+  <li class="image-gallery__item">
+      {% item.description %}
+  </li>
+  {% endfor %}
+</ul>

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -48,6 +48,10 @@
               <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                 {% component 'list', {list: bodyPart.value} %}
               </div>
+            {% elif bodyPart.type === 'imageGallery' %}
+              <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                {% component 'image-gallery', { imageGallery: bodyPart.value } %}
+              </div>
             {% else %}
               <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                   {% if loop.index === 1 %}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -27,12 +27,14 @@
         } %}
       </div>
     </div>
-    {% block articleBody %}
-      <div class="body-content">
-        {% for bodyPart in article.articleBody | parseBody %}
-          <div class="grid grid--dividers grid--flush-dividers">
-            {% if bodyPart.type === 'image' %}
-              <div class="grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
+  </div>
+  {% block articleBody %}
+    <div class="body-content">
+      {% for bodyPart in article.articleBody | parseBody %}
+        {% if bodyPart.type === 'image' %}
+          <div class="container">
+            <div class="grid">
+              <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                 {% component 'figure', {
                   type: 'picture',
                   sources: [{src: bodyPart.value.contentUrl, size: bodyPart.value.width}],
@@ -40,33 +42,51 @@
                   icon: 'other/picture'
                 } %}
               </div>
-            {% elif bodyPart.type === 'video' %}
+            </div>
+          </div>
+        {% elif bodyPart.type === 'video' %}
+          <div class="container">
+            <div class="grid">
               <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                 {% component 'iframed-video', {video: bodyPart.value} %}
               </div>
-            {% elif bodyPart.type === 'list' %}
+            </div>
+          </div>
+        {% elif bodyPart.type === 'list' %}
+          <div class="container">
+            <div class="grid">
               <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                 {% component 'list', {list: bodyPart.value} %}
               </div>
-            {% elif bodyPart.type === 'imageGallery' %}
-              <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
-                {% component 'image-gallery', { imageGallery: bodyPart.value } %}
-              </div>
-            {% else %}
-              <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
-                  {% if loop.index === 1 %}
-                    <div class="standfirst">
-                        {{bodyPart.value | safe}}
-                    </div>
-                  {% else %}
-                    {{bodyPart.value | safe}}
-                  {% endif %}
-              </div>
-            {% endif %}
+            </div>
           </div>
-        {% endfor %}
-      </div>
-    {% endblock %}
-  </div>
+        {% elif bodyPart.type === 'imageGallery' %}
+          <div class="row row--black">
+            <div class="container">
+              <div class="grid">
+                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                  {% component 'image-gallery', { imageGallery: bodyPart.value } %}
+                </div>
+              </div>
+            </div>
+          </div>
+        {% else %}
+          <div class="container">
+            <div class="grid">
+              <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                {% if loop.index === 1 %}
+                  <div class="standfirst">
+                      {{bodyPart.value | safe}}
+                  </div>
+                {% else %}
+                  {{bodyPart.value | safe}}
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% endblock %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Just a proof of concept of the idea of having vertical image galleries.

## Things I like about it:
* It feels more natural on a mobile device.
* It makes the image gallery a first class citizen, not something you scroll into. As with @RussellDornan's great piece the image galleries provide a nice stop from reading to elaborate and create a continuum from the text.
* No fiddly controls, we use scroll.

## Improvements from the POC
* We could make the images fill the viewport and the scroll snappy
* Better use of right hand space on desktop
* Loads more...

There are some questions:
## What if you have a massive list
I suppose you could always have a "More from this gallery" which loads more, similar to infinite scroll, but is limited by the gallery length. 

## What does it look like?

### Mobile
![image-gallery-mob](https://cloud.githubusercontent.com/assets/31692/21841996/ab905388-d7dc-11e6-8f64-a876dc6a2228.gif)

### Desktop
![image-gallery-vert-des](https://cloud.githubusercontent.com/assets/31692/21841997/ab90d524-d7dc-11e6-8257-71d1fd387528.gif)


## Have the following been considered/are they needed?
This is a POC
- [ ] Tests?
- [ ] Docs?
- [ ] A11y testing - if this PR affects a user interface component, have you run pa11y against the component and fixed/verified all errors, warnings and notices?


