### PR TITLE
Add thumbor Docker container and have it run in ECS

### DIFF
--- a/infra/terraform/container-definitions-thumbor.json
+++ b/infra/terraform/container-definitions-thumbor.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "thumbor",
+    "image": "wellcome/wellcomecollection-thumbor:test",
+    "cpu": 512,
+    "memory": 1000,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8000,
+        "hostPort": 0,
+        "protocol": "tcp"
+      }
+    ],
+    "environment": []
+  }
+]

--- a/infra/terraform/container-definitions.json
+++ b/infra/terraform/container-definitions.json
@@ -2,8 +2,8 @@
   {
     "name": "nginx-proxy",
     "image": "wellcome/wellcomecollection-nginx-proxy:${container_tag}",
-    "memory": 232,
-    "cpu": 128,
+    "cpu": 256,
+    "memory": 500,
     "portMappings": [
       {
         "containerPort": 80,
@@ -16,8 +16,8 @@
   {
     "name": "wellcomecollection",
     "image": "wellcome/wellcomecollection:${container_tag}",
-    "cpu": 384,
-    "memory": 768,
+    "cpu": 256,
+    "memory": 500,
     "essential": true,
     "portMappings": [
       {

--- a/infra/terraform/dev/wellcomecollection.tf
+++ b/infra/terraform/dev/wellcomecollection.tf
@@ -17,7 +17,10 @@ provider "aws" {
 module "wellcomecollection" {
   source                          = "../templates"
   project_name                    = "wellcomecollection"
+  ssl_cert_name                   = "*.dev-wellcomecollection.org"
+  alb_log_bucket                  = "wellcomecollection-dev-logs"
   container_definitions           = "${file("../container-definitions.json")}"
+  container_definitions_thumbor   = "${file("../container-definitions-thumbor.json")}"
   wellcomecollection_key_path     = "${var.wellcomecollection_key_path}"
   wellcomecollection_key_name     = "${var.wellcomecollection_key_name}"
   wellcomecollection_ssl_cert_arn = "${var.wellcomecollection_ssl_cert_arn}"

--- a/infra/terraform/prod/wellcomecollection.tf
+++ b/infra/terraform/prod/wellcomecollection.tf
@@ -17,7 +17,10 @@ provider "aws" {
 module "wellcomecollection" {
   source                          = "../templates"
   project_name                    = "wellcomecollection"
+  ssl_cert_name                   = "*.wellcomecollection.org"
+  alb_log_bucket                  = "wellcomecollection-logs"
   container_definitions           = "${file("../container-definitions.json")}"
+  container_definitions_thumbor   = "${file("../container-definitions-thumbor.json")}"
   wellcomecollection_key_path     = "${var.wellcomecollection_key_path}"
   wellcomecollection_key_name     = "${var.wellcomecollection_key_name}"
   wellcomecollection_ssl_cert_arn = "${var.wellcomecollection_ssl_cert_arn}"

--- a/infra/terraform/templates/ecs.tf
+++ b/infra/terraform/templates/ecs.tf
@@ -1,3 +1,19 @@
+data "template_file" "container_definitions" {
+  template = "${var.container_definitions}"
+
+  vars {
+    container_tag = "${var.container_tag}"
+  }
+}
+
+data "template_file" "container_definitions_thumbor" {
+  template = "${var.container_definitions_thumbor}"
+
+  vars {
+    container_tag = "${var.container_tag}"
+  }
+}
+
 resource "aws_ecs_cluster" "wellcomecollection" {
   name = "wellcomecollection"
 }
@@ -16,10 +32,46 @@ resource "aws_ecs_service" "wellcomecollection" {
   deployment_maximum_percent = 200
   iam_role = "${aws_iam_role.ecs_service_role.arn}"
 
+  placement_strategy {
+    type = "spread"
+    field = "instanceId"
+  }
+
   load_balancer {
     target_group_arn = "${aws_alb_target_group.wellcomecollection.id}"
     container_name = "nginx-proxy"
-    container_port = "80"
+    container_port = 80
+  }
+
+  depends_on = [
+    "aws_iam_role_policy.ecs_service_policy",
+    "aws_alb_listener.wellcomecollection",
+  ]
+}
+
+resource "aws_ecs_task_definition" "thumbor" {
+  family = "thumbor"
+  container_definitions = "${data.template_file.container_definitions_thumbor.rendered}"
+}
+
+resource "aws_ecs_service" "thumbor" {
+  name = "thumbor"
+  cluster = "${aws_ecs_cluster.wellcomecollection.id}"
+  task_definition = "${aws_ecs_task_definition.thumbor.arn}"
+  desired_count = 1
+  deployment_minimum_healthy_percent = 50
+  deployment_maximum_percent = 200
+  iam_role = "${aws_iam_role.ecs_service_role.arn}"
+
+  placement_strategy {
+    type = "spread"
+    field = "instanceId"
+  }
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.thumbor.id}"
+    container_name = "thumbor"
+    container_port = 8000
   }
 
   depends_on = [

--- a/infra/terraform/templates/launch.tf
+++ b/infra/terraform/templates/launch.tf
@@ -1,11 +1,3 @@
-data "template_file" "container_definitions" {
-  template = "${var.container_definitions}"
-
-  vars {
-    container_tag = "${var.container_tag}"
-  }
-}
-
 resource "aws_key_pair" "wellcomecollection" {
   key_name   = "${var.wellcomecollection_key_name}"
   public_key = "${file(var.wellcomecollection_key_path)}"
@@ -53,9 +45,9 @@ EOF
 
 resource "aws_autoscaling_group" "wellcomecollection_ecs_asg" {
   name = "wellcomecollection-cluster-instances"
-  desired_capacity = 2
-  min_size         = 2
-  max_size         = 4
+  desired_capacity = 3
+  min_size         = 3
+  max_size         = 6
   health_check_type         = "EC2"
   launch_configuration      = "${aws_launch_configuration.wellcomecollection_ecs.id}"
   vpc_zone_identifier       = ["${aws_subnet.public_a.id}", "${aws_subnet.public_b.id}"]

--- a/infra/terraform/templates/s3.tf
+++ b/infra/terraform/templates/s3.tf
@@ -1,0 +1,26 @@
+resource "aws_s3_bucket" "alb_log_bucket" {
+  bucket = "${var.alb_log_bucket}"
+}
+
+data "aws_iam_policy_document" "alb_log_bucket_policy_document" {
+  statement {
+    sid = ""
+    effect = "Allow"
+    actions = ["s3:PutObject"]
+    resources = [
+        "arn:aws:s3:::${var.alb_log_bucket}/${var.alb_log_prefix}/AWSLogs/*"
+    ]
+
+    principals {
+      // Comes from here:
+      // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#w28aac15b9c15b8c15b3b5b3
+      identifiers = ["156460612806"]
+      type = "AWS"
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "alb_log_bucket_policy" {
+  bucket = "${aws_s3_bucket.alb_log_bucket.id}"
+  policy = "${data.aws_iam_policy_document.alb_log_bucket_policy_document.json}"
+}

--- a/infra/terraform/templates/s3.tf
+++ b/infra/terraform/templates/s3.tf
@@ -8,13 +8,13 @@ data "aws_iam_policy_document" "alb_log_bucket_policy_document" {
     effect = "Allow"
     actions = ["s3:PutObject"]
     resources = [
-        "arn:aws:s3:::${var.alb_log_bucket}/${var.alb_log_prefix}/AWSLogs/*"
+        "${aws_s3_bucket.alb_log_bucket.arn}/${var.alb_log_prefix}/AWSLogs/*"
     ]
 
     principals {
       // Comes from here:
       // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#w28aac15b9c15b8c15b3b5b3
-      identifiers = ["156460612806"]
+      identifiers = ["arn:aws:iam::156460612806:root"]
       type = "AWS"
     }
   }

--- a/infra/terraform/templates/vars.tf
+++ b/infra/terraform/templates/vars.tf
@@ -5,3 +5,7 @@ variable "wellcomecollection_ssl_cert_arn" {}
 variable "container_tag" {}
 variable "website_uri" {}
 variable "container_definitions" {}
+variable "container_definitions_thumbor" {}
+variable "ssl_cert_name" {}
+variable "alb_log_bucket" {}
+variable "alb_log_prefix" { default = "dotorg-alb" }

--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -1,0 +1,4 @@
+FROM apsl/thumbor
+
+ENV ALLOWED_SOURCES="['prismic-io.s3.amazonaws.com/wellcomecollection', 'wellcomecollection.files.wordpress.com']" \
+    LOADER="thumbor.loaders.https_loader"

--- a/thumbor/docker-build.sh
+++ b/thumbor/docker-build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker build -t wellcome/wellcomecollection-thumbor:$1 .

--- a/thumbor/docker-push.sh
+++ b/thumbor/docker-push.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker push wellcome/wellcomecollection-thumbor:$1


### PR DESCRIPTION
## What is this PR trying to achieve?
As we'll be losing the Wordpress image resizer, and Prismic doesn't come with one, e need to roll our own (or, in this case, just host a well tested solution).

We'll need to add some perf metrics in here, and cache.

Next will be adding this to the build.

There's also a need to maybe start tidying the Terraform - but it works and is clear enough for now.

## What does it look like?
🎨 

