### PR TITLE
Added correct sizes attribute to transporter images

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -122,7 +122,7 @@ gulp.task('scss:compileCritical', () => {
     .pipe(devMode ? sourcemaps.write() : gutil.noop())
     .pipe(rename(function (path) {
       path.basename += path.extname;
-      path.extname = ".njk"
+      path.extname = '.njk';
     }))
     .pipe(gulp.dest(sources.scss.critical.distPath));
 });

--- a/server/views/components/numbered-list/index.njk
+++ b/server/views/components/numbered-list/index.njk
@@ -26,7 +26,7 @@
 
           {% if isTransporter %}
             <span data-track-click='{"position": {{ loop.index }}, "url": "{{ item.url }}" }'>
-              {% componentV2 'promo', item | objectAssign({ modifiers: ['slider-transporter-child'] }) %}
+              {% componentV2 'promo', item | objectAssign({ modifiers: ['slider-transporter-child'] }), {} , {sizes: '(min-width: 1340px) calc(15vw + 120px), (min-width: 960px) calc(40vw - 84px), (min-width: 600px) calc(60vw - 83px), calc(75vw - 72px)'} %}
             </span>
           {% else %}
             {% if item.url %}


### PR DESCRIPTION
## What's the purpose of this?
This is a:
- [ ] feature
- [X] fix
- [ ] test
- [X] health

which adds value by…

Reducing the size of images loaded on the explore landing page (by about 2.5 MB)
