### PR TITLE
Don't send old iOS errors to Sentry

### DIFF
--- a/server/views/partials/monitoring.njk
+++ b/server/views/partials/monitoring.njk
@@ -1,8 +1,8 @@
 <script src="https://cdn.ravenjs.com/3.9.2/raven.min.js"></script>
 <script>
-  var oldMobileSafari = /^.*AppleWebKit.*Version\/[0-8].*Mobile.*$/;
+  var oldSafari = /^.*Version\/[0-8].*Safari.*$/;
   var ignoredUserAgentRegex = [
-    oldMobileSafari
+    oldSafari
   ];
 
   var shouldIgnore = ignoredUserAgentRegex.some(function(regex) {

--- a/server/views/partials/monitoring.njk
+++ b/server/views/partials/monitoring.njk
@@ -1,6 +1,18 @@
 <script src="https://cdn.ravenjs.com/3.9.2/raven.min.js"></script>
 <script>
+  var oldMobileSafari = /^.*AppleWebKit.*Version\/[0-8].*Mobile.*$/;
+  var ignoredUserAgentRegex = [
+    oldMobileSafari
+  ];
+
+  var shouldIgnore = ignoredUserAgentRegex.some(function(regex) {
+    return regex.test(window.navigator.userAgent)
+  });
+
   Raven.config('https://f756b8d4b492473782987a054aa9a347@sentry.io/133634', {
-    whitelistUrls: [/next\.wellcomecollection\.org/]
+    whitelistUrls: [/next\.wellcomecollection\.org/],
+    shouldSendCallback: function(data) {
+      return !shouldIgnore;
+    }
   }).install();
 </script>


### PR DESCRIPTION
## What's the purpose of this?
Allowing us to prevent Sentry reporting on errors from browsers that we don't support.

This is a:
- [ ] feature
- [ ] fix
- [ ] test
- [x] health

# Q & A
## Has this been demoed this to the relevant people?
- [ ] Yes
- [x] No

## Is this introducing code complexity?
- [ ] Yes
- [x] No

## Is this PR labelled and assigned?
- [x] Yes
- [ ] No

## Is this A11y tested `npm run test:accessibility <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is this browser tested `npm run test:browsers <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Does this work without JS in the client?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is there a screenshot attached?
- [ ] Yes
- [ ] No
- [x] Not a UI component
