### PR TITLE
Shunt images offscreen instead of fading out

### DIFF
--- a/client/js/components/make-sticky.js
+++ b/client/js/components/make-sticky.js
@@ -18,6 +18,7 @@ const makeSticky = (els) => {
 
     document.addEventListener('readystatechange', applyPositioning);
     window.addEventListener('resize', debounce(applyPositioning, 500));
+    window.addEventListener('orientationchange', applyPositioning);
   }
 };
 

--- a/client/js/components/prevent-overlapping.js
+++ b/client/js/components/prevent-overlapping.js
@@ -19,6 +19,8 @@ const preventOverlapping = (els) => {
     return elsToStick[nextElIndex()];
   };
   const nextElFromTop = () => {
+    if (!nextEl()) return 0;
+
     return nextEl().getBoundingClientRect().top;
   };
   const currentEl = () => {
@@ -38,20 +40,18 @@ const preventOverlapping = (els) => {
     previousEl().style.top = '-100%';
   };
   const fixCurrentTop = () => {
-    if (currentEl().style.top === `${topOffset}px`) return;
-    if (currentEl().classList.contains('js-full-width')) return;
+    if (!currentEl()) return;
 
     currentEl().style.top = `${topOffset}px`;
   };
   const updateCurrentTop = () => {
     if (!currentEl()) return;
 
-    fixCurrentTop();
     fixPreviousTop();
 
     if (currentEl().classList.contains('js-full-width')) return;
     if (!nextEl()) return;
-    if (nextElFromTop() > currentElHeight() + topOffset) return;
+    if (nextElFromTop() > currentElHeight() + topOffset) return fixCurrentTop();
 
     window.requestAnimationFrame(() => {
       currentEl().style.top = `${nextElFromTop() - currentElHeight()}px`;

--- a/client/js/components/prevent-overlapping.js
+++ b/client/js/components/prevent-overlapping.js
@@ -1,4 +1,4 @@
-import {nodeList, featureTest} from '../util';
+import { nodeList, featureTest } from '../util';
 
 const preventOverlapping = (els) => {
   if (!featureTest('position', 'sticky')) return;
@@ -53,7 +53,9 @@ const preventOverlapping = (els) => {
     if (!nextEl()) return;
     if (nextElFromTop() > currentElHeight() + topOffset) return;
 
-    currentEl().style.top = `${nextElFromTop() - currentElHeight()}px`;
+    window.requestAnimationFrame(() => {
+      currentEl().style.top = `${nextElFromTop() - currentElHeight()}px`;
+    });
   };
 
   window.addEventListener('scroll', updateCurrentTop);

--- a/client/js/components/prevent-overlapping.js
+++ b/client/js/components/prevent-overlapping.js
@@ -1,6 +1,8 @@
-import { nodeList } from '../util';
+import { nodeList, featureTest } from '../util';
 
 const preventOverlapping = (els) => {
+  if (!featureTest('position', 'sticky')) return;
+
   const stickies = nodeList(els);
 
   const setsOfElsToWrap = stickies.map((sticky) => {

--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -119,7 +119,6 @@ $center-width-xlarge: (6/6) * 100%;
     @supports (width: calc(10px + 10px)) {
       position: sticky;
       top: $vertical-space-unit;
-      transition: opacity 0.4s ease;
     }
   }
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Scrolly-shove instead of fading out the sticky elements in the right-hand rail. Fixes #574.

- [x] Test perf – looks like it could get quite janky.
- [x] Squash bugs.

## What does it look like?
![ezgif com-resize](https://cloud.githubusercontent.com/assets/1394592/23561021/6f43ce0c-0034-11e7-8ebe-f38f26c458a0.gif)

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled