### PR TITLE
Pass series data into article header area

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -26,6 +26,20 @@
   .image {
     margin-bottom: 0;
   }
+
+  .image--clip-mask {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    clip-path: polygon(0% 100%, 0% 67%, 100% 67%, 100% 100%);
+    filter: grayscale(1);
+  }
+}
+
+.captioned-image__image-container {
+  position: relative;
 }
 
 .captioned-image__caption {

--- a/server/views/components/captioned-image/index.njk
+++ b/server/views/components/captioned-image/index.njk
@@ -1,6 +1,14 @@
 <figure class="{{ 'captioned-image' | componentClasses(modifiers) }}">
   <div class="captioned-image__image-container">
   {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
+  {% if data.positionInSeries and data.series.total and data.series.color %}
+    {% componentV2 'image', model, {}, {clipMask: true, lazyload: true, sizesQueries: data.sizesQueries} %}
+    {% set chapterIndicatorModel = {
+      position: data.positionInSeries,
+      series: data.series
+    } %}
+    {% componentV2 'chapter-indicator', chapterIndicatorModel %}
+  {% endif %}
   </div>
   {% block figcaption %}
     {% if model.caption %}

--- a/server/views/components/image/index.njk
+++ b/server/views/components/image/index.njk
@@ -1,6 +1,7 @@
 {% set sizes = model | getImageSizesFor %}
 {% set comma = joiner() %}
-<img class="image{{ ' lazyload' if data.lazyload }}"
+{# TODO: refactor to remove 'promo' from these classes #}
+<img class="image{{ ' lazyload' if data.lazyload }} {{ 'image--clip-mask' if data.clipMask }}"
 src="{{ model.contentUrl }}?w={{ sizes[0] }}"
 data-srcset="
 {%- for size in sizes -%}

--- a/server/views/components/image/index.njk
+++ b/server/views/components/image/index.njk
@@ -1,6 +1,5 @@
 {% set sizes = model | getImageSizesFor %}
 {% set comma = joiner() %}
-{# TODO: refactor to remove 'promo' from these classes #}
 <img class="image{{ ' lazyload' if data.lazyload }} {{ 'image--clip-mask' if data.clipMask }}"
 src="{{ model.contentUrl }}?w={{ sizes[0] }}"
 data-srcset="

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -17,7 +17,11 @@
 
 {% for media in article.mainMedia %}
   {% if (media.contentUrl) %}
-    {% componentV2 'main-media', media, {'full': true} %}
+    {% set seriesData = {
+      positionInSeries: article.positionInSeries,
+      series: article.series
+    } %}
+    {% componentV2 'main-media', media, {'full': true}, seriesData %}
   {% endif %}
 {% endfor %}
 

--- a/server/views/templates/article.config.yml
+++ b/server/views/templates/article.config.yml
@@ -3,6 +3,10 @@ handle: article-template
 context:
   inSection: explore
   article:
+    positionInSeries: 3
+    series:
+      total: 5
+      color: 'purple'
     headline: How cultural contexts can shape mental illness
     tags: "@tags.tags"
     author: "@author"


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding the chapter indicator bars to the hero image area where required. Allows the captioned-image template to choose whether it should have chapter indicator bars based on the presence/absence of series information in the model. Closes #653.

## What does it look like?
<img width="788" alt="screen shot 2017-03-06 at 14 39 18" src="https://cloud.githubusercontent.com/assets/1394592/23614449/d5f9f66a-027a-11e7-93a7-5c431e51828f.png">

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled