### PR TITLE
Layout social media icons 7-up at widest desktop size

### DIFF
--- a/client/scss/components/_footer_social.scss
+++ b/client/scss/components/_footer_social.scss
@@ -1,5 +1,35 @@
 //* @define footer-social
 
+.footer-social {
+  display: flex;
+  flex-wrap: wrap;
+
+  @include respond-to('xlarge') {
+    justify-content: space-between;
+    flex-wrap: nowrap;
+  }
+}
+
+.footer-social__cell {
+  flex-basis: 100%;
+  min-width: 100%;
+
+  @include respond-to('medium') {
+    flex-basis: 50%;
+    min-width: 50%;
+  }
+
+  @include respond-to('large') {
+    flex-basis: 25%;
+    min-width: 25%;
+  }
+
+  @include respond-to('xlarge') {
+    flex-basis: auto;
+    min-width: 0;
+  }
+}
+
 .footer-social__link {
   @include font('HNM6');
   color: color('white');

--- a/server/views/components/footer-social/index.config.yml
+++ b/server/views/components/footer-social/index.config.yml
@@ -3,56 +3,32 @@ handle: footer-social
 display:
   background: "#1d1d1d"
 context:
-  columns:
-  - items:
-    - title: Wellcome Collection
+  items:
+    - title: Twitter
       service: Twitter
       url: "#"
       icon: social/twitter
-    - title: Wellcome Collection
+    - title: Facebook
       service: Facebook
       url: "#"
       icon: social/facebook
-    - title: Wellcome Collection
+    - title: Instagram
       service: Instagram
       url: "#"
       icon: social/instagram
-  - items:
-    - title: Wellcome Library
-      service: Twitter
-      url: "#"
-      icon: social/twitter
-    - title: Wellcome Library
-      service: Facebook
-      url: "#"
-      icon: social/facebook
-    - title: Wellcome Library
-      service: Instagram
-      url: "#"
-      icon: social/instagram
-  - items:
-    - title: Wellcome Digital
-      service: Twitter
-      url: "#"
-      icon: social/twitter
-    - title: Wellcome Collection
-      service: Google+
-      url: "#"
-      icon: social/google-plus
-    - title: Wellcome Collection
-      service: Soundcloud
+    - title: SoundCloud
+      service: SoundCloud
       url: "#"
       icon: social/soundcloud
-  - items:
-    - title: Wellcome Library
-      service: Google+
-      url: "#"
-      icon: social/twitter
-    - title: Wellcome Collection
-      service: YouTube
-      url: "#"
-      icon: social/youtube
-    - title: Wellcome Collection
+    - title: Tumblr
       service: Tumblr
       url: "#"
       icon: social/tumblr
+    - title: YouTube
+      service: YouTube
+      url: "#"
+      icon: social/youtube
+    - title: TripAdvisor
+      service: TripAdvisor
+      url: "#"
+      icon: social/tripadvisor

--- a/server/views/components/footer-social/index.njk
+++ b/server/views/components/footer-social/index.njk
@@ -1,13 +1,11 @@
-<div class="grid grid--align-end">
-  {% for column in columns %}
-    <div class="{{ {s:4, m:4, l:3} | gridClasses }}">
-      {% for item in column.items %}
-        <a class="footer-social__link" href="{{ item.url }}">
-          {% icon item.icon %}
-          <span class="footer-social__title">{{ item.title }}</span>
-          <span class="footer-social__service">{{ item.service }}</span>
-        </a>
-      {% endfor %}
+<div class="footer-social">
+  {% for item in items %}
+    <div class="footer-social__cell">
+      <a class="footer-social__link" href="{{ item.url }}">
+        {% icon item.icon %}
+        <span class="footer-social__title">{{ item.title }}</span>
+        <span class="footer-social__service">{{ item.service }}</span>
+      </a>
     </div>
   {% endfor %}
 </div>

--- a/server/views/components/footer/index.njk
+++ b/server/views/components/footer/index.njk
@@ -15,10 +15,10 @@
     </div>
     <div class="grid">
       <div class="grid__cell">
-        <h3 class="footer__heading footer__heading--centered">Connect with us:</h3>
+        <h3 class="footer__heading">Connect with us:</h3>
       </div>
     </div>
-    {% component 'footer-social', {columns: footerSocial.columns} %}
+    {% component 'footer-social', {items: footerSocial.items} %}
 
     <div class="footer__bottom">
       <div class="footer__strap">

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -54,67 +54,52 @@
     </div>
 
     {% set footerSocial = {
-      columns: [
-        {
-          items: [
-            {
-              url: "https://twitter.com/explorewellcome",
-              title: "Twitter",
-              service: "Twitter",
-              icon: "social/twitter"
-            },
-            {
-              url: "https://www.facebook.com/wellcomecollection/",
-              title: "Facebook",
-              service: "Facebook",
-              icon: "social/facebook"
-            }
-          ]
-        },
-        {
-          items: [
-            {
-              url: "https://www.instagram.com/wellcomecollection/",
-              title: "Instagram",
-              service: "Instagram",
-              icon: "social/instagram"
-            },
-            {
-              url: "https://soundcloud.com/wellcomecollection",
-              title: "Soundcloud",
-              service: "Soundcloud",
-              icon: "social/soundcloud"
-            }
-          ]
-        },
-        {
-          items: [
-            {
-              url: "http://wellcomecollection.tumblr.com/",
-              title: "Tumblr",
-              service: "Tumblr",
-              icon: "social/tumblr"
-            },
-            {
-              url: "https://www.youtube.com/user/WellcomeCollection",
-              title: "YouTube",
-              service: "YouTube",
-              icon: "social/youtube"
-            }
-          ]
-        },
-        {
-          items: [
-            {
-              url: "https://www.tripadvisor.co.uk/Attraction_Review-g186338-d662065-Reviews-Wellcome_Collection-London_England.html",
-              title: "TripAdvisor",
-              service: "TripAdvisor",
-              icon: "social/tripadvisor"
-            }
-          ]
-        }
+        items: [
+          {
+            url: "https://twitter.com/explorewellcome",
+            title: "Twitter",
+            service: "Twitter",
+            icon: "social/twitter"
+          },
+          {
+            url: "https://www.facebook.com/wellcomecollection/",
+            title: "Facebook",
+            service: "Facebook",
+            icon: "social/facebook"
+          },
+          {
+            url: "https://www.instagram.com/wellcomecollection/",
+            title: "Instagram",
+            service: "Instagram",
+            icon: "social/instagram"
+          },
+          {
+            url: "https://soundcloud.com/wellcomecollection",
+            title: "Soundcloud",
+            service: "Soundcloud",
+            icon: "social/soundcloud"
+          },
+          {
+            url: "http://wellcomecollection.tumblr.com/",
+            title: "Tumblr",
+            service: "Tumblr",
+            icon: "social/tumblr"
+          },
+          {
+            url: "https://www.youtube.com/user/WellcomeCollection",
+            title: "YouTube",
+            service: "YouTube",
+            icon: "social/youtube"
+          },
+          {
+            url: "https://www.tripadvisor.co.uk/Attraction_Review-g186338-d662065-Reviews-Wellcome_Collection-London_England.html",
+            title: "TripAdvisor",
+            service: "TripAdvisor",
+            icon: "social/tripadvisor"
+          }
+        ]
       }
-    ] %}
+    %}
 
 
     {% component 'footer', {


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding a 7-up style for the social media icons on large desktops. Fixes #571.

## What does it look like?
![screen shot 2017-03-02 at 18 15 13](https://cloud.githubusercontent.com/assets/1394592/23520790/4cb17c9c-ff74-11e6-9019-e3c7b18a946d.png)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers