### PR TITLE
Use babel over webpack for server compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ EXPOSE 3000
 
 WORKDIR $HOME/server
 
-CMD ["npm", "run", "start"]
+CMD ["npm", "run", "app:docker"]

--- a/build-server.sh
+++ b/build-server.sh
@@ -1,4 +1,5 @@
+#!/usr/bin/env bash
 pushd server
-npm install --production
-npm run compile
+  npm install --production
+  npm run app:build
 popd

--- a/server/.babelrc
+++ b/server/.babelrc
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": "current"
+      }
+    }]
+  ],
+  "ignore": [
+    "node_modules"
+  ]
+}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,4 +1,2 @@
 node_modules/
-dist/
-app.pack.js
-app.pack.js.map
+.dist/

--- a/server/package.json
+++ b/server/package.json
@@ -4,18 +4,19 @@
   "description": "The node server serving content for wellcomecollection.org",
   "main": "app.js",
   "scripts": {
-    "start": "pm2-docker app.pack.js --name 'wellcomecollection.org'",
-    "start:watch": "nodemon app.pack.js -e js,njk",
     "test": "ava",
     "test:watch": "ava --watch",
     "test:accessibility": "pa11y",
     "test:browsers": "node ./browserstack/browserstack.js",
-    "compile": "webpack",
-    "compile:watch": "webpack --watch",
     "optimise:svg": "node ./optimise-svgs.js",
     "dev": "concurrently 'npm run compile:watch' 'npm run start:watch'",
     "fractal": "fractal start —sync --port 3002",
-    "fractal-build": "fractal build"
+    "fractal-build": "fractal build",
+
+    "app:dev": "nodemon app.js -e js,njk --exec babel-node",
+    "app:build": "babel . -d .dist --ignore=node_modules",
+    "app:start": "pm2 start ./.dist/app.js --name 'wellcomecollection.org'",
+    "app:docker": "pm2-docker ./.dist/app.js --name 'wellcomecollection.org'"
   },
   "repository": {
     "type": "git",
@@ -27,11 +28,8 @@
     "@frctl/fractal": "^1.0.11",
     "@frctl/nunjucks": "https://github.com/gestchild/nunjucks/tarball/66b327d3c9ac24f97784332c09669336fe4c650a",
     "ava": "^0.17.0",
-    "babel-core": "^6.18.2",
-    "babel-loader": "^6.2.8",
-    "babel-polyfill": "^6.16.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-stage-3": "^6.17.0",
+    "babel-cli": "^6.18.0",
+    "babel-preset-env": "^1.1.8",
     "immutable": "^3.8.1",
     "koa": "^2.0.0",
     "koa-router": "^7.1.0",


### PR DESCRIPTION
## What is this PR trying to achieve?
Webpack as a build step was slow and annoying - given we don't need bundling on the server, I thought I'd try use babel exclusively.

Webpack also makes it hard to use libs like [Flow](https://flowtype.org) (which I really want in) by adding the bundle step.

## What does it look like?
![screen shot 2017-01-13 at 16 58 39](https://cloud.githubusercontent.com/assets/31692/21938047/93ee6a90-d9b1-11e6-902d-48576597c08c.png)
