### PR TITLE
intervalCache object no longer on config

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -210,8 +210,8 @@ export const healthcheck = (ctx, next) => {
 export const featureFlags = (ctx, next) => {
   ctx.render('pages/flags', {
     pageConfig: createPageConfig({inSection: 'index'}),
-    flags: config.intervalCache.get('flags'),
-    cohorts: config.intervalCache.get('cohorts')
+    flags: ctx.intervalCache.get('flags'),
+    cohorts: ctx.intervalCache.get('cohorts')
   });
   return next();
 };


### PR DESCRIPTION
## What is this PR trying to achieve?

Just updating as the intervalCache is on the context now, so this is broken