### PR TITLE
add thumbor docker push to circle build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,9 @@ jobs:
               docker build -t wellcome/wellcomecollection:$CIRCLE_BUILD_NUM .
               docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
               docker push wellcome/wellcomecollection:$CIRCLE_BUILD_NUM
-              pushd nginx-proxy && ./docker-build.sh $CIRCLE_BUILD_NUM && ./docker-push.sh && popd
+
+              pushd nginx-proxy && ./docker-build.sh $CIRCLE_BUILD_NUM && ./docker-push.sh $CIRCLE_BUILD_NUM && popd
+              pushd thumbor && ./docker-build.sh $CIRCLE_BUILD_NUM && ./docker-push.sh $CIRCLE_BUILD_NUM && popd
 
               ./build-cardigan.sh
               ./build-speedtracker.sh

--- a/infra/terraform/container-definitions-thumbor.json
+++ b/infra/terraform/container-definitions-thumbor.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "thumbor",
-    "image": "wellcome/wellcomecollection-thumbor:test",
+    "image": "wellcome/wellcomecollection-thumbor:${container_tag}",
     "cpu": 512,
     "memory": 1000,
     "essential": true,

--- a/nginx-proxy/docker-push.sh
+++ b/nginx-proxy/docker-push.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker push wellcome/wellcomecollection-nginx-proxy
+docker push wellcome/wellcomecollection-nginx-proxy:$1


### PR DESCRIPTION
## What is this PR trying to achieve?
Push the thumbor docker build when we build in circle...

This is actually seeming like overkill, because the nginx-proxy, and the thumbor docker container is actually the same most of the time...

I\ve raised an issue to look at this at some stage:
https://github.com/wellcometrust/wellcomecollection.org/issues/874