### PR TITLE
Bail out if Element doesn't have a  method

### DIFF
--- a/client/js/components/prevent-overlapping.js
+++ b/client/js/components/prevent-overlapping.js
@@ -1,7 +1,9 @@
+/* global Element */
 import { nodeList, featureTest } from '../util';
 
 const preventOverlapping = (els) => {
   if (!featureTest('position', 'sticky')) return;
+  if (!Element.prototype.hasOwnProperty('before')) return;
 
   const stickies = nodeList(els);
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Checking if `Element`s prototype has a `before()` method (required for wrapping the sticky right-hand rail stuff) and bailing out if it isn't supported. Should reduce noise in Sentry.