### PR TITLE
Only deploy task definition with deploy script

### DIFF
--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -19,6 +19,10 @@ pushd terraform
         exit 1
     fi
 
-    terraform apply \
-        -var "container_tag=$CONTAINER_TAG"
+    # Legacy graph is on here due to:
+    # https://github.com/hashicorp/terraform/issues/8146
+    terraform apply -target=module.wellcomecollection.aws_ecs_task_definition.wellcomecollection \
+                    -Xlegacy-graph \
+                    -var "container_tag=$CONTAINER_TAG"
+
 popd


### PR DESCRIPTION
## What is this PR trying to achieve?
When we do a deploy - we are essentially deploying the whole stack.

This makes me uneasy - but also causes problems if the deployer isn't on master or the stack is out of sync for some reason. 

This will also allow me to let something like Circle deploy with minimal permissions.

