### PR TITLE
use left instead of center align to infer standalone

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -63,7 +63,7 @@ export function convertWpImage(node) {
     const className = getAttrVal(node.attrs, 'class');
     const weights = {
       alignright: 'supporting',
-      aligncenter: 'standalone'
+      alignleft: 'standalone'
     };
 
     const weightKey = Object.keys(weights).find(wpClassName => className.indexOf(wpClassName) !== -1);


### PR DESCRIPTION
## What is this PR trying to achieve?
Turns out centre align is used a lot for image that are portrait.
I cannot find instances of left (which would basically mean nothing), or right aligned images.

## What does it look like?
As per #381 

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?