### PR TITLE
Promo images

### DIFF
--- a/client/.stylelintrc
+++ b/client/.stylelintrc
@@ -40,6 +40,8 @@
       },
       "ignoreSelectors": [
         ".*\\.icon*",
+        ".*\\.captioned-image*",
+        ".*\\.image*",
         ".*\\.is-.*",
         ".*\\.enhanced.*",
         ".*\\.lt-ie.*"

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -1,3 +1,4 @@
+//* @define captioned-image
 .captioned-image {
   margin: 0 0 $vertical-space-unit;
 

--- a/client/scss/components/_image_gallery.scss
+++ b/client/scss/components/_image_gallery.scss
@@ -1,3 +1,4 @@
+//* @define image-gallery
 .image-gallery {
   width: 100%;
   display: flex;

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -20,11 +20,22 @@
     margin-bottom: $vertical-space-unit;
   }
 
+  &:hover .image,
+  &:focus .image {
+    transform: scale(1.2);
+  }
+
+  .image {
+    display: block;
+    width: 100%;
+    transition: transform 400ms ease;
+  }
+
   .icon {
     vertical-align: middle;
     margin-right: map-get($gutter-width, 'small')/2;
 
-      @include respond-to('medium') {
+    @include respond-to('medium') {
       margin-right: map-get($gutter-width, 'medium')/2;
     }
 
@@ -53,17 +64,6 @@
     order: 1;
     width: percentage(2 / 3);
     margin-bottom: 0;
-  }
-}
-
-.promo__image {
-  display: block;
-  width: 100%;
-  transition: transform 400ms ease;
-
-  .promo:hover &,
-  .promo:focus & {
-    transform: scale(1.2);
   }
 }
 

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -41,12 +41,14 @@ export const articles = async(ctx) => {
   });
 };
 
-function postsToPromos(posts) {
+function postsToPromos(posts, display) {
   return posts.map(articlePromo => {
     const promo: Promo = {
       modifiers: [],
       article: articlePromo,
-      meta: {}
+      meta: {
+        displayType: display,
+      }
     };
     return promo;
   });
@@ -55,9 +57,9 @@ function postsToPromos(posts) {
 export const explore = async(ctx) => {
   const wpPosts = await getPosts();
   const posts = wpPosts.data;
-  const topPromo = postsToPromos(posts.take(1)).first();
-  const second3Promos = postsToPromos(posts.slice(1, 4));
-  const next8Promos = postsToPromos(posts.slice(4, 12));
+  const topPromo = postsToPromos(posts.take(1), 'lead').first();
+  const second3Promos = postsToPromos(posts.slice(1, 4), 'regular');
+  const next8Promos = postsToPromos(posts.slice(4, 12), 'regular');
 
   return ctx.render('pages/explore', {
     pageConfig: createPageConfig({

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -41,14 +41,12 @@ export const articles = async(ctx) => {
   });
 };
 
-function postsToPromos(posts, display) {
+function postsToPromos(posts, weight) {
   return posts.map(articlePromo => {
     const promo: Promo = {
       modifiers: [],
       article: articlePromo,
-      meta: {
-        displayType: display,
-      }
+      weight: weight
     };
     return promo;
   });
@@ -58,8 +56,8 @@ export const explore = async(ctx) => {
   const wpPosts = await getPosts();
   const posts = wpPosts.data;
   const topPromo = postsToPromos(posts.take(1), 'lead').first();
-  const second3Promos = postsToPromos(posts.slice(1, 4), 'regular');
-  const next8Promos = postsToPromos(posts.slice(4, 12), 'regular');
+  const second3Promos = postsToPromos(posts.slice(1, 4), 'default');
+  const next8Promos = postsToPromos(posts.slice(4, 12), 'default');
 
   return ctx.render('pages/explore', {
     pageConfig: createPageConfig({

--- a/server/filters/image-sizes.js
+++ b/server/filters/image-sizes.js
@@ -1,6 +1,6 @@
 import {Set} from 'immutable';
 
-export const supportedSizes = Set([320, 420, 600, 960, 1024, 1338]);
+export const supportedSizes = Set([320, 420, 600, 880, 960, 1024, 1338]);
 
 export function getImageSizesFor(image) {
   const { width } = image;

--- a/server/model/body-part.js
+++ b/server/model/body-part.js
@@ -1,6 +1,8 @@
 // @flow
+import {type Weight} from './weight';
+
 export type BodyPart = {|
-  weight: string;
+  weight: Weight;
   type: string;
   value: any; // TODO: Make this not `any`
 |}

--- a/server/model/content-type.js
+++ b/server/model/content-type.js
@@ -1,7 +1,3 @@
 // @flow
 export type ContentType = 
   | "article"; // at the moment article is all we have
-
-export function createType(data: ContentType) {
-  return (data: ContentType);
-}

--- a/server/model/display-type.js
+++ b/server/model/display-type.js
@@ -1,8 +1,0 @@
-// @flow
-export type DisplayType = 
-  | "lead"
-  | "regular";
-
-export function createType(data: DisplayType) {
-  return (data: DisplayType);
-}

--- a/server/model/display-type.js
+++ b/server/model/display-type.js
@@ -1,0 +1,8 @@
+// @flow
+export type DisplayType = 
+  | "lead"
+  | "regular";
+
+export function createType(data: DisplayType) {
+  return (data: DisplayType);
+}

--- a/server/model/promo.js
+++ b/server/model/promo.js
@@ -1,13 +1,12 @@
 // @flow
-import {type DisplayType} from './display-type';
+import {type Weight} from './weight';
 import {type ArticlePromo} from './article-promo';
 
 export type Promo = {|
   modifiers: Array<string>;
   article: ArticlePromo;
+  weight?: Weight,
   meta?: {
-    display?: DisplayType,
-    small?: boolean,
     type?: string,
     length?: string
   };

--- a/server/model/promo.js
+++ b/server/model/promo.js
@@ -1,10 +1,13 @@
 // @flow
+import {type DisplayType} from './display-type';
 import {type ArticlePromo} from './article-promo';
 
 export type Promo = {|
   modifiers: Array<string>;
   article: ArticlePromo;
   meta?: {
+    display?: DisplayType,
+    small?: boolean,
     type?: string,
     length?: string
   };

--- a/server/model/weight.js
+++ b/server/model/weight.js
@@ -1,0 +1,6 @@
+// @flow
+export type Weight = 
+  | "lead"
+  | "standalone"
+  | "default"
+  | "supporting";

--- a/server/views/components/captioned-image/index.njk
+++ b/server/views/components/captioned-image/index.njk
@@ -1,19 +1,7 @@
 <figure class="{{ 'captioned-image' | componentClasses(modifiers) }}">
   <div class="captioned-image__image-container">
-  {% set sizes = model | getImageSizesFor %}
-  {% set comma = joiner() %}
-  <img class="image lazyload"
-        src="{{ model.contentUrl }}?w={{ sizes[0] }}"
-        data-srcset="
-        {%- for size in sizes -%}
-          {{ comma() }}{{ model.contentUrl }}?w={{ size }} {{ size }}w
-        {%- endfor %}"
-        {% if data.sizesQueries %}
-          sizes="{{ data.sizesQueries }}"
-        {% endif %}
-        alt="{{ model.caption | striptags() }}" />
+    {% component 'image', { image: {url: model.contentUrl, alt: model.caption | striptags(), lazyload: true, sizesQueries: data.sizesQueries} } %}
   </div>
-
   {% block figcaption %}
     {% if model.caption %}
       <figcaption class="captioned-image__caption">

--- a/server/views/components/captioned-image/index.njk
+++ b/server/views/components/captioned-image/index.njk
@@ -8,7 +8,7 @@
         {%- for size in sizes -%}
           {{ comma() }}{{ model.contentUrl }}?w={{ size }} {{ size }}w
         {%- endfor %}"
-        {% if sizesQueries %}
+        {% if data.sizesQueries %}
           sizes="{{ data.sizesQueries }}"
         {% endif %}
         alt="{{ model.caption | striptags() }}" />

--- a/server/views/components/image/index.config.js
+++ b/server/views/components/image/index.config.js
@@ -1,0 +1,2 @@
+export const name = 'Image';
+export const handle = 'image';

--- a/server/views/components/image/index.njk
+++ b/server/views/components/image/index.njk
@@ -1,0 +1,12 @@
+{% set sizes = image | getImageSizesFor %}
+{% set comma = joiner() %}
+<img class="image{{ ' lazyload' if image.lazyload }}"
+src="{{ image.url }}?w={{ sizes[0] }}"
+data-srcset="
+{%- for size in sizes -%}
+  {{ comma() }}{{ image.url }}?w={{ size }} {{ size }}w
+{%- endfor %}"
+{% if image.sizesQueries %}
+  sizes="{{ image.sizesQueries }}"
+{% endif %}
+alt="{{ 'image.alt' if image.alt }}" />

--- a/server/views/components/promo/index.config.js
+++ b/server/views/components/promo/index.config.js
@@ -37,5 +37,13 @@ export const variants = [
   {
     name: 'standalone',
     context: {promo: Object.assign({}, promo, {meta: {type: 'article'}}, {modifiers: ['series', 'standalone']})}
+  },
+  {
+    name: 'lead',
+    context: {promo: Object.assign({}, promo, {meta: {type: 'article', displayType: 'lead'}})}
+  },
+  {
+    name: 'regular',
+    context: {promo: Object.assign({}, promo, {meta: {type: 'article', displayType: 'regular'}})}
   }
 ];

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -1,9 +1,9 @@
 {% set leadPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 876px, 812px' %}
-{% set smallPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 276px, 386px' %}
-{% if promo.meta.displayType === 'lead' %}
+{% set defaultPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 276px, 386px' %}
+{% if promo.weight === 'lead' %}
   {% set sizes = leadPromoSizes %}
-{% elseif promo.meta.displayType === 'regular' %}
-  {% set sizes = smallPromoSizes %}
+{% elseif promo.weight === 'default' %}
+  {% set sizes = defaultPromoSizes %}
 {% else %}
   {% set sizes = 100vw %}
 {% endif %}

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -1,14 +1,17 @@
-{#TODO full width variant#}
-{#TODO full width/dark background variant#}
-{#TODO Test with screen reader#}
-{#TODO jsConfig#}
-{#TODO className unitlity for promo classes#}
+{% set leadPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 876px, 812px' %}
+{% set smallPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 276px, 386px' %}
+{% if promo.meta.displayType === 'lead' %}
+  {% set sizes = leadPromoSizes %}
+{% elseif promo.meta.displayType === 'regular' %}
+  {% set sizes = smallPromoSizes %}
+{% else %}
+  {% set sizes = 100vw %}
+{% endif %}
 
 <a href="{{ promo.article.url }}" class="promo {% for modifier in promo.modifiers %}promo--{{ modifier }} {% endfor %}">
   <div class="promo__image-container">
-    <img class="promo__image"
-      src="{{ promo.article.thumbnail.contentUrl }}"
-      alt="{{ promo.article.headline }}" />
+
+    {% component 'image', { image: {url: promo.article.thumbnail.contentUrl, lazyload: true, sizesQueries: sizes } } %}
 
     {% for modifier in promo.modifiers %}
       {% if modifier === 'series' %}
@@ -23,7 +26,7 @@
             </filter>
           </defs>
         </svg>
-        <img class="promo__image-mask promo__clip-path--{{ [1,2,3,4,5,6,7,8,9,10] | random }}" src="{{ promo.article.thumbnail.contentUrl }}" alt="" />
+        <img class="promo__image-mask promo__clip-path--{{ [1,2,3,4,5,6,7,8,9,10] | random }}" src="{{ promo.article.thumbnail.contentUrl }}?w=600" alt="" />
       {% endif %}
     {% endfor %}
 


### PR DESCRIPTION
## What is this PR trying to achieve?

Reduce explore landing page size by making promo images use responsive srcset/sizes attributes and lazy loading.

## What does it look like?
Before:
<img width="580" alt="screen shot 2017-02-11 at 09 15 56" src="https://cloud.githubusercontent.com/assets/6051896/22879083/38bd45a2-f1d4-11e6-84cb-f2666e367422.png">

After:
<img width="576" alt="screen shot 2017-02-11 at 09 15 06" src="https://cloud.githubusercontent.com/assets/6051896/22879088/3fe5fbf8-f1d4-11e6-8937-bae0564b90d9.png">

