### PR TITLE
infer weight of image from wordpress align

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -60,8 +60,17 @@ export function convertWpImage(node) {
 
   if (isWpImage) {
     const picture = getImageFromWpNode(node);
+    const className = getAttrVal(node.attrs, 'class');
+    const weights = {
+      alignright: 'supporting',
+      aligncenter: 'standalone'
+    };
+
+    const weightKey = Object.keys(weights).find(wpClassName => className.indexOf(wpClassName) !== -1);
+    const weight = weightKey ? weights[weightKey] : 'default';
 
     return new BodyPart({
+      weight,
       type: 'picture',
       value: picture
     });


### PR DESCRIPTION
## What is this PR trying to achieve?
We are going to infer weight of an image dependant on the alignment within the WordPress CMS.
It's a hack, but it's simple for editors, and simple to have the same inference when we migrate.

`right => supporting content`
`center => standalone content`

## What does it look like?
![supporting-standalone](https://cloud.githubusercontent.com/assets/31692/22259414/33b168a8-e25d-11e6-8b01-5e79fe925a35.png)


## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [X] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?