### PR TITLE
Add digitial story part to promo

### DIFF
--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -56,7 +56,13 @@
             <header class="promo__description">
               <div class="promo__heading">
                 {% if promo.contentType %}
-                  <span class="promo__type" aria-hidden="true">{{ promo.contentType }}</span>
+                  <span class="promo__type" aria-hidden="true">
+                    {% if commissionedSeries and promo.positionInSeries %}
+                      {{ commissionedSeries.name }}: Part {{ promo.positionInSeries }}
+                    {% else %}
+                      {{ promo.contentType }}
+                    {% endif %}
+                  </span>
                 {% endif %}
                   <{{ headingLevel or 'h2'}} class="promo__title{{ ' promo__title--lead' if promo.weight === 'lead' }}">
                     {{ promo.title }}


### PR DESCRIPTION
## What is this PR trying to achieve?
Adding the part of the digital story in place of the promo content type. Addresses #770.

## What does it look like?
![screen shot 2017-04-13 at 15 47 33](https://cloud.githubusercontent.com/assets/1394592/25010107/f885dec0-2060-11e7-9aea-b33a3fb5c24f.png)