### PR TITLE
Add a debounced window scroll event

### DIFF
--- a/client/js/components/make-sticky.js
+++ b/client/js/components/make-sticky.js
@@ -1,6 +1,6 @@
 import {nodeList, featureTest} from '../util';
 import dropRepeats from 'xstream/extra/dropRepeats';
-import {onWindowOrientationChange$, onWindowResize$, documentReadyState$} from '../utils/dom-events';
+import {onWindowOrientationChange$, onWindowResizeDebounce$, documentReadyState$} from '../utils/dom-events';
 import sampleCombine from 'xstream/extra/sampleCombine';
 
 const initialPxFromTop = 15; // TODO: remove magic
@@ -36,7 +36,7 @@ const makeSticky = (els, store$) => {
   };
 
   stickyNavHeight$.subscribe({ next: applyPositioning });
-  onWindowResize$.compose(sampleCombine(stickyNavHeight$)).subscribe(applyPositioningListener);
+  onWindowResizeDebounce$.compose(sampleCombine(stickyNavHeight$)).subscribe(applyPositioningListener);
   onWindowOrientationChange$.compose(sampleCombine(stickyNavHeight$)).subscribe(applyPositioningListener);
   documentReadyState$.compose(sampleCombine(stickyNavHeight$)).filter(state => state === 'complete').subscribe(applyPositioningListener);
 };

--- a/client/js/components/shrink-stories-nav.js
+++ b/client/js/components/shrink-stories-nav.js
@@ -1,6 +1,6 @@
 import { featureTest } from '../util';
 import { setStickyNavHeight } from '../reducers/sticky-nav-height';
-import { onWindowScroll$ } from '../utils/dom-events';
+import { onWindowScrollThrottle$, onWindowScrollDebounce$ } from '../utils/dom-events';
 
 const shrinkStoriesNav = (el, dispatch) => {
   if (!featureTest('position', 'sticky')) return;
@@ -28,7 +28,11 @@ const shrinkStoriesNav = (el, dispatch) => {
     }
   };
 
-  onWindowScroll$.subscribe({
+  onWindowScrollThrottle$.subscribe({
+    next: () => setIsNarrow(distanceScrolled() > elFromTop)
+  });
+
+  onWindowScrollDebounce$.subscribe({
     next: () => setIsNarrow(distanceScrolled() > elFromTop)
   });
 

--- a/client/js/utils/dom-events.js
+++ b/client/js/utils/dom-events.js
@@ -2,8 +2,9 @@ import fromEvent from 'xstream/extra/fromEvent';
 import debounce from 'xstream/extra/debounce';
 import throttle from 'xstream/extra/throttle';
 
-export const onWindowResize$ = fromEvent(window, 'resize').compose(debounce(500));
-export const onWindowScroll$ = fromEvent(window, 'scroll').compose(throttle(100));
+export const onWindowResizeDebounce$ = fromEvent(window, 'resize').compose(debounce(500));
+export const onWindowScrollThrottle$ = fromEvent(window, 'scroll').compose(throttle(100));
+export const onWindowScrollDebounce$ = fromEvent(window, 'scroll').compose(debounce(500));
 export const onWindowOrientationChange$ = fromEvent(window, 'orientationchange');
 export const documentReadyState$ =
   fromEvent(document, 'readystatechange')


### PR DESCRIPTION
## What is this PR trying to achieve?
Just throttling means the nav can end up at the wrong size if a user has scrolled quickly. A debounce that will always fire after scrolling finishes fixes this.

## What does it look like?
![debounce](https://cloud.githubusercontent.com/assets/1394592/24415775/7e46279c-13da-11e7-8b80-d76dffddd9af.gif)
