### PR TITLE
Decode HTML entities from WordPress

### DIFF
--- a/server/model/article.js
+++ b/server/model/article.js
@@ -1,3 +1,4 @@
+import entities from 'entities';
 import {Person} from './person';
 import {getWpFeaturedImage} from './media';
 import {bodyParser} from '../util/body-parser';
@@ -27,7 +28,7 @@ export default class Article {
         image: json.author.avatar_URL,
         sameAs: [{ wordpress: json.author.URL }]
       });
-      return new Article(json.title, json.content, mainImage, [mainImage], author, [mainImage]);
+      return new Article(entities.decode(json.title), json.content, mainImage, [mainImage], author, [mainImage]);
   }
 }
 

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,7 @@
     "ava": "^0.17.0",
     "babel-cli": "^6.18.0",
     "babel-preset-env": "^1.1.8",
+    "entities": "^1.1.1",
     "immutable": "^3.8.1",
     "koa": "^2.0.0",
     "koa-router": "^7.1.0",

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -1,5 +1,6 @@
 import parse from 'parse5';
 import url from 'url';
+import entities from 'entities';
 import {Record} from 'immutable';
 import {ImageGallery} from '../model/image-gallery';
 import {Picture} from '../model/picture';
@@ -14,7 +15,7 @@ const BodyPart = Record({
 
 export function bodyParser(bodyText) {
   const fragment = getFragment(bodyText);
-  const preCleaned = cleanNodes(fragment.childNodes, [removeEmptyTextNodes]);
+  const preCleaned = cleanNodes(fragment.childNodes, [removeEmptyTextNodes, decodeHtmlEntities]);
   const bodyParts = explodeIntoBodyParts(preCleaned);
 
   return bodyParts;
@@ -46,6 +47,19 @@ export function explodeIntoBodyParts(nodes) {
 
 export function removeEmptyTextNodes(nodes) {
   return nodes.filter(node => !isEmptyText(node));
+}
+
+function decodeHtmlEntities(nodes) {
+  return nodes.map(node => {
+    if (node.nodeName === '#text') {
+      const decodedVal = entities.decodeHTML(node.value);
+      // Bah, more mutation - I wish I had a copy.
+      node.value = decodedVal;
+      return node;
+    } else {
+      return node;
+    }
+  });
 }
 
 function convertWpStandfirst(node) {


### PR DESCRIPTION
## What is this PR trying to achieve?
WordPress sends over HTML as entities.
As we're rendering as UTF-8 it's not really necessary.

An example is here:
https://next.wellcomecollection.org/articles/no-photography

## What does it look like?
![htmlentities](https://cloud.githubusercontent.com/assets/31692/22419716/b1bd42ee-e6d6-11e6-8dc4-bbb5dd1418b1.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?
