### PR TITLE
Fix page-description spacing with/without lead bar/intro

### DIFF
--- a/client/scss/components/_page_description.scss
+++ b/client/scss/components/_page_description.scss
@@ -5,7 +5,7 @@
 }
 
 .page-description__title {
-  margin-top: $vertical-space-unit;
+  margin-top: 0;
   margin-bottom: 0;
   margin-left: -0.06em;
 
@@ -26,7 +26,7 @@
   }
 }
 
-.page-description__lead {
+.page-description__row {
   margin-bottom: 0.6em;
 
   // This aligns the grey lead bar with text baseline
@@ -39,6 +39,10 @@
       bottom: 0.4em;
     }
   }
+}
+
+.page-description__container {
+  padding-top: $vertical-space-unit;
 }
 
 .page-description__intro {

--- a/server/views/components/page-description/index.njk
+++ b/server/views/components/page-description/index.njk
@@ -1,6 +1,6 @@
 <header class="page-description {% for modifier in modifiers %}page-description--{{ modifier }} {% endfor %}">
-  <div class="row row--no-padding {{ 'row--lead row--lead--l page-description__lead' if lead }}">
-    <div class="container">
+  <div class="row row--no-padding page-description__row {{ 'row--lead row--lead--l' if lead }}">
+    <div class="container page-description__container">
       <div class="grid">
         <div class="grid__cell grid__cell--s4 grid__cell--m6 grid__cell--shift-m1 {{ 'grid__cell--shift-l1 grid__cell--l11 grid__cell--xl10' if lead else 'grid__cell--l12 grid__cell--xl11' }}">
           {% if intro %}
@@ -15,7 +15,7 @@
     <div class="row row--no-padding">
       <div class="container">
           <div class="grid">
-            <div class="grid__cell {{ 'grid__cell--shift-l1' if lead }}">
+            <div class="grid__cell grid__cell--shift-m1 {{ 'grid__cell--shift-l1' if lead }}">
               <span class="page-description__publication-date">
                 {% icon 'other/clock' %}{{ publicationDate }}
               </span>


### PR DESCRIPTION
## What is this PR trying to achieve?
Correcting some spacing inconsistencies within the page description when the lead grey bar and intro copy are/aren't present.

## What does it look like?
Before:
![screen shot 2017-01-19 at 10 23 47](https://cloud.githubusercontent.com/assets/1394592/22103068/929d38a4-de31-11e6-90ef-3ac5ea22d039.png)

After:
![screen shot 2017-01-19 at 10 24 32](https://cloud.githubusercontent.com/assets/1394592/22103070/965f1502-de31-11e6-8463-f8f1ffb64d55.png)
