### PR TITLE
Browserstack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ wellcomecollection.org.iml
 .vscode/
 
 cardigan/
+
+/server/local.log
+
+/server/browserstack/browserstack-config.json

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,12 @@
 
 ## What does it look like?
 
+## For interface components
+- [ ] Browser testing - Have you checked the component in our supported browsers
+- [ ] No javascript - Have you checked the component with javascript disabled
+- [ ] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?
+
 ## Have the following been considered/are they needed?
 
 - [ ] Tests?
 - [ ] Docs?
-- [ ] Browser testing - if this PR affects a user interface component, have you checked the component in our support browsers
-- [ ] No javascript - if this PR affects a user interface component, have you checked the component with javascript disabled
-- [ ] A11y testing - if this PR affects a user interface component, have you run pa11y against the component and fixed/verified all errors, warnings and notices?

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,6 @@
 
 - [ ] Tests?
 - [ ] Docs?
+- [ ] Browser testing - if this PR affects a user interface component, have you checked the component in our support browsers
+- [ ] No javascript - if this PR affects a user interface component, have you checked the component with javascript disabled
 - [ ] A11y testing - if this PR affects a user interface component, have you run pa11y against the component and fixed/verified all errors, warnings and notices?

--- a/server/README.md
+++ b/server/README.md
@@ -42,7 +42,8 @@ https://github.com/wellcometrust/developer-docs/blob/master/front-end/accessibil
 npm node test:browsers <url>
 ```
 
-The test opens your browser at browserstack.com with screenshots of the url in browsers we test on. You can click 
+The test opens your browser at browserstack.com with screenshots of the url in browsers we test on. 
+You can also click through to instances of those browsers.
 
 In order for this to work need to add your browserstack credentials to 'browserstack/browserstack-config.js'
 in the follwing format:

--- a/server/README.md
+++ b/server/README.md
@@ -34,3 +34,17 @@ The test outputs 3 message types:
 It is important to resolve/verify all 3 types in order to achieve standards compliance.
 Additional guidance on manually checking warnings and can be found here:
 https://github.com/wellcometrust/developer-docs/blob/master/front-end/accessibility/Webpage_Accessibility_Audit_Procedure.md 
+
+
+## Cross browser testing
+
+```bash
+npm node test:browsers <url>
+```
+
+The test opens your browser at browserstack.com with screenshots of the url in browsers we test on. You can click 
+
+In order for this to work need to set up environment variables
+
+export BROWSERSTACK_USERNAME="<browserstack_username>"
+export BROWSERSTACK_KEY="<browserstack_key>"

--- a/server/README.md
+++ b/server/README.md
@@ -44,7 +44,12 @@ npm node test:browsers <url>
 
 The test opens your browser at browserstack.com with screenshots of the url in browsers we test on. You can click 
 
-In order for this to work need to set up environment variables
+In order for this to work need to add your browserstack credentials to 'browserstack/browserstack-config.js'
+in the follwing format:
 
-export BROWSERSTACK_USERNAME="<browserstack_username>"
-export BROWSERSTACK_KEY="<browserstack_key>"
+{
+  "username": "<browserstack_username>",
+  "key": "browserstack_key"
+}
+
+**N.B. This file is git ignored, but worth mentioning that it should not be committed**

--- a/server/browserstack/browserstack.js
+++ b/server/browserstack/browserstack.js
@@ -3,14 +3,14 @@ const browserstack = require('browserstack');
 const open = require('open');
 const testBrowsers = require('./test-browsers.json');
 const url = process.argv[2];
-const {username, key} = require('./browserstack-config.json');
+const { username, key } = require('./browserstack-config.json');
 const settings = {
   "local": true,
   "url": url,
   "wait_time": "10",
   "browsers": testBrowsers
 }
-const bs_local = new browserstackLocal.Local();
+const bsLocal = new browserstackLocal.Local();
 const screenshotClient = browserstack.createScreenshotClient({
     "username": username,
     "password": key
@@ -23,7 +23,7 @@ const quitBrowserstackLocal = (job_id) => {
       }
       if(job.state === 'done'){
         console.info('Screenshots have been taken and can be viewed at https://www.browserstack.com/screenshots');
-        bs_local.stop(() => {
+        bsLocal.stop(() => {
           console.info("BrowserStackLocal has been stopped");
         });
       } else {
@@ -36,7 +36,7 @@ const quitBrowserstackLocal = (job_id) => {
 if (url === undefined) {
   console.info('You need to specify a url');
 } else {
-  bs_local.start({'key': key, 'binarypath': './browserstack/BrowserStackLocal', 'force': 'true'}, () => {
+  bsLocal.start({'key': key, 'binarypath': './browserstack/BrowserStackLocal', 'force': 'true'}, () => {
     screenshotClient.generateScreenshots(settings, (error, job) => {
       if(error) {
         return console.error(error);

--- a/server/browserstack/browserstack.js
+++ b/server/browserstack/browserstack.js
@@ -3,9 +3,7 @@ const browserstack = require('browserstack');
 const open = require('open');
 const testBrowsers = require('./test-browsers.json');
 const url = process.argv[2];
-const browserstackConfig = require('./browserstack-config.json');
-const user = browserstackConfig.username;
-const key = browserstackConfig.key;
+const {username, key} = require('./browserstack-config.json');
 const settings = {
   "local": true,
   "url": url,
@@ -14,7 +12,7 @@ const settings = {
 }
 const bs_local = new browserstackLocal.Local();
 const screenshotClient = browserstack.createScreenshotClient({
-    "username": user,
+    "username": username,
     "password": key
 });
 const quitBrowserstackLocal = (job_id) => {

--- a/server/browserstack/browserstack.js
+++ b/server/browserstack/browserstack.js
@@ -17,31 +17,30 @@ const screenshotClient = browserstack.createScreenshotClient({
     "password": key
 });
 const quitBrowserstackLocal = (job_id) => {
-  function checkStatus() {
+  (function checkStatus() {
     screenshotClient.getJob(job_id, (error, job) => {
       if(error) {
-        return console.log(error);
+        return console.error(error);
       }
       if(job.state === 'done'){
-        console.log('Screenshots have been taken and can be viewed at https://www.browserstack.com/screenshots');
-        bs_local.stop(function() {
-          console.log("BrowserStackLocal has been stopped");
+        console.info('Screenshots have been taken and can be viewed at https://www.browserstack.com/screenshots');
+        bs_local.stop(() => {
+          console.info("BrowserStackLocal has been stopped");
         });
       } else {
         setTimeout(checkStatus, 2000);
       }
     });
-  }
-  checkStatus();
+  })();
 }
 
 if (url === undefined) {
-  console.log('You need to specify a url');
+  console.info('You need to specify a url');
 } else {
   bs_local.start({'key': key, 'binarypath': './browserstack/BrowserStackLocal', 'force': 'true'}, () => {
     screenshotClient.generateScreenshots(settings, (error, job) => {
       if(error) {
-        return console.log(error);
+        return console.error(error);
       }
       open("https://www.browserstack.com/screenshots");
       quitBrowserstackLocal(job.job_id);

--- a/server/browserstack/browserstack.js
+++ b/server/browserstack/browserstack.js
@@ -1,0 +1,50 @@
+const browserstackLocal = require('browserstack-local');
+const browserstack = require('browserstack');
+const open = require('open');
+const testBrowsers = require('./test-browsers.json');
+const url = process.argv[2];
+const user = process.env.BROWSERSTACK_USERNAME;
+const key = process.env.BROWSERSTACK_KEY;
+const settings = {
+  "local": true,
+  "url": url,
+  "wait_time": "10",
+  "browsers": testBrowsers
+}
+const bs_local = new browserstackLocal.Local();
+const screenshotClient = browserstack.createScreenshotClient({
+    "username": user,
+    "password": key
+});
+const quitBrowserstackLocal = (job_id) => {
+  function checkStatus() {
+    screenshotClient.getJob(job_id, (error, job) => {
+      if(error) {
+        return console.log(error);
+      }
+      if(job.state === 'done'){
+        console.log('Screenshots have been taken and can be viewed at https://www.browserstack.com/screenshots');
+        bs_local.stop(function() {
+          console.log("BrowserStackLocal has been stopped");
+        });
+      } else {
+        setTimeout(checkStatus, 2000);
+      }
+    });
+  }
+  checkStatus();
+}
+
+if (url === undefined) {
+  console.log('You need to specify a url');
+} else {
+  bs_local.start({'key': key, 'binarypath': './browserstack/BrowserStackLocal', 'force': 'true'}, () => {
+    screenshotClient.generateScreenshots(settings, (error, job) => {
+      if(error) {
+        return console.log(error);
+      }
+      open("https://www.browserstack.com/screenshots");
+      quitBrowserstackLocal(job.job_id);
+    });
+  });
+}

--- a/server/browserstack/browserstack.js
+++ b/server/browserstack/browserstack.js
@@ -3,8 +3,9 @@ const browserstack = require('browserstack');
 const open = require('open');
 const testBrowsers = require('./test-browsers.json');
 const url = process.argv[2];
-const user = process.env.BROWSERSTACK_USERNAME;
-const key = process.env.BROWSERSTACK_KEY;
+const browserstackConfig = require('./browserstack-config.json');
+const user = browserstackConfig.username;
+const key = browserstackConfig.key;
 const settings = {
   "local": true,
   "url": url,

--- a/server/browserstack/test-browsers.json
+++ b/server/browserstack/test-browsers.json
@@ -1,0 +1,61 @@
+[{
+	"os": "Windows",
+	"os_version": "7",
+	"browser": "ie",
+	"device": null,
+	"browser_version": "10.0"
+}, {
+	"os": "Windows",
+	"os_version": "8.1",
+	"browser": "ie",
+	"device": null,
+	"browser_version": "11.0"
+}, {
+	"os": "Windows",
+	"os_version": "10",
+	"browser": "edge",
+	"device": null,
+	"browser_version": "13.0"
+}, {
+	"os": "OS X",
+	"os_version": "Yosemite",
+	"browser": "chrome",
+	"device": null,
+	"browser_version": "49.0"
+}, {
+	"os": "OS X",
+	"os_version": "Mavericks",
+	"browser": "chrome",
+	"device": null,
+	"browser_version": "50.0"
+}, {
+	"os": "OS X",
+	"os_version": "El Capitan",
+	"browser": "safari",
+	"device": null,
+	"browser_version": "9.1"
+}, {
+	"os": "OS X",
+	"os_version": "El Capitan",
+	"browser": "firefox",
+	"device": null,
+	"browser_version": "44.0"
+}, {
+	"os": "OS X",
+	"os_version": "El Capitan",
+	"browser": "firefox",
+	"device": null,
+	"browser_version": "45.0"
+}, {
+	"os": "Windows",
+	"os_version": "7",
+	"browser": "ie",
+	"device": null,
+	"browser_version": "8.0"
+}, {
+	"os": "ios",
+	"os_version": "8.3",
+	"browser": "Mobile Safari",
+	"device": "iPhone 6 Plus",
+	"browser_version": null
+}]

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "test": "ava",
     "test:watch": "ava --watch",
     "test:accessibility": "pa11y",
+    "test:browsers": "node ./browserstack/browserstack.js",
     "compile": "webpack",
     "compile:watch": "webpack --watch",
     "optimise:svg": "node ./optimise-svgs.js",

--- a/server/package.json
+++ b/server/package.json
@@ -42,8 +42,11 @@
     "webpack": "^2.1.0-beta.27"
   },
   "devDependencies": {
+    "browserstack": "^1.5.0",
+    "browserstack-local": "^1.3.0",
     "concurrently": "^3.1.0",
     "nodemon": "^1.10.2",
+    "open": "0.0.5",
     "pa11y": "^4.2.0"
   },
   "babel": {


### PR DESCRIPTION
## What is this PR trying to achieve?

- Allows us to make a call to the Browserstack screenshots API to generate screenshots of a local url in a variety of supported browsers. Can then follow links to actual instances of those browsers.

From the server folder you can generate screenshots against a local URL with the following command:

    npm run test:browsers <url>

In order for this to work need to add your browserstack credentials to 'browserstack/browserstack-config.js' in the following format:

{
  "username": "<browserstack_username>",
  "key": "browserstack_key"
}

**N.B. This file is git ignored, but worth mentioning that it should not be committed**

## What does it look like?
![screen shot 2017-01-10 at 17 59 09](https://cloud.githubusercontent.com/assets/6051896/21845844/36c63b98-d7ec-11e6-9dbd-d33e93b47805.png)

N.B. Not all supported browsers are available via the screenshots API
