### PR TITLE
Correct the capitalistion of 'Wellcome' in the footer

### DIFF
--- a/server/views/components/footer/index.njk
+++ b/server/views/components/footer/index.njk
@@ -23,7 +23,7 @@
     <div class="footer__bottom">
       <div class="footer__strap">
         {% icon 'other/wellcome' %}
-        <span class="footer__strap-text">The free museum and library from wellcome</span>
+        <span class="footer__strap-text">The free museum and library from Wellcome</span>
       </div>
       <nav class="footer__hygiene-nav">
         <ul class="footer__hygiene-list">


### PR DESCRIPTION
Per the commit message.

“Wellcome” is a proper noun and should be capitalised as such.