### PR TITLE
add article schema tags

### DIFF
--- a/server/views/components/page-description/index.njk
+++ b/server/views/components/page-description/index.njk
@@ -6,7 +6,7 @@
           {% if model.intro %}
             <span class="page-description__intro {{ {s:1, m:1, l:2} | spacingClasses({margin: ['bottom']}) }}">{{ model.intro }}</span>
           {% endif %}
-          <h1 class="page-description__title">
+          <h1 class="page-description__title" itemprop="headline">
             {% if data.icon %}{% icon data.icon %}{% endif %}
             {{ model.title }}
           </h1>

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -23,55 +23,57 @@
   {% set seriesTitle = null %}
 {% endif %}
 
-{% componentV2 'page-description', {intro: seriesTitle, title: article.headline, meta: {type: 'date', value: article.datePublished}, lead: true}, {'a': true}, {icon: article.contentType | getIconForContentType} %}
+<article itemscope itemtype="http://schema.org/Article">
+  {% componentV2 'page-description', {intro: seriesTitle, title: article.headline, meta: {type: 'date', value: article.datePublished}, lead: true}, {'a': true}, {icon: article.contentType | getIconForContentType} %}
 
-{% set mainMediaData = {
-  contentType: article.contentType,
-  positionInSeries: article.positionInSeries,
-  series: commissionedSeries
-} %}
+  {% set mainMediaData = {
+    contentType: article.contentType,
+    positionInSeries: article.positionInSeries,
+    series: commissionedSeries
+  } %}
 
-{% componentV2 'main-media', article.mainMedia | getPrincipleMainMedia, {'full': true, 'comic': article.contentType === 'comic'}, mainMediaData %}
+  {% componentV2 'main-media', article.mainMedia | getPrincipleMainMedia, {'full': true, 'comic': article.contentType === 'comic'}, mainMediaData %}
 
-<div class="row row--cream {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top', 'bottom']}) }} ">
-  <div class="container">
-    <div class="grid grid--no-gutters">
-      <div class="grid__cell grid__cell--s4 grid__cell--m6 grid__cell--shift-m1 grid__cell--l7 grid__cell--xl6 grid__cell--shift-xl1">
-        {% if article.author and article.bodyParts.length > 0  %}
-          {% component 'author', {
-            name: article.author.name,
-            twitterHandle: article.author.twitterHandle,
-            modifiers: ['border-bottom'],
-            image: article.author.image
-          } %}
-        {% endif %}
-
-        <div class="article">
-          {% block articleBody %}
-            {% component 'article-body', {articleBody: article.bodyParts, contentType: article.contentType} %}
-          {% endblock %}
-
-          {% if article.author %}
+  <div class="row row--cream {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top', 'bottom']}) }} ">
+    <div class="container">
+      <div class="grid grid--no-gutters">
+        <div class="grid__cell grid__cell--s4 grid__cell--m6 grid__cell--shift-m1 grid__cell--l7 grid__cell--xl6 grid__cell--shift-xl1">
+          {% if article.author and article.bodyParts.length > 0  %}
             {% component 'author', {
               name: article.author.name,
               twitterHandle: article.author.twitterHandle,
-              modifiers: ['border-left'],
-              description: article.author.description,
+              modifiers: ['border-bottom'],
               image: article.author.image
             } %}
           {% endif %}
 
-          <hr class="divider divider--stub divider--black {{ {s:4, m:4, l:4} | spacingClasses({margin: ['top']}) }} {{ {s:1, m:1, l:1} | spacingClasses({margin: ['bottom']}) }}" />
+          <div class="article" itemprop="articleBody">
+            {% block articleBody %}
+              {% component 'article-body', {articleBody: article.bodyParts, contentType: article.contentType} %}
+            {% endblock %}
 
-          {% if article.tags.length > 0 %}
-            {% component 'tags', { tags: article.tags } %}
-          {% endif %}
+            {% if article.author %}
+              {% component 'author', {
+                name: article.author.name,
+                twitterHandle: article.author.twitterHandle,
+                modifiers: ['border-left'],
+                description: article.author.description,
+                image: article.author.image
+              } %}
+            {% endif %}
+
+            <hr class="divider divider--stub divider--black {{ {s:4, m:4, l:4} | spacingClasses({margin: ['top']}) }} {{ {s:1, m:1, l:1} | spacingClasses({margin: ['bottom']}) }}" />
+
+            {% if article.tags.length > 0 %}
+              {% component 'tags', { tags: article.tags } %}
+            {% endif %}
+          </div>
+
         </div>
-
       </div>
     </div>
   </div>
-</div>
+</article>
 
 {% block transporters %}
   {% for series in article.series %}


### PR DESCRIPTION
## What is this PR trying to achieve?
While adding content to Pocket, I realised it wasn't parsing our article.
Weirdly this doesn't work either, but it's something we should probably do.

I haven't added a whole bunch of the stuff (author etc) as I'm waiting to hear back from Pocket to see if they support JSON-LD - if they do, we'll just dump that on the page.

