### PR TITLE
Fix featured grid in IE

### DIFF
--- a/client/scss/grids/_grid_featured.scss
+++ b/client/scss/grids/_grid_featured.scss
@@ -22,6 +22,7 @@
 
   &:before,
   &:after {
+    display: block;
     content: '';
     width: 100%;
     margin-left: map-get($gutter-width, 'small');


### PR DESCRIPTION
## What is this PR trying to achieve?
Unbreaking the 'featured' grid on IE.

## What does it look like?
Before:
![screen shot 2017-02-20 at 10 23 19](https://cloud.githubusercontent.com/assets/1394592/23121036/be728a7c-f756-11e6-90ac-284ed1b559c6.png)

After:
![screen shot 2017-02-20 at 10 23 48](https://cloud.githubusercontent.com/assets/1394592/23121041/c4be1d1a-f756-11e6-9b96-9f8698dfa798.png)


## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
