### PR TITLE
Remove browser common ligature correction

### DIFF
--- a/client/scss/base/_typography.scss
+++ b/client/scss/base/_typography.scss
@@ -10,6 +10,8 @@ body {
   @include respond-to('medium') {
     @include font('HNL3');
   }
+
+  font-variant-ligatures: no-common-ligatures;
 }
 
 h1,


### PR DESCRIPTION
## What is this PR trying to achieve?
Removing browser common ligature correction (which doesn't play nice with our loosened up Helvetica). Fixes #490.

## What does it look like?
See [here](https://github.com/wellcometrust/wellcomecollection.org/issues/490#issuecomment-282158278) for before/after. Props to @alexwlchan for debugging skills.

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers