### PR TITLE
Fixing firefox bug on article pages

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -62,6 +62,7 @@
     @include font('LR2');
   }
 
+  display: inline-block;
   color: color('black');
   padding-top: #{($v-spacing-unit * 4) - 8px}; // - to make to adjust for line-height, want padding from x-height
   padding-bottom: #{($v-spacing-unit * 4) - 8px};


### PR DESCRIPTION
## What is this PR trying to achieve?

Fixes bug in firefox. When scrolling on article pages with sticky images, the height of the figcaption on images in the main section would keep increasing in size, which had the effect that the user constantly scrolled passed the same content.

## What does it look like?

**Before**:
![before](https://cloud.githubusercontent.com/assets/6051896/26198206/28aa53ca-3bbd-11e7-9188-1876137e36ac.gif)

**After**:
![after](https://cloud.githubusercontent.com/assets/6051896/26198216/2fca02f4-3bbd-11e7-9232-eba2b00bad37.gif)

