### PR TITLE
Image loading

### DIFF
--- a/client/scss/application.scss
+++ b/client/scss/application.scss
@@ -43,6 +43,7 @@
 @import 'components/iframed_video';
 @import 'components/image_gallery';
 @import 'components/interview';
+@import 'components/lazyload';
 @import 'components/more_info_link';
 @import 'components/new_site_notice';
 @import 'components/numbered_list';

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -1,11 +1,6 @@
 //* @define captioned-image
 .captioned-image {
   margin: 0 0 $vertical-space-unit;
-
-  .image {
-    width: 100%;
-    display: block;
-  }
 }
 
 .captioned-image--bleed {

--- a/client/scss/components/_lazyload.scss
+++ b/client/scss/components/_lazyload.scss
@@ -1,0 +1,12 @@
+.lazy-image.lazy-image {
+  display: none;
+  opacity: 0.6;
+
+  .enhanced & {
+    display: block;
+  }
+
+  &.lazyloaded {
+    opacity: 1;
+  }
+}

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -238,7 +238,7 @@
     display: block;
     width: 100%;
     backface-visibility: hidden; // Fixes chrome bug where image shifts slightly and appears blurry during transition
-    transition: transform 200ms ease;
+    transition: transform 200ms ease, opacity 500ms ease;
   }
 
   #{$interactionElement}:hover #{$zoomElement},

--- a/server/filters/image-sizes.js
+++ b/server/filters/image-sizes.js
@@ -2,7 +2,7 @@ import {OrderedSet} from 'immutable';
 
 // We add 2048 as Wordpresses image service only supports image resizing up till then
 const maxWidth = 2048;
-export const supportedSizes = OrderedSet([320, 420, 600, 880, 960, 1024, 1338, maxWidth]);
+export const supportedSizes = OrderedSet([160, 320, 420, 600, 880, 960, 1024, 1338, maxWidth]);
 
 export function getImageSizesFor(image) {
   const { width } = image;

--- a/server/views/components/article-body/index.njk
+++ b/server/views/components/article-body/index.njk
@@ -16,7 +16,14 @@
       {% elif bodyPart.type === 'heading' %}
         <h2>{{ bodyPart.value.value | safe }}</h2>
       {% elif bodyPart.type === 'picture' %}
-        {% componentV2 'captioned-image', bodyPart.value, {}, {sizesQueries: '(min-width: 960px) 710px, 100vw'} %}
+        {% if bodyPart.weight === 'standalone' %}
+          {% set sizes = '100vw' %}
+        {% elif bodyPart.weight === 'supporting' %}
+          {% set sizes = '(min-width: 1340px) 406px, (min-width: 960px) calc(41.67vw - 50px), (min-width: 600px) calc(75vw - 63px), calc(100vw - 36px)' %}
+        {% else %}
+          {% set sizes ='(min-width: 1340px) 579px, (min-width: 960px) calc(58.33vw - 100px), (min-width: 600px) calc(75vw - 63px), calc(100vw - 36px)' %}
+        {% endif %}
+        {% componentV2 'captioned-image', bodyPart.value, {}, {sizesQueries: sizes} %}
       {% elif bodyPart.type === 'video' %}
         {% componentV2 'iframed-video', bodyPart.value %}
       {% elif bodyPart.type === 'list' %}

--- a/server/views/components/captioned-image/index.njk
+++ b/server/views/components/captioned-image/index.njk
@@ -1,13 +1,14 @@
 <figure class="{{ 'captioned-image' | componentClasses(modifiers) }}">
   <div class="captioned-image__image-container">
-  {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
   {% if data.positionInSeries and data.series.commissionedLength and data.series.color and data.contentType === 'article' %}
-    {% componentV2 'image', model, {}, {clipMask: true, lazyload: true, sizesQueries: data.sizesQueries} %}
+    {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries, clipPathClass: 'promo__clip-path--chapters-third'} %}
     {% set chapterIndicatorModel = {
       position: data.positionInSeries,
       series: data.series
     } %}
     {% componentV2 'chapter-indicator', chapterIndicatorModel %}
+  {% else %}
+    {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
   {% endif %}
   </div>
   {% block figcaption %}

--- a/server/views/components/find-us/index.njk
+++ b/server/views/components/find-us/index.njk
@@ -24,12 +24,7 @@
             {{ baseUrl }}{{ size }}x{{ size }}@2x.png32?{{ accessToken }} {{ size * 2 }}w
           {%- endfor %}
         "
-        sizes="
-        (min-width: 600px) 563px,
-        (min-width: 780px) 425px,
-        (min-width: 960px) 282px,
-        600px
-        "
+        sizes="(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)"
         alt="Directions to Wellcome Collection">
     </div>
   </a>

--- a/server/views/components/image-gallery/index.njk
+++ b/server/views/components/image-gallery/index.njk
@@ -1,9 +1,7 @@
 <div class="image-gallery touch-scroll js-image-gallery {{ {s:5, m:10, l:10} | spacingClasses({padding: ['top', 'bottom']}) }}" id="{{ id }}">
   {% for item in imageGallery.items %}
     {% set slideNumbers = {current: loop.index, total: loop.length} %}
-    {% set smallWidth = item.width/item.height*204 %}
-    {% set largeWidth = item.width/item.height*640 %}
-    {% set queries = '(max-width: 600px) ' + smallWidth + 'px, ' + largeWidth + 'px' %}
+    {% set queries = '(max-width: 600px) 100vw, ' + (item.width/item.height)*640 + 'px' %}
     <div class="image-gallery__item">
       {% componentV2 'captioned-image', item, {}, {sizesQueries: queries, slideNumbers: slideNumbers} %}
     </div>

--- a/server/views/components/image/index.njk
+++ b/server/views/components/image/index.njk
@@ -1,8 +1,11 @@
 {% set sizes = model | getImageSizesFor %}
 {% set comma = joiner() %}
-
-<img width="{{model.width}}" height="{{model.height}}" class="image{{ ' lazyload' if data.lazyload }} {{ 'image--clip-mask' if data.clipMask }}"
-src="{{ model.contentUrl }}?w=600"
+<noscript>
+  <img data-width="{{model.width}}" data-height="{{model.height}}" class="image {{ 'image--clip-mask' if data.clipMask }}" src="{{ model.contentUrl }}?w=320"
+alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{ model.caption | striptags() }}{% endif %}" />
+</noscript>
+<img width="{{model.width}}" height="{{model.height}}" class="image{{ ' lazy-image lazyload' if data.lazyload }} {{ 'image--clip-mask' if data.clipMask }}"
+src="{{ model.contentUrl }}?w=30"
 data-srcset="
 {%- for size in sizes -%}
   {{ comma() }}{{ model.contentUrl }}?w={{ size }} {{ size }}w

--- a/server/views/components/image/index.njk
+++ b/server/views/components/image/index.njk
@@ -1,21 +1,37 @@
 {% set sizes = model | getImageSizesFor %}
 {% set comma = joiner() %}
+{% if data.clipPathClass %}
+  {% set loop = [1,2] %}
+{% else %}
+  {% set loop = [1] %}
+{% endif %}
 <noscript>
-  <img data-width="{{model.width}}" data-height="{{model.height}}" class="image {{ 'image--clip-mask' if data.clipMask }}" src="{{ model.contentUrl }}?w=320"
+  <img data-width="{{model.width}}" data-height="{{model.height}}" class="image
+  {#{{ 'image--clip-mask' if data.clipMask }}#}
+  "
+  src="{{ model.contentUrl }}?w=320"
 alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{ model.caption | striptags() }}{% endif %}" />
 </noscript>
-<img width="{{model.width}}" height="{{model.height}}" class="image{{ ' lazy-image lazyload' if data.lazyload }} {{ 'image--clip-mask' if data.clipMask }}"
-src="{{ model.contentUrl }}?w=30"
-data-srcset="
-{%- for size in sizes -%}
-  {{ comma() }}{{ model.contentUrl }}?w={{ size }} {{ size }}w
-{%- endfor %}"
-{% if data.sizesQueries %}
-  sizes="{{ data.sizesQueries }}"
-{% else %}
-  sizes="100vw"
-{% endif %}
-{% if model.copyright %}
-  data-copyright="{{ model.copyright }}"
-{% endif %}
-alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{ model.caption | striptags() }}{% endif %}" />
+
+{% for item in loop %}
+  <img width="{{model.width}}" height="{{model.height}}" class="image{{ ' lazy-image lazyload' if data.lazyload }}
+  {#{{ 'image--clip-mask' if data.clipMask }}#}
+  {% if loop.index0 === 1 %}
+    promo__image-mask {{data.clipPathClass}}
+  {% endif %}
+  "
+  src="{{ model.contentUrl }}?w=30"
+  data-srcset="
+  {%- for size in sizes -%}
+    {{ comma() }}{{ model.contentUrl }}?w={{ size }} {{ size }}w
+  {%- endfor %}"
+  {% if data.sizesQueries %}
+    sizes="{{ data.sizesQueries }}"
+  {% else %}
+    sizes="100vw"
+  {% endif %}
+  {% if model.copyright %}
+    data-copyright="{{ model.copyright }}"
+  {% endif %}
+  alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{ model.caption | striptags() }}{% endif %}" />
+{% endfor %}

--- a/server/views/components/image/index.njk
+++ b/server/views/components/image/index.njk
@@ -1,5 +1,6 @@
 {% set sizes = model | getImageSizesFor %}
 {% set comma = joiner() %}
+{# Note to future selves - having the clipPathClass means we need 2 images on the page (with slightly different classes). Creating an array here, so can loop over the image code instead of repeating it. #}
 {% if data.clipPathClass %}
   {% set loop = [1,2] %}
 {% else %}

--- a/server/views/components/image/index.njk
+++ b/server/views/components/image/index.njk
@@ -6,16 +6,12 @@
   {% set loop = [1] %}
 {% endif %}
 <noscript>
-  <img data-width="{{model.width}}" data-height="{{model.height}}" class="image
-  {#{{ 'image--clip-mask' if data.clipMask }}#}
-  "
-  src="{{ model.contentUrl }}?w=320"
+  <img data-width="{{model.width}}" data-height="{{model.height}}" class="image" src="{{ model.contentUrl }}?w=320"
 alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{ model.caption | striptags() }}{% endif %}" />
 </noscript>
 
 {% for item in loop %}
   <img width="{{model.width}}" height="{{model.height}}" class="image{{ ' lazy-image lazyload' if data.lazyload }}
-  {#{{ 'image--clip-mask' if data.clipMask }}#}
   {% if loop.index0 === 1 %}
     promo__image-mask {{data.clipPathClass}}
   {% endif %}

--- a/server/views/components/numbered-list/index.njk
+++ b/server/views/components/numbered-list/index.njk
@@ -24,7 +24,7 @@
           <span class="numbered-list__number" aria-hidden="true">{{ loop.index }}</span>
 
           {% if isTransporter %}
-            {% component 'promo', {promo: item} %}
+            {% componentV2 'promo', item %}
           {% else %}
             {% if item.url %}
               <a href="{{ item.url }}" class="numbered-list__link">

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -20,23 +20,6 @@
       </div>
     {% endif %}
 
-    {% for modifier in promo.modifiers %}
-      {% if modifier === 'series' %}
-        <svg class="promo__defs">{# TODO proper filter - see Tomi; and only want this on the page once, where's best to move?#}
-          <defs>
-            <filter id="duotone" color-interpolation-filters="sRGB" x="0" y="0" height="100%" width="100%">
-              <feColorMatrix type="matrix"
-                values="0.90 0 0 0   0.40
-                        0.95 0 0 0  -0.10
-                      -0.20 0 0 0   0.65
-                          0  0 0 1   0" />
-            </filter>
-          </defs>
-        </svg>
-        <img class="image promo__image-mask promo__clip-path--{{ [1,2,3,4,5,6,7,8,9,10] | random }}" src="{{ promo.article.thumbnail.contentUrl }}?w=600" alt="" />
-      {% endif %}
-    {% endfor %}
-
     {% if promo.series %}
       {% set seriesTitle = promo.series | getSeriesTitle %}
       {% set commissionedSeries = promo.series | getCommissionedSeries %}

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -1,9 +1,11 @@
-{% set leadPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 876px, 812px' %}
-{% set defaultPromoSizes = '(max-width: 599px) 564px, (max-width: 959px) 276px, 386px' %}
 {% if promo.weight === 'lead' %}
-  {% set sizes = leadPromoSizes %}
+  {% set sizes = '(min-width: 1420px) 812px, (min-width: 600px) 58.5vw, calc(100vw - 36px)' %}
 {% else %}
-  {% set sizes = defaultPromoSizes %}
+  {% if promo.modifiers and promo.modifiers | contains('standalone') %}
+    {% set sizes = '100vw' %}
+  {% else %}
+    {% set sizes = '(min-width: 1340px) 178px, (min-width: 960px) calc(33.33vw - 60px), (min-width: 600px) calc(50vw - 54px), calc(66.79vw - 18px)' %}
+  {% endif %}
 {% endif %}
 
 <{{ 'a' if promo.url else 'span' }}

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -8,25 +8,34 @@
   {% endif %}
 {% endif %}
 
+{% if promo.series %}
+  {% set seriesTitle = promo.series | getSeriesTitle %}
+  {% set commissionedSeries = promo.series | getCommissionedSeries %}
+  {% if commissionedSeries and promo.positionInSeries and promo.url %}
+    {% set addImageMask = true %}
+    {% set addIndicatorBars = true %}
+    {% if promo.modifiers and promo.modifiers | contains('standalone') %}
+      {% set clipPathClass = 'promo__clip-path--chapters-half' %}
+    {% else %}
+      {% set clipPathClass = 'promo__clip-path--chapters-third' %}
+    {% endif %}
+  {% endif %}
+{% endif %}
+
 <{{ 'a' if promo.url else 'span' }}
   {% if promo.url %}href="{{ promo.url }}"{% endif %}
   class="promo {% for modifier in promo.modifiers %}promo--{{ modifier }} {% endfor %} promo--{{ promo.contentType }} {{ 'promo--surrogate' if not promo.url }}">
   <div class="promo__image-container">
     {% if promo.image %}
-      {% componentV2 'image', promo.image, {}, {lazyload: true, sizesQueries: sizes} %}
+      {% componentV2 'image', promo.image, {}, {lazyload: true, sizesQueries: sizes, clipPathClass: clipPathClass} %}
     {% else %}
       <div class="promo__image-surrogate">
         <div class="promo__image-surrogate-inner"></div>
       </div>
     {% endif %}
 
-    {% if promo.series %}
-      {% set seriesTitle = promo.series | getSeriesTitle %}
-      {% set commissionedSeries = promo.series | getCommissionedSeries %}
-      {% if commissionedSeries and promo.positionInSeries and promo.url %}
-        <img class="image promo__image-mask {{'promo__clip-path--chapters-half' if promo.modifiers and promo.modifiers | contains('standalone') else 'promo__clip-path--chapters-third'}}" src="{{ promo.image.contentUrl }}?w=600" alt="" />
+    {% if addIndicatorBars %}
         {% componentV2 'chapter-indicator', {series: commissionedSeries, position: promo.positionInSeries}, {'half': promo.modifiers and promo.modifiers | contains('standalone')}, {showSingle: promo.modifiers and promo.modifiers | contains('standalone')} %}
-      {% endif %}
     {% endif %}
 
     {% if promo.contentType === 'gallery' or promo.contentType === 'audio' or promo.contentType === 'video' %}

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -1,20 +1,16 @@
-{% if promo.weight === 'lead' %}
-  {% set sizes = '(min-width: 1420px) 812px, (min-width: 600px) 58.5vw, calc(100vw - 36px)' %}
+{% if data.sizes %}
+  {% set sizes = data.sizes %}
 {% else %}
-  {% if promo.modifiers and promo.modifiers | contains('standalone') %}
-    {% set sizes = '100vw' %}
-  {% else %}
-    {% set sizes = '(min-width: 1340px) 178px, (min-width: 960px) calc(33.33vw - 60px), (min-width: 600px) calc(50vw - 54px), calc(66.79vw - 18px)' %}
-  {% endif %}
+  {% set sizes = '100vw' %}
 {% endif %}
 
-{% if promo.series %}
-  {% set seriesTitle = promo.series | getSeriesTitle %}
-  {% set commissionedSeries = promo.series | getCommissionedSeries %}
-  {% if commissionedSeries and promo.positionInSeries and promo.url %}
+{% if model.series %}
+  {% set seriesTitle = model.series | getSeriesTitle %}
+  {% set commissionedSeries = model.series | getCommissionedSeries %}
+  {% if commissionedSeries and model.positionInSeries and model.url %}
     {% set addImageMask = true %}
     {% set addIndicatorBars = true %}
-    {% if promo.modifiers and promo.modifiers | contains('standalone') %}
+    {% if model.modifiers and model.modifiers | contains('standalone') %}
       {% set clipPathClass = 'promo__clip-path--chapters-half' %}
     {% else %}
       {% set clipPathClass = 'promo__clip-path--chapters-third' %}
@@ -22,12 +18,12 @@
   {% endif %}
 {% endif %}
 
-<{{ 'a' if promo.url else 'span' }}
-  {% if promo.url %}href="{{ promo.url }}"{% endif %}
-  class="promo {% for modifier in promo.modifiers %}promo--{{ modifier }} {% endfor %} promo--{{ promo.contentType }} {{ 'promo--surrogate' if not promo.url }}">
+<{{ 'a' if model.url else 'span' }}
+  {% if model.url %}href="{{ model.url }}"{% endif %}
+  class="promo {% for modifier in model.modifiers %}promo--{{ modifier }} {% endfor %} promo--{{ model.contentType }} {{ 'promo--surrogate' if not model.url }}">
   <div class="promo__image-container">
-    {% if promo.image %}
-      {% componentV2 'image', promo.image, {}, {lazyload: true, sizesQueries: sizes, clipPathClass: clipPathClass} %}
+    {% if model.image %}
+      {% componentV2 'image', model.image, {}, {lazyload: true, sizesQueries: sizes, clipPathClass: clipPathClass} %}
     {% else %}
       <div class="promo__image-surrogate">
         <div class="promo__image-surrogate-inner"></div>
@@ -35,23 +31,23 @@
     {% endif %}
 
     {% if addIndicatorBars %}
-        {% componentV2 'chapter-indicator', {series: commissionedSeries, position: promo.positionInSeries}, {'half': promo.modifiers and promo.modifiers | contains('standalone')}, {showSingle: promo.modifiers and promo.modifiers | contains('standalone')} %}
+        {% componentV2 'chapter-indicator', {series: commissionedSeries, position: model.positionInSeries}, {'half': model.modifiers and model.modifiers | contains('standalone')}, {showSingle: model.modifiers and model.modifiers | contains('standalone')} %}
     {% endif %}
 
-    {% if promo.contentType === 'gallery' or promo.contentType === 'audio' or promo.contentType === 'video' %}
+    {% if model.contentType === 'gallery' or model.contentType === 'audio' or model.contentType === 'video' %}
       <div class="promo__icon-container">
-        {% icon promo.contentType | getIconForContentType %}
-        {% if promo.contentType === 'gallery' and promo.length %}
-          <span class="promo__length"><span class="promo__sr">Gallery with</span> {{ promo.length }} <span class="promo__sr">item{{ 's' if promo.length > 1 }}</span></span>
+        {% icon model.contentType | getIconForContentType %}
+        {% if model.contentType === 'gallery' and model.length %}
+          <span class="promo__length"><span class="promo__sr">Gallery with</span> {{ model.length }} <span class="promo__sr">item{{ 's' if model.length > 1 }}</span></span>
         {% endif %}
-        {% if promo.contentType === 'audio' or promo.contentType === 'video' and promo.length %}
-          <span class="promo__sr">{% if promo.contentType === 'audio' %}Audio{% else %}Video{% endif %} lasting</span>
-          <span class="promo__length">{{ promo.length }}</span>
+        {% if model.contentType === 'audio' or model.contentType === 'video' and model.length %}
+          <span class="promo__sr">{% if model.contentType === 'audio' %}Audio{% else %}Video{% endif %} lasting</span>
+          <span class="promo__length">{{ model.length }}</span>
         {% endif %}
       </div>
     {% endif %}
   </div>
-  {% if promo.modifiers and promo.modifiers | contains('standalone') %}
+  {% if model.modifiers and model.modifiers | contains('standalone') %}
     <div class="row row--cream {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }} ">
       <div class="container">
         <div class="grid">
@@ -59,29 +55,29 @@
           {% endif %}
             <header class="promo__description">
               <div class="promo__heading">
-                {% if promo.contentType %}
+                {% if model.contentType %}
                   <span class="promo__type" aria-hidden="true">
-                    {% if commissionedSeries and promo.positionInSeries %}
-                      {{ commissionedSeries.name }}: Part {{ promo.positionInSeries }}
+                    {% if commissionedSeries and model.positionInSeries %}
+                      {{ commissionedSeries.name }}: Part {{ model.positionInSeries }}
                     {% elif seriesTitle %}
                       {{ seriesTitle }}
                     {% else %}
-                      {{ promo.contentType }}
+                      {{ model.contentType }}
                     {% endif %}
                   </span>
                 {% endif %}
-                  <{{ headingLevel or 'h2'}} class="promo__title{{ ' promo__title--lead' if promo.weight === 'lead' }}">
-                    {{ promo.title if promo.url else 'Coming soon…' }}
+                  <{{ headingLevel or 'h2'}} class="promo__title{{ ' promo__title--lead' if model.weight === 'lead' }}">
+                    {{ model.title if model.url else 'Coming soon…' }}
                   </{{ headingLevel or 'h2'}}>
               </div>
-              {% if promo.description %}
-                <span class="promo__copy">{{ promo.description | striptags | safe | truncate(140) }}</span>
+              {% if model.description %}
+                <span class="promo__copy">{{ model.description | striptags | safe | truncate(140) }}</span>
               {% endif %}
             </header>
-          {% if promo.modifiers and promo.modifiers | contains('standalone') %}
+          {% if model.modifiers and model.modifiers | contains('standalone') %}
           </div>
         </div>
       </div>
     </div>
   {% endif %}
-</{{ 'a' if promo.url else 'span' }}>
+</{{ 'a' if model.url else 'span' }}>

--- a/server/views/components/series-container/index.njk
+++ b/server/views/components/series-container/index.njk
@@ -1,3 +1,8 @@
+{% set sizes1 = '(min-width: 1400px) 594px, (min-width: 600px) calc(44.62vw - 22px), calc(66.79vw - 18px)' %}
+{% set sizes2 = '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(66.79vw - 18px)' %}
+{% set sizes3 = '(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(33.24vw - 43px), calc(66.79vw - 18px)' %}
+{% set sizes4 = '(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(50vw - 54px), calc(66.79vw - 18px)' %}
+
 <div class="row {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }} ">
   <div class="container">
     <div class="grid">
@@ -16,8 +21,30 @@
   <div class="container container--scroll touch-scroll">
     <div class="grid grid--dividers grid--scroll grid--theme-{{ model.items.size if model.items.size < 8 else '8' }}">
       {% for promo in model.items.take(8).toJS() %}
+        {% if loop.length % 3 == 0 %}
+          {% set sizes = sizes2 %}
+        {% endif %}
+        {% if loop.length % 4 == 0 %}
+          {% set sizes = sizes3 %}
+        {% endif %}
+        {% if loop.length === 5 %}
+          {% if loop.index0 < 2 %}
+            {% set sizes = sizes1 %}
+          {% else %}
+            {% set sizes = sizes2 %}
+          {% endif %}
+        {% endif %}
+        {% if loop.length === 7 %}
+          {% if loop.index0 < 3 %}
+            {% set sizes = sizes2 %}
+          {% elif loop.index0 === 3 %}
+            {% set sizes = sizes4 %}
+          {% else %}
+            {% set sizes = sizes3 %}
+          {% endif %}
+        {% endif %}
         <div class="grid__cell">
-          {% component 'promo', { promo: promo } %}
+          {% componentV2 'promo', promo, {}, {sizes: sizes} %}
         </div>
       {% endfor %}
     </div>

--- a/server/views/components/transporter/index.njk
+++ b/server/views/components/transporter/index.njk
@@ -14,8 +14,7 @@
     {% for promo in promos %}
     <div class="{{ {s:4, m:8} | gridClasses }} transporter__item">
       {% set modifiers = promo.modifiers.concat('large-text') if (promos.length <= 4) else promo.modifiers %}
-
-      {% component 'promo', { promo: promo | objectAssign({ modifiers: modifiers }) } %}
+      {% componentV2 'promo', promo | objectAssign({ modifiers: modifiers }) %}
     </div>
     {% endfor %}
   </div>

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -6,7 +6,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s:4, m:8, l:12, xl:12} | gridClasses }}">
-          {% component 'promo', { promo: topPromo } %}
+          {% componentV2 'promo', topPromo, {}, {sizes: '(min-width: 1420px) 812px, (min-width: 600px) 58.5vw, calc(100vw - 36px)'} %}
         </div>
       </div>
     </div>
@@ -18,7 +18,7 @@
       <div class="grid grid--dividers grid--scroll">
         {% for promo in second3Promos.toJS() %}
           <div class="grid__cell">
-            {% component 'promo', { promo: promo } %}
+            {% componentV2 'promo', promo, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(33.24vw - 43px), calc(66.79vw - 18px)'} %}
           </div>
         {% endfor %}
       </div>
@@ -52,12 +52,12 @@
       <div class="grid grid--scroll grid--dividers grid--theme-6-strip">
         {% for promo in next8Promos.take(6).toJS() %}
           <div class="grid__cell">
-            {% component 'promo', { promo: promo } %}
+            {% componentV2 'promo', promo, {}, {sizes: '(min-width: 1340px) 178px, (min-width: 960px) calc(33.33vw - 60px), (min-width: 600px) calc(50vw - 54px), calc(66.79vw - 18px)'} %}
           </div>
         {% endfor %}
       </div>
     </div>
   </div>
 
-  {% component 'promo', { promo: collectorsPromo } %}
+  {% componentV2 'promo', collectorsPromo, {}, {sizes: '100vw'} %}
 {% endblock %}

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -42,7 +42,7 @@
       <div class="grid">
         {% for promo in list.items.toJS() %}
           <div class="{{ {s:4, m:4, l:3, xl:3} | gridClasses }}">
-            {% component 'promo', { promo: promo } %}
+            {% componentV2 'promo', promo, {}, {sizes: '(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'} %}
           </div>
         {% endfor %}
       </div>

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -35,7 +35,7 @@
       <div class="grid grid--scroll grid--dividers grid--theme-6-strip">
         {% for i in range(0, 6) %}
           <div class="grid__cell">
-            {% component 'promo', { promo: promo } %}
+            {% componentV2 'promo', promo %}
           </div>
         {% endfor %}
       </div>

--- a/server/views/templates/explore-landing.njk
+++ b/server/views/templates/explore-landing.njk
@@ -7,7 +7,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s:4, m:8, l:12, xl:12} | gridClasses }}">
-          {% component 'promo', { promo: comicPromo } %}
+          {% componentV2 'promo', comicPromo %}
         </div>
       </div>
     </div>
@@ -18,15 +18,15 @@
     <div class="container container--scroll container--scroll-cream touch-scroll">
       <div class="grid grid--dividers grid--scroll">
         <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
-          {% component 'promo', { promo: promo } %}
+          {% componentV2 'promo', promo %}
         </div>
 
         <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
-          {% component 'promo', { promo: comicPromo } %}
+          {% componentV2 'promo', comicPromo %}
         </div>
 
         <div class="{{ {s:4, m:8, l:4} | gridClasses }}">
-          {% component 'promo', { promo: seriesArticlePromo } %}
+          {% componentV2 'promo', seriesArticlePromo %}
         </div>
       </div>
     </div>
@@ -36,13 +36,13 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s:4, m:4, l:12, xl:12} | gridClasses }}">
-          {% component 'promo', { promo: promo } %}
+          {% componentV2 'promo', promo %}
         </div>
         <div class="{{ {s:4, m:4, l:8} | gridClasses }}">
-          {% component 'promo', { promo: promo } %}
+          {% componentV2 'promo', promo %}
         </div>
         <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
-          {% component 'promo', { promo: promo } %}
+          {% componentV2 'promo', promo %}
         </div>
         <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
           {% component 'numbered-list', { numberedList: numberedList } %}
@@ -52,7 +52,7 @@
   </div>
 
   <div class="row {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }}">
-    {% component 'promo', { promo: standaloneArticlePromo } %}
+    {% componentV2 'promo', standaloneArticlePromo %}
   </div>
 
 {% endblock %}


### PR DESCRIPTION
## What is this PR trying to achieve?

Reduce the size and number of images we are loading

## What does it look like?

e.g explore landing page

Before:
![explore-images-before](https://cloud.githubusercontent.com/assets/6051896/26316838/6e7618a0-3f0d-11e7-99fc-832fa5221530.png)


After:
![screen shot 2017-05-22 at 16 35 21](https://cloud.githubusercontent.com/assets/6051896/26316844/76d17e5e-3f0d-11e7-9472-44691bbe85b7.png)

