### PR TITLE
add cloudfront distribution for next.

### DIFF
--- a/infra/terraform/templates/cloudfront.tf
+++ b/infra/terraform/templates/cloudfront.tf
@@ -40,3 +40,46 @@ resource "aws_cloudfront_distribution" "cardigan" {
     }
   }
 }
+
+resource "aws_cloudfront_distribution" "next" {
+  origin {
+    domain_name = "${aws_alb.wellcomecollection_alb.dns_name}"
+    origin_id   = "${aws_alb.wellcomecollection_alb.id}"
+  }
+
+  enabled             = true
+  default_root_object = "/"
+  is_ipv6_enabled     = true
+
+  aliases = ["next.wellcomecollection.org", "wellcomecollection.org"]
+
+  default_cache_behavior {
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id       = "${aws_alb.wellcomecollection_alb.id}"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${var.wellcomecollection_ssl_cert_arn}"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}


### PR DESCRIPTION
## What is this PR trying to achieve?

Adding CloudFront to the site as the response times are slow.

I suppose some might be from the small stack we're using, but the latency between us and Wordpress is something we can't control, which makes this seem more like a good idea.
