### PR TITLE
Use foreground colour for chapter bars

### DIFF
--- a/server/views/components/chapter-indicator/index.njk
+++ b/server/views/components/chapter-indicator/index.njk
@@ -1,9 +1,9 @@
 {% set colorDataUris = {
   white:'P///wAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
-  red: 'P9DVQAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
-  purple: 'LZ7wgAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
-  turquoise: 'Fy4vwAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
-  orange: 'Oh1AAAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw=='
+  red: 'McuPQAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
+  purple: 'IlXkQAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
+  turquoise: 'DZzeAAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw==',
+  orange: 'K1OAAAAACH5BAAAAAAALAAAAAABAAQAAAIChFEAOw=='
 } %}
 <div aria-label="part {{ model.position }} of {{ model.series.commissionedLength }}" class="chapter-indicator chapter-indicator--{{ model.series.color }} {{ 'chapter-indicator' | componentClasses(modifiers) if modifiers }}">
 


### PR DESCRIPTION
Fixes #948.

## What's the purpose of this?
This is a:
- [x] fix

Making the digital story text/chapter-indicator bar colour match.

![screen shot 2017-05-26 at 13 09 43](https://cloud.githubusercontent.com/assets/1394592/26494076/fa12142c-4214-11e7-8383-f17498e5c5bd.png)


# Q & A
## Has this been demoed this to the relevant people?
- [ ] Yes
- [x] No

## Is this introducing code complexity?
- [ ] Yes
- [x] No

## Is this PR labelled and assigned?
- [ ] Yes
- [ ] No

## Is this A11y tested `npm run test:accessibility <URL>`?
- [ ] Yes
- [x] No
- [ ] Not a UI component

## Is this browser tested `npm run test:browsers <URL>`?
- [ ] Yes
- [x] No
- [ ] Not a UI component

## Does this work without JS in the client?
- [x] Yes
- [ ] No
- [ ] Not a UI component

## Is there a screenshot attached?
- [x] Yes
- [ ] No
- [ ] Not a UI component
