### PR TITLE
use autho lookup rather than WP author

### DIFF
--- a/server/data/people.js
+++ b/server/data/people.js
@@ -1,0 +1,9 @@
+// @flow
+import {type Person} from '../model/person';
+
+export const russellDornan: Person = {
+  givenName: 'Russell',
+  familyName: 'Dornan',
+  name: 'Russell Dornan',
+  image: 'https://0.gravatar.com/avatar/9da762e9919b09b8d0c0b3f006c354f2?s=96&d=identicon&r=G'
+};

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -4,6 +4,7 @@ import {type Person} from './person';
 import {type Picture} from './picture';
 import {getWpFeaturedImage} from './media';
 import {bodyParser} from '../util/body-parser';
+import {authorMap} from '../services/author-lookup';
 
 export type BodyPart = {};
 
@@ -20,7 +21,7 @@ export type Article = {|
   thumbnail: Picture;
   articleBody: string;
   associatedMedia: Array<Picture>;
-  author: Person;
+  author?: Person; // TODO: Make this manditory once we know al the authors
   bodyParts: Array<BodyPart>;
 |}
 
@@ -39,13 +40,7 @@ export class ArticleFactory {
       height: wpThumbnail.height
     };
 
-    const author: Person = {
-      givenName: json.author.first_name,
-      familyName: json.author.last_name,
-      name: `${json.author.first_name} ${json.author.last_name}`,
-      image: json.author.avatar_URL,
-      sameAs: [{ wordpress: json.author.URL }]
-    };
+    const author = authorMap[json.slug];
 
     const bodyParts = bodyParser(articleBody);
     const standfirst = bodyParts.find(part => part.type === 'standfirst');

--- a/server/model/person.js
+++ b/server/model/person.js
@@ -1,10 +1,10 @@
 // @flow
 export type Person = {|
   givenName: string;
-  familyName: null;
+  familyName: string;
   name?: string;
   image?: string; // TODO: Make this Picture
-  sameAs: Array<any>; //TODO: Make this Array<something>
+  sameAs?: Array<any>; //TODO: Make this Array<something>
 |}
 
 export function createPerson(data: Person) {

--- a/server/services/author-lookup.js
+++ b/server/services/author-lookup.js
@@ -1,0 +1,7 @@
+// @flow
+import {type Person} from '../model/person';
+import * as people from '../data/people';
+
+export const authorMap: { [key: string]: Person } = {
+  'oops-i-wrote-a-britney-blog-post': people.russellDornan
+};


### PR DESCRIPTION
## What is this PR trying to achieve?
Authors will have to be from a lookup somewhere.
At the moment this will be manual - we will be having someone help assign articles to authors.

## What does it look like?
# Version No author
![author-nonono](https://cloud.githubusercontent.com/assets/31692/22790791/43ae6f06-eedf-11e6-9284-b8583444e8e9.png)

# Version Britney
![author-yesyesyes](https://cloud.githubusercontent.com/assets/31692/22790794/45fbc98e-eedf-11e6-9be1-1b869b7d12ad.png)

- [ ] Spoken to the right people? @jennpb 
