### PR TITLE
Nginx proxy with https x header

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -35,12 +35,14 @@ http {
 
   server {
     listen           80;
+    listen           443 ssl;
     server_name      wellcomecollection.org;
     add_header       'X-wc-nginx-proxy' 'true';
 
     location / {
       proxy_pass                 http://prev.wellcomecollection.org;
       proxy_set_header           Host $host;
+      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
   }
 

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -9,7 +9,6 @@ import { getSeriesColor } from '../data/series';
 import {PromoListFactory} from '../model/promo-list';
 import {PaginationFactory} from '../model/pagination';
 import {createNumberedList} from '../model/numbered-list';
-import config from '../config';
 const maxItemsPerPage = 32;
 
 export const article = async(ctx, next) => {


### PR DESCRIPTION
## What's the purpose of this?
This is a:
- [ ] feature
- [x] fix
- [ ] test
- [ ] health

which adds value by…
Allowing us to forward traffic to the new old site successfully thus take over the URL without having to proxy via `next.`. This was just a header missing that @alfraser86 let me know about to make drupal use https.

# Q & A
## Has this been demoed this to the relevant people?
- [x] Yes
- [ ] No

## Is this introducing code complexity?
- [ ] Yes
- [x] No

## Is this PR labelled and assigned?
- [x] Yes
- [ ] No

## Is this A11y tested `npm run test:accessibility <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is this browser tested `npm run test:browsers <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Does this work without JS in the client?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is there a screenshot attached?
- [ ] Yes
- [ ] No
- [x] Not a UI component
