### PR TITLE
Reduce padding on narrow screens; add containers to article template

### DIFF
--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -195,7 +195,7 @@ $fonts: (
 $container-width-max: 1338px;
 
 $container-padding: (
-  'small': 30px,
+  'small': 18px,
   'medium': 42px,
   'large': 60px
 );

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -3,31 +3,33 @@
 {% block articleBody %}
   <div class="body-content">
     {% for bodyPart in bodyParts %}
-      <div class="grid grid--dividers grid--flush-dividers">
-      {% if bodyPart.copy %}
-        <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
-          {{ bodyPart.copy | safe }}
-        </div>
-        {% if bodyPart.figure %}
-          <div class="grid__cell grid__cell--xl4 grid__cell--l5 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+      <div class="container">
+        <div class="grid grid--dividers grid--flush-dividers">
+        {% if bodyPart.copy %}
+          <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+            {{ bodyPart.copy | safe }}
+          </div>
+          {% if bodyPart.figure %}
+            <div class="grid__cell grid__cell--xl4 grid__cell--l5 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+              {% component 'figure', {
+                type: 'picture',
+                sources: bodyPart.figure.sources,
+                caption: bodyPart.figure.caption,
+                modifiers: ['sticky'],
+                icon: bodyPart.figure.icon } %}
+            </div>
+          {% endif %}
+        {% elif bodyPart.figure %}
+          <div class="grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
             {% component 'figure', {
               type: 'picture',
               sources: bodyPart.figure.sources,
               caption: bodyPart.figure.caption,
-              modifiers: ['sticky'],
               icon: bodyPart.figure.icon } %}
           </div>
         {% endif %}
-      {% elif bodyPart.figure %}
-        <div class="grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
-          {% component 'figure', {
-            type: 'picture',
-            sources: bodyPart.figure.sources,
-            caption: bodyPart.figure.caption,
-            icon: bodyPart.figure.icon } %}
         </div>
-      {% endif %}
-    </div>
+      </div>
     {% endfor %}
   </div>
 {% endblock %}


### PR DESCRIPTION
## What is this PR trying to achieve?

Giving a bit more room to the content on mobile (36px of horizontal padding, rather than 60px).

## What does it look like?
Before:
![screen shot 2017-01-11 at 14 19 34](https://cloud.githubusercontent.com/assets/1394592/21852122/c1c2b2cc-d809-11e6-91e9-1dc8444e4822.png)

After:
![screen shot 2017-01-11 at 14 19 51](https://cloud.githubusercontent.com/assets/1394592/21852123/c1c5629c-d809-11e6-950c-ed599d10f91b.png)


