### PR TITLE
add standfirst bodypart type

### DIFF
--- a/server/test/util/body-parser.js
+++ b/server/test/util/body-parser.js
@@ -72,3 +72,9 @@ test('findWpImageGallery', t => {
   const wpImageGalleries = bodyParts.filter(part => part.type === 'imageGallery');
   t.is(wpImageGalleries.length, 1);
 });
+
+test('findWpStandfirst', t => {
+  const bodyParts = bodyParser(wpApiResp.content);
+  const wpImageStandFirst = bodyParts.filter(part => part.type === 'standfirst');
+  t.is(wpImageStandFirst.length, 1);
+});

--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -1,6 +1,8 @@
 <div class="body-content">
   {% for bodyPart in articleBody %}
-    {% if bodyPart.type === 'picture' %}
+    {% if bodyPart.type === 'standfirst' %}
+      {% component 'standfirst', { body: bodyPart.value } %}
+    {% elif bodyPart.type === 'picture' %}
       {% component 'figure', {
         type: 'picture',
         sources: [{src: bodyPart.value.contentUrl, size: bodyPart.value.width}],
@@ -16,11 +18,7 @@
     {% elif bodyPart.type === 'imageGallery' %}
       {% component 'image-gallery', { imageGallery: bodyPart.value } %}
     {% else %}
-      {% if loop.index === 1 %}
-        {% component 'standfirst', { body: bodyPart.value } %}
-      {% else %}
-        {{bodyPart.value | safe}}
-      {% endif %}
+      {{bodyPart.value | safe}}
     {% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding the standfirst body part type.
This is to try and get the model into a more complete state.

We are currently importing all the HTML content into the field as it seems variable (Sometimes there's links, italics, quotes etc) and a standfirst should be able to support HTML rather than just text - so this is good for now.

## What does it look like?
Same as before

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?

## Have the following been considered/are they needed?

- [x] Tests?
- [ ] ~~Docs?~~
