### PR TITLE
Add speedtracker api call to circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,3 +15,4 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push wellcome/wellcomecollection:$CIRCLE_BUILD_NUM
       - ./build-cardigan.sh
+      - curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/master/default?key=$SPEEDTRACKER_KEY

--- a/circle.yml
+++ b/circle.yml
@@ -15,4 +15,8 @@ deployment:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push wellcome/wellcomecollection:$CIRCLE_BUILD_NUM
       - ./build-cardigan.sh
-      - curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/master/default?key=$SPEEDTRACKER_KEY
+      - curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/master/v1-homepage?key=$SPEEDTRACKER_KEY
+      - curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/master/v1-article?key=$SPEEDTRACKER_KEY
+      - curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/master/v2-homepage?key=$SPEEDTRACKER_KEY
+      - curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/master/v2-article?key=$SPEEDTRACKER_KEY
+      - curl https://api.speedtracker.org/v1/test/wellcometrust/speedtracker/master/wp-article?key=$SPEEDTRACKER_KEY


### PR DESCRIPTION
## What is this PR trying to achieve?
Run a speedtracker test on merge with master.

This isn't perfect as it will actually track the last deploy's performance, but it will at least have it automated. It will be easier when we're deploying master automatically.

