### PR TITLE
check for childnodes in body parser when looking for an image

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -133,7 +133,7 @@ function isCaption(node) {
 }
 
 function isImg(node) {
-  const mayBeWrapperA = node.childNodes.find(node => node.nodeName === 'a');
+  const mayBeWrapperA = node.childNodes && node.childNodes.find(node => node.nodeName === 'a');
   const parentNode = mayBeWrapperA || node;
 
   return parentNode.childNodes && parentNode.childNodes[0] && parentNode.childNodes[0].nodeName === 'img';


### PR DESCRIPTION
## What is this PR trying to achieve?
We've had this error before where Wordpress misformats the HTML.
I thought it was a once off thing - much better to not throw an error here.
