### PR TITLE
Add unwrapFromEm method to fix standfirst style

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -74,10 +74,21 @@ function decodeHtmlEntities(nodes) {
   });
 }
 
+
+function unwrapFromEm(node) {
+  const firstChild = node.childNodes[0];
+
+  if (firstChild.nodeName === 'em') {
+    node.childNodes = firstChild.childNodes;
+  }
+
+  return node;
+}
+
 function convertWpStandfirst(node) {
   return new BodyPart({
     type: 'standfirst',
-    value: serializeAndCleanNode(node)
+    value: serializeAndCleanNode(unwrapFromEm(node))
   });
 }
 
@@ -92,7 +103,7 @@ export function convertWpHeading(node) {
         level: headingMatch[1],
         value: serializeAndCleanNode(node.childNodes[0])
       })
-    })
+    });
   } else {
     return node;
   }


### PR DESCRIPTION
## What is this PR trying to achieve?
Removing the `em` from the WP inferred standfirst (i.e. first paragraph).

## What does it look like?
![screen shot 2017-02-02 at 17 01 20](https://cloud.githubusercontent.com/assets/1394592/22559567/686578e2-e969-11e6-8493-1a638faacca0.png)