### PR TITLE
Redisplay contentType icons on promos (using filter)

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -293,7 +293,7 @@
   }
 }
 
-.promo--podcast {
+.promo--audio {
   .icon { // aspect ratio: 27 x 22
     width: (27/22) * 1.6em;
     height: (22/22) * 1.6em;

--- a/server/filters/get-icon-for-content-type.js
+++ b/server/filters/get-icon-for-content-type.js
@@ -2,7 +2,7 @@ export default function getIconForContentType(type) {
   switch (type) {
     case 'video':
       return 'actions/play';
-    case 'podcast':
+    case 'audio':
       return 'actions/volume';
     case 'gallery':
       return 'actions/gallery-link';

--- a/server/filters/get-icon-for-content-type.js
+++ b/server/filters/get-icon-for-content-type.js
@@ -2,7 +2,7 @@ export default function getIconForContentType(type) {
   switch (type) {
     case 'video':
       return 'actions/play';
-    case 'audio':
+    case 'podcast':
       return 'actions/volume';
     case 'gallery':
       return 'actions/gallery-link';

--- a/server/model/content-type.js
+++ b/server/model/content-type.js
@@ -1,6 +1,6 @@
 // @flow
 export type ContentType =
   | 'article'
-  | 'podcast'
+  | 'audio'
   | 'video'
   | 'gallery'; // at the moment article is all we have

--- a/server/views/components/promo/index.config.js
+++ b/server/views/components/promo/index.config.js
@@ -40,8 +40,8 @@ export const variants = [
     context: {promo: Object.assign({}, promo, {modifiers: ['underlined', 'gallery']}, {contentType: 'gallery'})}
   },
   {
-    name: 'podcast',
-    context: {promo: Object.assign({}, promo, {modifiers: ['underlined', 'podcast']}, { contentType: 'podcast', length: '01:35' })}
+    name: 'audio',
+    context: {promo: Object.assign({}, promo, {modifiers: ['underlined', 'audio']}, { contentType: 'audio', length: '01:35' })}
   },
   {
     name: 'video',

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -35,15 +35,9 @@
       {% componentV2 'chapter-indicator', {series: promo.series, position: promo.positionInSeries}, ['large' if promo.modifiers and promo.modifiers | contains('standalone')] %}
     {% endif %}
 
-    {% if promo.meta.contentType === 'gallery' or promo.meta.contentType === 'podcast' or promo.meta.contentType === 'video' %}
+    {% if promo.contentType === 'gallery' or promo.contentType === 'podcast' or promo.contentType === 'video' %}
       <div class="promo__icon-container">
-        {% if promo.meta.contentType === 'gallery' %}
-          {% icon 'actions/gallery-link' %}
-        {% elif promo.contentType === 'podcast' %}
-          {% icon 'actions/volume'  %}
-        {% elif promo.contentType === 'video' %}
-            {% icon 'actions/play' %}
-        {% endif %}
+        {% icon promo.contentType | getIconForContentType %}
         {% if promo.contentType === 'gallery' and promo.length %}
           <span class="promo__length"><span class="promo__sr">Gallery with</span> {{ promo.length }} <span class="promo__sr">item{{ 's' if promo.length > 1 }}</span></span>
         {% endif %}

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -35,14 +35,14 @@
       {% componentV2 'chapter-indicator', {series: promo.series, position: promo.positionInSeries}, ['large' if promo.modifiers and promo.modifiers | contains('standalone')] %}
     {% endif %}
 
-    {% if promo.contentType === 'gallery' or promo.contentType === 'podcast' or promo.contentType === 'video' %}
+    {% if promo.contentType === 'gallery' or promo.contentType === 'audio' or promo.contentType === 'video' %}
       <div class="promo__icon-container">
         {% icon promo.contentType | getIconForContentType %}
         {% if promo.contentType === 'gallery' and promo.length %}
           <span class="promo__length"><span class="promo__sr">Gallery with</span> {{ promo.length }} <span class="promo__sr">item{{ 's' if promo.length > 1 }}</span></span>
         {% endif %}
-        {% if promo.contentType === 'podcast' or promo.contentType === 'video' and promo.length %}
-          <span class="promo__sr">{% if promo.contentType === 'podcast' %}Podcast{%else%}Video{% endif %} lasting</span>
+        {% if promo.contentType === 'audio' or promo.contentType === 'video' and promo.length %}
+          <span class="promo__sr">{% if promo.contentType === 'audio' %}Audio{% else %}Video{% endif %} lasting</span>
           {{ promo.length }}
         {% endif %}
       </div>


### PR DESCRIPTION
## What is this PR trying to achieve?
Using the correct model key to display icons on promos.

## What does it look like?
![screen shot 2017-03-22 at 14 05 42](https://cloud.githubusercontent.com/assets/1394592/24201684/ada7c56c-0f08-11e7-98cc-6b7eb1ff7136.png)