### PR TITLE
Video in main media

### DIFF
--- a/server/model/article-stub.js
+++ b/server/model/article-stub.js
@@ -6,7 +6,7 @@ export type ArticleStub = {|
   url: string;
   headline: string;
   description: string;
-  thumbnail?: Picture;
+  thumbnail?: ?Picture;
   datePublished: Date;
   series?: Array<ArticleSeries>;
 |};
@@ -16,13 +16,13 @@ export class ArticleStubFactory {
     const url = `/articles/${json.slug}`; // TODO: this should be discoverable, not hard coded
     const headline = entities.decode(json.title);
     const description = entities.decode(json.excerpt);
-    const wpThumbnail = json.post_thumbnail || {};
-    const thumbnail: Picture = {
+    const wpThumbnail = json.post_thumbnail || null;
+    const thumbnail: ?Picture = wpThumbnail ? {
       type: 'picture',
       contentUrl: wpThumbnail.URL,
       width: wpThumbnail.width,
       height: wpThumbnail.height
-    };
+    } : null;
     const datePublished = new Date(json.date);
     const series: Array<ArticleSeries> = Object.keys(json.categories).map(catKey => {
       const cat = json.categories[catKey];

--- a/server/model/article-stub.js
+++ b/server/model/article-stub.js
@@ -18,6 +18,7 @@ export class ArticleStubFactory {
     const description = entities.decode(json.excerpt);
     const wpThumbnail = json.post_thumbnail || {};
     const thumbnail: Picture = {
+      type: 'picture',
       contentUrl: wpThumbnail.URL,
       width: wpThumbnail.width,
       height: wpThumbnail.height

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -44,6 +44,8 @@ export class ArticleFactory {
 
     const mainImage: ?Picture = getWpFeaturedImage(json.featured_image, json.attachments);
     const mainVideo: ?Video = bodyParts[0] && bodyParts[0].type === 'video' ? bodyParts[0].value : null;
+    const mainMedia: Array<Video | Picture> = [mainImage, mainVideo].filter(Boolean);
+    console.info(mainMedia);
 
 
     const wpThumbnail = json.post_thumbnail;
@@ -72,7 +74,7 @@ export class ArticleFactory {
       standfirst: entities.decode(standfirst),
       description: entities.decode(json.excerpt),
       datePublished: new Date(json.date),
-      mainMedia: mainImage ? [mainImage] : [],
+      mainMedia: mainMedia,
       thumbnail: thumbnail,
       articleBody: articleBody,
       associatedMedia: mainImage ? [mainImage] : [],

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -41,7 +41,7 @@ export class ArticleFactory {
     const bodyParts = bodyParser(articleBody);
     const standfirst = bodyParts.find(part => part.type === 'standfirst');
 
-    const mainImage: Picture = getWpFeaturedImage(json.featured_image, json.attachments);
+    const mainImage: ?Picture = getWpFeaturedImage(json.featured_image, json.attachments);
     const wpThumbnail = json.post_thumbnail;
     const thumbnail: ?Picture = wpThumbnail ? {
       type: 'picture',
@@ -68,10 +68,10 @@ export class ArticleFactory {
       standfirst: entities.decode(standfirst),
       description: entities.decode(json.excerpt),
       datePublished: new Date(json.date),
-      mainMedia: [mainImage],
+      mainMedia: mainImage ? [mainImage] : [],
       thumbnail: thumbnail,
       articleBody: articleBody,
-      associatedMedia: [mainImage],
+      associatedMedia: mainImage ? [mainImage] : [],
       author: author,
       bodyParts: bodyParts,
       series: series

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -1,5 +1,6 @@
 // @flow
 import entities from 'entities';
+import {List} from 'immutable';
 import {type Person} from './person';
 import {type Picture} from './picture';
 import {type ContentType} from './content-type';
@@ -42,6 +43,9 @@ export class ArticleFactory {
     const standfirst = bodyParts.find(part => part.type === 'standfirst');
 
     const mainImage: ?Picture = getWpFeaturedImage(json.featured_image, json.attachments);
+    const mainVideo: ?Video = bodyParts[0] && bodyParts[0].type === 'video' ? bodyParts[0].value : null;
+
+
     const wpThumbnail = json.post_thumbnail;
     const thumbnail: ?Picture = wpThumbnail ? {
       type: 'picture',

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -3,6 +3,7 @@ import entities from 'entities';
 import {type Person} from './person';
 import {type Picture} from './picture';
 import {type ContentType} from './content-type';
+import {type Video} from './video';
 import {type ArticleSeries, getSeriesCommissionedLength} from './series';
 import {getWpFeaturedImage} from './media';
 import {bodyParser} from '../util/body-parser';
@@ -37,9 +38,13 @@ export class ArticleFactory {
     const url = `/articles/${json.slug}`; // TODO: this should be discoverable, not hard coded
     const articleBody = json.content;
 
+    const bodyParts = bodyParser(articleBody);
+    const standfirst = bodyParts.find(part => part.type === 'standfirst');
+
     const mainImage: Picture = getWpFeaturedImage(json.featured_image, json.attachments);
     const wpThumbnail = json.post_thumbnail;
     const thumbnail: ?Picture = wpThumbnail ? {
+      type: 'picture',
       contentUrl: wpThumbnail.URL,
       width: wpThumbnail.width,
       height: wpThumbnail.height
@@ -55,9 +60,6 @@ export class ArticleFactory {
         commissionedLength: getSeriesCommissionedLength(cat.slug)
       };
     });
-
-    const bodyParts = bodyParser(articleBody);
-    const standfirst = bodyParts.find(part => part.type === 'standfirst');
 
     const article: Article = {
       type: "article",

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -51,12 +51,14 @@ export class ArticleFactory {
     const bodyParts = mainVideo ? List(bodyPartsRaw).skip(1).toJS() : bodyPartsRaw;
 
     const wpThumbnail = json.post_thumbnail;
-    const thumbnail: ?Picture = wpThumbnail ? {
-      type: 'picture',
-      contentUrl: wpThumbnail.URL,
-      width: wpThumbnail.width,
-      height: wpThumbnail.height
-    } : null;
+    const thumbnail: ?Picture =
+      mainVideo ? mainVideo.posterImage :
+      (wpThumbnail ? {
+        type: 'picture',
+        contentUrl: wpThumbnail.URL,
+        width: wpThumbnail.width,
+        height: wpThumbnail.height
+      } : null);
 
     const author = authorMap[json.slug];
     const series: Array<ArticleSeries> = Object.keys(json.categories).map(catKey => {

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -39,14 +39,16 @@ export class ArticleFactory {
     const url = `/articles/${json.slug}`; // TODO: this should be discoverable, not hard coded
     const articleBody = json.content;
 
-    const bodyParts = bodyParser(articleBody);
-    const standfirst = bodyParts.find(part => part.type === 'standfirst');
+    const bodyPartsRaw = bodyParser(articleBody);
+    const standfirst = bodyPartsRaw.find(part => part.type === 'standfirst');
 
     const mainImage: ?Picture = getWpFeaturedImage(json.featured_image, json.attachments);
-    const mainVideo: ?Video = bodyParts[0] && bodyParts[0].type === 'video' ? bodyParts[0].value : null;
+    const mainVideo: ?Video = bodyPartsRaw[0] && bodyPartsRaw[0].type === 'video' ? bodyPartsRaw[0].value : null;
     const mainMedia: Array<Video | Picture> = [mainImage, mainVideo].filter(Boolean);
-    console.info(mainMedia);
 
+    // If we have a video as the main media, remove it from the bodyParts to not let it show twice
+    // This is due to the fact that WP doesn't allow you to set mainMedia as Youtube embeds.
+    const bodyParts = mainVideo ? List(bodyPartsRaw).skip(1).toJS() : bodyPartsRaw;
 
     const wpThumbnail = json.post_thumbnail;
     const thumbnail: ?Picture = wpThumbnail ? {

--- a/server/model/media.js
+++ b/server/model/media.js
@@ -1,17 +1,18 @@
-import {createPicture} from '../model/picture';
+// @flow
+import {type Picture, createPicture} from '../model/picture';
 
-export function getWpFeaturedImage(uri, images) {
+export function getWpFeaturedImage(uri: string, images: Object): ?Picture {
   const i = findWpFeaturedImage(uri, images);
   // I wish we had options ;_;
-  return i ? convertWpImageToMedia(i) : null;
+  return i ? convertWpImageToPicture(i) : null;
 }
 
-function findWpFeaturedImage(uri, images) {
+function findWpFeaturedImage(uri, images): ?Object {
   const imagesArr = Object.keys(images).map(k => images[k]);
   return imagesArr.find(i => i.URL === uri);
 }
 
-function convertWpImageToMedia(wpImage) {
+function convertWpImageToPicture(wpImage) {
   return createPicture({
     contentUrl: wpImage.URL,
     caption: wpImage.caption,

--- a/server/model/promo.js
+++ b/server/model/promo.js
@@ -10,7 +10,7 @@ import {type ArticleStub} from './article-stub';
 export type Promo = UiComponent & {
   url: string;
   title: string;
-  image?: Picture;
+  image?: ?Picture;
   contentType: ContentType;
   description?: string;
   chapter?: Chapter;

--- a/server/model/video.js
+++ b/server/model/video.js
@@ -1,9 +1,11 @@
 // @flow
+import {type Picture} from './picture';
 export type Video = {|
   type: 'video';
+  embedUrl: string;
   name?: string;
   description?: string;
-  embedUrl: string;
+  posterImage?: ?Picture;
 |}
 export function createVideo(data: Video) { return (data: Video); }
 

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -4,7 +4,7 @@ import url from 'url';
 import entities from 'entities';
 
 import {createImageGallery} from '../model/image-gallery';
-import {createPicture} from '../model/picture';
+import {createPicture, type Picture} from '../model/picture';
 import {createVideo} from '../model/video';
 import {createList} from '../model/list';
 import {createTweet} from '../model/tweet';
@@ -153,7 +153,14 @@ export function convertWpVideo(node) {
   if (isWpVideo) {
     const iframe = maybeSpan.childNodes[0];
     const embedUrl = getAttrVal(iframe.attrs, 'src');
-    const video = createVideo({ type: 'video', embedUrl });
+    const youtubeId = embedUrl.match(/embed\/[^\?](.*)\?/)[1];
+    const posterImage: Picture = {
+      type: 'picture',
+      contentUrl: `https://i3.ytimg.com/vi/${youtubeId}/hqdefault.jpg`,
+      width: 480,
+      height: 360
+    };
+    const video = createVideo({ type: 'video', embedUrl, posterImage });
 
     return createBodyPart({
       type: 'video',

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -153,7 +153,7 @@ export function convertWpVideo(node) {
   if (isWpVideo) {
     const iframe = maybeSpan.childNodes[0];
     const embedUrl = getAttrVal(iframe.attrs, 'src');
-    const video = createVideo({ embedUrl });
+    const video = createVideo({ type: 'video', embedUrl });
 
     return createBodyPart({
       type: 'video',
@@ -281,6 +281,7 @@ function getImageFromWpNode(node) {
   const [width, height] = getAttrVal(img.attrs, 'data-orig-size').split(',');
 
   return createPicture({
+    type: 'picture',
     contentUrl,
     caption,
     url: href,

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -26,6 +26,8 @@ export function getFragment(bodyText) {
 
 export function explodeIntoBodyParts(nodes) {
   const parts = nodes.map((node, nodeIndex) => {
+    // Note to self - the type here should be:
+    // (node: Node) => ?BodyPart
     const converters = [
       convertWpHeading,
       convertWpImage,
@@ -37,16 +39,20 @@ export function explodeIntoBodyParts(nodes) {
     ];
 
     // TODO: Tidy up typing here
-    const maybeBodyPart = nodeIndex === 0 ? convertWpStandfirst(node) :
-      converters.reduce((node, converter) => {
+    if (nodeIndex === 0) {
+      const maybeVideoNode = convertWpVideo(node);
+      return maybeVideoNode.type ? maybeVideoNode : convertWpStandfirst(node);
+    } else {
+      const maybeBodyPart = converters.reduce((node, converter) => {
         // Don't bother converting if it's been converted
         // We could use clever typing here, but we don't have to because JS
         return node.type ? node : converter(node);
       }, node);
 
-    const bodyPart = maybeBodyPart.type ? maybeBodyPart : convertDomNode(maybeBodyPart);
+      const bodyPart = maybeBodyPart.type ? maybeBodyPart : convertDomNode(maybeBodyPart);
 
-    return bodyPart;
+      return bodyPart;
+    }
   }).filter(part => part); // get rid of any nulls = Maybe.flatten would be good.
 
   return parts;

--- a/server/views/components/captioned-image/index.config.js
+++ b/server/views/components/captioned-image/index.config.js
@@ -4,6 +4,7 @@ import {createPicture, type Picture} from '../../../model/picture';
 export const name = 'Captioned image';
 export const handle = 'captioned-image';
 const image: Picture = createPicture({
+  type: 'picture',
   contentUrl: 'https://wellcomecollection.files.wordpress.com/2016/10/featured-image-dans-blog2.jpg',
   caption: 'An edited frame from Animating the Body',
   width: 1380,


### PR DESCRIPTION
## What is this PR trying to achieve?
Implementing @davidpmccormick's good work on the Video main media.

## Notes
I haven't thought of a way to bring in a thumbnail / promo image.

Normally we get it from the featured image in WP, but we don't have this on video pages so as not to knock dow the video.

The reason we can't get it on promo pages is because we would have to ask for the article content for every articles, which is way to much data to send down the pipes.

This is the current functionality on WP, but it would be nice to not have it like that.

e.g:
![videoonwordpress](https://cloud.githubusercontent.com/assets/31692/24151486/dad1c4b6-0e40-11e7-9144-24393a7e0a64.png)


Options:
* We add a featured image and accept that it will look strange on the blog.
* ???

## What does it look like?
![videomainmedia](https://cloud.githubusercontent.com/assets/31692/24151489/dd314196-0e40-11e7-899d-de1caa58a215.png)


## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?

## Have the following been considered/are they needed?
- [ ] Tests?
- [ ] Docs?
- [x] Spoken to the right people?
