### PR TITLE
remove max height form images

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -83,12 +83,4 @@
   .captioned-image__image-container {
     background: color('black');
   }
-
-  .image {
-    max-height: 70vh;
-    width: auto;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: 100%;
-  }
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Fixes #553  
We've decided that we don't want max-height on images.