### PR TITLE
Add scrolling grid-strip

### DIFF
--- a/client/scss/grids/_grid_scroll.scss
+++ b/client/scss/grids/_grid_scroll.scss
@@ -38,5 +38,18 @@
       // (100vw - #{$container-width-max}) here accounts for any whitespace wide of the container max-width
       min-width: calc(((100vw + #{map-get($gutter-width, 'large')} - (2 * #{map-get($container-padding, 'large')})) - (100vw - #{$container-width-max})) / 3);
     }
+
+  }
+
+  &.grid--strip {
+    .grid__cell {
+      @include respond-to('large') {
+        min-width: calc((100vw + #{map-get($gutter-width, 'large')} - (2 * #{map-get($container-padding, 'large')})) / 4);
+      }
+
+      @include respond-to('xlarge') {
+        min-width: calc(((100vw + #{map-get($gutter-width, 'large')} - (2 * #{map-get($container-padding, 'large')})) - (100vw - #{$container-width-max})) / 6);
+      }
+    }
   }
 }

--- a/client/scss/grids/_grid_scroll.scss
+++ b/client/scss/grids/_grid_scroll.scss
@@ -35,8 +35,8 @@
     }
 
     @include respond-to('xlarge') {
-      // (100vw - #{$container-width-max}) here accounts for any whitespace wide of the container max-width
-      min-width: calc(((100vw + #{map-get($gutter-width, 'large')} - (2 * #{map-get($container-padding, 'large')})) - (100vw - #{$container-width-max})) / 3);
+      min-width: ($container-width-max - (2 * map-get($container-padding, 'large')) + map-get($gutter-width, 'large')) / 3;
+      max-width: ($container-width-max - (2 * map-get($container-padding, 'large')) + map-get($gutter-width, 'large')) / 3;
     }
 
   }
@@ -48,7 +48,8 @@
       }
 
       @include respond-to('xlarge') {
-        min-width: calc(((100vw + #{map-get($gutter-width, 'large')} - (2 * #{map-get($container-padding, 'large')})) - (100vw - #{$container-width-max})) / 6);
+        min-width: ($container-width-max - (2 * map-get($container-padding, 'large')) + map-get($gutter-width, 'large')) / 6;
+        max-width: ($container-width-max - (2 * map-get($container-padding, 'large')) + map-get($gutter-width, 'large')) / 6;
       }
     }
   }

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -43,10 +43,10 @@
   </div>
 
   <div class="row row--small-top-padding">
-    <div class="container">
-      <div class="grid">
+    <div class="container container--scroll container--no-max-width">
+      <div class="grid grid--scroll grid--strip">
         {% for promo in next8Promos.toJS() %}
-          <div class="{{ {s:4, m:4, l:3, xl:3} | gridClasses }}">
+          <div class="grid__cell">
             {% component 'promo', { promo: promo } %}
           </div>
         {% endfor %}

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -43,7 +43,7 @@
   </div>
 
   <div class="row row--small-top-padding">
-    <div class="container container--scroll container--no-max-width">
+    <div class="container container--scroll container--no-max-width touch-scroll">
       <div class="grid grid--scroll grid--strip">
         {% for promo in next8Promos.toJS() %}
           <div class="grid__cell">


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding a scrolling strip for a row of e.g. 'you may have missed' items. This is a modification of the `grid--scroll` class.

## What does it look like?
6-up on xlarge:
![screen shot 2017-02-21 at 15 03 29](https://cloud.githubusercontent.com/assets/1394592/23170403/f0eb4048-f846-11e6-99d7-c2e6b213ee2b.png)

4-up on large:
![screen shot 2017-02-21 at 15 03 16](https://cloud.githubusercontent.com/assets/1394592/23170406/f40dd0ba-f846-11e6-9bf9-3a00a143e8b6.png)

Same as `grid--scroll` on medium and below.

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers

## Next up
- Replace `grid--featured` with `grid--scroll`