### PR TITLE
Prevent iOS double-tap link issue

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -369,6 +369,12 @@ $tweakpoints: (
   &:focus {
     &:after {
       width: 100%;
+
+      // Prevent iOS double-tap link issue
+      // https://css-tricks.com/annoying-mobile-double-tap-link-issue/
+      @media (pointer: coarse) {
+        width: 0;
+      }
     }
   }
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Fixing issue where two taps are required on a nav link in order to follow link on iOS. Fixes #622.

Adding the `pointer: coarse` media query to _remove_ the desktop styles rather than adding the required styles with `pointer: fine` is necessary because IE only supports the `pointer` media query property in nightly builds, at present.
