### PR TITLE
use image resizer on author image

### DIFF
--- a/server/views/components/author/index.njk
+++ b/server/views/components/author/index.njk
@@ -2,7 +2,7 @@
   <div class="author__upper">
     {% if image %}
       <div class="author__image-wrap">
-        <img class="author__image" src="{{ image }}" alt="Image of {{ name }}" />
+        <img class="author__image" src="{{ image }}?w=64" alt="Image of {{ name }}" />
       </div>
     {% endif %}
     <div class="author__details">


### PR DESCRIPTION
## What is this PR trying to achieve?
We're serving up the full image size, and we shouldn't be.

## What does it look like?
![screen shot 2017-05-05 at 11 06 55](https://cloud.githubusercontent.com/assets/31692/25741521/0b539172-3183-11e7-83f1-ae16f1cdd3f4.png)

![screen shot 2017-05-05 at 11 07 01](https://cloud.githubusercontent.com/assets/31692/25741520/0b52a1e0-3183-11e7-8de6-39f8ebc20184.png)