### PR TITLE
Update author to include border-left variant

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -28,6 +28,7 @@
 @import 'components/blockquote';
 @import 'components/body_content';
 @import 'components/cookie_notification';
+@import 'components/divider';
 @import 'components/buttons';
 @import 'components/figure';
 @import 'components/find_us';

--- a/client/scss/components/_author.scss
+++ b/client/scss/components/_author.scss
@@ -1,20 +1,39 @@
-.author {
-  display: flex;
-  border-bottom: 1px solid color('keyline-grey');
-  margin-bottom: 2 * $vertical-space-unit;
-  align-items: center;
-  padding: 0.2rem 0 1.2rem;
+//* @define author
 
-  @include respond-to('medium') {
-    padding-top: 0.5rem;
-    padding-bottom: 1.5rem;
+.author {
+  margin-bottom: 2 * $vertical-space-unit;
+  padding-bottom: 0.2rem;
+
+  &.author--border-bottom {
+    padding-bottom: 1.2rem;
+    border-bottom: 1px solid color('keyline-grey');
+
+    @include respond-to('medium') {
+      padding-bottom: 1.5rem;
+    }
+  }
+
+  &.author--border-left {
+    padding-top: 0;
+    padding-left: 1.2rem;
+    border-left: 5px solid color('keyline-grey');
   }
 }
 
-.author__image {
+.author__upper {
+  display: flex;
+  align-items: center;
+}
+
+.author__image-wrap {
   width: 4rem;
-  border-radius: 5px;
+  height: 4rem;
   margin-right: 1.2rem;
+}
+
+.author__image {
+  width: 100%;
+  border-radius: 5px;
 }
 
 .author__name {
@@ -41,4 +60,18 @@
   display: flex;
   align-items: center;
   text-decoration: none;
+}
+
+.author__bio {
+  @include font('LR3');
+
+  @include respond-to('medium') {
+    @include font('LR2');
+  }
+
+  margin-top: 2 * $vertical-space-unit;
+
+  :last-child {
+    margin-bottom: 0;
+  }
 }

--- a/client/scss/components/_author.scss
+++ b/client/scss/components/_author.scss
@@ -62,7 +62,7 @@
   text-decoration: none;
 }
 
-.author__bio {
+.author__description {
   @include font('LR3');
 
   @include respond-to('medium') {

--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -1,4 +1,6 @@
 .body-content {
+  margin-bottom: 2 * $vertical-space-unit;
+
   h2 {
     @include font('WB6');
 
@@ -41,13 +43,5 @@
     &:focus {
       box-shadow: inset 0 -0.2em 0 0 color('action-green-1');
     }
-  }
-
-  .body-content__hr {
-    width: 60px;
-    height: 5px;
-    background: color('black');
-    margin: 6 * $vertical-space-unit 0 $vertical-space-unit 0;
-    border: 0;
   }
 }

--- a/client/scss/components/_divider.scss
+++ b/client/scss/components/_divider.scss
@@ -4,6 +4,7 @@
   width: 60px;
   height: 5px;
   background: color('black');
-  margin: 4 * $vertical-space-unit 0 $vertical-space-unit 0;
+  margin: 4 * $vertical-space-unit 0 $vertical-space-unit;
+  text-align: left;
   border: 0;
 }

--- a/client/scss/components/_divider.scss
+++ b/client/scss/components/_divider.scss
@@ -1,0 +1,9 @@
+//* @define divider
+
+.divider {
+  width: 60px;
+  height: 5px;
+  background: color('black');
+  margin: 4 * $vertical-space-unit 0 $vertical-space-unit 0;
+  border: 0;
+}

--- a/server/views/components/author/index.config.yml
+++ b/server/views/components/author/index.config.yml
@@ -4,7 +4,7 @@ context:
   name: Daniel Regan
   twitterHandle: funnytimeofyear
   image: https://dummyimage.com/400x400
-  bio: <p>Daniel Regan is a photographer and artist based in London, working on themes of mental health and wellbeing. He is the current director of the <a href="https://freespacegallery.org/">Free Space Gallery</a> and Kentish Town Improvement Fund, a charity providing arts activities and therapies across two NHS sites in north London.</p>
+  description: <p>Daniel Regan is a photographer and artist based in London, working on themes of mental health and wellbeing. He is the current director of the <a href="https://freespacegallery.org/">Free Space Gallery</a> and Kentish Town Improvement Fund, a charity providing arts activities and therapies across two NHS sites in north London.</p>
 variants:
   - name: default
     label: Border Bottom

--- a/server/views/components/author/index.config.yml
+++ b/server/views/components/author/index.config.yml
@@ -1,6 +1,17 @@
 name: Author
 handle: author
 context:
-  name: Gylve NagellLL
-  twitterHandle: darkthrone
-  image: https://dummyimage.com/400x500
+  name: Daniel Regan
+  twitterHandle: funnytimeofyear
+  image: https://dummyimage.com/400x400
+  bio: <p>Daniel Regan is a photographer and artist based in London, working on themes of mental health and wellbeing. He is the current director of the <a href="https://freespacegallery.org/">Free Space Gallery</a> and Kentish Town Improvement Fund, a charity providing arts activities and therapies across two NHS sites in north London.</p>
+variants:
+  - name: default
+    label: Border Bottom
+    context:
+      modifiers:
+        - border-bottom
+  - name: border-left
+    context:
+      modifiers:
+        - border-left

--- a/server/views/components/author/index.njk
+++ b/server/views/components/author/index.njk
@@ -1,15 +1,24 @@
-<div class="author">
-  <img class="author__image" src="{{ image }}" alt="Image of {{ name }}" />
-  <div class="author__copy">
-    <span class="author__name">{{ name }}</span>
-    {% if twitterHandle %}
-      <span class="author__twitter">
-        <a href="https://twitter.com/{{ twitterHandle }}"
-          class="author__link"
-          aria-label="{{ name }} (screen name: {{ twitterHandle }})">
-          {% icon 'social/twitter' %} @{{ twitterHandle }}
-        </a>
-      </span>
+<div class="author {% for modifier in modifiers %} author--{{ modifier }} {% endfor %}">
+  <div class="author__upper">
+    {% if image %}
+      <div class="author__image-wrap">
+        <img class="author__image" src="{{ image }}" alt="Image of {{ name }}" />
+      </div>
     {% endif %}
+    <div class="author__details">
+      <span class="author__name">{{ name }}</span>
+      {% if twitterHandle %}
+        <span class="author__twitter">
+          <a href="https://twitter.com/{{ twitterHandle }}"
+            class="author__link"
+            aria-label="{{ name }} (screen name: {{ twitterHandle }})">
+            {% icon 'social/twitter' %} @{{ twitterHandle }}
+          </a>
+        </span>
+      {% endif %}
+    </div>
   </div>
+  {% if bio %}
+    <div class="author__bio">{{ bio | safe }}</div>
+  {% endif %}
 </div>

--- a/server/views/components/author/index.njk
+++ b/server/views/components/author/index.njk
@@ -18,7 +18,7 @@
       {% endif %}
     </div>
   </div>
-  {% if bio %}
-    <div class="author__bio">{{ bio | safe }}</div>
+  {% if description %}
+    <div class="author__description">{{ description | safe }}</div>
   {% endif %}
 </div>

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -97,7 +97,7 @@
               name: article.author.name,
               twitterHandle: article.author.twitterHandle,
               modifiers: ['border-left'],
-              bio: article.author.bio,
+              description: article.author.description,
               image: article.author.image
             } %}
           {% endif %}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -18,17 +18,20 @@
 {% endfor %}
 
 <div class="row row--cream">
-  <div class="container">
-    <div class="grid">
-      <div class="{{ gridCellClasses }}">
-        {% component 'author', {
-          name: article.author.name,
-          twitterHandle: author.twitterHandle,
-          image: article.author.image
-        } %}
+  {% if article.author %}
+    <div class="container">
+      <div class="grid">
+        <div class="{{ gridCellClasses }}">
+          {% component 'author', {
+            name: article.author.name,
+            twitterHandle: article.author.twitterHandle,
+            modifiers: ['border-bottom'],
+            image: article.author.image
+          } %}
+        </div>
       </div>
     </div>
-  </div>
+  {% endif %}
   {% block articleBody %}
     <div class="body-content">
       {% for bodyPart in article.articleBody | parseBody %}
@@ -84,16 +87,23 @@
               </div>
             </div>
           {% endif %}
-          {% if loop.last %}
-            <div class="container">
-              <div class="grid">
-                <div class="{{ gridCellClasses }}">
-                  <hr class="body-content__hr" />
-                </div>
-              </div>
-            </div>
-          {% endif %}
       {% endfor %}
+    </div>
+    <div class="container">
+      <div class="grid">
+        <div class="{{ gridCellClasses }}">
+          {% if article.author %}
+            {% component 'author', {
+              name: article.author.name,
+              twitterHandle: article.author.twitterHandle,
+              modifiers: ['border-left'],
+              bio: article.author.bio,
+              image: article.author.image
+            } %}
+          {% endif %}
+          <hr class="divider" />
+        </div>
+      </div>
     </div>
   {% endblock %}
 

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -37,7 +37,7 @@
             name: article.author.name,
             twitterHandle: article.author.twitterHandle,
             modifiers: ['border-left'],
-            bio: article.author.bio,
+            description: article.author.description,
             image: article.author.image
           } %}
         {% endif %}

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -28,14 +28,21 @@
         </div>
       </div>
     </div>
-
-    <div class="container">
-      <div class="grid">
-        <div class="{{ gridCellClasses }}">
-          <hr class="body-content__hr" />
-        </div>
+  </div>
+  <div class="container">
+    <div class="grid">
+      <div class="{{ gridCellClasses }}">
+        {% if article.author %}
+          {% component 'author', {
+            name: article.author.name,
+            twitterHandle: article.author.twitterHandle,
+            modifiers: ['border-left'],
+            bio: article.author.bio,
+            image: article.author.image
+          } %}
+        {% endif %}
+        <hr class="divider" />
       </div>
     </div>
-
   </div>
 {% endblock %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding a variant of the author component to appear after the article. It appears after the body content, but before the dividing rule that was previously part of `body-content` element. Done some rejigging accordingly. Closes #280.

## What does it look like?
The template is defensive enough to handle combinations of with/without twitter handle/image
![screen shot 2017-01-12 at 16 52 05](https://cloud.githubusercontent.com/assets/1394592/21899243/7955103c-d8e7-11e6-8ac1-b243fe2ef906.png)
![screen shot 2017-01-12 at 16 50 15](https://cloud.githubusercontent.com/assets/1394592/21899206/5d7f4d64-d8e7-11e6-967a-047f188b0818.png)
![screen shot 2017-01-12 at 16 50 39](https://cloud.githubusercontent.com/assets/1394592/21899208/5d8367f0-d8e7-11e6-8230-55e58742d3be.png)
![screen shot 2017-01-12 at 16 50 58](https://cloud.githubusercontent.com/assets/1394592/21899207/5d828ed4-d8e7-11e6-81e4-d22378ce2975.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?