### PR TITLE
Don't apply sticky class if 'before' not supported

### DIFF
--- a/client/js/components/make-sticky.js
+++ b/client/js/components/make-sticky.js
@@ -1,3 +1,4 @@
+/* global Element */
 import {nodeList, featureTest} from '../util';
 import dropRepeats from 'xstream/extra/dropRepeats';
 import {onWindowOrientationChange$, onWindowResizeDebounce$, documentReadyState$} from '../utils/dom-events';
@@ -7,6 +8,7 @@ const initialPxFromTop = 15; // TODO: remove magic
 
 const makeSticky = (els, store$) => {
   if (!featureTest('position', 'sticky')) return;
+  if (!Element.prototype.hasOwnProperty('before')) return;
 
   const elements = nodeList(els);
 


### PR DESCRIPTION
## What is this PR trying to achieve?
We don't want to add sticky behaviour on browsers that don't support `before`, because it's required to do the element wrapping that allows for the shunting of sticky right-hand rail stuff on/off the screen. Fixes #743.
