### PR TITLE
Remove colour treatment from standalone promo

### DIFF
--- a/server/views/components/promo/index.config.js
+++ b/server/views/components/promo/index.config.js
@@ -36,7 +36,7 @@ export const variants = [
   },
   {
     name: 'standalone',
-    context: {promo: Object.assign({}, promo, {meta: {type: 'article'}}, {modifiers: ['series', 'standalone']})}
+    context: {promo: Object.assign({}, promo, {meta: {type: 'article'}}, {modifiers: ['standalone']})}
   },
   {
     name: 'lead',


### PR DESCRIPTION
## What is this PR trying to achieve?
Removing the colour treatment from the standalone article promo as per discussion on #352.

## What does it look like?
![screen shot 2017-02-16 at 16 28 49](https://cloud.githubusercontent.com/assets/1394592/23030375/814d727c-f465-11e6-96f6-f3a7d36cabd6.png)