### PR TITLE
Add keyline to top of burger nav

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -94,6 +94,10 @@ $tweakpoints: (
   padding-left: map-get($container-padding, 'small') + map-get($gutter-width, 'small');
   padding-right: map-get($container-padding, 'small');
 
+  @include respond-between('small', 'header-medium') {
+    border-top: 1px solid color('keyline-grey');
+  }
+
   @include respond-to('medium') {
     padding-left: map-get($container-padding, 'medium') + map-get($gutter-width, 'medium');
     padding-right: map-get($container-padding, 'medium');


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding a keyline to the top of the burger navigation. Fixes #261.

## What does it look like?
<img width="539" alt="screen shot 2017-03-06 at 09 14 36" src="https://cloud.githubusercontent.com/assets/1394592/23603675/f8340d9c-024d-11e7-83e6-3273b11294b1.png">
