### PR TITLE
Lazyloading

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -9,7 +9,9 @@ import wobblyEdge from './components/wobbly-edge';
 import cookieNotification from './components/cookie-notification';
 import preventOverlapping from './components/prevent-overlapping';
 import makeSticky from './components/make-sticky.js';
+import lazySizes from 'lazySizes';
 message();
+lazySizes.init();
 
 const init = () => {
   const cookieEl = document.getElementById('cookie-notification');

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -1,3 +1,4 @@
+/* global Raven */
 import 'core-js/fn/object/assign';
 
 import {message} from './wellcome';
@@ -49,11 +50,10 @@ const init = () => {
   }
 };
 
-
 function initWithRaven() {
   try {
     init();
-  } catch(e) {
+  } catch (e) {
     Raven.captureException(e);
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "cookie-cutter": "^0.2.0",
     "core-js": "^2.4.1",
+    "lazysizes": "^3.0.0-rc3",
     "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1"
   }

--- a/client/scss/components/_wobbly_edge.scss
+++ b/client/scss/components/_wobbly_edge.scss
@@ -5,6 +5,11 @@
   top: 2px;
   z-index: 2;
   transition: clip-path 2000ms ease-in-out;
+  display: none;
+
+  .enhanced & {
+    display: block;
+  }
 
   @supports not ((clip-path: polygon(0 0)) or (-webkit-clip-path: polygon(0 0))) {
     display: none;

--- a/server/views/components/captioned-image/index.njk
+++ b/server/views/components/captioned-image/index.njk
@@ -2,9 +2,9 @@
   <div class="captioned-image__image-container">
   {% set sizes = image | getImageSizesFor %}
   {% set comma = joiner() %}
-  <img class="image"
-        src="{{ image.contentUrl }}?w={{ sizes[3] }}"
-        srcset="
+  <img class="image lazyload"
+        src="{{ image.contentUrl }}?w={{ sizes[0] }}"
+        data-srcset="
         {%- for size in sizes -%}
           {{ comma() }}{{ image.contentUrl }}?w={{ size }} {{ size }}w
         {%- endfor %}"


### PR DESCRIPTION
## What is this PR trying to achieve?

Adds lazyloading to images, so the initial page weight is reduced and high quality images are only loaded if the user sees them.

## What does it look like?

Same but reduces initial page load (most significant on wide screens).

Before:
![pre_lazyload](https://cloud.githubusercontent.com/assets/6051896/22432397/ad6f0c28-e70c-11e6-93d8-4af23c454f44.png)

After:
![post_lazyload](https://cloud.githubusercontent.com/assets/6051896/22432403/b198bfe2-e70c-11e6-88e2-60830b988f02.png)

## For interface components
- [X] Browser testing - Have you checked the component in our supported browsers
- [X] No javascript - Have you checked the component with javascript disabled
~~- [ ] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?~~
