### PR TITLE
find images wrapped in a tags

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -56,10 +56,7 @@ function convertWpStandfirst(node) {
 }
 
 export function convertWpImage(node) {
-  const isWpImage = (
-    (node.attrs && node.attrs.find(attr => attr.name === 'data-shortcode' && attr.value === 'caption'))
-    || (node.childNodes && node.childNodes[0] && node.childNodes[0].nodeName === 'img')
-  );
+  const isWpImage = isCaption(node) || isImg(node);
 
   if (isWpImage) {
     const picture = getImageFromWpNode(node);
@@ -80,6 +77,17 @@ export function convertWpImage(node) {
   } else {
     return node;
   }
+}
+
+function isCaption(node) {
+  return node.attrs && node.attrs.find(attr => attr.name === 'data-shortcode' && attr.value === 'caption');
+}
+
+function isImg(node) {
+  const mayBeWrapperA = node.childNodes.find(node => node.nodeName === 'a');
+  const parentNode = mayBeWrapperA || node;
+
+  return parentNode.childNodes && parentNode.childNodes[0] && parentNode.childNodes[0].nodeName === 'img';
 }
 
 export function convertWpVideo(node) {


### PR DESCRIPTION
## What is this PR trying to achieve?
Fixes #369 

Turns out you can have:
* images
* images wrapped in `a`s
* images with captions
* images with captions in `a`s

This caters for all of those. There might be something more elegant, but the quicker we can get rid of the need for these parsers, the better.

## What does it look like?
![imagecaptionlinkd](https://cloud.githubusercontent.com/assets/31692/22302491/f57e18c2-e326-11e6-8364-1fa850d76666.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?