### PR TITLE
access prismic over https

### DIFF
--- a/server/services/prismic-api.js
+++ b/server/services/prismic-api.js
@@ -4,7 +4,7 @@ import Prismic from 'prismic.io';
 let memoizedPrismic;
 export async function prismicApi() {
   if (!memoizedPrismic) {
-    memoizedPrismic = await Prismic.api('http://wellcomecollection.prismic.io/api');
+    memoizedPrismic = await Prismic.api('https://wellcomecollection.prismic.io/api');
   }
 
   return memoizedPrismic;


### PR DESCRIPTION
## What is this PR trying to achieve?
Access prismic over https because we should (and it's causing problems moving over to the new API).