### PR TITLE
bump servers up just slightly

### DIFF
--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -2,8 +2,8 @@
   {
     "name": "wellcomecollection",
     "image": "wellcome/wellcomecollection:${container_tag}",
-    "cpu": 256,
-    "memory": 256,
+    "cpu": 512,
+    "memory": 1024,
     "essential": true,
     "portMappings": [
       {

--- a/infra/terraform/templates/launch.tf
+++ b/infra/terraform/templates/launch.tf
@@ -33,7 +33,7 @@ resource "aws_launch_configuration" "wellcomecollection_ecs" {
   name_prefix            = "wellcomecollection-ecs-instance-"
   key_name               = "${aws_key_pair.wellcomecollection.id}"
   image_id               = "${data.aws_ami.ecs_optimized.id}"
-  instance_type          = "t2.micro"
+  instance_type          = "t2.small"
   iam_instance_profile   = "${aws_iam_instance_profile.wellcomecollection.id}"
   security_groups        = [
     "${aws_security_group.ssh_in.id}",


### PR DESCRIPTION
## What is this PR trying to achieve?
I think this is overkill - but as we'll be driving traffic from FB etc - seems better safe than sorry.

I'd like to look at optimising this as we still have a lot of unallocated resource as we need to leave some spare for deployments - @kenoir - do you have the same thing?

## What does it look like?
![cpu-mem](https://cloud.githubusercontent.com/assets/31692/23014925/d94e814c-f428-11e6-913b-5078910f20c7.png)