### PR TITLE
Unbreak footer grid classes (add quote marks)

### DIFF
--- a/server/views/components/footer/index.njk
+++ b/server/views/components/footer/index.njk
@@ -1,10 +1,10 @@
 <div class="footer row row--dark-black">
   <div class="container">
     <div class="grid">
-      <div class={{ {s:4, m:4, l:3} | gridClasses }}">
+      <div class="{{ {s:4, m:4, l:3} | gridClasses }}">
         {% component 'footer-nav', {navLinks: navLinks} %}
       </div>
-      <div class={{ {s:4, m:4, l:3} | gridClasses }}">
+      <div class="{{ {s:4, m:4, l:3} | gridClasses }}">
         <h3 class="footer__heading">Finding us:</h3>
         {% component 'find-us' %}
       </div>


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding missing quotes to fix the footer grid. Fixes #389.
## What does it look like?
Before:
![screen shot 2017-01-25 at 12 27 58](https://cloud.githubusercontent.com/assets/1394592/22290710/70f5f1f0-e2fa-11e6-8046-bfbcf74d75a0.png)
After:
![screen shot 2017-01-25 at 12 33 29](https://cloud.githubusercontent.com/assets/1394592/22290723/82c1c2ec-e2fa-11e6-938b-89ffe3430157.png)