### PR TITLE
Remove babel-polyfill

### DIFF
--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,3 +1,4 @@
-{
-  "presets": [ "es2015" ]
+{ 
+  "presets": [ "es2015" ],
+  "plugins": ["transform-object-assign"] 
 }

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -1,4 +1,3 @@
 { 
-  "presets": [ "es2015" ],
-  "plugins": ["transform-object-assign"] 
+  "presets": [ "es2015" ]
 }

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -1,3 +1,5 @@
+import 'core-js/fn/object/assign';
+
 import {message} from './wellcome';
 import { nodeList } from './util';
 import headerBurger from './components/header/burger';

--- a/client/js/util.js
+++ b/client/js/util.js
@@ -9,7 +9,7 @@ const KEYS = {
 };
 
 const nodeList = (nl) => {
-  return [...nl];
+  return Array.prototype.slice.call(nl || []);
 };
 
 const setPropertyPrefixed = (el, property, value) => {

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,6 @@
   "devDependencies": {
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
-    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.16.0",
     "eslint-config-wellcome": "^1.0.8",
     "glob": "^7.1.0",
@@ -35,6 +34,7 @@
   },
   "dependencies": {
     "cookie-cutter": "^0.2.0",
+    "core-js": "^2.4.1",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1"
   }

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
-    "babel-polyfill": "^6.20.0",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.16.0",
     "eslint-config-wellcome": "^1.0.8",
     "glob": "^7.1.0",

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  entry: ['babel-polyfill', './js/app.js'],
+  entry: './js/app.js',
   output: {
     filename: 'app.js'
   },


### PR DESCRIPTION
This reverts commit dcbef7fbc5ac0373a8853017242406430860b297.

## What is this PR trying to achieve?
`babel-polyfill` adds about 250kb onto the JS pack.
Let's not do that - I've reverted out the change, and if we want to use specific polyfils, let's make sure we keep an eye on the monitoring (or better yet, setup alerting) and use [`core-js`](https://github.com/zloirock/core-js) if we need to (which is what babel-polyfill uses anyway).

## What does it look like?
💨 

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
