### PR TITLE
Remove wobbly line from videos and 'image' contentType

### DIFF
--- a/server/views/components/captioned-image/index.njk
+++ b/server/views/components/captioned-image/index.njk
@@ -1,7 +1,7 @@
 <figure class="{{ 'captioned-image' | componentClasses(modifiers) }}">
   <div class="captioned-image__image-container">
   {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
-  {% if data.positionInSeries and data.series.total and data.series.color %}
+  {% if data.positionInSeries and data.series.total and data.series.color and data.contentType === 'article' %}
     {% componentV2 'image', model, {}, {clipMask: true, lazyload: true, sizesQueries: data.sizesQueries} %}
     {% set chapterIndicatorModel = {
       position: data.positionInSeries,

--- a/server/views/components/main-media/index.njk
+++ b/server/views/components/main-media/index.njk
@@ -1,7 +1,9 @@
 {% if model.type === 'picture' %}
   {% extends 'components/captioned-image/index.njk' %}
   {% block figcaption %}
-    {% component 'wobbly-edge', {background: 'cream'} %}
+    {% if data.contentType === 'article' %}
+      {% component 'wobbly-edge', {background: 'cream'} %}
+    {% endif %}
     {% if model.caption %}
       <div class="row row--cream">
         <div class="container">
@@ -26,5 +28,4 @@
       </div>
     </div>
   </div>
-  {% component 'wobbly-edge', {background: 'cream'} %}
 {% endif %}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -18,7 +18,13 @@
 {% endblock %}
 {% componentV2 'page-description', {title: article.headline, meta: {type: 'date', value: article.datePublished}, lead: true}, {'a': true}, {icon: article.contentType | getIconForContentType} %}
 
-{% componentV2 'main-media', article.mainMedia | getPrincipleMainMedia, {'full': true}, seriesData %}
+{% set mainMediaData = {
+  contentType: article.contentType,
+  positionInSeries: article.positionInSeries,
+  series: article.series
+} %}
+
+{% componentV2 'main-media', article.mainMedia | getPrincipleMainMedia, {'full': true}, mainMediaData %}
 
 <div class="row row--cream {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top', 'bottom']}) }} ">
   <div class="container">


### PR DESCRIPTION
## What is this PR trying to achieve?
Removing the wobbly line from articles with a `contentType` of `video` or `image` to prevent unwanted distraction from the main content.

Also re-adds the accidentally removed series data, used to display chapter indicator bars on main-media images. And only displays those bars if the `contentType` is 'article' (so they don't overlay e.g. videos or webcomics).

## What does it look like?
![screen shot 2017-03-29 at 14 24 38](https://cloud.githubusercontent.com/assets/1394592/24456788/06e73bc0-148c-11e7-95f6-d40ec20d43b0.png)
