### PR TITLE
Remove 'More from' before series title

### DIFF
--- a/server/views/components/more-info-link/index.njk
+++ b/server/views/components/more-info-link/index.njk
@@ -1,4 +1,4 @@
 <a class="more-info-link" href="{{ model.url }}">
   {% icon 'actions/arrow-small', null, ['icon--270', 'icon--action'] %}
-  <span class="more-info-link__text">More from {{ model.name }}</span>
+  <span class="more-info-link__text">{{ model.name }}</span>
 </a>


### PR DESCRIPTION
## What is this PR trying to achieve?
Removes the 'More from' before a series title to avoid clunky mid-sentence title case. Fixes #575.

## What does it look like?
![screen shot 2017-03-02 at 10 52 02](https://cloud.githubusercontent.com/assets/1394592/23504219/7479ea54-ff36-11e6-973c-2757c1197c53.png)

