### PR TITLE
Add hover transitions to promos

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -58,6 +58,7 @@
   width: 100%;
   display: block;
   margin-bottom: 1rem;
+  transform: translateZ(0); // Fixes scale/border-radius overflow bug: http://stackoverflow.com/a/31686781
   border-radius: $border-radius-unit;
   overflow: hidden;
 
@@ -71,6 +72,12 @@
 .promo__image {
   display: block;
   width: 100%;
+  transition: transform 400ms ease;
+
+  .promo:hover &,
+  .promo:focus & {
+    transform: scale(1.2);
+  }
 }
 
 .promo__defs {
@@ -160,9 +167,15 @@
   color: color('action-green-2');
   display: block;
   text-transform: capitalize;
+  transition: color 400ms ease;
 
   .promo--series & {
     color: color('purple');
+  }
+
+  .promo:hover &,
+  .promo:focus & {
+    color: color('black');
   }
 }
 
@@ -171,9 +184,15 @@
   color: color('black');
   margin-top: 0;
   margin-bottom: 0.9em;
+  transition: color 400ms ease;
 
   @include container-query(('l': ('12'))) {
     @include font('WB3');
+  }
+
+  .promo:hover &,
+  .promo:focus & {
+    color: color('action-green-2');
   }
 }
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding hover transitions to promos. Closes #346.

## What does it look like?
 ![promo](https://cloud.githubusercontent.com/assets/1394592/22147430/77e1e36e-df00-11e6-9b57-769b04dd477d.gif)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers