### PR TITLE
add format query param to cloudfront

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "next" {
 
     forwarded_values {
       query_string = true
-      query_string_cache_keys = ["page", "current", "q"]
+      query_string_cache_keys = ["page", "current", "q", "format"]
 
       cookies {
         forward = "whitelist"


### PR DESCRIPTION
## What is this PR trying to achieve?
Allow the format param, we'll need this for migration to get the articles in JSON format.

