### PR TITLE
account for articles that have the first body part as an image

### DIFF
--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -10,6 +10,9 @@
         {# checking the index here is a bit of a hack around when we have a video as the mainMedia #}
         {% if contentType === 'comic' %}
           {{ bodyPart.value | safe }}
+        {% elif bodyPart.type === 'picture' %}
+          {# On old content, the first paragraph is sometimes a picture #}
+          {% componentV2 'captioned-image', bodyPart.value, {}, {sizesQueries: '(min-width: 960px) 710px, 100vw'} %}
         {% else %}
           {% component 'standfirst', { body: bodyPart.value } %}
         {% endif %}


### PR DESCRIPTION
## What is this PR trying to achieve?
Old content sometimes has images as the first bit of content.
Assuming that's before the world of featured image.

We could have made it main media - but the content actually doesn't seem high enough quality to.

e.g: https://next.wellcomecollection.org/articles/lunch-on-drugs
 
## What does it look like?
![drugs](https://cloud.githubusercontent.com/assets/31692/26258702/b41c9bc4-3cbd-11e7-8ac5-96d4fc516784.png)
