### PR TITLE
Keep m8 promo in side-by-side configuration

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -9,7 +9,7 @@
     padding-bottom: 5 * $v-spacing-unit;
   }
 
-  @include container-query(('l': ('8', '12'))) {
+  @include container-query(('m': ('8'), 'l': ('8', '12'))) {
     display: flex;
     align-items: flex-start;
   }
@@ -48,7 +48,7 @@
     margin-bottom: 0;
   }
 
-  @include container-query(('l': ('8', '12'))) {
+  @include container-query(('m': ('8'), 'l': ('8', '12'))) {
     order: 1;
     width: percentage(2 / 3);
     margin-bottom: 0;
@@ -222,6 +222,10 @@
 
   @include container-query(('l': ('8', '12'))) {
     padding-right: map-get($gutter-width, 'large');
+  }
+
+  @include container-query(('m': ('8'))) {
+    padding-right: map-get($gutter-width, 'medium');
   }
 }
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Keeping the promos in a `grid--m8` in a side-by-side configuration rather than breaking them into a one-column layout.

## What does it look like?
Before:
![screen shot 2017-02-22 at 17 04 58](https://cloud.githubusercontent.com/assets/1394592/23222866/22451436-f921-11e6-8f8c-bad3d8f43c3a.png)

After:
![screen shot 2017-02-22 at 17 05 09](https://cloud.githubusercontent.com/assets/1394592/23222872/278dcfe6-f921-11e6-8c23-ca2e6b1c7e7a.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers

## Have the following been considered/are they needed?
- [x] Spoken to the right people? Checked with @Norvard 
