### PR TITLE
add preformatted text to article body

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -48,6 +48,7 @@
 @import 'components/numbered_list';
 @import 'components/opening_hours';
 @import 'components/page_description';
+@import 'components/preformatted';
 @import 'components/promo';
 @import 'components/series-nav';
 @import 'components/skip_link';

--- a/client/scss/components/_preformatted.scss
+++ b/client/scss/components/_preformatted.scss
@@ -1,0 +1,5 @@
+.preformatted {
+  @include font('LR3');
+
+  background: color('white');
+}

--- a/server/util/body-parser.js
+++ b/server/util/body-parser.js
@@ -37,7 +37,8 @@ export function explodeIntoBodyParts(nodes) {
       convertTweet,
       convertInstagramEmbed,
       findWpImageGallery,
-      convertQuote
+      convertQuote,
+      convertPreformatedText
     ];
 
     // TODO: Tidy up typing here
@@ -171,6 +172,24 @@ export function convertQuote(node) {
       type: 'quote',
       value: splitBlockquote(content)
     });
+  } else {
+    return node;
+  }
+}
+
+export function convertPreformatedText(node) {
+  const isPre = node.nodeName === 'pre';
+  if (isPre) {
+    const content = node.childNodes && node.childNodes[0];
+
+    if (content) {
+      return createBodyPart({
+        type: 'pre',
+        value: content.value
+      });
+    } else {
+      return node;
+    }
   } else {
     return node;
   }

--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -4,7 +4,7 @@
       <h2>{{ bodyPart.value.name }}</h2>
     {% endif %}
     <div class="body-part
-                {{- ' body-part--full-width js-full-width' if bodyPart.weight === 'standalone'  -}}
+                {{- ' body-part--full-width js-full-width' if bodyPart.weight === 'standalone' or bodyPart.type === 'pre' -}}
                 {{- ' body-part--sticky js-sticky' if bodyPart.weight === 'supporting'  -}}">
       {% if bodyPart.type === 'standfirst' or loop.index === 1 %}
         {# checking the index here is a bit of a hack around when we have a video as the mainMedia #}
@@ -31,6 +31,10 @@
         {% component 'instagram-embed', { instagramEmbed: bodyPart.value } %}
       {% elif bodyPart.type === 'quote' %}
         {% component 'quote', { body: bodyPart.value.body | safe, footer: bodyPart.value.footer | safe, modifiers: ['block'] } %}
+      {% elif bodyPart.type === 'pre' %}
+        <pre class="preformatted {{ {s:5, m:10, l:10} | spacingClasses({padding: ['top', 'bottom', 'left', 'right']}) }}">
+          {{- bodyPart.value -}}
+        </pre>
       {% else %}
         {{ bodyPart.value | safe }}
       {% endif %}


### PR DESCRIPTION
# Awaiting style from @Norvard 

## What is this PR trying to achieve?
Adding to poetry to the article body from the Wordpress preformatted text.

## What does it look like?
### Just a first pass
![screen shot 2017-05-16 at 10 28 31](https://cloud.githubusercontent.com/assets/31692/26099430/93af23d6-3a22-11e7-8fbe-fefa3ab700cb.png)

## For interface components
- [ ] Browser testing - Have you checked the component in our supported browsers
- [ ] No javascript - Have you checked the component with javascript disabled
- [ ] A11y testing - Have you run pa11y against the component and fixed/verified all errors, warnings and notices?

## Have the following been considered/are they needed?
- [ ] Tests?
- [ ] Docs?
- [ ] Spoken to the right people?
