### PR TITLE
add script to be included on v1 for perf testing

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -43,4 +43,14 @@ export const explore = async(ctx) => {
 export const index = (ctx) => ctx.render('pages/index', {
   pageConfig: new PageConfig({inSection: 'index'})
 });
+
 export const healthcheck = (ctx) => ctx.body = 'ok';
+
+export const performanceTest = (ctx) => {
+  ctx.type = 'application/javascript';
+  ctx.body = `
+    if (console) {
+      console.log('Incoming from next.wellcomecollection.org');
+    }
+  `;
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,5 +1,5 @@
 import Router from 'koa-router';
-import {index, article, artefact, explore, healthcheck} from '../controllers';
+import {index, article, artefact, explore, healthcheck, performanceTest} from '../controllers';
 
 const r = new Router();
 
@@ -8,5 +8,6 @@ r.get('/healthcheck', healthcheck);
 r.get('/explore', explore);
 r.get('/articles/:id', article);
 r.get('/artefacts/:id*', artefact);
+r.get('/performance-test.js', performanceTest);
 
 export const router = r.middleware();


### PR DESCRIPTION
## What is this PR trying to achieve?
[We are adding a script to the v1 site](https://github.com/wellcometrust/collection/pull/254) that will link to this file.

Given that it's generated dynamically, the point would be to do the heavy lifting of rendering a page (API calls etc), but then just return a boring JS file. This way we can see how our infrastructure holds up against real time users metrics, but also not vacuum up their bandwidth.

## What does it look like?
Nothing to see here.

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [ ] ~~No javascript - Have you checked the component with javascript disabled~~
- [ ] ~~A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?~~
