### PR TITLE
Fix page-description spacings

### DIFF
--- a/client/scss/components/_page_description.scss
+++ b/client/scss/components/_page_description.scss
@@ -2,6 +2,10 @@
 
 .page-description {
   margin-bottom: $vertical-space-unit;
+
+  @include respond-to('large') {
+    margin-bottom: 3 * $vertical-space-unit;
+  }
 }
 
 .page-description--hidden {
@@ -31,7 +35,7 @@
 }
 
 .page-description__row {
-  margin-bottom: 0.6em;
+  margin-bottom: 0.3em;
 
   // This aligns the grey lead bar with text baseline
   &:before {
@@ -47,6 +51,10 @@
 
 .page-description__container {
   padding-top: $vertical-space-unit;
+
+  @include respond-to('large') {
+    padding-top: 3 * $vertical-space-unit;
+  }
 }
 
 .page-description__intro {
@@ -61,6 +69,11 @@
   display: flex;
   align-items: center;
   color: color('accessible-grey-1');
+  margin-bottom: 0.3rem;
+
+  @include respond-to('large') {
+    margin-bottom: -1.2rem;
+  }
 
   .icon {
     margin-right: 0.5em;


### PR DESCRIPTION
## What is this PR trying to achieve?
Correcting the spacings in the page-description – doing [pixel manager's bidding](https://github.com/wellcometrust/wellcomecollection.org/issues/366#issue-202162846). Closes #366.

## What does it look like?
With date:
![screen shot 2017-01-25 at 17 47 44](https://cloud.githubusercontent.com/assets/1394592/22302378/78b1bb28-e326-11e6-8bec-0294c381d04d.png)

Without date:
![screen shot 2017-01-25 at 17 46 48](https://cloud.githubusercontent.com/assets/1394592/22302382/7f74d558-e326-11e6-9744-18012982b8a2.png)