### PR TITLE
dont' compile hotjar NJK file with babel

### DIFF
--- a/server/.babelrc
+++ b/server/.babelrc
@@ -8,7 +8,8 @@
   ],
   "ignore": [
     "node_modules",
-    "views/partials/analytics.js"
+    "views/partials/analytics.js",
+    "views/partials/hotjar.js"
   ],
   "plugins": ["transform-flow-strip-types"]
 }


### PR DESCRIPTION
This doesn't error as there is no nunjucks specific code in it - but we should exclude it.
Let's have a think of a more scalable solution.