### PR TITLE
Remove copy from below 'border-bottom' author in Cardigan

### DIFF
--- a/server/views/components/author/index.config.yml
+++ b/server/views/components/author/index.config.yml
@@ -4,7 +4,6 @@ context:
   name: Daniel Regan
   twitterHandle: funnytimeofyear
   image: https://dummyimage.com/400x400
-  description: <p>Daniel Regan is a photographer and artist based in London, working on themes of mental health and wellbeing. He is the current director of the <a href="https://freespacegallery.org/">Free Space Gallery</a> and Kentish Town Improvement Fund, a charity providing arts activities and therapies across two NHS sites in north London.</p>
 variants:
   - name: default
     label: Border Bottom
@@ -15,3 +14,4 @@ variants:
     context:
       modifiers:
         - border-left
+      description: <p>Daniel Regan is a photographer and artist based in London, working on themes of mental health and wellbeing. He is the current director of the <a href="https://freespacegallery.org/">Free Space Gallery</a> and Kentish Town Improvement Fund, a charity providing arts activities and therapies across two NHS sites in north London.</p>


### PR DESCRIPTION
## What is this PR trying to achieve?
Removing the copy beneath the author in the 'border-bottom' variant (which appears above the article) in Cardigan, so that it is a better representation of how it will display in reality (see #257).

## What does it look like?
![screen shot 2017-01-20 at 13 50 15](https://cloud.githubusercontent.com/assets/1394592/22151763/651fa060-df17-11e6-9379-28101c4277dc.png)