### PR TITLE
Fix series nav

### DIFF
--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -39,7 +39,7 @@ const contentSlider = (el, options) => {
   function setModifiers(cssBlock) {
     return settings.modifiers.reduce((acc, curr) => {
       return `${acc} ${settings.cssPrefix}${cssBlock}--${curr}`;
-    }, '').trim();
+    }, '');
   }
 
   const sliderModifiers = setModifiers('slider');
@@ -78,7 +78,10 @@ const contentSlider = (el, options) => {
     sliderElements.sliderInner.className = classes.sliderInner;
     sliderElements.slidesContainer.classList.add(classes.slidesContainer);
     slidesContainerModifiers.split(' ').forEach((modifier) => {
-      sliderElements.slidesContainer.classList.add(modifier);
+      // TODO: remove this with the data-modifiers above
+      if (modifier.trim() !== '') {
+        sliderElements.slidesContainer.classList.add(modifier);
+      }
     });
     sliderElements.sliderControls.className = classes.sliderControls;
     sliderElements.prevControl.className = classes.prevControl;


### PR DESCRIPTION
Quick fix for broken digital story series nav (no prev/next buttons and horizontal page scroll). Git bisect put it down to the `.trim()` move, so I've put it back to how it was. All of this will be refactored out with an upcoming re-implementation of the slider/numbered-list.