### PR TITLE
Sorting image sizes smallest to largest

### DIFF
--- a/server/filters/image-sizes.js
+++ b/server/filters/image-sizes.js
@@ -5,5 +5,5 @@ export const supportedSizes = Set([320, 420, 600, 880, 960, 1024, 1338, 2048]);
 
 export function getImageSizesFor(image) {
   const { width } = image;
-  return supportedSizes.add(width).toJS();
+  return supportedSizes.add(width).sort().toJS();
 }

--- a/server/filters/image-sizes.js
+++ b/server/filters/image-sizes.js
@@ -1,9 +1,9 @@
-import {Set} from 'immutable';
+import {OrderedSet} from 'immutable';
 
 // We add 2048 as Wordpresses image service only supports image resizing up till then
-export const supportedSizes = Set([320, 420, 600, 880, 960, 1024, 1338, 2048]);
+export const supportedSizes = OrderedSet([320, 420, 600, 880, 960, 1024, 1338, 2048]);
 
 export function getImageSizesFor(image) {
   const { width } = image;
-  return supportedSizes.add(width).sort().toJS();
+  return supportedSizes.add(width).toJS();
 }


### PR DESCRIPTION
## What is this PR trying to achieve?

Reduce the size of images loaded on small screens.

The getImageSizesFor filter was jumbling up the order of the sizes array, which meant the default image src being selected was larger than intended. This makes sure the array is ordered correctly, so the small size is chosen by default.
