### PR TITLE
Rework page-description to allow grey lead bar to run off text baseline

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -17,9 +17,13 @@
   background: color('yellow');
 }
 
+.row--no-padding {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .row--lead {
   position: relative;
-  margin-bottom: $vertical-space-unit;
 
   &:before {
     position: absolute;

--- a/client/scss/components/_page_description.scss
+++ b/client/scss/components/_page_description.scss
@@ -1,14 +1,11 @@
 //* @define page-description;
 
 .page-description {
-  &.page-description--b {
-    padding-bottom: 1.2rem;
-    border-bottom: 1px solid color('keyline-grey');
-  }
+  margin-bottom: $vertical-space-unit;
 }
 
 .page-description__title {
-  margin-top: 0;
+  margin-top: $vertical-space-unit;
   margin-bottom: 0;
   margin-left: -0.06em;
 
@@ -22,12 +19,25 @@
     @include respond-to('large') {
       @include font('WB3');
     }
-
-    margin-bottom: 0.25em;
   }
 
   .page-description--b & {
     @include font('HNM1');
+  }
+}
+
+.page-description__lead {
+  margin-bottom: 0.6em;
+
+  // This aligns the grey lead bar with text baseline
+  &:before {
+    .page-description--a & {
+      bottom: 0.6em;
+    }
+
+    .page-description--b & {
+      bottom: 0.4em;
+    }
   }
 }
 
@@ -49,8 +59,4 @@
     width: 1.3em;
     height: 1.3em;
   }
-}
-
-.page-description__use {
-  fill: color('currentColor');
 }

--- a/server/views/components/page-description/index.config.yml
+++ b/server/views/components/page-description/index.config.yml
@@ -1,6 +1,7 @@
 name: page description
 handle: page-description
 label: Page description
+preview: "@preview-no-container"
 variants:
 - name: default
   label: A (article)
@@ -8,6 +9,7 @@ variants:
   context:
     modifiers:
     - a
+    lead: true
     intro: States of Mind
     title: 'Inspired: Alchemists and housewives around a long table'
     publicationDate: September 9th 2016

--- a/server/views/components/page-description/index.njk
+++ b/server/views/components/page-description/index.njk
@@ -1,9 +1,27 @@
 <header class="page-description {% for modifier in modifiers %}page-description--{{ modifier }} {% endfor %}">
-  <span class="page-description__intro">{{ intro }}</span>
-  <h1 class="page-description__title">{{ title }}</h1>
+  <div class="row row--no-padding {{ 'row--lead row--lead--l page-description__lead' if lead }}">
+    <div class="container">
+      <div class="grid">
+        <div class="grid__cell {{ 'grid__cell--shift-l1' if lead }}">
+          {% if intro %}
+            <span class="page-description__intro">{{ intro }}</span>
+          {% endif %}
+          <h1 class="page-description__title">{{ title }}</h1>
+        </div>
+      </div>
+    </div>
+  </div>
   {% if publicationDate %}
-    <span class="page-description__publication-date">
-      {% icon 'other/clock' %}{{ publicationDate }}
-    </span>
+    <div class="row row--no-padding">
+      <div class="container">
+          <div class="grid">
+            <div class="grid__cell {{ 'grid__cell--shift-l1' if lead }}">
+              <span class="page-description__publication-date">
+                {% icon 'other/clock' %}{{ publicationDate }}
+              </span>
+            </div>
+          </div>
+      </div>
+    </div>
   {% endif %}
 </header>

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -1,15 +1,8 @@
 {% extends "layout/default.njk" %}
 
 {% block body %}
-<div class="row row--lead row--lead--l">
-  <div class="container">
-    <div class="grid">
-      <div class="grid__cell grid__cell--shift-l1">
-        {% component 'page-description', {title: article.headline, modifiers: ['a']} %}
-      </div>
-    </div>
-  </div>
-</div>
+
+{% component 'page-description', { title: article.headline, modifiers: ['a'], lead: true } %}
 
 {% for media in article.mainMedia %}
   {% if media.weighting == 'leading' %}
@@ -21,7 +14,7 @@
   <div class="container">
     <div class="grid">
       <div class="grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4">
-        
+
         {% if article.author %}
           {% component 'author', {
             name: article.author.name,
@@ -30,7 +23,7 @@
             image: article.author.image
           } %}
         {% endif %}
-        
+
         <div class="article">
           {% block articleBody %}
             {% component 'article-body', { articleBody: article.articleBody | parseBody } %}


### PR DESCRIPTION
## What is this PR trying to achieve?
This optionally includes the 'lead' row as part of the page-description component to allow the bottom of the grey bar to align with the title baseline, even when the component contains date info. Fixes #246.

## What does it look like?
![screen shot 2017-01-16 at 12 51 50](https://cloud.githubusercontent.com/assets/1394592/21983831/f6047aea-dbea-11e6-82d9-ea1cd978c4a4.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers