### PR TITLE
remove spacing from the 'May have missed' container

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -29,10 +29,6 @@
   padding-top: $v-spacing-unit * 4;
 }
 
-.row--no-bottom-padding {
-  padding-bottom: 0;
-}
-
 .row--text-bar {
   padding-top: $v-spacing-unit * 3;
   padding-bottom: $v-spacing-unit * 3;

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -2,7 +2,7 @@
 
 {% block body %}
   {% component 'page-description', { title: 'Explore', modifiers: ['hidden'] } %}
-  <div class="row row--no-bottom-padding row--cream row--has-wobbly-background">
+  <div class="row row--cream row--has-wobbly-background">
     <div class="container">
       <div class="grid">
         <div class="{{ {s:4, m:8, l:12, xl:12} | gridClasses }}">
@@ -26,7 +26,7 @@
   {% componentV2 'series-container', aDropInTheOcean %}
 
   {# Chronological #}
-  <div class="row">
+  <div class="row row--no-padding">
     <div class="container">
       <div class="grid">
         <div class="{{ {s:4, m:8, l:12, xl: 12} | gridClasses }}">


### PR DESCRIPTION
## What is this PR trying to achieve?
Fixes #557 

## What does it look like?
![mayhavemissedspacing](https://cloud.githubusercontent.com/assets/31692/23064580/bb65db0e-f508-11e6-8a4c-60abf3cc4904.png)