### PR TITLE
remove koa-compress as we're gziping with nginx

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,6 @@
 import Koa from 'koa';
 import config from './config';
 import serve from 'koa-static';
-import compress from 'koa-compress';
 import {router} from './routes';
 import render from './view/render';
 import {enforceSSL} from './middleware/enforce-ssl';
@@ -12,7 +11,6 @@ const app = new Koa();
 
 app.use(enforceSSL());
 app.use(setCacheControl(config.cacheControl));
-app.use(compress(config.compress));
 app.use(serve(config.static.path));
 app.use(serve(config.favicon.path));
 app.use(render(config.views.path));

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -20,14 +20,6 @@ const config = {
   },
   cacheControl: {
     files: ['text/css','application/javascript', 'application/font-woff', 'application/font-woff2']
-  },
-  compress: {
-    filter: (content_type) => {
-      const typesToCompress = ['text/html','text/css','application/javascript'];
-      if (typesToCompress.indexOf(content_type) > -1) {
-        return true;
-      }
-    }
   }
 };
 

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,6 @@
     "entities": "^1.1.1",
     "immutable": "^3.8.1",
     "koa": "^2.0.0",
-    "koa-compress": "^2",
     "koa-router": "^7.1.0",
     "koa-static": "^3.0.0",
     "marked": "^0.3.6",


### PR DESCRIPTION
## What is this PR trying to achieve?
Removing the compression from the JS app.
[We've moved this into the `nginx` config](https://github.com/wellcometrust/wellcomecollection.org/blob/master/nginx-proxy/nginx.conf#L33-L36) as Nginx is made for this, JS isn't really.

It also nicely decouples HTTP logic from app logic.

@gestchild what do you think about moving cache controlling here too?
e.g. https://serversforhackers.com/nginx-caching

## What does it look like?
🌵 