### PR TITLE
ensure that we install root packages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
     version: 6.1.0
 dependencies:
   override:
+    - npm install
     - ./build-client.sh
     - ./build-server.sh
 deployment:


### PR DESCRIPTION
## What is this PR trying to achieve?
As we override the deps step we need to ensure running the default `npm install`
