### PR TITLE
Add underline below main media (hero)

### DIFF
--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -34,7 +34,15 @@
 
   {% componentV2 'main-media', article.mainMedia | getPrincipleMainMedia, {'full': true, 'comic': article.contentType === 'comic'}, mainMediaData %}
 
-  <div class="row row--cream {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top', 'bottom']}) }} ">
+  <div class="row row--cream">
+    <div class="container">
+      <div class="{{ {s:6, m:6, l:6} | spacingClasses({padding: ['top']}) }}">
+        <hr class="divider divider--pumice divider--keyline" />
+      </div>
+    </div>
+  </div>
+
+  <div class="row row--cream {{ {s:4, m:4, l:4} | spacingClasses({padding: ['top', 'bottom']}) }} ">
     <div class="container">
       <div class="grid grid--no-gutters">
         <div class="{{ {s: 4, m: 6, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">


### PR DESCRIPTION
References #919.

## What's the purpose of this?
This is a:
- [x] fix

Adding a consistent underline beneath the hero image.

![screen shot 2017-05-30 at 12 53 03](https://cloud.githubusercontent.com/assets/1394592/26582041/6009d83a-4537-11e7-8b9a-bbc8e76788d6.png)

# Q & A
## Has this been demoed this to the relevant people?
- [ ] Yes
- [x] No

## Is this introducing code complexity?
- [ ] Yes
- [x] No

## Is this PR labelled and assigned?
- [x] Yes
- [ ] No

## Is this A11y tested `npm run test:accessibility <URL>`?
- [ ] Yes
- [x] No
- [ ] Not a UI component

## Is this browser tested `npm run test:browsers <URL>`?
- [ ] Yes
- [x] No
- [ ] Not a UI component

## Does this work without JS in the client?
- [x] Yes
- [ ] No
- [ ] Not a UI component

## Is there a screenshot attached?
- [x] Yes
- [ ] No
- [ ] Not a UI component
