### PR TITLE
add standfirst if it's the first in the body parts loop

### DIFF
--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -6,7 +6,8 @@
     <div class="body-part
                 {{- ' body-part--full-width js-full-width' if bodyPart.weight === 'standalone'  -}}
                 {{- ' body-part--sticky js-sticky' if bodyPart.weight === 'supporting'  -}}">
-      {% if bodyPart.type === 'standfirst' %}
+      {% if bodyPart.type === 'standfirst' or loop.index === 1 %}
+        {# checking the index here is a bit of a hack around when we have a video as the mainMedia #}
         {% component 'standfirst', { body: bodyPart.value } %}
       {% elif bodyPart.type === 'heading' %}
         <h2>{{ bodyPart.value.value | safe }}</h2>


### PR DESCRIPTION
## What is this PR trying to achieve?
Making sure that the standfirst is the standfirst on pages with mainMedia as video.
This won't cause regressions as the standfirst is always the first paragraph anyway. 

## What does it look like?
![frogs-standfirst](https://cloud.githubusercontent.com/assets/31692/24349067/cec0a84c-12d5-11e7-88e7-7be9fc11bba2.png)
