### PR TITLE
Ensure polyfills are available before anything else

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -25,11 +25,12 @@ import truncateText from './components/truncate-text';
 import fontObserver from './utils/font-observer';
 
 const init = () => {
+  polyfills.init();
+
   nodeList(document.querySelectorAll('.async-content')).forEach((el) => {
     asynContent(el, dispatch);
   });
 
-  polyfills.init();
   lazysizes.init();
   instagram.init();
   tracking.init();


### PR DESCRIPTION
## What's the purpose of this?
This is a:
- [x] fix

Ensuring any polyfills are available in the browser before they may be needed.


# Q & A
## Has this been demoed this to the relevant people?
- [ ] Yes
- [x] No

## Is this introducing code complexity?
- [ ] Yes
- [x] No

## Is this PR labelled and assigned?
- [ ] Yes
- [ ] No

## Is this A11y tested `npm run test:accessibility <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is this browser tested `npm run test:browsers <URL>`?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Does this work without JS in the client?
- [ ] Yes
- [ ] No
- [x] Not a UI component

## Is there a screenshot attached?
- [ ] Yes
- [ ] No
- [x] Not a UI component
