### PR TITLE
remove keymetrics from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,5 @@
 FROM node:6.1.0
 
-ARG KEYMETRICS_PUBLIC
-ARG KEYMETRICS_SECRET
-ENV KEYMETRICS_PUBLIC=$KEYMETRICS_PUBLIC
-ENV KEYMETRICS_SECRET=$KEYMETRICS_SECRET
-
 # setup a user so as not to run as root
 # see: https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user
 RUN useradd --create-home --user-group wellcomecollection

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ deployment:
   master:
     branch: [master]
     commands:
-      - docker build --rm=false --build-arg KEYMETRICS_PUBLIC=$KEYMETRICS_PUBLIC --build-arg KEYMETRICS_SECRET=$KEYMETRICS_SECRET -t wellcome/wellcomecollection:$CIRCLE_BUILD_NUM .
+      - docker build --rm=false -t wellcome/wellcomecollection:$CIRCLE_BUILD_NUM .
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
       - docker push wellcome/wellcomecollection:$CIRCLE_BUILD_NUM
       - ./build-cardigan.sh


### PR DESCRIPTION
## What is this PR trying to achieve?
Main reason being it puts the secret into our public docker.
I've deleted those docker tags and cycled the key,