### PR TITLE
Added default sizes attribute to articles promos

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -50,7 +50,7 @@ export const articles = async(ctx, next) => {
 export const series = async(ctx, next) => {
   const {id} = ctx.params;
   const wpPosts = await getPosts(32, {category: id});
-  const items = postsToPromos(wpPosts.data);
+  const items = postsToPromos(wpPosts.data, 'default');
   // TODO: So So nasty
   const {name, description} = wpPosts.data.first().series[0];
   const {total} = wpPosts;
@@ -81,7 +81,7 @@ export const explore = async(ctx, next) => {
   const topPromo = postsToPromos(theRest.take(1), 'lead').first();
   const second3Promos = postsToPromos(theRest.slice(1, 4), 'default');
   const next8Promos = postsToPromos(theRest.slice(4, 12), 'default');
-  const aDropInTheOceanPromos = postsToPromos(grouped.last()).take(7);
+  const aDropInTheOceanPromos = postsToPromos(grouped.last().take(7), 'default');
   const aDropInTheOcean: Series = {
     url: '/series/a-drop-in-the-ocean',
     name: 'A drop in the ocean',

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -28,7 +28,7 @@ export const article = async(ctx, next) => {
 
 export const articles = async(ctx, next) => {
   const wpPosts = await getPosts(32);
-  const items = postsToPromos(wpPosts.data);
+  const items = postsToPromos(wpPosts.data, 'default');
   const {total} = wpPosts;
   const series: Series = {
     url: '/articles',

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -2,10 +2,8 @@
 {% set defaultPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 276px, 386px' %}
 {% if promo.weight === 'lead' %}
   {% set sizes = leadPromoSizes %}
-{% elseif promo.weight === 'default' %}
-  {% set sizes = defaultPromoSizes %}
 {% else %}
-  {% set sizes = 100vw %}
+  {% set sizes = defaultPromoSizes %}
 {% endif %}
 
 <a href="{{ promo.article.url }}" class="promo {% for modifier in promo.modifiers %}promo--{{ modifier }} {% endfor %}">


### PR DESCRIPTION
## What is this PR trying to achieve?

Reduce the page size by providing sizes attribute to images

## What does it look like?

Before:
![screen shot 2017-02-17 at 11 49 00](https://cloud.githubusercontent.com/assets/6051896/23064329/6cc3f504-f507-11e6-86f8-5a4b6c43f86a.png)
After:
![screen shot 2017-02-17 at 11 48 34](https://cloud.githubusercontent.com/assets/6051896/23064335/758a6970-f507-11e6-992c-dc1d5a2e7b59.png)

