### PR TITLE
parse images that aren't from WC Wordpress

### DIFF
--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -285,10 +285,17 @@ function getImageFromWpNode(node) {
     node.attrs && getAttrVal(node.attrs, 'class') === 'wp-caption-text'
   );
 
-  const urlObj = url.parse(getAttrVal(img.attrs, 'data-orig-file'));
+  if(!getAttrVal(img.attrs, 'data-orig-file')) {
+    console.log(img);
+  }
+  // We need to lookup the src for images that aren't from the Wellcome Collection Wordpress
+  const imgSrc = getAttrVal(img.attrs, 'data-orig-file') || getAttrVal(img.attrs, 'src');
+  const urlObj = url.parse(imgSrc);
+
   const contentUrl = `https://${urlObj.hostname}${urlObj.pathname}`;
   const caption = captionNode ? captionNode.childNodes[0].value : null;
-  const [width, height] = getAttrVal(img.attrs, 'data-orig-size').split(',');
+  // We need to lookup the dims for images that aren't from the Wellcome Collection Wordpress
+  const [width, height] = (getAttrVal(img.attrs, 'data-orig-size') || `${getAttrVal(img.attrs, 'width')},${getAttrVal(img.attrs, 'height')}`).split(',');
 
   return createPicture({
     type: 'picture',


### PR DESCRIPTION
## What is this PR trying to achieve?
Parsing images that aren't from the WC blog.

e.g. https//i1.wp.com/www.sciencemuseum.org.uk/HoMImages/Components/400/40024_3.png
on: https://next.wellcomecollection.org/articles/mummies-revealed

## What does it look like?
![mummy](https://cloud.githubusercontent.com/assets/31692/24897661/b051a3bc-1e91-11e7-971a-1f1ffd57dc83.png)


