### PR TITLE
swap wordpress inferance of supporting and standalone around

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -111,8 +111,8 @@ export function convertWpImage(node) {
     const picture = getImageFromWpNode(node);
     const className = getAttrVal(node.attrs, 'class') || '';
     const weights = {
-      alignright: 'supporting',
-      alignleft: 'standalone'
+      alignleft: 'supporting',
+      alignright: 'standalone'
     };
 
     const weightKey = Object.keys(weights).find(wpClassName => className.indexOf(wpClassName) !== -1);


### PR DESCRIPTION
## What is this PR trying to achieve?
We've decided that we want to have supporting more than standalone.

This shouldn't be an issue once wordpress rendering is deprecated.
