### PR TITLE
format wordpress videos and remove scripts and hrs

### DIFF
--- a/server/test/util/body-parser.js
+++ b/server/test/util/body-parser.js
@@ -9,7 +9,7 @@ import {
   removeExtraAttrs,
   convertDomNode,
   convertWpImage,
-  convertWpVideo
+  convertWpYtVideo
 } from '../../util/body-parser';
 import {domNodeHtml, wpImageNodeHtml, wpVideoNodeHtml} from '../mocks/dom-nodes';
 
@@ -56,9 +56,9 @@ test('convertWpImage', t => {
   );
 });
 
-test('convertWpVideo', t => {
+test('convertWpYtVideo', t => {
   const wpVideoNode = parse.parseFragment(wpVideoNodeHtml).childNodes[0];
-  const v = convertWpVideo(wpVideoNode);
+  const v = convertWpYtVideo(wpVideoNode);
 
   t.is(
     v.value.embedUrl,


### PR DESCRIPTION
## What is this PR trying to achieve?
While doing the Prismic migration I noticed from [this article](https://next.wellcomecollection.org/articles/voicings) we have wordpress embedded articles.

We're not doing anything special with them now, it's just so I can semantically get the embed code later.

also removed `hr` tag and `script` tags.