### PR TITLE
use root source for prismic bucket in thumbor

### DIFF
--- a/thumbor/Dockerfile
+++ b/thumbor/Dockerfile
@@ -1,4 +1,5 @@
 FROM apsl/thumbor
 
-ENV ALLOWED_SOURCES="['prismic-io.s3.amazonaws.com/wellcomecollection', 'wellcomecollection.files.wordpress.com']" \
+# TODO: Find a wat to restrict the prismic bucket to `/wellcomecollection`
+ENV ALLOWED_SOURCES="['prismic-io.s3.amazonaws.com', 'wellcomecollection.files.wordpress.com']" \
     LOADER="thumbor.loaders.https_loader"


### PR DESCRIPTION
## What is this PR trying to achieve?
Sources are meant to be the source only as they're matched against the host.

We can use regex's - but as the aspl/thumbor uses ENV vars over python config, I haven't quite found a way to do this.

This is the line of code from thumbor that uses regex:
https://github.com/thumbor/thumbor/blob/522a0ec364285662e6101b8cc479b928b90078eb/tests/loaders/test_http_loader.py#L124

I'd just like to get this on to move forward.