### PR TITLE
drop memory requirements on ecs

### DIFF
--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -3,7 +3,7 @@
     "name": "wellcomecollection",
     "image": "wellcome/wellcomecollection:${container_tag}",
     "cpu": 512,
-    "memory": 1024,
+    "memory": 768,
     "essential": true,
     "portMappings": [
       {


### PR DESCRIPTION
## What is this PR trying to achieve?
Had to drop it slightly as Docker uses up memory so you can't just divide by 2.
We're still running at way below 10% - I'd like to find a way to be more efficient with this.