### PR TITLE
Move margin from icon to length

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -22,15 +22,6 @@
 
   .icon {
     vertical-align: middle;
-    margin-right: map-get($gutter-width, 'small')/2;
-
-    @include respond-to('medium') {
-      margin-right: map-get($gutter-width, 'medium')/2;
-    }
-
-    @include respond-to('large') {
-      margin-right: map-get($gutter-width, 'large')/2;
-    }
   }
 }
 
@@ -153,6 +144,15 @@
 
 .promo__length {
   display: inline-block;
+  margin-left: map-get($gutter-width, 'small')/2;
+
+  @include respond-to('medium') {
+    margin-left: map-get($gutter-width, 'medium')/2;
+  }
+
+  @include respond-to('large') {
+    margin-left: map-get($gutter-width, 'large')/2;
+  }
 }
 
 .promo__sr {

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -42,7 +42,7 @@
         {% endif %}
         {% if promo.contentType === 'audio' or promo.contentType === 'video' and promo.length %}
           <span class="promo__sr">{% if promo.contentType === 'audio' %}Audio{% else %}Video{% endif %} lasting</span>
-          {{ promo.length }}
+          <span class="promo__length">{{ promo.length }}</span>
         {% endif %}
       </div>
     {% endif %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Moving the margin from the icon to the meta info so the icon has equal padding when e.g. the timestamp isn't present. Fixes #732.

## What does it look like?
![screen shot 2017-04-03 at 10 17 40](https://cloud.githubusercontent.com/assets/1394592/24602926/cdf9c228-1856-11e7-8171-7ca0732ca988.png)
