### PR TITLE
Add divider after body content

### DIFF
--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -42,4 +42,17 @@
       box-shadow: inset 0 -0.2em 0 0 color('action-green-1');
     }
   }
+
+  .body-content__cell--last {
+    position: relative;
+
+    &:after {
+      content: '';
+      width: 60px;
+      height: 5px;
+      display: block;
+      background: color('black');
+      margin-top: 6 * $vertical-space-unit;
+    }
+  }
 }

--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -47,7 +47,7 @@
     width: 60px;
     height: 5px;
     background: color('black');
-    margin: 6 * $vertical-space-unit 0 0 0;
+    margin: 6 * $vertical-space-unit 0 $vertical-space-unit 0;
     border: 0;
   }
 }

--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -43,16 +43,11 @@
     }
   }
 
-  .body-content__cell--last {
-    position: relative;
-
-    &:after {
-      content: '';
-      width: 60px;
-      height: 5px;
-      display: block;
-      background: color('black');
-      margin-top: 6 * $vertical-space-unit;
-    }
+  .body-content__hr {
+    width: 60px;
+    height: 5px;
+    background: color('black');
+    margin: 6 * $vertical-space-unit 0 0 0;
+    border: 0;
   }
 }

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -34,7 +34,7 @@
           {% if bodyPart.type === 'picture' %}
             <div class="container">
               <div class="grid">
-                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
+                <div class="grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
                   {% component 'figure', {
                     type: 'picture',
                     sources: [{src: bodyPart.value.contentUrl, size: bodyPart.value.width}],
@@ -47,7 +47,7 @@
           {% elif bodyPart.type === 'video' %}
             <div class="container">
               <div class="grid">
-                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                   {% component 'iframed-video', {video: bodyPart.value} %}
                 </div>
               </div>
@@ -55,7 +55,7 @@
           {% elif bodyPart.type === 'list' %}
             <div class="container">
               <div class="grid">
-                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                   {% component 'list', {list: bodyPart.value} %}
                 </div>
               </div>
@@ -63,7 +63,7 @@
           {% elif bodyPart.type === 'imageGallery' %}
             <div class="container">
               <div class="grid">
-                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
+                <div class="grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
                   {% component 'image-gallery', { imageGallery: bodyPart.value } %}
                 </div>
               </div>
@@ -71,7 +71,7 @@
           {% else %}
             <div class="container">
               <div class="grid">
-                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                     {% if loop.index === 1 %}
                       <div class="standfirst">
                           {{bodyPart.value | safe}}
@@ -79,6 +79,15 @@
                     {% else %}
                       {{bodyPart.value | safe}}
                     {% endif %}
+                </div>
+              </div>
+            </div>
+          {% endif %}
+          {% if loop.last %}
+            <div class="container">
+              <div class="grid">
+                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                  <hr class="body-content__hr" />
                 </div>
               </div>
             </div>

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -34,7 +34,7 @@
           {% if bodyPart.type === 'picture' %}
             <div class="container">
               <div class="grid">
-                <div class="grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
+                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
                   {% component 'figure', {
                     type: 'picture',
                     sources: [{src: bodyPart.value.contentUrl, size: bodyPart.value.width}],
@@ -47,7 +47,7 @@
           {% elif bodyPart.type === 'video' %}
             <div class="container">
               <div class="grid">
-                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                   {% component 'iframed-video', {video: bodyPart.value} %}
                 </div>
               </div>
@@ -55,7 +55,7 @@
           {% elif bodyPart.type === 'list' %}
             <div class="container">
               <div class="grid">
-                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                   {% component 'list', {list: bodyPart.value} %}
                 </div>
               </div>
@@ -63,7 +63,7 @@
           {% elif bodyPart.type === 'imageGallery' %}
             <div class="container">
               <div class="grid">
-                <div class="grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
+                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--l12 grid__cell--m8, grid__cell--s4">
                   {% component 'image-gallery', { imageGallery: bodyPart.value } %}
                 </div>
               </div>
@@ -71,7 +71,7 @@
           {% else %}
             <div class="container">
               <div class="grid">
-                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                <div class="body-content__cell {{ 'body-content__cell--last' if loop.last }} grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
                     {% if loop.index === 1 %}
                       <div class="standfirst">
                           {{bodyPart.value | safe}}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -87,7 +87,7 @@
           {% if loop.last %}
             <div class="container">
               <div class="grid">
-                <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
+                <div class="{{ gridCellClasses }}">
                   <hr class="body-content__hr" />
                 </div>
               </div>

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -4,7 +4,7 @@
   <div class="body-content">
     <div class="container">
       <div class="grid grid--dividers grid--flush-dividers">
-        <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4 article__main">
+        <div class="{{ gridCellClasses }} article__main">
           {% for bodyPart in bodyParts %}
               {% if bodyPart.copy %}
                   {{ bodyPart.copy | safe }}
@@ -28,5 +28,14 @@
         </div>
       </div>
     </div>
+
+    <div class="container">
+      <div class="grid">
+        <div class="{{ gridCellClasses }}">
+          <hr class="body-content__hr" />
+        </div>
+      </div>
+    </div>
+
   </div>
 {% endblock %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding a divider after the body content. Closes #255.

This was more convoluted than I had initially imagined, given that the divider needs to run off the horizontal position of the content, which can be shifted by any number of grid cells. I've added a class to the final grid cell within the body content (rather than creating a long and confusing selector with lots of pseudo-selectors) – I'm sure there's a way to do this with less duplication in the nunjucks, though (cc @jamesgorrie).

## What does it look like?
![screen shot 2017-01-11 at 18 19 04](https://cloud.githubusercontent.com/assets/1394592/21861087/48668dbe-d82b-11e6-9f0a-422ef7dfcc0d.png)
