### PR TITLE
Nginx proxy

### DIFF
--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -1,12 +1,13 @@
 [
   {
     "name": "nginx-proxy",
-    "image": "wellcome/wellcomecollection:latest",
-    "memory": 256,
+    "image": "wellcome/wellcomecollection-nginx-proxy:latest",
+    "memory": 232,
+    "cpu": 128,
     "portMappings": [
       {
         "containerPort": 80,
-        "hostPort": 80,
+        "hostPort": 0,
         "protocol": "tcp"
       }
     ],
@@ -15,7 +16,7 @@
   {
     "name": "wellcomecollection",
     "image": "wellcome/wellcomecollection:${container_tag}",
-    "cpu": 512,
+    "cpu": 384,
     "memory": 768,
     "essential": true,
     "portMappings": [

--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -9,6 +9,8 @@
         "hostPort": 80,
         "protocol": "tcp"
       }
+    ],
+    "links": ["wellcomecollection"]
   },
   {
     "name": "wellcomecollection",

--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -1,5 +1,16 @@
 [
   {
+    "name": "nginx-proxy",
+    "image": "wellcome/wellcomecollection:latest",
+    "memory": 256,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80,
+        "protocol": "tcp"
+      }
+  },
+  {
     "name": "wellcomecollection",
     "image": "wellcome/wellcomecollection:${container_tag}",
     "cpu": 512,


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding nginx so we can start proxing to different places.
First on the list is making sure we can redirect traffic from `blog.` => `next.`.

The corresponding project is here:
https://github.com/wellcometrust/wellcomecollection-nginx-proxy

I'm not sure how we will do service discovery as yet.