### PR TITLE
Prevent >100% width image

### DIFF
--- a/client/scss/components/_figure.scss
+++ b/client/scss/components/_figure.scss
@@ -85,5 +85,6 @@
     width: auto;
     margin-left: auto;
     margin-right: auto;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Limits the max-width of the hero-image to 100%, preventing horizontal scrollbars. Fixes #373.
