### PR TITLE
Add explore landing (hidden) h1

### DIFF
--- a/client/scss/components/_footer_social.scss
+++ b/client/scss/components/_footer_social.scss
@@ -32,5 +32,5 @@
 }
 
 .footer-social__service {
-  @include visuallyhidden();
+  @include visually-hidden();
 }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -178,7 +178,7 @@ $tweakpoints: (
 }
 
 .header__label {
-  @include visuallyhidden();
+  @include visually-hidden();
 }
 
 .header__input {
@@ -275,11 +275,11 @@ $tweakpoints: (
 
 .header__button-text {
   .header__form--is-active & {
-    @include visuallyhidden();
+    @include visually-hidden();
   }
 
   @include respond-between('small', 'header-medium') {
-    @include visuallyhidden();
+    @include visually-hidden();
   }
 }
 

--- a/client/scss/components/_opening_hours.scss
+++ b/client/scss/components/_opening_hours.scss
@@ -80,7 +80,7 @@
 .opening-hours__caption,
 .opening-hours__thead {
   .enhanced & {
-    @include visuallyhidden();
+    @include visually-hidden();
   }
 }
 

--- a/client/scss/components/_page_description.scss
+++ b/client/scss/components/_page_description.scss
@@ -4,6 +4,10 @@
   margin-bottom: $vertical-space-unit;
 }
 
+.page-description--hidden {
+  @include visually-hidden();
+}
+
 .page-description__title {
   margin-top: 0;
   margin-bottom: 0;

--- a/client/scss/components/_skip_link.scss
+++ b/client/scss/components/_skip_link.scss
@@ -1,4 +1,4 @@
 .skip-link {
-  @include visuallyhidden;
-  @include visuallyhidden-focusable;
+  @include visually-hidden;
+  @include visually-hidden-focusable;
 }

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -141,7 +141,7 @@
   }
 }
 
-@mixin visuallyhidden {
+@mixin visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
@@ -153,7 +153,7 @@
   white-space: nowrap;
 }
 
-@mixin visuallyhidden-focusable {
+@mixin visually-hidden-focusable {
   &:active,
   &:focus {
     clip: auto;

--- a/server/views/components/skip-link/index.njk
+++ b/server/views/components/skip-link/index.njk
@@ -1,1 +1,1 @@
-<a class="skip-link visuallyhidden focusable" href="#main">Skip to main content</a>
+<a class="skip-link" href="#main">Skip to main content</a>

--- a/server/views/templates/explore-landing.njk
+++ b/server/views/templates/explore-landing.njk
@@ -1,6 +1,8 @@
 {% extends "pages/explore-landing.njk" %}
 
 {% block body %}
+  {% component 'page-description', { title: 'Explore landing', modifiers: ['hidden'] } %}
+
   <div class="row">
     <div class="container">
       <div class="grid">

--- a/server/views/templates/explore-landing.njk
+++ b/server/views/templates/explore-landing.njk
@@ -1,7 +1,7 @@
 {% extends "pages/explore-landing.njk" %}
 
 {% block body %}
-  {% component 'page-description', { title: 'Explore landing', modifiers: ['hidden'] } %}
+  {% component 'page-description', { title: 'Explore', modifiers: ['hidden'] } %}
 
   <div class="row">
     <div class="container">


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding an `h1` to the explore landing page for good markup-validation/a11y/~snake-oil sales~SEO.

## What does it look like?
Like this:

![screen shot 2017-01-19 at 16 50 07](https://cloud.githubusercontent.com/assets/1394592/22116119/611ef1c4-de67-11e6-8c83-482c14f641ca.png)

It's hidden. Geddit?

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?