### PR TITLE
send HSTS header across to enforce SSL

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -3,9 +3,12 @@ import config from './config';
 import serve from 'koa-static';
 import {router} from './routes';
 import render from './view/render';
+import {enforceSSL} from './middleware/enforce-ssl';
+import enforceHttps from 'koa-sslify';
 
 const app = new Koa();
 
+app.use(enforceSSL);
 app.use(serve(config.static.path));
 app.use(serve(config.favicon.path));
 app.use(render(config.views.path));

--- a/server/app.js
+++ b/server/app.js
@@ -4,7 +4,6 @@ import serve from 'koa-static';
 import {router} from './routes';
 import render from './view/render';
 import {enforceSSL} from './middleware/enforce-ssl';
-import enforceHttps from 'koa-sslify';
 
 const app = new Koa();
 

--- a/server/middleware/enforce-ssl.js
+++ b/server/middleware/enforce-ssl.js
@@ -1,0 +1,5 @@
+export function enforceSSL(ctx, next) {
+  // TODO: Bump the max-age way higher - this is just for initial testing.
+  ctx.response.set('Strict-Transport-Security', 'max-age=60');
+  return next();
+}


### PR DESCRIPTION
## What is this PR trying to achieve?
Might fix #317 

Adds the [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header over. We're sending a very lax `max-age` across to allow for some wriggle room if we've got something that __needs__ to be sent over `http`, but it'd be good to change that as soon as.

## What does it look like?
![Boya](https://media.giphy.com/media/bWqZQ2qlXV0Gc/giphy.gif)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
