### PR TITLE
use proper vertical spacing (6px) on rows

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -1,8 +1,11 @@
 //* @define row
 
 .row {
-  padding-top: $vertical-space-unit;
-  padding-bottom: $vertical-space-unit;
+  padding-top: $v-spacing-unit * 5;
+
+  @include respond-to('large') {
+    padding-top: $v-spacing-unit * 10;
+  }
 }
 
 .row--dark-black {
@@ -24,6 +27,11 @@
 
 .row--no-bottom-padding {
   padding-bottom: 0;
+}
+
+.row--text-bar {
+  padding-top: $v-spacing-unit * 3;
+  padding-bottom: $v-spacing-unit * 3;
 }
 
 .row--lead {
@@ -87,4 +95,8 @@
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgMTAwMCAxMDAiPjxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik0wLDFsMTQyLjgsNTguMmMwLDAsNzQuNi0zNS43LDE2Ny00NC41YzAsMCwyMDEuMSw0Mi45LDI2MS45LDY4LjJTODgyLjksMTUsODgyLjksMTVMMTAwMCwxSDB6Ii8+PC9zdmc+');
     background-size: cover;
   }
+}
+
+.row--extra-top-padding {
+  padding-top: $v-spacing-unit * 10;
 }

--- a/client/scss/components/_new_site_notice.scss
+++ b/client/scss/components/_new_site_notice.scss
@@ -37,12 +37,14 @@ $mega-w-size: 400px;
 
   @include respond-to('notification-break') {
     display: flex;
+    align-items: center;
   }
 }
 
 .new-site-notice__msg {
-  margin: 0;
   display: flex;
+  align-items: center;
+  margin: 0;
   margin-right: 1rem;
   margin-bottom: 0.8em;
 

--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -240,7 +240,7 @@ $grid-config: (
   )
 );
 
-$vertical-space-unit: 15px;
+$vertical-space-unit: 15px; // Deprecated - please use a multiple of $v-spacing-unit
 $v-spacing-unit: 6px;
 $article-top-space: 2 * $vertical-space-unit;
 $border-radius-unit: 6px;

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -11,9 +11,7 @@
       </div>
     </div>
     <div class="row__wobbly-background"></div>
-  </div>
 
-  <div class="row row--cream row--no-padding">
     <div class="container container--scroll touch-scroll">
       <div class="grid grid--dividers grid--featured">
         {% for promo in second3Promos.toJS() %}


### PR DESCRIPTION
## What is this PR trying to achieve?
After talking to @Norvard it seems we should be using vertical spacing that is multiples of 6, specifically 60 for desktop, 30 for mobile.

See #496 as a solution.

## What does it look like?
## Desktop
![newrowspacing](https://cloud.githubusercontent.com/assets/31692/22789876/596ff236-eedc-11e6-8bde-37d41fee194d.png)

## Mobile
![rowspacingmobile](https://cloud.githubusercontent.com/assets/31692/22790197/4cb8bfa4-eedd-11e6-91c0-cca6f310c44a.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?

## Have the following been considered/are they needed?
- [x] Spoken to the right people? @Norvard 
