### PR TITLE
Add 'smoke' grey for lead-in block

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -24,7 +24,7 @@
   &:before {
     position: absolute;
     content: '';
-    background: color('keyline-grey');
+    background: color('smoke');
     top: 0;
     bottom: 0;
     left: 0;

--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -258,6 +258,7 @@ $colors: (
   'yellow': (#ffce3c, 'secondary'),
   'accessible-grey-1': (#717171, 'secondary'),
   'accessible-grey-2': (#8f8f8f, 'secondary'),
+  'smoke': (#e8e8e8, 'secondary'),
   'keyline-grey': (#d9d6ce, 'secondary'),
   'charcoal': (#323232, 'secondary'),
   'transparent': (transparent, 'secondary'),

--- a/server/views/global/palette.config.yml
+++ b/server/views/global/palette.config.yml
@@ -33,6 +33,8 @@ context:
     hex: "#717171"
   - name: accessible-grey-2
     hex: "#8f8f8f"
+  - name: smoke
+    hex: "#e8e8e8"
   - name: keyline-grey
     hex: "#d9d6ce"
   - name: charcoal

--- a/server/views/global/palette.config.yml
+++ b/server/views/global/palette.config.yml
@@ -1,3 +1,4 @@
+# TODO: collect these values from client/scss/utilies/_variables.scss
 context:
   primary:
   - name: action-green-1


### PR DESCRIPTION
## What is this PR trying to achieve?
The `keyline-grey` used to be `#e8e8e8`. It was darkened in order for it to work with the darkened `cream` page background.

The lead-in block (running alongside e.g. the page title) uses that variable currently, but sits on a white background, so didn't need the update.

This PR re-adds the trusty `#e8e8e8` as the new color variable, 'smoke'.

## What does it look like?
![screen shot 2017-01-12 at 17 36 42](https://cloud.githubusercontent.com/assets/1394592/21901097/5258b9dc-d8ee-11e6-8da3-1263dc18ec18.png)

Fixes #247.
