### PR TITLE
Promo component

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -87,15 +87,53 @@
   width: 100%;
   height: 100%;
   border-radius: $border-radius-unit;
-  filter: url(#duotone);
-  clip-path: polygon(0% 55%, 0% 100%, 100% 100%, 100% 60%, 80% 54%, 74% 56%, 80% 54%, 35% 67%, 20% 60%);
+  filter: url('#duotone') saturate(80%);
+}
+
+.promo__clip-path--1 {
+  clip-path: polygon(0% 65%, 0% 100%, 100% 100%, 100% 64%, 92% 57%, 70% 50%, 57% 60%, 45% 68%, 20% 70%);
+}
+
+.promo__clip-path--2 {
+  clip-path: polygon(0% 55%, 0% 100%, 100% 100%, 100% 60%, 82% 57%, 74% 54%, 60% 60%, 55% 63%, 40% 60%, 27% 64%);
+}
+
+.promo__clip-path--3 {
+  clip-path: polygon(0% 45%, 0% 100%, 100% 100%, 100% 42%, 75% 59%, 47% 50%, 27% 54%);
+}
+
+.promo__clip-path--4 {
+  clip-path: polygon(0% 39%, 0% 100%, 100% 100%, 100% 50%, 72% 45%, 62% 55%, 52% 44%, 48% 50%, 30% 45%, 17% 42%);
+}
+
+.promo__clip-path--5 {
+  clip-path: polygon(0% 58%, 0% 100%, 100% 100%, 100% 60%, 90% 68%, 84% 57%, 60% 60%, 45% 33%, 30% 40%, 13% 50%);
+}
+
+.promo__clip-path--6 {
+  clip-path: polygon(0% 21%, 0% 100%, 100% 100%, 100% 24%, 92% 30%, 84% 26%, 70% 37%, 45% 45%, 36% 49%, 27% 42%, 14% 28%);
+}
+
+.promo__clip-path--7 {
+  clip-path: polygon(0% 52%, 0% 100%, 100% 100%, 100% 57%, 70% 60%, 50% 53%, 40% 60%, 27% 64%);
+}
+
+.promo__clip-path--8 {
+  clip-path: polygon(0% 45%, 0% 100%, 100% 100%, 100% 45%, 82% 52%, 74% 44%, 60% 50%, 55% 57%, 40% 52%, 27% 48%);
+}
+
+.promo__clip-path--9 {
+  clip-path: polygon(0% 65%, 0% 100%, 100% 100%, 100% 30%, 84% 37%, 69% 32%, 60% 60%, 55% 63%, 40% 60%, 27% 64%);
+}
+
+.promo__clip-path--10 {
+  clip-path: polygon(0% 85%, 0% 100%, 100% 100%, 100% 60%, 90% 50%, 78% 45%, 60% 60%, 55% 66%, 40% 76%, 27% 82%);
 }
 
 .promo__image {
   display: block;
   width: 100%;
   border-radius: $border-radius-unit;
-  filter: grayscale(100%);
 }
 
 .promo__icon-container {

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -13,31 +13,37 @@
   }
 
   .icon {
-    margin-right: 0.8em;
+    vertical-align: middle;
+    margin-right: map-get($gutter-width, 'small')/2;
+
+    @include respond-to('medium') {
+      margin-right: map-get($gutter-width, 'medium')/2;
+    }
+
+    @include respond-to('large') {
+      margin-right: map-get($gutter-width, 'large')/2;
+    }
   }
 }
 
 .promo--gallery {
-  .icon {
-    width: 1.5em;
-    height: 1.187em;
-    min-width: 1.5em;
+  .icon { // aspect ratio: 24 x 19
+    width: (24/19) * 1.6em;
+    height: (19/19) * 1.6em;
   }
 }
 
 .promo--podcast {
-  .icon {
-    width: 1.6875em;
-    height: 1.375em;
-    min-width: 1.6875em;
+  .icon { // aspect ratio: 27 x 22
+    width: (27/22) * 1.6em;
+    height: (22/22) * 1.6em;
   }
 }
 
 .promo--video {
-  .icon {
-    width: 1.0625em;
-    height: 1.187em;
-    min-width: 1.0625em;
+  .icon { // aspect ratio: 17 x 19
+    width: (17/19) * 1.6em;
+    height: (19/19) * 1.6em;
   }
 }
 
@@ -125,10 +131,24 @@
 }
 
 .promo__icon-container {
+  @include font('HNL7');
   background: color('white');
   position: absolute;
   bottom: 0;
   left: 0;
+  padding: map-get($gutter-width, 'small')/2;
+
+  @include respond-to('medium') {
+    padding: map-get($gutter-width, 'medium')/2;
+  }
+
+  @include respond-to('large') {
+    padding: map-get($gutter-width, 'large')/2;
+  }
+}
+
+.promo__length {
+  display: inline-block;
 }
 
 .promo__sr {
@@ -139,6 +159,11 @@
   @include font('HNL5');
   color: color('action-green-2');
   display: block;
+  text-transform: capitalize;
+
+  .promo--series & {
+    color: color('purple');
+  }
 }
 
 .promo__title {
@@ -153,6 +178,7 @@
 }
 
 .promo__date {
+  @include font('HNL5');
   display: block;
 }
 

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -1,6 +1,9 @@
 //* @define promo
-
+//TODO hover/focus styles
 .promo {
+  display: block;
+  text-decoration: none;
+
   @include container-query(('l': ('8', '12'))) {
     display: flex;
     align-items: flex-start;
@@ -45,17 +48,65 @@
   border-bottom: 2px solid color('black');
 }
 
-.promo__image {
+.promo--series {
+  .promo__image-container {
+    position: relative;
+
+    &:before {
+      //content: 'test';
+      content: attr(data-image url);
+      //filter: hue-rotate(90deg);
+    }
+  }
+}
+
+.promo__image-container {
+  position: relative;
   width: 100%;
   display: block;
   margin-bottom: 1rem;
-  border-radius: $border-radius-unit;
 
   @include container-query(('l': ('8', '12'))) {
     order: 1;
     width: percentage(2 / 3);
     margin-bottom: 0;
   }
+}
+
+.defs-only {
+  position: absolute;
+  height: 0; width: 0;
+  overflow: none;
+  left: -100%;
+}
+
+.promo__image-mask {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: $border-radius-unit;
+  filter: url(#duotone);
+  clip-path: polygon(0% 55%, 0% 100%, 100% 100%, 100% 60%, 80% 54%, 74% 56%, 80% 54%, 35% 67%, 20% 60%);
+}
+
+.promo__image {
+  display: block;
+  width: 100%;
+  border-radius: $border-radius-unit;
+  filter: grayscale(100%);
+}
+
+.promo__icon-container {
+  background: color('white');
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.promo__sr {
+  @include visuallyhidden;
 }
 
 .promo__type {
@@ -75,8 +126,8 @@
   }
 }
 
-.promo__link {
-  text-decoration: none;
+.promo__date {
+  display: block;
 }
 
 .promo__description {

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -1,10 +1,6 @@
 //* @define promo
 
 .promo {
-  padding-bottom: 3 * $vertical-space-unit;
-  margin-bottom: $vertical-space-unit;
-  border-bottom: 2px solid color('black');
-
   @include container-query(('l': ('8', '12'))) {
     display: flex;
     align-items: flex-start;
@@ -13,6 +9,40 @@
   @include container-query(('l': ('12'), 'm': ('8'))) {
     border-bottom: 0;
   }
+
+  .icon {
+    margin-right: 0.8em;
+  }
+}
+
+.promo--gallery {
+  .icon {
+    width: 1.5em;
+    height: 1.187em;
+    min-width: 1.5em;
+  }
+}
+
+.promo--podcast {
+  .icon {
+    width: 1.6875em;
+    height: 1.375em;
+    min-width: 1.6875em;
+  }
+}
+
+.promo--video {
+  .icon {
+    width: 1.0625em;
+    height: 1.187em;
+    min-width: 1.0625em;
+  }
+}
+
+.promo--underlined {
+  padding-bottom: 3 * $vertical-space-unit;
+  margin-bottom: $vertical-space-unit;
+  border-bottom: 2px solid color('black');
 }
 
 .promo__image {
@@ -28,7 +58,7 @@
   }
 }
 
-.promo__intro {
+.promo__type {
   @include font('HNL5');
   color: color('action-green-2');
   display: block;

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -1,5 +1,4 @@
 //* @define promo
-//TODO hover/focus styles
 .promo {
   display: block;
   text-decoration: none;
@@ -48,23 +47,13 @@
   border-bottom: 2px solid color('black');
 }
 
-.promo--series {
-  .promo__image-container {
-    position: relative;
-
-    &:before {
-      //content: 'test';
-      content: attr(data-image url);
-      //filter: hue-rotate(90deg);
-    }
-  }
-}
-
 .promo__image-container {
   position: relative;
   width: 100%;
   display: block;
   margin-bottom: 1rem;
+  border-radius: $border-radius-unit;
+  overflow: hidden;
 
   @include container-query(('l': ('8', '12'))) {
     order: 1;
@@ -73,9 +62,15 @@
   }
 }
 
+.promo__image {
+  display: block;
+  width: 100%;
+}
+
 .promo__defs {
   position: absolute;
-  height: 0; width: 0;
+  height: 0;
+  width: 0;
   overflow: none;
   left: -100%;
 }
@@ -86,7 +81,6 @@
   left: 0;
   width: 100%;
   height: 100%;
-  border-radius: $border-radius-unit;
   filter: url('#duotone') saturate(80%);
 }
 
@@ -128,12 +122,6 @@
 
 .promo__clip-path--10 {
   clip-path: polygon(0% 85%, 0% 100%, 100% 100%, 100% 60%, 90% 50%, 78% 45%, 60% 60%, 55% 66%, 40% 76%, 27% 82%);
-}
-
-.promo__image {
-  display: block;
-  width: 100%;
-  border-radius: $border-radius-unit;
 }
 
 .promo__icon-container {

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -73,7 +73,7 @@
   }
 }
 
-.defs-only {
+.promo__defs {
   position: absolute;
   height: 0; width: 0;
   overflow: none;

--- a/server/views/components/promo/index.config.yml
+++ b/server/views/components/promo/index.config.yml
@@ -1,15 +1,130 @@
 name: promo
 context:
+  modifiers: ['underlined']
+  url: http://google.com
   image:
     sources:
+    - src: https://placehold.it/1200x900
+      size: '1200'
+    - src: https://placehold.it/900x600
+      size: '900'
+    - src: https://placehold.it/450x300
+      size: '450'
+    alt: image alt text
+  meta: 
+    type: type
+    date: date
+  title: Title
+  copy: Copy lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
+variants:
+- name: Article
+  context:
+    modifiers: ['underlined']
+    url: http://google.com
+    image:
+      sources:
       - src: https://placehold.it/1200x900
         size: '1200'
       - src: https://placehold.it/900x600
         size: '900'
       - src: https://placehold.it/450x300
         size: '450'
-    alt: placeholder image
-  intro: Article
-  title: Animating the Body
-  url: http://google.com
-  copy: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
+      alt: placeholder image
+    meta: 
+      type: article
+      date:
+    title: Animating the body
+    copy: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
+- name: Series article
+  context:
+    modifiers: ['series']
+    url: http://google.com
+    image:
+      sources:
+      - src: https://placehold.it/1200x900
+        size: '1200'
+      - src: https://placehold.it/900x600
+        size: '900'
+      - src: https://placehold.it/450x300
+        size: '450'
+      alt: placeholder image
+    meta: 
+      type: 'electricity: part 02'
+      date:
+    title: Frakenstein's Monster
+    copy: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
+- name: Latest article
+  context:
+    modifiers: ['underlined']
+    url: http://google.com
+    image:
+      sources:
+      - src: https://placehold.it/1200x900
+        size: '1200'
+      - src: https://placehold.it/900x600
+        size: '900'
+      - src: https://placehold.it/450x300
+        size: '450'
+      alt: placeholder image
+    meta: 
+      type: article
+      date: 2 days ago
+    title: Oops!...I wrote a Britney blog post
+    copy:
+- name: Gallery
+  context:
+    modifiers:
+    url: http://google.com
+    image:
+      sources:
+      - src: https://placehold.it/1200x900
+        size: '1200'
+      - src: https://placehold.it/900x600
+        size: '900'
+      - src: https://placehold.it/450x300
+        size: '450'
+      alt: placeholder image
+    meta: 
+      type: gallery
+      date:
+      length: 37
+    title: Science and art
+    copy:
+- name: Podcast
+  context:
+    modifiers:
+    url: http://google.com
+    image:
+      sources:
+      - src: https://placehold.it/1200x900
+        size: '1200'
+      - src: https://placehold.it/900x600
+        size: '900'
+      - src: https://placehold.it/450x300
+        size: '450'
+      alt: placeholder image
+    meta: 
+      type: podcast
+      date:
+      length: '56:02'
+    title: The designs of the Festival Pattern Group
+    copy:
+- name: Video
+  modifiers:
+  context:
+    url: http://google.com
+    image:
+      sources:
+      - src: https://placehold.it/1200x900
+        size: '1200'
+      - src: https://placehold.it/900x600
+        size: '900'
+      - src: https://placehold.it/450x300
+        size: '450'
+      alt: placeholder image
+    meta: 
+      type: video
+      date:
+      length: '1:37'
+    title: Tomorrow Belongs to Me
+    copy:

--- a/server/views/components/promo/index.config.yml
+++ b/server/views/components/promo/index.config.yml
@@ -13,8 +13,8 @@ context:
       size: '450'
     alt: image alt text
   meta: 
-    type: gallery
-    date: date
+    type: article
+    date: 
     length: length
   title: Title
   copy: Copy lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
@@ -89,7 +89,7 @@ variants:
     meta: 
       type: gallery
       date:
-      length: 37
+      length: 1
     title: Science and art
     copy:
 - name: Podcast

--- a/server/views/components/promo/index.config.yml
+++ b/server/views/components/promo/index.config.yml
@@ -41,11 +41,11 @@ variants:
     url: http://google.com
     image:
       sources:
-      - src: https://placehold.it/1200x900
+      - src: https://wellcomecollection.files.wordpress.com/2017/01/copyright-daniel-regan-2.png?w=1400&h=&crop=1
         size: '1200'
-      - src: https://placehold.it/900x600
+      - src: https://wellcomecollection.files.wordpress.com/2017/01/copyright-daniel-regan-2.png?w=1400&h=&crop=1
         size: '900'
-      - src: https://placehold.it/450x300
+      - src: https://wellcomecollection.files.wordpress.com/2017/01/copyright-daniel-regan-2.png?w=1400&h=&crop=1
         size: '450'
       alt: placeholder image
     meta: 
@@ -55,7 +55,7 @@ variants:
     copy: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
 - name: Latest article
   context:
-    modifiers: ['underlined']
+    modifiers:
     url: http://google.com
     image:
       sources:
@@ -67,7 +67,7 @@ variants:
         size: '450'
       alt: placeholder image
     meta: 
-      type: article
+      type:
       date: 2 days ago
     title: Oops!...I wrote a Britney blog post
     copy:

--- a/server/views/components/promo/index.config.yml
+++ b/server/views/components/promo/index.config.yml
@@ -1,4 +1,5 @@
 name: promo
+collated: true
 context:
   modifiers: ['underlined']
   url: http://google.com
@@ -12,8 +13,9 @@ context:
       size: '450'
     alt: image alt text
   meta: 
-    type: type
+    type: gallery
     date: date
+    length: length
   title: Title
   copy: Copy lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
 variants:
@@ -37,7 +39,7 @@ variants:
     copy: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
 - name: Series article
   context:
-    modifiers: ['series']
+    modifiers: ['series', 'underlined']
     url: http://google.com
     image:
       sources:
@@ -55,7 +57,7 @@ variants:
     copy: Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eos eius debitis, ad unde laborum assumenda numquam suscipit sint iure itaque aut pariatur, neque omnis vel tenetur sapiente nam iusto quas.
 - name: Latest article
   context:
-    modifiers:
+    modifiers: ['underlined']
     url: http://google.com
     image:
       sources:
@@ -73,7 +75,7 @@ variants:
     copy:
 - name: Gallery
   context:
-    modifiers:
+    modifiers: ['underlined']
     url: http://google.com
     image:
       sources:
@@ -92,7 +94,7 @@ variants:
     copy:
 - name: Podcast
   context:
-    modifiers:
+    modifiers: ['underlined']
     url: http://google.com
     image:
       sources:
@@ -110,7 +112,7 @@ variants:
     title: The designs of the Festival Pattern Group
     copy:
 - name: Video
-  modifiers:
+  modifiers: ['underlined']
   context:
     url: http://google.com
     image:

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -1,4 +1,10 @@
-<div class="promo">
+{% set gallery = 'actions/gallery-link' %}
+{% set podcast = 'actions/volume' %}
+{% set video = 'actions/play' %}
+{#TODO block level link?#}
+{#TODO full width variant?#}
+{#TODO full width/dark background variant?#}
+<div class="promo promo--{{meta.type}} {% for modifier in modifiers %}promo--{{ modifier }} {% endfor %} ">
   <img class="promo__image"
     src="{{ image.sources[(image.sources | length) - 1].src }}"
       srcset="{%- for source in image.sources %}
@@ -6,9 +12,23 @@
         {%- if (source !== (image.sources | last)) %}, {%- endif %}
       {%- endfor %}"
       alt="{{ image.alt }}" />
+  {% if meta.type == 'gallery' %}
+    {% icon gallery %}
+  {% elif meta.type == 'podcast' %}
+    {% icon podcast %}
+  {% elif meta.type == 'video' %}
+      {% icon video %}
+  {% endif %}
+  {% if meta.type == 'gallery' and meta.length %}
+    {{ meta.length }} items
+  {% endif %}
+  {% if meta.type == 'podcast' or meta.type == 'video' and meta.length %}
+    {{ meta.length }} time {#TODO timestamp #}
+  {% endif %}
   <header class="promo__description">
-    <span class="promo__intro">{{ intro }}</span>
+    <span class="promo__type">{{ meta.type }}</span>
     <h2 class="promo__title"><a href="{{ url }}" class="promo__link">{{ title }}</a></h2>
+    {{meta.date }}
     <span class="promo__copy">{{ copy }}</span>
   </header>
 </div>

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -4,7 +4,6 @@
 {#TODO full width variant?#}
 {#TODO full width/dark background variant?#}
 {#TODO Test with screen reader?#}
-{#TODO styling video/podcast/gallery version#}
 <a href="{{ url }}" class="promo  {% if meta.type == 'gallery' or meta.type == 'podcast' or meta.type == 'video' %}promo--{{meta.type}}{% endif %} {% for modifier in modifiers %}promo--{{ modifier }} {% endfor %} ">
   <div class="promo__image-container">
     <img class="promo__image"
@@ -17,7 +16,7 @@
 
     {% for modifier in modifiers %}
       {% if modifier == 'series' %}
-        <svg class="promo__defs">{# TODO proper filter - see Tomi #}
+        <svg class="promo__defs">{# TODO proper filter - see Tomi, only want this on the page once #}
           <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
             <feColorMatrix type="matrix"
               values="0.90 0 0 0   0.40 
@@ -40,7 +39,7 @@
             {% icon video %}
         {% endif %}
         {% if meta.type == 'gallery' and meta.length %}
-          <span class="promo__sr">Gallery with</span> {{ meta.length }} <span class="promo__sr">items</span>
+          <span class="promo__length"><span class="promo__sr">Gallery with</span> {{ meta.length }} <span class="promo__sr">items</span></span>
         {% endif %}
         {% if meta.type == 'podcast' or meta.type == 'video' and meta.length %}
           <span class="promo__sr">{% if meta.type == 'podcast' %}Podcast{%else%}Video{% endif %} lasting</span>

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -1,34 +1,63 @@
 {% set gallery = 'actions/gallery-link' %}
 {% set podcast = 'actions/volume' %}
 {% set video = 'actions/play' %}
-{#TODO block level link?#}
 {#TODO full width variant?#}
 {#TODO full width/dark background variant?#}
-<div class="promo promo--{{meta.type}} {% for modifier in modifiers %}promo--{{ modifier }} {% endfor %} ">
-  <img class="promo__image"
-    src="{{ image.sources[(image.sources | length) - 1].src }}"
-      srcset="{%- for source in image.sources %}
-        {{ source.src }} {{ source.size }}w
-        {%- if (source !== (image.sources | last)) %}, {%- endif %}
-      {%- endfor %}"
-      alt="{{ image.alt }}" />
-  {% if meta.type == 'gallery' %}
-    {% icon gallery %}
-  {% elif meta.type == 'podcast' %}
-    {% icon podcast %}
-  {% elif meta.type == 'video' %}
-      {% icon video %}
-  {% endif %}
-  {% if meta.type == 'gallery' and meta.length %}
-    {{ meta.length }} items
-  {% endif %}
-  {% if meta.type == 'podcast' or meta.type == 'video' and meta.length %}
-    {{ meta.length }} time {#TODO timestamp #}
-  {% endif %}
+{#TODO Test with screen reader?#}
+<a href="{{ url }}" class="promo  {% if meta.type == 'gallery' or meta.type == 'podcast' or meta.type == 'video' %}promo--{{meta.type}}{% endif %} {% for modifier in modifiers %}promo--{{ modifier }} {% endfor %} ">
+  <div class="promo__image-container">
+    <img class="promo__image"
+      src="{{ image.sources[(image.sources | length) - 1].src }}"
+        srcset="{%- for source in image.sources %}
+          {{ source.src }} {{ source.size }}w
+          {%- if (source !== (image.sources | last)) %}, {%- endif %}
+        {%- endfor %}"
+        alt="" />
+
+    {% for modifier in modifiers %}
+      {% if modifier == 'series' %}
+        <svg class="defs-only">
+          <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
+            <feColorMatrix type="matrix"
+              values="0.90 0 0 0   0.40 
+                      0.95 0 0 0  -0.10  
+                    -0.20 0 0 0   0.65 
+                        0  0 0 1   0" />
+          </filter>
+        </svg>
+        <img class="promo__image-mask" src="{{image.sources[(image.sources | length) - 1].src}}" alt="" />
+      {% endif %}
+    {% endfor %}
+
+    {% if meta.type == 'gallery' or meta.type == 'podcast' or meta.type == 'video' %}
+      <div class="promo__icon-container">
+        {% if meta.type == 'gallery' %}
+          {% icon gallery %}
+        {% elif meta.type == 'podcast' %}
+          {% icon podcast %}
+        {% elif meta.type == 'video' %}
+            {% icon video %}
+        {% endif %}
+        {% if meta.type == 'gallery' and meta.length %}
+          <span class="promo__sr">Gallery with</span> {{ meta.length }} <span class="promo__sr">items</span>
+        {% endif %}
+        {% if meta.type == 'podcast' or meta.type == 'video' and meta.length %}
+          <span class="promo__sr">{% if meta.type == 'podcast' %}Podcast{%else%}Video{% endif %} lasting</span>
+          {{ meta.length }} {#TODO timestamp #}
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
   <header class="promo__description">
-    <span class="promo__type">{{ meta.type }}</span>
-    <h2 class="promo__title"><a href="{{ url }}" class="promo__link">{{ title }}</a></h2>
-    {{meta.date }}
-    <span class="promo__copy">{{ copy }}</span>
+    {% if meta.type %}
+      <span class="promo__type" aria-hidden="true">{{ meta.type }}</span>
+    {% endif %}
+    <h2 class="promo__title">{{ title }}</h2>
+    {% if meta.date %}
+      <span class="promo__date">{{ meta.date }}</span>
+    {% endif %}
+    {% if copy %}
+      <span  class="promo__copy">{{ copy }}</span>
+    {% endif %}
   </header>
-</div>
+</a>

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -4,6 +4,7 @@
 {#TODO full width variant?#}
 {#TODO full width/dark background variant?#}
 {#TODO Test with screen reader?#}
+{#TODO styling video/podcast/gallery version#}
 <a href="{{ url }}" class="promo  {% if meta.type == 'gallery' or meta.type == 'podcast' or meta.type == 'video' %}promo--{{meta.type}}{% endif %} {% for modifier in modifiers %}promo--{{ modifier }} {% endfor %} ">
   <div class="promo__image-container">
     <img class="promo__image"
@@ -16,7 +17,7 @@
 
     {% for modifier in modifiers %}
       {% if modifier == 'series' %}
-        <svg class="promo__defs">{# TODO proper filter #}
+        <svg class="promo__defs">{# TODO proper filter - see Tomi #}
           <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
             <feColorMatrix type="matrix"
               values="0.90 0 0 0   0.40 

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -16,7 +16,7 @@
 
     {% for modifier in modifiers %}
       {% if modifier == 'series' %}
-        <svg class="defs-only">{# TODO proper filter #}
+        <svg class="promo__defs">{# TODO proper filter #}
           <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
             <feColorMatrix type="matrix"
               values="0.90 0 0 0   0.40 

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -16,7 +16,7 @@
 
     {% for modifier in modifiers %}
       {% if modifier == 'series' %}
-        <svg class="defs-only">
+        <svg class="defs-only">{# TODO proper filter #}
           <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
             <feColorMatrix type="matrix"
               values="0.90 0 0 0   0.40 
@@ -25,7 +25,7 @@
                         0  0 0 1   0" />
           </filter>
         </svg>
-        <img class="promo__image-mask" src="{{image.sources[(image.sources | length) - 1].src}}" alt="" />
+        <img class="promo__image-mask promo__clip-path--{{ [1,2,3,4,5,6,7,8,9,10] | random }}" src="{{image.sources[(image.sources | length) - 1].src}}" alt="" />
       {% endif %}
     {% endfor %}
 

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -1,10 +1,9 @@
-{% set gallery = 'actions/gallery-link' %}
-{% set podcast = 'actions/volume' %}
-{% set video = 'actions/play' %}
-{#TODO full width variant?#}
-{#TODO full width/dark background variant?#}
-{#TODO Test with screen reader?#}
-<a href="{{ url }}" class="promo  {% if meta.type == 'gallery' or meta.type == 'podcast' or meta.type == 'video' %}promo--{{meta.type}}{% endif %} {% for modifier in modifiers %}promo--{{ modifier }} {% endfor %} ">
+{#TODO full width variant#}
+{#TODO full width/dark background variant#}
+{#TODO Test with screen reader#}
+{#TODO jsConfig#}
+{#TODO className unitlity for promo classes#}
+<a href="{{ url }}" class="promo  {% if meta.type === 'gallery' or meta.type === 'podcast' or meta.type === 'video' %}promo--{{meta.type}}{% endif %} {% for modifier in modifiers %}promo--{{ modifier }} {% endfor %} ">
   <div class="promo__image-container">
     <img class="promo__image"
       src="{{ image.sources[(image.sources | length) - 1].src }}"
@@ -15,35 +14,37 @@
         alt="" />
 
     {% for modifier in modifiers %}
-      {% if modifier == 'series' %}
-        <svg class="promo__defs">{# TODO proper filter - see Tomi, only want this on the page once #}
-          <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
-            <feColorMatrix type="matrix"
-              values="0.90 0 0 0   0.40 
-                      0.95 0 0 0  -0.10  
-                    -0.20 0 0 0   0.65 
-                        0  0 0 1   0" />
-          </filter>
+      {% if modifier === 'series' %}
+        <svg class="promo__defs">{# TODO proper filter - see Tomi; and only want this on the page once, where's best to move?#}
+          <defs>
+            <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
+              <feColorMatrix type="matrix"
+                values="0.90 0 0 0   0.40 
+                        0.95 0 0 0  -0.10  
+                      -0.20 0 0 0   0.65 
+                          0  0 0 1   0" />
+            </filter>
+          </defs>
         </svg>
         <img class="promo__image-mask promo__clip-path--{{ [1,2,3,4,5,6,7,8,9,10] | random }}" src="{{image.sources[(image.sources | length) - 1].src}}" alt="" />
       {% endif %}
     {% endfor %}
 
-    {% if meta.type == 'gallery' or meta.type == 'podcast' or meta.type == 'video' %}
+    {% if meta.type === 'gallery' or meta.type === 'podcast' or meta.type === 'video' %}
       <div class="promo__icon-container">
-        {% if meta.type == 'gallery' %}
-          {% icon gallery %}
-        {% elif meta.type == 'podcast' %}
-          {% icon podcast %}
-        {% elif meta.type == 'video' %}
-            {% icon video %}
+        {% if meta.type === 'gallery' %}
+          {% icon 'actions/gallery-link' %}
+        {% elif meta.type === 'podcast' %}
+          {% icon 'actions/volume'  %}
+        {% elif meta.type === 'video' %}
+            {% icon 'actions/play' %}
         {% endif %}
-        {% if meta.type == 'gallery' and meta.length %}
-          <span class="promo__length"><span class="promo__sr">Gallery with</span> {{ meta.length }} <span class="promo__sr">items</span></span>
+        {% if meta.type === 'gallery' and meta.length %}
+          <span class="promo__length"><span class="promo__sr">Gallery with</span> {{ meta.length }} <span class="promo__sr">item{{ 's' if meta.length > 1 }}</span></span>
         {% endif %}
-        {% if meta.type == 'podcast' or meta.type == 'video' and meta.length %}
-          <span class="promo__sr">{% if meta.type == 'podcast' %}Podcast{%else%}Video{% endif %} lasting</span>
-          {{ meta.length }} {#TODO timestamp #}
+        {% if meta.type === 'podcast' or meta.type === 'video' and meta.length %}
+          <span class="promo__sr">{% if meta.type === 'podcast' %}Podcast{%else%}Video{% endif %} lasting</span>
+          {{ meta.length }}
         {% endif %}
       </div>
     {% endif %}

--- a/server/views/templates/explore-landing.njk
+++ b/server/views/templates/explore-landing.njk
@@ -5,13 +5,13 @@
     <div class="container">
       <div class="grid">
         <div class="{{ gridClasses(s=4, m=4, l=12) }}">
-          {% component 'promo', { image: promo.image, intro: promo.intro, title: promo.title, url: promo.url, copy: promo.copy } %}
+          {% component 'promo', { modifiers: promo.modifiers, image: promo.image, meta: promo.meta, title: promo.title, url: promo.url, copy: promo.copy } %}
         </div>
         <div class="{{ gridClasses(s=4, m=4, l=8) }}">
-          {% component 'promo', { image: promo.image, intro: promo.intro, title: promo.title, url: promo.url, copy: promo.copy } %}
+          {% component 'promo', { modifiers: promo.modifiers, image: promo.image, meta: promo.meta, title: promo.title, url: promo.url, copy: promo.copy } %}
         </div>
         <div class="{{ gridClasses(s=4, m=4, l=4) }}">
-          {% component 'promo', { image: promo.image, intro: promo.intro, title: promo.title, url: promo.url, copy: promo.copy } %}
+          {% component 'promo', { modifiers: promo.modifiers, image: promo.image, meta: promo.meta, title: promo.title, url: promo.url, copy: promo.copy } %}
         </div>
         <div class="{{ gridClasses(s=4, m=4, l=4) }}">
           {% component 'numbered-list', { heading: numbered_list.heading, items: numbered_list.items } %}


### PR DESCRIPTION
## What is this PR trying to achieve?

- Makes the promo component more generic for use in the various explore page blocks.
- Adds some styles for the different promo variants.

## What does it look like?
![screencapture-localhost-3000-components-preview-promo-1484832440963](https://cloud.githubusercontent.com/assets/6051896/22108563/a4db2b2e-de4b-11e6-8fca-1877f2e13498.png)

## For interface components
- [X] Browser testing - Have you checked the component in our supported browsers
- [X] No javascript - Have you checked the component with javascript disabled
- [ ] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?
