### PR TITLE
use supported Object.keys instead of .values

### DIFF
--- a/server/model/article-promo.js
+++ b/server/model/article-promo.js
@@ -23,7 +23,8 @@ export class ArticlePromoFactory {
       height: wpThumbnail.height
     };
     const datePublished = new Date(json.date);
-    const series: Array<ArticleSeries> = Object.values(json.categories).map(cat => {
+    const series: Array<ArticleSeries> = Object.keys(json.categories).map(catKey => {
+      const cat = json.categories[catKey];
       return {
         url: cat.slug,
         name: cat.name,


### PR DESCRIPTION
## What is this PR trying to achieve?
`.values` is part of es2017 - I thought this would have been added using [`babel-preset-env`](https://github.com/babel/babel-preset-env) - alas not. 

__TODO:__
Either add some health checks to the ALB to not use the service is `/explore` isn't up - or add it to the tests to break the build.