### PR TITLE
Image gallery quick fixes

### DIFF
--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -365,6 +365,14 @@ const contentSlider = (el, options) => {
   sliderElements.prevControl.addEventListener('click', prevSlide, true);
   sliderElements.nextControl.addEventListener('click', nextSlide, true);
 
+  nodeList(sliderElements.slideItems).forEach((item) => {
+    item.addEventListener('click', ({ currentTarget }) => {
+      const slideIndex = parseInt(currentTarget.getAttribute(indexAttr), 10);
+
+      updatePosition(slideIndex, positionArray);
+    });
+  });
+
   // Handle touch
   sliderTouch.on('swiperight', prevSlide);
   sliderTouch.on('swipeleft', nextSlide);

--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -366,10 +366,10 @@ const contentSlider = (el, options) => {
   sliderElements.nextControl.addEventListener('click', nextSlide, true);
 
   nodeList(sliderElements.slideItems).forEach((item) => {
-    item.addEventListener('click', ({ currentTarget }) => {
-      const slideIndex = parseInt(currentTarget.getAttribute(indexAttr), 10);
+    item.addEventListener('click', ({ target, currentTarget }) => {
+      if (!target.matches('img')) return;
 
-      updatePosition(slideIndex, positionArray);
+      updatePosition(parseInt(currentTarget.getAttribute(indexAttr), 10), positionArray);
     });
   });
 

--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -92,7 +92,6 @@ const contentSlider = (el, options) => {
 
     // Set transition style for slider
     setPropertyPrefixed(sliderElements.slidesContainer, 'transition', `transform ${settings.transitionSpeed}s ease`);
-
     calculateDimensions(); // Dimensions which determine movement amounts
     setSlideIndexes(slidesWidthArray, containerWidth, sliderElements, indexAttr);
     toggleControlsVisibility(slidesCombinedWidth, containerWidth, sliderElements.sliderControls);

--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -366,6 +366,8 @@ const contentSlider = (el, options) => {
 
   nodeList(sliderElements.slideItems).forEach((item) => {
     item.addEventListener('click', ({ target, currentTarget }) => {
+      // We only want to match clicks on the img, because clicks on the
+      // caption could be on the 'more/less' controls
       if (!target.matches('img')) return;
 
       updatePosition(parseInt(currentTarget.getAttribute(indexAttr), 10), positionArray);

--- a/client/js/components/truncate-text.js
+++ b/client/js/components/truncate-text.js
@@ -1,6 +1,8 @@
 import fromEvent from 'xstream/extra/fromEvent';
+import { onWindowResizeDebounce$ } from '../utils/dom-events';
 
 const truncateClass = 'captioned-image__caption-text--truncate';
+const hiddenControlClass = 'captioned-image__truncate-control--is-hidden';
 const moreText = '+ More';
 const lessText = '- Less';
 
@@ -18,7 +20,7 @@ const truncateText = (caption) => {
   const hasBeenEllipsified = (e) => {
     return (e.scrollWidth > e.offsetWidth);
   };
-  const createControl = (controlledElement) => {
+  const createControl = () => {
     const control = document.createElement('button');
     control.className = 'captioned-image__truncate-control';
     control.innerHTML = moreText;
@@ -39,6 +41,16 @@ const truncateText = (caption) => {
       }
     });
   }
+
+  onWindowResizeDebounce$.subscribe({
+    next() {
+      if (hasBeenEllipsified(caption)) {
+        truncateControl.classList.remove(hiddenControlClass);
+      } else {
+        truncateControl.classList.add(hiddenControlClass);
+      }
+    }
+  });
 };
 
 export default truncateText;

--- a/client/js/components/truncate-text.js
+++ b/client/js/components/truncate-text.js
@@ -2,7 +2,6 @@ import fromEvent from 'xstream/extra/fromEvent';
 import { onWindowResizeDebounce$ } from '../utils/dom-events';
 
 const truncateClass = 'captioned-image__caption-text--truncate';
-const hiddenControlClass = 'captioned-image__truncate-control--is-hidden';
 const moreText = '+ More';
 const lessText = '- Less';
 
@@ -45,9 +44,9 @@ const truncateText = (caption) => {
   onWindowResizeDebounce$.subscribe({
     next() {
       if (hasBeenEllipsified(caption)) {
-        truncateControl.classList.remove(hiddenControlClass);
+        truncateControl.classList.remove('is-hidden');
       } else {
-        truncateControl.classList.add(hiddenControlClass);
+        truncateControl.classList.add('is-hidden');
       }
     }
   });

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -86,6 +86,12 @@
   /* stylelint-enable plugin/selector-bem-pattern */
 }
 
+.captioned-image__number {
+  @include font('HNM5');
+  display: inline-block;
+  border-right: 1px solid color('keyline-grey');
+}
+
 .captioned-image__caption-text {
   float: left;
   width: calc(100% - 2.1em);

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -119,6 +119,10 @@
   &:focus {
     text-decoration: underline;
   }
+
+  &.captioned-image__truncate-control--is-hidden {
+    display: none;
+  }
 }
 
 .captioned-image__underline {

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -89,7 +89,7 @@
 .captioned-image__number {
   @include font('HNM5');
   display: inline-block;
-  border-right: 1px solid color('keyline-grey');
+  border-right: 1px solid color('pumice');
 }
 
 .captioned-image__caption-text {

--- a/client/scss/components/_image_gallery.scss
+++ b/client/scss/components/_image_gallery.scss
@@ -126,13 +126,40 @@ $image-gallery-control-margin: 18px;
     justify-content: center;
     background: color('smoke');
   }
+
+  .captioned-image__caption {
+    position: relative;
+    opacity: 0;
+    z-index: 0;
+    transition: opacity 700ms ease;
+    width: calc(100vw - #{(map-get($container-padding, 'small') * 2)});
+
+    @include respond-to('medium') {
+      width: calc(100vw - (#{map-get($container-padding, 'medium')} * 2) - 12.5%);
+    }
+
+    @include respond-to('large') {
+      width: calc(((100vw - #{map-get($container-padding, 'large')}  * 2) / 12) * 10);
+    }
+
+    @include respond-to('xlarge') {
+      width: ($container-width-max / 12) * 7;
+    }
+  }
 }
 
 .image-gallery__slide-item--current {
   opacity: 1;
+
+  .captioned-image__caption {
+    opacity: 1;
+    z-index: 1;
+  }
 }
 
 .image-gallery__slider-controls {
+  top: -190px;
+  position: relative;
 
   /* stylelint-disable plugin/selector-bem-pattern */
   .control-arrow {
@@ -154,7 +181,6 @@ $image-gallery-control-margin: 18px;
   outline: none;
   overflow: hidden;
   position: relative;
-  top: -130px;
   margin-left: calc(100% - (2 * #{$image-gallery-control-size} + #{$image-gallery-control-margin}));
 
   // this calculation is related to the gallery appearing in the article template

--- a/client/scss/components/_image_gallery.scss
+++ b/client/scss/components/_image_gallery.scss
@@ -104,7 +104,7 @@ $image-gallery-control-margin: 18px;
 }
 
 .image-gallery__slide-item {
-  opacity: 0.2;
+  opacity: 0.5;
   transition: opacity 0.7s ease;
   align-self: flex-start;
 

--- a/client/scss/components/_image_gallery.scss
+++ b/client/scss/components/_image_gallery.scss
@@ -1,4 +1,7 @@
 //* @define image-gallery
+$image-gallery-control-size: 48px;
+$image-gallery-control-margin: 18px;
+
 .image-gallery {
   width: 100%;
   display: flex;
@@ -130,28 +133,7 @@
 }
 
 .image-gallery__slider-controls {
-  background: color('white');
-  min-height: 40px;
-  padding: $v-spacing-unit * 3 map-get($container-padding, 'small');
-  margin-bottom: $v-spacing-unit * 3;
-  margin-left: map-get($container-padding, 'small') * -1;
-  margin-right: map-get($container-padding, 'small') * -1;
-  text-align: right;
 
-  @include respond-to('medium') {
-    margin-left: map-get($container-padding, 'medium') * -1;
-    margin-right: map-get($container-padding, 'medium') * -1;
-    padding-left: map-get($container-padding, 'medium');
-    padding-right: map-get($container-padding, 'medium');
-    text-align: left;
-  }
-
-  @include respond-to('large') {
-    margin-left: map-get($container-padding, 'large') * -1;
-    margin-right: map-get($container-padding, 'large') * -1;
-    padding-left: map-get($container-padding, 'large');
-    padding-right: map-get($container-padding, 'large');
-  }
   /* stylelint-disable plugin/selector-bem-pattern */
   .control-arrow {
     width: 20px;
@@ -163,28 +145,22 @@
 .image-gallery__slider-control--prev,
 .image-gallery__slider-control--next {
   background: color('white');
-  width: 48px;
-  height: 48px;
+  width: $image-gallery-control-size;
+  height: $image-gallery-control-size;
   line-height: 0;
-  padding: 0;
   border-radius: 50%;
   border: 2px solid color('accessible-grey-2');
   cursor: pointer;
   outline: none;
   overflow: hidden;
   position: relative;
-  // these left calculations are related to the gallery appearing in the article template
-  @include respond-to('medium') {
-    margin-left: 12.5%;
-  }
+  top: -130px;
+  margin-left: calc(100% - (2 * #{$image-gallery-control-size} + #{$image-gallery-control-margin}));
 
-  @include respond-to('large') {
-    margin-left: 0;
-  }
-
+  // this calculation is related to the gallery appearing in the article template
   @include respond-to('xlarge') {
     margin-left: 50%;
-    left: (($container-width-max - (map-get($container-padding, 'large') * 2)) / 2) * (-5/6);
+    left: -(($container-width-max - (map-get($container-padding, 'large') * 2)) / 2) * (-5/6) - ((2 * $image-gallery-control-size) + $image-gallery-control-margin);
   }
 
   &:focus {
@@ -193,5 +169,5 @@
 }
 
 .image-gallery__slider-control--next {
-  margin-left: map-get($gutter-width , 'small') * 2;
+  margin-left: $image-gallery-control-margin;
 }

--- a/client/scss/components/_image_gallery.scss
+++ b/client/scss/components/_image_gallery.scss
@@ -123,8 +123,8 @@ $image-gallery-control-margin: 18px;
   .captioned-image__image-container {
     display: flex;
     flex-direction: column;
-    justify-content: center;
-    background: color('smoke');
+    justify-content: flex-end;
+    background: color('cream');
   }
 
   .captioned-image__caption {

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -14,6 +14,10 @@
   }
 }
 
+.is-hidden {
+  display: none;
+}
+
 // Adds momentum scrolling to iOS
 // TODO: consider removing if/when scroll snapping is implemented
 .touch-scroll {

--- a/server/views/components/captioned-image/index.njk
+++ b/server/views/components/captioned-image/index.njk
@@ -14,7 +14,13 @@
     {% if model.caption %}
       <figcaption class="captioned-image__caption">
         {% icon 'other/picture' %}
-        <div class="captioned-image__caption-text">
+        <div class="captioned-image__caption-text" tabindex="0">
+          {% if data.slideNumbers %}
+            <span class="captioned-image__number {{ {s:2, m:2, l:2} | spacingClasses({padding: ['right']}) }}"
+              aria-label="slide {{ data.slideNumbers.current }} of {{ data.slideNumbers.total }}">
+              <span aria-hidden="true">{{ data.slideNumbers.current }}/{{ data.slideNumbers.total }}</span>
+            </span>
+          {% endif %}
           {{ model.caption }}
         </div>
       </figcaption>

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,4 +1,4 @@
-<div class="image-gallery touch-scroll js-image-gallery" id="{{ id }}">
+<div class="image-gallery touch-scroll js-image-gallery {{ {s:5, m:10, l:10} | spacingClasses({padding: ['top']}) }}" id="{{ id }}">
   {% for item in imageGallery.items %}
   {% set smallWidth = item.width/item.height*204 %}
   {% set largeWidth = item.width/item.height*640 %}

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,10 +1,11 @@
 <div class="image-gallery touch-scroll js-image-gallery {{ {s:5, m:10, l:10} | spacingClasses({padding: ['top', 'bottom']}) }}" id="{{ id }}">
   {% for item in imageGallery.items %}
-  {% set smallWidth = item.width/item.height*204 %}
-  {% set largeWidth = item.width/item.height*640 %}
-  {% set queries = '(max-width: 600px) ' + smallWidth + 'px, ' + largeWidth + 'px' %}
-  <div class="image-gallery__item">
-    {% componentV2 'captioned-image', item, {}, {sizesQueries: queries} %}
-  </div>
+    {% set slideNumbers = {current: loop.index, total: loop.length} %}
+    {% set smallWidth = item.width/item.height*204 %}
+    {% set largeWidth = item.width/item.height*640 %}
+    {% set queries = '(max-width: 600px) ' + smallWidth + 'px, ' + largeWidth + 'px' %}
+    <div class="image-gallery__item">
+      {% componentV2 'captioned-image', item, {}, {sizesQueries: queries, slideNumbers: slideNumbers} %}
+    </div>
   {% endfor %}
 </div>

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,4 +1,4 @@
-<div class="image-gallery touch-scroll js-image-gallery {{ {s:5, m:10, l:10} | spacingClasses({padding: ['top']}) }}" id="{{ id }}">
+<div class="image-gallery touch-scroll js-image-gallery {{ {s:5, m:10, l:10} | spacingClasses({padding: ['top', 'bottom']}) }}" id="{{ id }}">
   {% for item in imageGallery.items %}
   {% set smallWidth = item.width/item.height*204 %}
   {% set largeWidth = item.width/item.height*640 %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Addressing 'quick fixes' to image gallery. Closes #777.

## What does it look like?
- One caption visible at a time,
- Control buttons moved over (and to the right of) images
- 50% opacity non-selected images
- Clicking image moves to that image
![screen shot 2017-04-19 at 13 07 54](https://cloud.githubusercontent.com/assets/1394592/25179336/5d450c7e-2501-11e7-8b6b-0eb7f1af2105.png)

- Cream slide background
- Slides bottom-aligned with background
![screen shot 2017-04-19 at 13 08 31](https://cloud.githubusercontent.com/assets/1394592/25179337/5d45b430-2501-11e7-9ee9-70a6708b39de.png)


## For interface components
- [x] Browser testing - Have you checked the component in our supported browsers
- [x] No javascript - Have you checked the component with javascript disabled
- [x] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?
