### PR TITLE
remove certain atts from WP API

### DIFF
--- a/server/test/util/body-parser.js
+++ b/server/test/util/body-parser.js
@@ -6,6 +6,7 @@ import {
   bodyParser,
   getFragment,
   removeEmptyTextNodes,
+  removeExtraAttrs,
   convertDomNode,
   convertWpImage,
   convertWpVideo,
@@ -20,6 +21,21 @@ test('removeEmptyTextNodes', t => {
 
   t.is(uncleanNodes.length, 18);
   t.is(cleanNodes.length, 9);
+});
+
+test('removeExtraAttrs', t => {
+  // Not using a string template here to avoid empty text nodes
+  const fragment = getFragment(
+    '<p class="notwelcome">Hello</p>' +
+    '<p style="notwelcome">Hello</p>' +
+    '<p title="notwelcome">Hello</p>'
+  );
+
+  const cleanNodes = removeExtraAttrs(fragment.childNodes);
+
+  t.is(cleanNodes[0].attrs.length, 0);
+  t.is(cleanNodes[1].attrs.length, 0);
+  t.is(cleanNodes[2].attrs.length, 1);
 });
 
 test('convertDomNode', t => {

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -185,10 +185,10 @@ export function convertDomNode(node) {
 }
 
 export function removeExtraAttrs(nodes) {
-  const superflousAttrs = ['class', 'style'];
+  const superfluousAttrs = ['class', 'style'];
   return nodes.map(node => {
     if (node.attrs) {
-      const cleanedAttrs = node.attrs.filter(attr => superflousAttrs.indexOf(attr.name) === -1);
+      const cleanedAttrs = node.attrs.filter(attr => superfluousAttrs.indexOf(attr.name) === -1);
       // Boo! Mutation.
       node.attrs = cleanedAttrs;
       return node;

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -13,8 +13,10 @@ const BodyPart = Record({
 
 export function bodyParser(bodyText) {
   const fragment = getFragment(bodyText);
-  const nodes = explodeIntoBodyParts(cleanNodes(fragment.childNodes));
-  return nodes;
+  const preCleaned = cleanNodes(fragment.childNodes, [removeEmptyTextNodes]);
+  const bodyParts = explodeIntoBodyParts(preCleaned);
+
+  return bodyParts;
 }
 
 export function getFragment(bodyText) {
@@ -35,20 +37,13 @@ export function explodeIntoBodyParts(nodes) {
     const bodyPart = maybeBodyPart.type ? maybeBodyPart : convertDomNode(maybeBodyPart);
 
     return bodyPart;
-  });
+  }).filter(part => part); // get rid of any nulls = Maybe.flatten would be good.
 
   return parts;
 }
 
 export function removeEmptyTextNodes(nodes) {
   return nodes.filter(node => !isEmptyText(node));
-}
-
-export function convertDomNode(node) {
-  return new BodyPart({
-    type: 'html',
-    value: serializeNode(node)
-  });
 }
 
 export function convertWpImage(node) {
@@ -112,7 +107,7 @@ export function convertWpList(node) {
 }
 
 export function findWpImageGallery(node) {
-  const className = getAttrVal(node.attrs, 'class');
+  const className = node.attrs && getAttrVal(node.attrs, 'class');
   const isWpImageGallery = Boolean(className && className.match('tiled-gallery'));
 
   if (isWpImageGallery) {
@@ -144,6 +139,7 @@ export function findWpImageGallery(node) {
         })
       });
     } catch(e) {
+      console.info(e)
       return node;
     }
   } else {
@@ -175,13 +171,38 @@ function getImageFromWpNode(node) {
   });
 }
 
-// This recursively cleans the nodes.
-function cleanNodes(nodes) {
-  const cleaners = [removeEmptyTextNodes];
+export function convertDomNode(node) {
+  const cleaned = cleanNodes([node], [removeExtraAttrs]);
 
+  if (cleaned.length === 1) {
+    return new BodyPart({
+      type: 'html',
+      value: serializeNode(cleaned[0])
+    });
+  } else {
+    return null;
+  }
+}
+
+export function removeExtraAttrs(nodes) {
+  const superflousAttrs = ['class', 'style'];
+  return nodes.map(node => {
+    if (node.attrs) {
+      const cleanedAttrs = node.attrs.filter(attr => superflousAttrs.indexOf(attr.name) === -1);
+      // Boo! Mutation.
+      node.attrs = cleanedAttrs;
+      return node;
+    } else {
+      return node;
+    }
+  });
+}
+
+// This recursively cleans the nodes.
+function cleanNodes(nodes, cleaners) {
   return cleaners.reduce((nodes, parser) => parser(nodes), nodes).map(node => {
     if (node.childNodes && node.childNodes.length > 0) {
-      const childNodes = cleanNodes(node.childNodes);
+      const childNodes = cleanNodes(node.childNodes, cleaners);
       return Object.assign({}, node, {childNodes});
     } else {
       return node;


### PR DESCRIPTION
## What is this PR trying to achieve?
Fixes #283

We now remove a whitelist of attributes from the HTML from WP.
The `bodyParser` now works like:
* Clean Nodes
* Convert Nodes
* If not converted, change to DomNode and clean. 

## What does it look like?
# before
![cleaners-before](https://cloud.githubusercontent.com/assets/31692/21927560/022f854a-d97e-11e6-9e73-3efc77a96276.png)

# after
![cleaners-after](https://cloud.githubusercontent.com/assets/31692/21927562/090d7458-d97e-11e6-8f35-6333b12ad5f7.png)


## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [X] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?

## Have the following been considered/are they needed?

- [x] Tests?
- [ ] Docs?
