### PR TITLE
clear floated elements

### DIFF
--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -120,6 +120,10 @@ $center-width-xlarge: (6/6) * 100%;
 }
 
 /* stylelint-disable plugin/selector-bem-pattern */
+.sticky-wrapper {
+  @include clearfix;
+}
+
 .sticky-applied {
   @include respond-to('large') {
     @supports (width: calc(10px + 10px)) {


### PR DESCRIPTION
## What is this PR trying to achieve?

Fixes bug where an image caption can overlap the footer if it doesn't have position: sticky applied (which it won't if it's longer than the window)

## What does it look like?

Not like this anymore:
![pasted image at 2017_04_18 10_50 am](https://cloud.githubusercontent.com/assets/6051896/25126563/9fc57106-242a-11e7-9461-ad09b11b05bb.png)