### PR TITLE
Compensate for disappearing border in Chrome on series nav

### DIFF
--- a/client/scss/components/_numbered_list.scss
+++ b/client/scss/components/_numbered_list.scss
@@ -122,6 +122,8 @@ $numbered-list-number-size-large: 96px;
 
 .numbered-list--horizontal,
 .numbered-list--horizontal-narrow {
+  background: color('keyline-grey');// Chrome has bug where borders sometimes disappear on elements with position:sticky, this compensates
+
   @include respond-to('medium') {
     display: flex;
   }


### PR DESCRIPTION
## What is this PR trying to achieve?
Chrome has a bug where the borders sometimes vanish on elements that have position:sticky applied. This would occasionally happen to the series nav when the page was scrolled.

Compensating by adding a background to the series nav.

## What does it look like?
![screen-shot-2017-04-13-at-15 50 09](https://cloud.githubusercontent.com/assets/6051896/25010393/e8d119e4-2061-11e7-9a43-a14ccbed8403.jpg)

![screen-shot-2017-04-13-at-15 58 52](https://cloud.githubusercontent.com/assets/6051896/25010608/8b653c9e-2062-11e7-8e60-8c1184878667.jpg)

