### PR TITLE
Add starter explore-landing template

### DIFF
--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -1,3 +1,13 @@
+{# TODO: add shift classes and update all templates to use this macro for grid clases #}
+{%- macro gridClasses(s, m, l, xl) %}
+  {%- set gc="grid__cell" -%}
+  {{ gc }} {# Output as variable to control whitespace #}
+  {%- if s %}grid__cell--s{{ s }} {% endif %}
+  {%- if m %}grid__cell--m{{ m }} {% endif %}
+  {%- if l %}grid__cell--l{{ l }} {% endif %}
+  {%- if xl %}grid__cell--xl{{ xl }} {% endif %}
+{%- endmacro %}
+
 <!DOCTYPE html>
 <html id="top" lang="en">
   <head>

--- a/server/views/pages/explore-landing.njk
+++ b/server/views/pages/explore-landing.njk
@@ -1,0 +1,4 @@
+{% extends "layout/default.njk" %}
+
+{% block body %}
+{% endblock %}

--- a/server/views/templates/explore-landing.config.yml
+++ b/server/views/templates/explore-landing.config.yml
@@ -1,0 +1,5 @@
+name: Explore landing
+handle: explore-landing-template
+context:
+  promo: "@promo"
+  numbered_list: "@numbered-list"

--- a/server/views/templates/explore-landing.njk
+++ b/server/views/templates/explore-landing.njk
@@ -1,0 +1,22 @@
+{% extends "pages/explore-landing.njk" %}
+
+{% block body %}
+  <div class="row">
+    <div class="container">
+      <div class="grid">
+        <div class="{{ gridClasses(s=4, m=4, l=12) }}">
+          {% component 'promo', { image: promo.image, intro: promo.intro, title: promo.title, url: promo.url, copy: promo.copy } %}
+        </div>
+        <div class="{{ gridClasses(s=4, m=4, l=8) }}">
+          {% component 'promo', { image: promo.image, intro: promo.intro, title: promo.title, url: promo.url, copy: promo.copy } %}
+        </div>
+        <div class="{{ gridClasses(s=4, m=4, l=4) }}">
+          {% component 'promo', { image: promo.image, intro: promo.intro, title: promo.title, url: promo.url, copy: promo.copy } %}
+        </div>
+        <div class="{{ gridClasses(s=4, m=4, l=4) }}">
+          {% component 'numbered-list', { heading: numbered_list.heading, items: numbered_list.items } %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding a template to house components being built for the explore landing page.

Also adding a macro to set grid classes.

## What does it look like?
![explore-landing](https://cloud.githubusercontent.com/assets/1394592/22106869/cd56128e-de42-11e6-8075-2115993071cb.gif)