### PR TITLE
add bodyParts to article model and return article as JSON

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -14,12 +14,22 @@ export const artefact = async(ctx, next) => {
 
 export const article = async(ctx, next) => {
     const id = ctx.params.id;
+    const format = ctx.request.query.format;
     const article = await getArticle(id);
 
-    return article ? ctx.render('pages/article', {
-      pageConfig: new PageConfig({inSection: 'explore'}),
-      article: article
-    }) : next();
+    if (article) {
+      if (format === 'json') {
+        ctx.body = article;
+        return article;
+      } else {
+        return ctx.render('pages/article', {
+          pageConfig: new PageConfig({inSection: 'explore'}),
+          article: article
+        });
+      }
+    } else {
+      return next();
+    }
 };
 
 export const explore = async(ctx) => {

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -1,9 +1,7 @@
-import parseBody from './parse-body';
 import youtubeEmbedUrl from './youtube-embed-url';
 
 // We could do this automatically with `fs`, but that's unnecessary I/O
 // And doesn't allow us to exclude some.
 module.exports = new Map([
-  ['youtubeEmbedUrl', youtubeEmbedUrl],
-  ['parseBody', parseBody]
+  ['youtubeEmbedUrl', youtubeEmbedUrl]
 ]);

--- a/server/filters/parse-body.js
+++ b/server/filters/parse-body.js
@@ -1,4 +1,0 @@
-import {bodyParser} from '../util/body-parser';
-export default function parseBody(body) {
-  return bodyParser(body);
-}

--- a/server/fractal-app.js
+++ b/server/fractal-app.js
@@ -4,7 +4,6 @@ import Nunjucks from '@frctl/nunjucks';
 import mandelbrot from '@frctl/mandelbrot';
 import Component from './extensions/component';
 import Icon from './extensions/icon';
-import parseBody from './filters/parse-body';
 import {getEnvWithExtensionsAndFilters} from './view/env-utils';
 const fractal = Fractal.create();
 const root = dir('/views');
@@ -14,9 +13,6 @@ const root = dir('/views');
 const nunjucksEnv = getEnvWithExtensionsAndFilters(root);
 
 const nunjucks = Nunjucks({
-    filters: {
-        parseBody: parseBody
-    },
     extensions: {
         component: new Component(nunjucksEnv),
         icon: new Icon(nunjucksEnv)

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -1,5 +1,6 @@
 import {Person} from './person';
 import {getWpFeaturedImage} from './media';
+import {bodyParser} from '../util/body-parser';
 
 export default class Article {
   constructor(headline, articleBody, mainImage, associatedMedia, author) {
@@ -7,8 +8,9 @@ export default class Article {
     this.articleBody = articleBody;
     this.mainImage = mainImage;
     this.associatedMedia = associatedMedia;
-    this.mainMedia = getMainMedia(associatedMedia);
     this.author = author;
+    this.mainMedia = getMainMedia(associatedMedia);
+    this.bodyParts = bodyParser(articleBody);
   }
 
   static fromDrupalApi(json) {

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -26,7 +26,7 @@
 
         <div class="article">
           {% block articleBody %}
-            {% component 'article-body', { articleBody: article.articleBody | parseBody } %}
+            {% component 'article-body', { articleBody: article.bodyParts } %}
           {% endblock %}
 
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Just gives me an endpoint to lookat to see what the JSON would look like for the article.

As I am experimenting with Contentful and WP APIs for content creation (as a intermediary step before the API team get going) - this is very useful to me.

## What does it look like?
![json](https://cloud.githubusercontent.com/assets/31692/21992136/31d5c728-dc0d-11e6-9871-1d461a673fc8.png)

## For interface components
- [ ] ~~Browser testing - Have you checked the component in our supported browsers~~
- [ ] ~~No javascript - Have you checked the component with javascript disabled~~
- [ ] ~~A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?~~

## Have the following been considered/are they needed?

- [ ] ~~Tests?~~
- [ ] ~~Docs?~~
