### PR TITLE
align new site notice correctly

### DIFF
--- a/server/views/components/new-site-notice/index.njk
+++ b/server/views/components/new-site-notice/index.njk
@@ -1,7 +1,7 @@
 <div class="row row--yellow row--text-bar new-site-notice">
   <div class="container">
     <div class="grid">
-      <div class="{{ {shiftL: 1} | gridClasses }}">
+      <div class="{{ {} | gridClasses }}">
         <div class="new-site-notice__inner">
           <p class="new-site-notice__msg">
             <span class="new-site-notice__device-ico">{% icon 'other/devices' %}</span>


### PR DESCRIPTION
## What is this PR trying to achieve?
Fixes #484 

## What does it look like?
![newsitenoticealign](https://cloud.githubusercontent.com/assets/31692/22784506/3c5755d6-eec8-11e6-9191-8c9cff024c4b.png)
