### PR TITLE
Add content types for GA tracking

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -2,7 +2,7 @@
 import type {Series} from '../model/series';
 import type {Promo} from '../model/promo';
 import {PromoFactory} from '../model/promo';
-import {createPageConfig} from '../model/page-config';
+import {createPageConfig, getGaContentType} from '../model/page-config';
 import {getArticleStubs, getArticle, getSeries} from '../services/wordpress';
 import {getForwardFill, getUnpublishedSeries} from '../model/series';
 import { getSeriesColor } from '../data/series';
@@ -24,7 +24,8 @@ export const article = async(ctx, next) => {
       ctx.render('pages/article', {
         pageConfig: createPageConfig({
           title: article.headline,
-          inSection: 'explore'
+          inSection: 'explore',
+          gaContentType: getGaContentType(article)
         }),
         article: article
       });
@@ -49,7 +50,8 @@ export const articles = async(ctx, next) => {
   ctx.render('pages/list', {
     pageConfig: createPageConfig({
       title: 'Articles',
-      inSection: 'explore'
+      inSection: 'explore',
+      gaContentType: 'article list'
     }),
     list: promoList,
     pagination
@@ -67,7 +69,8 @@ export const series = async(ctx, next) => {
   ctx.render('pages/list', {
     pageConfig: createPageConfig({
       title: series.name,
-      inSection: 'explore'
+      inSection: 'explore',
+      gaContentType: 'series list'
     }),
     list: promoList,
     pagination

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -51,7 +51,7 @@ export const articles = async(ctx, next) => {
     pageConfig: createPageConfig({
       title: 'Articles',
       inSection: 'explore',
-      gaContentType: 'article list'
+      gaContentType: 'list:articles'
     }),
     list: promoList,
     pagination
@@ -70,7 +70,7 @@ export const series = async(ctx, next) => {
     pageConfig: createPageConfig({
       title: series.name,
       inSection: 'explore',
-      gaContentType: 'series list'
+      gaContentType: 'list:series'
     }),
     list: promoList,
     pagination

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -51,7 +51,7 @@ export const articles = async(ctx, next) => {
     pageConfig: createPageConfig({
       title: 'Articles',
       inSection: 'explore',
-      gaContentType: 'list:articles'
+      gaContentType: 'list:editorial:articles'
     }),
     list: promoList,
     pagination
@@ -70,7 +70,7 @@ export const series = async(ctx, next) => {
     pageConfig: createPageConfig({
       title: series.name,
       inSection: 'explore',
-      gaContentType: 'list:series'
+      gaContentType: `list:editorial:series:${id}`
     }),
     list: promoList,
     pagination

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -2,7 +2,7 @@
 import type {Series} from '../model/series';
 import type {Promo} from '../model/promo';
 import {PromoFactory} from '../model/promo';
-import {createPageConfig, getGaContentType} from '../model/page-config';
+import {createPageConfig, getEditorialAnalyticsInfo} from '../model/page-config';
 import {getArticleStubs, getArticle, getSeries} from '../services/wordpress';
 import {getForwardFill, getUnpublishedSeries} from '../model/series';
 import { getSeriesColor } from '../data/series';
@@ -16,19 +16,18 @@ export const article = async(ctx, next) => {
   const slug = ctx.params.slug;
   const format = ctx.request.query.format;
   const article = await getArticle(`slug:${slug}`);
+  const editorialAnalyticsInfo = getEditorialAnalyticsInfo(article);
+  const pageConfig = createPageConfig(Object.assign({}, {
+    title: article.headline,
+    inSection: 'explore',
+    category: 'editorial'
+  }, editorialAnalyticsInfo));
 
   if (article) {
     if (format === 'json') {
       ctx.body = article;
     } else {
-      ctx.render('pages/article', {
-        pageConfig: createPageConfig({
-          title: article.headline,
-          inSection: 'explore',
-          gaContentType: getGaContentType(article)
-        }),
-        article: article
-      });
+      ctx.render('pages/article', {pageConfig, article});
     }
   }
 
@@ -51,7 +50,7 @@ export const articles = async(ctx, next) => {
     pageConfig: createPageConfig({
       title: 'Articles',
       inSection: 'explore',
-      gaContentType: 'list:editorial:articles'
+      category: 'list'
     }),
     list: promoList,
     pagination
@@ -70,7 +69,8 @@ export const series = async(ctx, next) => {
     pageConfig: createPageConfig({
       title: series.name,
       inSection: 'explore',
-      gaContentType: `list:editorial:series:${id}`
+      category: 'list',
+      series: id
     }),
     list: promoList,
     pagination

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -1,6 +1,5 @@
 // @flow
 import type {Article} from './article';
-import getCommissionedSeries from '../filters/get-commissioned-series';
 import type {PlacesOpeningHours} from './opening-hours';
 import type {Organization} from './organization';
 import {defaultPlacesOpeningHours} from './opening-hours';
@@ -12,7 +11,10 @@ export type PageConfig = {
   inSection?: string;
   openingHours?: PlacesOpeningHours;
   organization?: Organization;
-  gaContentType?: string;
+  category?: 'editorial' | 'list' | 'info' | 'item';
+  series?: ?string;
+  positionInSeries?: ?number;
+  featuredContent?: ?string;
 };
 
 export function createPageConfig(data: PageConfig) {
@@ -24,8 +26,18 @@ export function createPageConfig(data: PageConfig) {
   return (withOpeningHours: PageConfig);
 }
 
-export function getGaContentType(article: Article) {
-  const digitalStory = getCommissionedSeries(article.series);
+const seriesUrls = [
+  'a-drop-in-the-ocean',
+  'electric-sublime',
+  'body-squabbles',
+  'electric-age'
+];
 
-  return digitalStory ? `editorial:chapter:${digitalStory.url}` : `editorial:${article.contentType}`;
+export function getEditorialAnalyticsInfo(article: Article) {
+  const series = article.series.find(a => seriesUrls.indexOf(a.url) > -1);
+  const seriesUrl = series.url;
+  const positionInSeries = article.positionInSeries;
+  const featuredContent = article.contentType;
+
+  return {seriesUrl, positionInSeries, featuredContent};
 }

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -1,4 +1,6 @@
 // @flow
+import type {Article} from './article';
+import getCommissionedSeries from '../filters/get-commissioned-series';
 import type {PlacesOpeningHours} from './opening-hours';
 import type {Organization} from './organization';
 import {defaultPlacesOpeningHours} from './opening-hours';
@@ -10,6 +12,7 @@ export type PageConfig = {
   inSection?: string;
   openingHours?: PlacesOpeningHours;
   organization?: Organization;
+  gaContentType?: string;
 };
 
 export function createPageConfig(data: PageConfig) {
@@ -19,4 +22,10 @@ export function createPageConfig(data: PageConfig) {
   };
   const withOpeningHours = Object.assign({}, defaults, data);
   return (withOpeningHours: PageConfig);
+}
+
+export function getGaContentType(article: Article) {
+  const digitalStory = getCommissionedSeries(article.series);
+
+  return digitalStory ? `digital story: ${digitalStory.name}` : article.contentType;
 }

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -27,5 +27,5 @@ export function createPageConfig(data: PageConfig) {
 export function getGaContentType(article: Article) {
   const digitalStory = getCommissionedSeries(article.series);
 
-  return digitalStory ? `digital story: ${digitalStory.name}` : article.contentType;
+  return digitalStory ? `content:article:digital-story:${digitalStory.url}` : `content:${article.contentType}`;
 }

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -27,5 +27,5 @@ export function createPageConfig(data: PageConfig) {
 export function getGaContentType(article: Article) {
   const digitalStory = getCommissionedSeries(article.series);
 
-  return digitalStory ? `content:article:digital-story:${digitalStory.url}` : `content:${article.contentType}`;
+  return digitalStory ? `editorial:chapter:${digitalStory.url}` : `editorial:${article.contentType}`;
 }

--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -12,8 +12,23 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 ga('create', 'UA-55614-6', 'auto');
-ga('set', 'dimension1', '2');
-ga('set', 'dimension2', '{{ pageConfig.gaContentType }}');
+
+if ('{{ pageConfig.category }}') {
+  ga('set', 'dimension2', '{{ pageConfig.category }}');
+}
+
+if ('{{ pageConfig.series }}') {
+  ga('set', 'dimension3', '{{ pageConfig.series }}');
+}
+
+if ('{{ pageConfig.positionInSeries }}') {
+  ga('set', 'dimension4', '{{ pageConfig.positionInSeries }}');
+}
+
+if ('{{ pageConfig.featuredContent }}') {
+  ga('set', 'dimension5', '{{ pageConfig.featuredContent }}');
+}
+
 ga('require', 'GTM-NXMJ6D9');
 ga('send', 'pageview');
 </script>

--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -13,6 +13,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 ga('create', 'UA-55614-6', 'auto');
 ga('set', 'dimension1', '2');
+ga('set', 'dimension2', '{{ pageConfig.gaContentType }}');
 ga('require', 'GTM-NXMJ6D9');
 ga('send', 'pageview');
 </script>


### PR DESCRIPTION
Closes #940.

## What's the purpose of this?
This is a:
- [x] feature

Sends the page content type through as a custom dimension to GA.

Can be one of
- article
- digital story ('digital story: name of digital story')
- comic
- video
- article list
- series list

# Q & A
## Has this been demoed this to the relevant people?
- [x] Yes
- [ ] No

## Is this introducing code complexity?
- [ ] Yes
- [x] No

## Is this PR labelled and assigned?
- [x] Yes
- [ ] No

## Is this A11y tested `npm run test:accessibility <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is this browser tested `npm run test:browsers <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Does this work without JS in the client?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is there a screenshot attached?
- [ ] Yes
- [ ] No
- [x] Not a UI component
