### PR TITLE
remove redirect to https

### DIFF
--- a/server/middleware/enforce-ssl.js
+++ b/server/middleware/enforce-ssl.js
@@ -1,11 +1,5 @@
 export function enforceSSL() {
   return (ctx, next) => {
-    const host = ctx.request.host;
-    if (host.indexOf('https:') !== 0) {
-      ctx.response.status = 301;
-      ctx.response.redirect(host.replace('http:', 'https:'));
-    }
-
     // This is the minimum required age as per Chrome's preload list:
     // see: https://hstspreload.org
     const maxAge = 10886400;


### PR DESCRIPTION
## What is this PR trying to achieve?
Removing this as it's a bit more complicated as headers etc from AWS vs local Nginx are completely different.

I will do this on the URL level to avoid application complexity.
