### PR TITLE
Scroll touch

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -5,6 +5,7 @@
 @import 'utilities/variables';
 @import 'utilities/mixins';
 @import 'utilities/functions';
+@import 'utilities/classes';
 
 // Base
 @import 'base/fonts';

--- a/client/scss/base/_container.scss
+++ b/client/scss/base/_container.scss
@@ -15,5 +15,6 @@
 
 .container--scroll {
   overflow: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 0;
 }

--- a/client/scss/base/_container.scss
+++ b/client/scss/base/_container.scss
@@ -15,6 +15,5 @@
 
 .container--scroll {
   overflow: auto;
-  -webkit-overflow-scrolling: touch;
   padding: 0;
 }

--- a/client/scss/utilities/_classes.scss
+++ b/client/scss/utilities/_classes.scss
@@ -1,3 +1,5 @@
-.touch-scroll { // Adds momentum scrolling to iOS
+// Adds momentum scrolling to iOS
+// TODO: consider removing if/when scroll snapping is implemented
+.touch-scroll {
   -webkit-overflow-scrolling: touch;
 }

--- a/client/scss/utilities/_classes.scss
+++ b/client/scss/utilities/_classes.scss
@@ -1,0 +1,3 @@
+.touch-scroll { // Adds momentum scrolling to iOS
+  -webkit-overflow-scrolling: touch;
+}

--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -4,7 +4,7 @@
       <h2>{{ bodyPart.value.name }}</h2>
     {% endif %}
     <div class="body-part
-                {{- ' body-part--full-width js-full-width' if bodyPart.weight === 'standalone'  -}}
+                {{- ' body-part--full-width touch-scroll js-full-width' if bodyPart.weight === 'standalone'  -}}
                 {{- ' body-part--sticky js-sticky' if bodyPart.weight === 'supporting'  -}}">
       {% if bodyPart.type === 'standfirst' %}
         {% component 'standfirst', { body: bodyPart.value } %}

--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -4,7 +4,7 @@
       <h2>{{ bodyPart.value.name }}</h2>
     {% endif %}
     <div class="body-part
-                {{- ' body-part--full-width touch-scroll js-full-width' if bodyPart.weight === 'standalone'  -}}
+                {{- ' body-part--full-width js-full-width' if bodyPart.weight === 'standalone'  -}}
                 {{- ' body-part--sticky js-sticky' if bodyPart.weight === 'supporting'  -}}">
       {% if bodyPart.type === 'standfirst' %}
         {% component 'standfirst', { body: bodyPart.value } %}
@@ -17,7 +17,7 @@
       {% elif bodyPart.type === 'interview' %}
         {% component 'interview', { interview: bodyPart.value } %}
       {% elif bodyPart.type === 'imageGallery' %}
-        <div class="body-part__scroller">
+        <div class="body-part__scroller touch-scroll">
           <div class="body-part__scroller-content">
             {% component 'image-gallery', { imageGallery: bodyPart.value } %}
           </div>

--- a/server/views/templates/explore-landing.njk
+++ b/server/views/templates/explore-landing.njk
@@ -15,7 +15,7 @@
   </div>
 
   <div class="row row--cream row--no-padding">
-    <div class="container container--scroll">
+    <div class="container container--scroll touch-scroll">
       <div class="grid grid--dividers grid--featured">
         <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
           {% component 'promo', {image: promo.image, meta: promo.meta, title: promo.title, url: promo.url, copy: promo.copy } %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Containers with overflowing content don't, by default, have momentum scrolling (the kind you _do_ get when scrolling down the body of a page) by default on iOS.

This PR adds a utility class – `touch-scroll` – to enable that behaviour for use on our horizontal scrolling containers.