### PR TITLE
add integration / endpoint tests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,7 +31,6 @@
     "build": "gulp build",
     "compile": "gulp compile",
     "compile:dev": "gulp dev --dev",
-    "test": "exit 0",
     "prepush": "gulp lint"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The new home of the betanextbest.wellcomecollection.org website.",
   "main": "server/app.js",
   "scripts": {
-    "test": "concurrently --kill-others './test.sh client' './test.sh server'"
+    "test": "./test.sh server"
   },
   "repository": {
     "type": "git",
@@ -15,8 +15,5 @@
   "bugs": {
     "url": "https://github.com/wellcometrust/wellcomecollection.org/issues"
   },
-  "homepage": "https://github.com/wellcometrust/wellcomecollection.org#readme",
-  "dependencies": {
-    "concurrently": "^3.3.0"
-  }
+  "homepage": "https://github.com/wellcometrust/wellcomecollection.org#readme"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The new home of the betanextbest.wellcomecollection.org website.",
   "main": "server/app.js",
   "scripts": {
-    "test": "concurrently './test.sh client' './test.sh server'"
+    "test": "concurrently --kill-others './test.sh client' './test.sh server'"
   },
   "repository": {
     "type": "git",

--- a/server/app.js
+++ b/server/app.js
@@ -17,6 +17,4 @@ app.use(serve(config.favicon.path));
 app.use(render(config.views.path));
 app.use(router);
 
-app.listen(config.server.port);
-
-console.info(`Server up and running on http://localhost:${config.server.port}`);
+export default app;

--- a/server/package.json
+++ b/server/package.json
@@ -5,9 +5,9 @@
   "main": "app.js",
   "scripts": {
     "app:build": "babel . -d .dist --ignore=node_modules --copy-files",
-    "app:dev": "nodemon -e js,njk,json --exec babel-node app.js",
-    "app:docker": "pm2-docker ./.dist/app.js --name 'wellcomecollection.org'",
-    "app:start": "pm2 start ./.dist/app.js --name 'wellcomecollection.org'",
+    "app:dev": "nodemon -e js,njk,json --exec babel-node run.js",
+    "app:docker": "pm2-docker ./.dist/run.js --name 'wellcomecollection.org'",
+    "app:run": "pm2 start ./.dist/run.js --name 'wellcomecollection.org'",
     "fractal": "fractal start —sync --port 3002",
     "fractal:build": "fractal build",
     "fractal:watch": "nodemon -e js,njk,yml --exec 'fractal start —sync --port 3002'",
@@ -45,6 +45,7 @@
     "parse5": "^3.0.1",
     "pm2": "^2.1.5",
     "superagent": "^3.3.1",
+    "supertest": "^3.0.0",
     "svgo": "^0.7.1"
   },
   "devDependencies": {

--- a/server/run.js
+++ b/server/run.js
@@ -1,0 +1,5 @@
+import config from './config';
+import app from './app';
+
+app.listen(config.server.port);
+console.info(`Server up and running on http://localhost:${config.server.port}`);

--- a/server/test/app/app.js
+++ b/server/test/app/app.js
@@ -1,0 +1,20 @@
+import test from 'ava';
+import app from '../../app';
+import supertest from 'supertest';
+
+const request = supertest.agent(app.listen());
+
+test('/', async t => {
+  const res = await request.get('/');
+  t.is(res.status, 200);
+});
+
+test('/explore', async t => {
+  const res = await request.get('/explore');
+  t.is(res.status, 200);
+});
+
+test('/articles/:slug', async t => {
+  const res = await request.get('/articles/a-drop-in-the-ocean-daniel-regan');
+  t.is(res.status, 200);
+});

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 pushd $1
-npm test
+  npm test
 popd


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding a few integration / endpoint tests.
These are rudimentary - and would like to keep them that way.

## What does it look like?
![screen shot 2017-02-20 at 09 09 42](https://cloud.githubusercontent.com/assets/31692/23118518/5927adfa-f74c-11e6-8744-11f39456fac7.png)

## Consideration
It'd be good to see if keeping the WP API call in here slows the build too much - if so, we'll have to create some mock API - and then probably start looking at dependency injection os the Wordpress service... quite a bit of work for something that I am unsure will be a problem.

Locally I don't think this a problem locally as you can run `npm run test:watch ./test/app/app.js` to not run all the tests.