### PR TITLE
loop through gallery items in bodyParser for image galleries

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -242,20 +242,23 @@ export function findWpImageGallery(node) {
         ).map(
           r => r.childNodes.filter(n => n.attrs && getAttrVal(n.attrs, 'class').match('gallery-group'))
         ).reduce((acc, group) => acc.concat(group)).map(group => {
-          const img = group.childNodes[0].childNodes[0].childNodes.find((node) => {
-            return node.nodeName === 'img';
-          });
-          const width = parseInt(getAttrVal(img.attrs, 'data-original-width'), 10);
-          const height = parseInt(getAttrVal(img.attrs, 'data-original-height'), 10);
-          const contentUrl = getAttrVal(img.attrs, 'data-orig-file');
-          const caption = getAttrVal(img.attrs, 'alt');
-          return createPicture({
-            contentUrl,
-            caption,
-            width,
-            height
-          });
-        });
+          const imgs = group.childNodes && group.childNodes.map(galleryItem => {
+            const img = galleryItem.childNodes[0].childNodes.find((node) => {
+              return node.nodeName === 'img';
+            });
+            const width = parseInt(getAttrVal(img.attrs, 'data-original-width'), 10);
+            const height = parseInt(getAttrVal(img.attrs, 'data-original-height'), 10);
+            const contentUrl = getAttrVal(img.attrs, 'data-orig-file');
+            const caption = getAttrVal(img.attrs, 'alt');
+            return createPicture({
+              contentUrl,
+              caption,
+              width,
+              height
+            });
+          }) || [];
+          return imgs;
+        }).reduce((acc, imgs) => acc.concat(imgs));
 
       return createBodyPart({
         type: 'imageGallery',


### PR DESCRIPTION
## What is this PR trying to achieve?
From the past it seemed like a gallery group would only ever have one gallery item.

This isn't the case - so we then great groups of images, and reduce them into a single dimensional array.

## What does it look like?
MORE 🖼 !
