### PR TITLE
add some consistency to njk templates with regards to quotes and spacing

### DIFF
--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -29,7 +29,7 @@
           </div>
         </div>
       {% else %}
-        {{bodyPart.value | safe}}
+        {{ bodyPart.value | safe }}
       {% endif %}
     </div>
   {% endfor %}

--- a/server/views/components/button-button/index.njk
+++ b/server/views/components/button-button/index.njk
@@ -1,4 +1,4 @@
-<button class="btn {{modifierClasses}}" {{attributes}}>
+<button class="btn {{ modifierClasses }}" {{ attributes }}>
   {% if icon %}
     {% icon icon, null, iconExtraClasses %}
   {% endif %}

--- a/server/views/components/button-input/index.njk
+++ b/server/views/components/button-input/index.njk
@@ -1,1 +1,1 @@
-<input class="btn {{modifierClasses}}" type="{{type}}" {{attributes}} value="{{value}}" />
+<input class="btn {{ modifierClasses }}" type="{{ type }}" {{ attributes }} value="{{ value }}" />

--- a/server/views/components/button-link/index.njk
+++ b/server/views/components/button-link/index.njk
@@ -1,7 +1,7 @@
 {# button-link component data: modifierClasses, href, text, icon #}
-<a class="btn {{modifierClasses}}" href="{{href}}">
+<a class="btn {{ modifierClasses }}" href="{{ href }}">
   {% if icon %}
     {% icon icon, null, iconExtraClasses %}
   {% endif %}
-  {{text}}
+  {{ text }}
 </a>

--- a/server/views/components/figure/index.njk
+++ b/server/views/components/figure/index.njk
@@ -1,4 +1,4 @@
-<figure class="figure{% if full %} figure--full{% endif %} figure--{{type}}{% if bleed %} figure--bleed{% endif %}">
+<figure class="figure{% if full %} figure--full{% endif %} figure--{{ type }}{% if bleed %} figure--bleed{% endif %}">
   {% if type === 'picture' %}
     <picture class="figure__picture">
       {%- for source in sources %}

--- a/server/views/components/footer/index.njk
+++ b/server/views/components/footer/index.njk
@@ -2,15 +2,15 @@
   <div class="container">
     <div class="grid">
       <div class="grid__cell grid__cell--s4 grid__cell--m4 grid__cell--l3">
-        {% component "footer-nav", {navLinks: navLinks} %}
+        {% component 'footer-nav', {navLinks: navLinks} %}
       </div>
       <div class="grid__cell grid__cell--s4 grid__cell--m4 grid__cell--l3">
         <h3 class="footer__heading">Finding us:</h3>
-        {% component "find-us" %}
+        {% component 'find-us' %}
       </div>
       <div class="grid__cell grid__cell--s4">
         <h3 class="footer__heading">Opening times:</h3>
-        {% component "opening-hours", {places: openingHours.places} %}
+        {% component 'opening-hours', {places: openingHours.places} %}
       </div>
     </div>
     <div class="grid">
@@ -18,7 +18,7 @@
         <h3 class="footer__heading footer__heading--centered">Connect with us:</h3>
       </div>
     </div>
-    {% component "footer-social", {columns: footerSocial.columns} %}
+    {% component 'footer-social', {columns: footerSocial.columns} %}
 
     <div class="footer__bottom">
       <div class="footer__strap">

--- a/server/views/components/gallery/index.njk
+++ b/server/views/components/gallery/index.njk
@@ -1,7 +1,7 @@
 <div class="gallery">
     <div class="gallery__item">
         {% for media in items %}
-            {% component "media-item", { media: media } %}
+            {% component 'media-item', { media: media } %}
         {% endfor %}
     </div>
 </div>

--- a/server/views/components/icon/index.njk
+++ b/server/views/components/icon/index.njk
@@ -1,8 +1,8 @@
-<svg class="icon{% for class in extraClasses %} {{class}}{% endfor %}"
+<svg class="icon{% for class in extraClasses %} {{ class }}{% endfor %}"
     {% if title %} role="img"{% else %} aria-hidden="true"{% endif %}
     {% for attr in attrs %}
-        {{attr.name}}="{{attr.value}}"
+        {{ attr.name }}="{{ attr.value }}"
     {% endfor %}>
-  {% if title %}<title>{{title}}</title>{% endif %}
-  {{pathData|safe}}
+  {% if title %}<title>{{ title }}</title>{% endif %}
+  {{ pathData|safe }}
 </svg>

--- a/server/views/components/media-item/index.njk
+++ b/server/views/components/media-item/index.njk
@@ -11,13 +11,13 @@
 {% endif %}
 
 {% if media.mediaType == 'audio' %}
-  <audio controls="controls" src="{{media.uri}}"></audio>
+  <audio controls="controls" src="{{ media.uri }}"></audio>
 {% endif %}
 
 {% if media.mediaType == 'video' %}
-  <iframe width="640" height="360" src="{{media.uri | youtubeEmbedUrl}}" frameborder="0"></iframe>
+  <iframe width="640" height="360" src="{{ media.uri | youtubeEmbedUrl }}" frameborder="0"></iframe>
 {% endif %}
 
 {% if media.mediaType == 'gallery' %}
-  {% component "gallery", { items: media.items } %}
+  {% component 'gallery', { items: media.items } %}
 {% endif %}

--- a/server/views/global/icons.njk
+++ b/server/views/global/icons.njk
@@ -1,6 +1,6 @@
 {% for icon in icons %}
 <div class="styleguide__icon">
-  <p class="styleguide__icon__id">{{icon.icon}}</p>
+  <p class="styleguide__icon__id">{{ icon.icon }}</p>
   {% icon icon.icon, icon.title, icon.extraClasses %}
 </div>
 {% endfor %}

--- a/server/views/global/palette.njk
+++ b/server/views/global/palette.njk
@@ -1,8 +1,8 @@
 {% macro colorBlock(name, hex) %}
   <div class="styleguide__palette__block">
-    <h2 class="styleguide__palette__name">{{name}}</h2>
-    <div class="styleguide__palette__color styleguide__palette__color--{{name}}" style="background: {{hex}};"></div>
-    <span class="styleguide__palette__hex">Hex: <code class="styleguide__palette__code">{{hex}}</code></span>
+    <h2 class="styleguide__palette__name">{{ name }}</h2>
+    <div class="styleguide__palette__color styleguide__palette__color--{{ name }}" style="background: {{ hex }};"></div>
+    <span class="styleguide__palette__hex">Hex: <code class="styleguide__palette__code">{{ hex }}</code></span>
   </div>
 {% endmacro %}
 
@@ -15,6 +15,6 @@
 <div class="styleguide__palette__section">
   <h2 class="styleguide__palette__heading">Secondary Colours</h2>
   {% for color in secondary %}
-    {{ colorBlock(name=color.name, hex=color.hex)}}
+    {{ colorBlock(name=color.name, hex=color.hex) }}
   {% endfor %}
 </div>

--- a/server/views/global/typography/typography.njk
+++ b/server/views/global/typography/typography.njk
@@ -1,5 +1,5 @@
 {% for font in fonts %}
-  {% component "font-example", {
+  {% component 'font-example', {
     font__name: font.font__name,
     font__example: font.font__example,
     font__size: font.font__size,

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -13,7 +13,7 @@
   </head>
 
   <body>
-    {% component "skip-link" %}
+    {% component 'skip-link' %}
 
     {% set navLinks = [
       {
@@ -34,20 +34,20 @@
         title: "What we do"
       }
     ] %}
-    {% component "header", { navLinks: navLinks } %}
+    {% component 'header', { navLinks: navLinks } %}
 
-    {% component "new-site-notice" %}
+    {% component 'new-site-notice' %}
     <div id="main" class="main" role="main">
       {% block body %}
       {% endblock %}
     </div>
-    {% component "footer", {
+    {% component 'footer', {
       navLinks: navLinks,
       openingHours: {places: pageConfig.openingHours},
       footerSocial: footerSocial
     } %}
 
-    {% component "cookie-notification" %}
+    {% component 'cookie-notification' %}
 
     {% include "partials/analytics.njk" %}
   </body>

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -1,4 +1,4 @@
-{% extends "layout/default.njk" %}
+{% extends 'layout/default.njk' %}
 {% set gridCellClasses = 'grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4' %}
 
 {% block body %}
@@ -7,7 +7,7 @@
 
 {% for media in article.mainMedia %}
   {% if media.weighting == 'leading' %}
-    {% component "media-item", { media: media } %}
+    {% component 'media-item', { media: media } %}
   {% endif %}
 {% endfor %}
 

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -1,4 +1,4 @@
-{% extends "layout/default.njk" %}
+{% extends 'layout/default.njk' %}
 
 {% block body %}
   <div class="row">

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -1,4 +1,4 @@
-{% extends "layout/default.njk" %}
+{% extends 'layout/default.njk' %}
 
 {% block body %}
 <div class="row">

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -1,4 +1,4 @@
-{% extends "pages/article.njk" %}
+{% extends 'pages/article.njk' %}
 
 {% block articleBody %}
   {% component 'article-body', { articleBody: article.articleBody } %}


### PR DESCRIPTION
## What is this PR trying to achieve?
I got bored of looking at different things, and though I'd try write a regex for my find/replace.
This is the result.

We use single quotes as that's what we do in JS, and HTML often uses double, and Jinja use them.
I've added a space between the template var denoter and the content for clarity.
