### PR TITLE
Add space to bottom of article

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -29,6 +29,10 @@
   padding-top: $v-spacing-unit * 4;
 }
 
+.row--large-bottom-padding {
+  padding-bottom: $v-spacing-unit * 10;
+}
+
 .row--text-bar {
   padding-top: $v-spacing-unit * 3;
   padding-bottom: $v-spacing-unit * 3;

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -21,7 +21,7 @@
   {% endif %}
 {% endfor %}
 
-<div class="row row--cream">
+<div class="row row--cream row--large-bottom-padding">
   <div class="container">
     <div class="grid grid--no-gutters">
       <div class="grid__cell grid__cell--s4 grid__cell--m6 grid__cell--shift-m1 grid__cell--l7 grid__cell--xl6 grid__cell--shift-xl1">


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding space to the bottom of the article (before the footer). Fixes #560.

It is our intention to try and refactor out the `$v-spacing-unit` altogether (creating standalone classes to handle component spacing), but this quicker solution to this issue will only create negligible extra effort for that much larger piece of work.

## What does it look like?
<img width="896" alt="screen shot 2017-03-06 at 15 10 50" src="https://cloud.githubusercontent.com/assets/1394592/23615683/2488f6ce-027f-11e7-8eb6-cb69189a6ba8.png">