### PR TITLE
Align standalone promo copy with meta on desktop

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -260,10 +260,6 @@
       flex-basis: 60%;
       padding-right: 20%;
     }
-
-    @include respond-to('large') {
-      margin-top: 2 * $vertical-space-unit;
-    }
   }
 }
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Moving the standalone promo description text to the top of the containing box on desktop. Fixes #483.

## What does it look like?
![screen shot 2017-03-03 at 12 38 04](https://cloud.githubusercontent.com/assets/1394592/23551483/be808fa8-000e-11e7-8e6e-83a7bfee3d26.png)

(guide for illustration, obvz).