### PR TITLE
Add an intermediate title size to prevent text overlapping

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -210,6 +210,10 @@
 
 .promo__title--lead {
   @include container-query(('l': ('12'))) {
+    @include font('WB4');
+  }
+
+  @include container-query(('xl': ('12'))) {
     @include font('WB3');
   }
 }


### PR DESCRIPTION
## What is this PR trying to achieve?
Preventing large hero promo type overlapping the image. The largest type size is still used at the very largest screen size ('xl'), but a slightly smaller one between 'l' and 'xl'

## What does it look like?
Before:
![screen shot 2017-04-06 at 10 37 40](https://cloud.githubusercontent.com/assets/1394592/24747840/9322ed9e-1ab5-11e7-9b71-544b32116e9a.png)

After:
![screen shot 2017-04-06 at 10 36 24](https://cloud.githubusercontent.com/assets/1394592/24747856/9d4fd66a-1ab5-11e7-9452-e05747d9a300.png)