### PR TITLE
add title to pageConfig

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -7,7 +7,10 @@ export const artefact = async(ctx, next) => {
   const artefact = await getArtefact(id);
 
   return artefact ? ctx.render('pages/article', {
-    pageConfig: new PageConfig({inSection: 'explore'}),
+    pageConfig: new PageConfig({
+      title: artefact.title,
+      inSection: 'explore'
+    }),
     article: artefact
   }) : next();
 };
@@ -23,7 +26,10 @@ export const article = async(ctx, next) => {
         return article;
       } else {
         return ctx.render('pages/article', {
-          pageConfig: new PageConfig({inSection: 'explore'}),
+          pageConfig: new PageConfig({
+            title: article.headline,
+            inSection: 'explore'
+          }),
           article: article
         });
       }
@@ -35,7 +41,10 @@ export const article = async(ctx, next) => {
 export const explore = async(ctx) => {
   const wpPosts = await getPosts();
   return ctx.render('pages/explore', {
-    pageConfig: new PageConfig({inSection: 'explore'}),
+    pageConfig: new PageConfig({
+      title: 'Explore',
+      inSection: 'explore'
+    }),
     wpPosts
   });
 };

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -2,6 +2,7 @@ import {Record} from 'immutable';
 import {defaultPlacesOpeningHours} from './opening-hours';
 
 export const PageConfig = Record({
+  title: null,
   inSection: null,
   openingHours: defaultPlacesOpeningHours
 });

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <title>Wellcome Collection</title>
+    <title>{{ pageConfig.title + ' | ' if pageConfig.title }}Wellcome Collection</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     {% include "partials/css-head.njk" %}
     <link rel="stylesheet" href="/assets/css/application.css" />


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding titles to pages.

I thought about adding it to the template in a `{% block title %}{% endblock %}` - but that felt like it wasn't the templates job.

## What does it look like?
![screen shot 2017-01-26 at 18 45 49](https://cloud.githubusercontent.com/assets/31692/22345347/b7299836-e3f7-11e6-9eed-9f88ae635efe.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?
