### PR TITLE
Preview

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -108,22 +108,17 @@ export const explosion = (ctx) => {
 
 export const preview = async(ctx) => {
   const id = ctx.params.id;
-  const format = ctx.request.query.format;
-  const article = await getArticle(id);
+  const authToken = ctx.cookies.get('WC_wpAuthToken');
+  const article = await getArticle(id, authToken);
 
   if (article) {
-    if (format === 'json') {
-      ctx.body = article;
-      return article;
-    } else {
-      return ctx.render('pages/article', {
-        pageConfig: createPageConfig({
-          title: article.headline,
-          inSection: 'explore'
-        }),
-        article: article
-      });
-    }
+    return ctx.render('pages/article', {
+      pageConfig: createPageConfig({
+        title: article.headline,
+        inSection: 'explore'
+      }),
+      article: article
+    });
   } else {
     return next();
   }

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -4,9 +4,9 @@ import {createPageConfig} from '../model/page-config';
 import {getPosts, getArticle} from '../services/wordpress';
 
 export const article = async(ctx, next) => {
-    const id = ctx.params.id;
+    const slug = ctx.params.slug;
     const format = ctx.request.query.format;
-    const article = await getArticle(id);
+    const article = await getArticle(`slug:${slug}`);
 
     if (article) {
       if (format === 'json') {
@@ -77,9 +77,9 @@ export const index = (ctx) => ctx.render('pages/index', {
 export const healthcheck = (ctx) => ctx.body = 'ok';
 
 export const performanceTest = async(ctx, next) => {
-  const articleId = 'a-drop-in-the-ocean-daniel-regan';
+  const slug = 'a-drop-in-the-ocean-daniel-regan';
   const startTime = process.hrtime();
-  const article = await getArticle(articleId);
+  const article = await getArticle(`slug:${slug}`);
 
   ctx.render('pages/article', {
     pageConfig: createPageConfig({inSection: 'explore'}),
@@ -104,4 +104,27 @@ export const explosion = (ctx) => {
   const message = `Forced explosion of type ${errorCode}`;
   ctx.status = parseInt(errorCode, 10);
   ctx.body = { errorCode, message };
+};
+
+export const preview = async(ctx) => {
+  const id = ctx.params.id;
+  const format = ctx.request.query.format;
+  const article = await getArticle(id);
+
+  if (article) {
+    if (format === 'json') {
+      ctx.body = article;
+      return article;
+    } else {
+      return ctx.render('pages/article', {
+        pageConfig: createPageConfig({
+          title: article.headline,
+          inSection: 'explore'
+        }),
+        article: article
+      });
+    }
+  } else {
+    return next();
+  }
 };

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,8 +8,9 @@ r.get('/', index);
 r.get('/healthcheck', healthcheck);
 r.get('/explore', explore);
 r.get('/articles', articles);
-r.get('/articles/:id', article);
+r.get('/articles/:slug', article);
 r.get('/performance-test.js', performanceTest);
 r.get('/explosion/:errorCode', explosion);
+r.get('/preview/:id', explosion);
 
 export const router = r.middleware();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -11,6 +11,6 @@ r.get('/articles', articles);
 r.get('/articles/:slug', article);
 r.get('/performance-test.js', performanceTest);
 r.get('/explosion/:errorCode', explosion);
-r.get('/preview/:id', explosion);
+r.get('/articles/preview/:id', explosion);
 
 export const router = r.middleware();

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,6 +1,6 @@
 import Router from 'koa-router';
 import {index, article, articles, explore, healthcheck, performanceTest,
-        explosion} from '../controllers';
+        explosion, preview} from '../controllers';
 
 const r = new Router();
 
@@ -11,6 +11,6 @@ r.get('/articles', articles);
 r.get('/articles/:slug', article);
 r.get('/performance-test.js', performanceTest);
 r.get('/explosion/:errorCode', explosion);
-r.get('/articles/preview/:id', explosion);
+r.get('/articles/preview/:id', preview);
 
 export const router = r.middleware();

--- a/server/services/wordpress.js
+++ b/server/services/wordpress.js
@@ -31,7 +31,7 @@ export async function getPosts(size: number = 20): Promise<PostsResponse> {
 }
 
 export async function getArticle(id: string) {
-  const uri = `${baseUri}/posts/slug:${id}`;
+  const uri = `${baseUri}/posts/${id}`;
   const response = await request(uri);
   const valid = response.type === 'application/json' && response.status === 200;
 

--- a/server/services/wordpress.js
+++ b/server/services/wordpress.js
@@ -30,9 +30,9 @@ export async function getPosts(size: number = 20): Promise<PostsResponse> {
   };
 }
 
-export async function getArticle(id: string) {
+export async function getArticle(id: string, authToken: ?string = null) {
   const uri = `${baseUri}/posts/${id}`;
-  const response = await request(uri);
+  const response = authToken ? await request(uri).set('Authorization', `Bearer ${authToken}`) : await request(uri);
   const valid = response.type === 'application/json' && response.status === 200;
 
   if (valid) {


### PR DESCRIPTION
## What is this PR trying to achieve?
If we have an auth token - send it across.
This will be used for accessing preview content from Wordpress.

The other option was to add Wordpress oAuth2 - but then we would still have to store the app key and secret. 

This will be thrown away so pragmatism wins.