### PR TITLE
Don't init with Raven when localhost/cardigan

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -70,8 +70,16 @@ function initWithRaven() {
   }
 }
 
+const getInitType = () => {
+  if (['localhost', 'cardigan.wellcomecollection.org'].indexOf(document.location.hostname) === -1) {
+    return initWithRaven;
+  }
+
+  return init;
+};
+
 if (document.readyState !== 'loading') {
-  initWithRaven();
+  getInitType();
 } else {
-  document.addEventListener('DOMContentLoaded', initWithRaven);
+  document.addEventListener('DOMContentLoaded', getInitType);
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Reducing noise in Sentry by not reporting local/Cardigan errors. Fixes #664.