### PR TITLE
only add thumbnail if we have one from Wordpress

### DIFF
--- a/server/model/article-promo.js
+++ b/server/model/article-promo.js
@@ -6,7 +6,7 @@ export type ArticlePromo = {|
   url: string;
   headline: string;
   description: string;
-  thumbnail: Picture;
+  thumbnail?: Picture;
   datePublished: Date;
   series?: Array<ArticleSeries>;
 |};

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -21,7 +21,7 @@ export type Article = {|
   // It's also an Array because it's not unfathomable to think of having
   // an audio and image mainMedia.
   mainMedia: Array<Picture>;
-  thumbnail: Picture;
+  thumbnail?: Picture;
   articleBody: string;
   associatedMedia: Array<Picture>;
   bodyParts: Array<BodyPart>;

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -38,11 +38,11 @@ export class ArticleFactory {
 
     const mainImage: Picture = getWpFeaturedImage(json.featured_image, json.attachments);
     const wpThumbnail = json.post_thumbnail;
-    const thumbnail: Picture = {
+    const thumbnail: Picture = wpThumbnail ? {
       contentUrl: wpThumbnail.URL,
       width: wpThumbnail.width,
       height: wpThumbnail.height
-    };
+    } : null;
 
     const author = authorMap[json.slug];
 


### PR DESCRIPTION
## What is this PR trying to achieve?
We won't always have a thumbnail from WP - so make it nullable.
There's a bit of modelling to be done here around allowed data vs validated data.
