### PR TITLE
Use init without raven if DOM isn't loading

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -73,7 +73,7 @@ function initWithRaven() {
 // If the DOM is not loading, we can init, else wait till we do
 const domNotLoading = document.readyState !== 'loading';
 if (domNotLoading) {
-  initWithRaven();
+  init();
 } else {
   document.addEventListener('DOMContentLoaded', initWithRaven);
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Firing the JS at the right time.
