### PR TITLE
Center content in grid--no-gutters

### DIFF
--- a/client/scss/components/_article.scss
+++ b/client/scss/components/_article.scss
@@ -11,7 +11,7 @@
       content: '';
       position: absolute;
       z-index: 0;
-      right: -(map-get($gutter-width, 'large')/2);
+      right: map-get($gutter-width, 'large') / 2;
       top: 0;
       width: 1px;
       height: 100%;

--- a/client/scss/components/_author.scss
+++ b/client/scss/components/_author.scss
@@ -4,20 +4,42 @@
   margin-bottom: 2 * $vertical-space-unit;
   padding-bottom: 0.2rem;
 
-  &.author--border-bottom {
-    padding-bottom: 1.2rem;
-    border-bottom: 1px solid color('keyline-grey');
-
-    @include respond-to('medium') {
-      padding-bottom: 1.5rem;
+  .grid--no-gutters & {
+    @include respond-to('large') {
+      padding-right: map-get($gutter-width, 'large');
     }
   }
+}
 
-  &.author--border-left {
-    padding-top: 0;
-    padding-left: 1.2rem;
-    border-left: 5px solid color('keyline-grey');
+.author--border-bottom {
+  padding-bottom: 1.2rem;
+  position: relative;
+
+  @include respond-to('medium') {
+    padding-bottom: 1.5rem;
   }
+
+  &:after {
+    position: absolute;
+    content: '';
+    height: 1px;
+    background: color('keyline-grey');
+    left: 0;
+    right: 0;
+    bottom: 0;
+
+    .grid--no-gutters & {
+      @include respond-to('large') {
+        right: map-get($gutter-width, 'large');
+      }
+    }
+  }
+}
+
+.author--border-left {
+  padding-top: 0;
+  padding-left: 1.2rem;
+  border-left: 5px solid color('keyline-grey');
 }
 
 .author__upper {

--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -59,6 +59,7 @@
 }
 
 $narrow-width: (5/7) * 100%; // calculates the narrow column width as a percentage of the main column.
+$narrow-width-xlarge: (4/6) * 100%;
 $center-width-large: (6/7) * 100%; // calculates the halfway point of the container, as a percentage of the main column.
 $center-width-xlarge: (6/6) * 100%;
 
@@ -71,6 +72,10 @@ $center-width-xlarge: (6/6) * 100%;
     /* stylelint-disable declaration-no-important */
     top: 0 !important;
     /* stylelint-enable */
+  }
+
+  @include respond-to('large') {
+    padding-right: map-get($gutter-width, 'large');
   }
 }
 
@@ -87,7 +92,7 @@ $center-width-xlarge: (6/6) * 100%;
 
   @include respond-to('large') {
     left: $center-width-large;
-    margin-right: calc((#{$narrow-width} + #{map-get($gutter-width, 'large')})* -1);
+    margin-right: calc((#{$narrow-width} + #{map-get($gutter-width, 'large')}) * -1);
     background-color: color('cream');
     padding: 0 map-get($container-padding, 'large');
     padding-top: $vertical-space-unit;
@@ -106,16 +111,23 @@ $center-width-xlarge: (6/6) * 100%;
 
 .body-part--sticky {
   @include respond-to('large') {
+    padding-right: 0;
+
     @supports (width: calc(10px + 10px)) {
       float: right;
       clear: right;
-      width: #{$narrow-width};
-      margin-right: calc((#{$narrow-width} + #{map-get($gutter-width, 'large')} ) * -1);
+      width: $narrow-width;
+      margin-right: -$narrow-width;
 
       .author + .article &:first-child {
         margin-top: -$article-top-space;
       }
     }
+  }
+
+  @include respond-to('xlarge') {
+    width: $narrow-width-xlarge;
+    margin-right: -$narrow-width-xlarge;
   }
 }
 


### PR DESCRIPTION
## What is this PR trying to achieve?
Ensuring the content is centred on the page – currently there is less space to the right of the content than there is on the left.

## What does it look like?
![window](https://cloud.githubusercontent.com/assets/1394592/25190475/39890a88-2524-11e7-8b76-d07ca722e3aa.png)
