### PR TITLE
Import getSeriesCommissionedLength from data directory

### DIFF
--- a/server/model/article-stub.js
+++ b/server/model/article-stub.js
@@ -2,7 +2,8 @@
 import entities from 'entities';
 import {type ContentType} from './content-type';
 import {type Picture} from './picture';
-import {type  ArticleSeries, getSeriesCommissionedLength} from "./series";
+import {type  ArticleSeries } from "./series";
+import { getSeriesCommissionedLength } from "../data/series";
 export type ArticleStub = {|
   contentType: ContentType;
   url: string;


### PR DESCRIPTION
## What is this PR trying to achieve?
Importing `getSeriesCommissionedLength` from `data` rather than `model` (fixes promos on e.g. explore landing).