### PR TITLE
Revert "Revert "add main image to index page""

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -78,9 +78,3 @@
 .captioned-image__caption--no-underline {
   border-bottom: 0;
 }
-
-.captioned-image--max-out-height {
-  .captioned-image__image-container {
-    background: color('black');
-  }
-}

--- a/server/views/components/captioned-image/index.config.js
+++ b/server/views/components/captioned-image/index.config.js
@@ -13,6 +13,5 @@ const image: Picture = createPicture({
 export const context = { model: image, modifiers: [] };
 export const variants = [
   { name: 'full', context: { model: image, modifiers: ['full'] } },
-  { name: 'bleed', context: { model: image, modifiers: ['bleed'] } },
-  { name: 'max-out-height', context: { model: image, modifiers: ['max-out-height'] } }
+  { name: 'bleed', context: { model: image, modifiers: ['bleed'] } }
 ];

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -4,7 +4,7 @@
   {% set largeWidth = item.width/item.height*640 %}
   {% set queries = '(max-width: 600px) ' + smallWidth + 'px, ' + largeWidth + 'px' %}
   <div class="image-gallery__item">
-    {% componentV2 'captioned-image', item, {'max-out-height': true}, {sizesQueries: queries} %}
+    {% componentV2 'captioned-image', item, {}, {sizesQueries: queries} %}
   </div>
   {% endfor %}
 </div>

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -11,7 +11,7 @@
 
 {% for media in article.mainMedia %}
   {% if (media.contentUrl) %}
-    {% componentV2 'main-media', media, {'full': true, 'max-out-height': true} %}
+    {% componentV2 'main-media', media, {'full': true} %}
   {% endif %}
 {% endfor %}
 

--- a/server/views/pages/index.njk
+++ b/server/views/pages/index.njk
@@ -4,13 +4,18 @@
   {% component 'new-site-notice', {showLink: false} %}
 {% endblock %}
 {% block body %}
+  {% componentV2 'captioned-image', {
+    contentUrl: 'https://wellcomecollection.files.wordpress.com/2017/02/wc_promo_next_02.png',
+    width: 1600,
+    height: 618
+  }, {'full': true} %}
 <div class="row">
     <div class="container">
         <div class="grid">
             <div class="grid__cell">
               <div class="body-content">
                 {% markdown %}
-                {% include '../docs/PROGRESS_NOTES.md' %}
+                  {% include '../docs/PROGRESS_NOTES.md' %}
                 {% endmarkdown %}
               </div>
             </div>


### PR DESCRIPTION
This reverts commit 3bc550714d553524eb4261a773fcd51332a09354.

## What is this PR trying to achieve?
Sorry for the reversion. I merged into master mistakenly.
This adds the main  image to the homepage.
It also removes the `max-out-height` that was hangover of not making images full width.

## What does it look like?
![homemainimage](https://cloud.githubusercontent.com/assets/31692/23122015/7deda316-f75a-11e6-82ad-73ac1ab3acd8.png)
