### PR TITLE
Update colour of chapter-indicator image bar in line with hex value

### DIFF
--- a/server/views/components/chapter-indicator/index.njk
+++ b/server/views/components/chapter-indicator/index.njk
@@ -2,7 +2,7 @@
   white:'P///wAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
   red: 'P9DVQAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
   purple: 'IxHmQAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
-  turquoise: 'Fy4vwAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
+  turquoise: 'EiRmQAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
   orange: 'Oh1AAAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw=='
 } %}
 <div aria-label="part {{ model.position }} of {{ model.series.commissionedLength }}" class="chapter-indicator chapter-indicator--{{ model.series.color }} {{ 'chapter-indicator' | componentClasses(modifiers) if modifiers }}">


### PR DESCRIPTION
## What is this PR trying to achieve?
Updating the colour of the turquoise chapter indicator bar in line with the hex value.

## What does it look like?
![screen shot 2017-05-23 at 14 50 52](https://cloud.githubusercontent.com/assets/1394592/26357472/4572eaa4-3fc7-11e7-8cad-660f69ce3c60.png)