### PR TITLE
Aligned top of vertical  keyline to bottom of author block

### DIFF
--- a/client/scss/components/_article.scss
+++ b/client/scss/components/_article.scss
@@ -2,6 +2,11 @@
   @include respond-to('large') {
     position: relative;
 
+    .author + & {
+      margin-top: -2 * $vertical-space-unit;
+      padding-top: 2 * $vertical-space-unit;
+    }
+
     &:after {
       content: '';
       position: absolute;


### PR DESCRIPTION
## What is this PR trying to achieve?

Fixes #243

## What does it look like?

Before:
![screen shot 2017-01-13 at 16 55 09](https://cloud.githubusercontent.com/assets/6051896/21938010/60f1ff1c-d9b1-11e6-8ff7-6418c95958a1.png)

After:
![screen shot 2017-01-13 at 16 55 55](https://cloud.githubusercontent.com/assets/6051896/21938005/5ba56e86-d9b1-11e6-9f06-5edea52b9985.png)

