### PR TITLE
Use first body image as 'main-media'

### DIFF
--- a/server/filters/get-principle-main-media.js
+++ b/server/filters/get-principle-main-media.js
@@ -1,7 +1,6 @@
 export default function getPrincipleMainMedia(arr: []) {
   const video = arr.find(item => item.type === 'video');
-  const mainPicture = arr.find(item => item.isMain);
   const picture = arr.find(item => item.type === 'picture');
 
-  return video || mainPicture || picture;
+  return video || picture;
 }

--- a/server/filters/get-principle-main-media.js
+++ b/server/filters/get-principle-main-media.js
@@ -1,10 +1,7 @@
-export default function getPrincipleMainMedia(arr) {
-  const video = arr.find((item) => {
-    return item.type === 'video';
-  });
-  const picture = arr.find((item) => {
-    return item.type === 'picture';
-  });
+export default function getPrincipleMainMedia(arr: []) {
+  const video = arr.find(item => item.type === 'video');
+  const mainPicture = arr.find(item => item.isMain);
+  const picture = arr.find(item => item.type === 'picture');
 
-  return video || picture;
+  return video || mainPicture || picture;
 }

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -49,7 +49,6 @@ export class ArticleFactory {
     }
 
     const mainVideo: ?Video = bodyPartsRaw[0] && bodyPartsRaw[0].type === 'video' ? bodyPartsRaw[0].value : null;
-    console.log(mainVideo);
     const wpThumbnail = json.post_thumbnail;
 
     const thumbnail: ?Picture = mainVideo ? mainVideo.posterImage : (wpThumbnail ? {

--- a/server/model/article.js
+++ b/server/model/article.js
@@ -44,10 +44,6 @@ export class ArticleFactory {
     const standfirst = bodyPartsRaw.find(part => part.type === 'standfirst');
     const mainComic: ?Picture = bodyPartsRaw[0] && bodyPartsRaw[0].type === 'picture' && contentType === 'comic' ? bodyPartsRaw[0].value : null;
 
-    if (mainComic) {
-      mainComic.isMain = true;
-    }
-
     const mainVideo: ?Video = bodyPartsRaw[0] && bodyPartsRaw[0].type === 'video' ? bodyPartsRaw[0].value : null;
     const wpThumbnail = json.post_thumbnail;
 
@@ -60,7 +56,7 @@ export class ArticleFactory {
     // Annoyingly Wordpress doesn't always send the featured image over with the attachments,
     // so we revert to the thumbnail.
     const mainImage: ?Picture = getWpFeaturedImage(json.featured_image, json.attachments) || thumbnail;
-    const mainMedia: Array<Video | Picture> = [mainImage, mainVideo, mainComic].filter(Boolean);
+    const mainMedia: Array<Video | Picture> = [(mainComic || mainImage), mainVideo].filter(Boolean);
 
     // If we have a video as the main media, remove it from the bodyParts to not let it show twice
     // This is due to the fact that WP doesn't allow you to set mainMedia as Youtube embeds.

--- a/server/model/picture.js
+++ b/server/model/picture.js
@@ -11,6 +11,7 @@ export type Picture = {|
   author?: string;
   copyrightHolder?: string;
   fileFormat?: string;
+  isMain?: boolean;
   url?: ?string;
 |}
 

--- a/server/model/picture.js
+++ b/server/model/picture.js
@@ -11,7 +11,6 @@ export type Picture = {|
   author?: string;
   copyrightHolder?: string;
   fileFormat?: string;
-  isMain?: boolean;
   url?: ?string;
 |}
 

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -42,8 +42,16 @@ export function explodeIntoBodyParts(nodes) {
 
     // TODO: Tidy up typing here
     if (nodeIndex === 0) {
+      const maybeImageNode = convertWpImage(node);
       const maybeVideoNode = convertWpVideo(node);
-      return maybeVideoNode.type ? maybeVideoNode : convertWpStandfirst(node);
+
+      if (maybeVideoNode.type) {
+        return maybeVideoNode;
+      } else if (maybeImageNode.type) {
+        return maybeImageNode;
+      } else {
+        return convertWpStandfirst(node);
+      }
     } else {
       const maybeBodyPart = converters.reduce((node, converter) => {
         // Don't bother converting if it's been converted


### PR DESCRIPTION
## What is this PR trying to achieve?
Leaving the WP 'featured image' free to operate as the (16:9) promo image, similar to how we've done it with video articles.