### PR TITLE
remove readystate check for DOMContentLoaded

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -70,8 +70,5 @@ function initWithRaven() {
   }
 }
 
-if (document.readyState !== 'loading') {
-  initWithRaven();
-} else {
-  document.addEventListener('DOMContentLoaded', initWithRaven);
-}
+document.addEventListener('DOMContentLoaded', initWithRaven);
+


### PR DESCRIPTION
## What is this PR trying to achieve?
We don't serve the enhanced version to anyone who doesn't support `DOMContentLoaded` - so let's not pretend we do.

## What does it look like?
🐐 

## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
