### PR TITLE
decouple a few more slider scss things

### DIFF
--- a/client/scss/components/_slider__in-article.scss
+++ b/client/scss/components/_slider__in-article.scss
@@ -10,6 +10,7 @@
     }
 
     @include respond-to('xlarge') {
+      position: relative;
       width: $container-width-max - (map-get($container-padding, 'large') * 2);
       margin-left: 50%;
       left: (($container-width-max - (map-get($container-padding, 'large') * 2)) / 2) * (-5/6);

--- a/client/scss/components/_slider__in-content.scss
+++ b/client/scss/components/_slider__in-content.scss
@@ -33,25 +33,6 @@ $slider-control-margin: 18px;
       padding-right: map-get($container-padding, 'large');
     }
   }
-
-  .slides-container {
-    margin: 0;
-    position: relative;
-    width: calc(100vw - #{map-get($container-padding, 'small')});
-
-    @include respond-to('medium') {
-      width: calc(100vw - #{map-get($container-padding, 'medium')});
-    }
-
-    @include respond-to('large') {
-      width: calc(100vw - #{map-get($container-padding, 'large')});
-    }
-
-    @include respond-to('xlarge') {
-      width: calc(100vw - ((100vw - #{$container-width-max}) / 2) - #{map-get($container-padding, 'large')});
-      left: calc((100vw - #{$container-width-max}) / 2);
-    }
-  }
 }
 
 .slider-controls--in-content {

--- a/client/scss/components/_slider__in-explore.scss
+++ b/client/scss/components/_slider__in-explore.scss
@@ -1,0 +1,20 @@
+.slider--in-explore {
+  .slides-container {
+    margin: 0;
+    position: relative;
+    width: calc(100vw - #{map-get($container-padding, 'small')});
+
+    @include respond-to('medium') {
+      width: calc(100vw - #{map-get($container-padding, 'medium')});
+    }
+
+    @include respond-to('large') {
+      width: calc(100vw - #{map-get($container-padding, 'large')});
+    }
+
+    @include respond-to('xlarge') {
+      width: calc(100vw - ((100vw - #{$container-width-max}) / 2) - #{map-get($container-padding, 'large')});
+      left: calc((100vw - #{$container-width-max}) / 2);
+    }
+  }
+}

--- a/client/scss/non-critical.scss
+++ b/client/scss/non-critical.scss
@@ -20,6 +20,7 @@
 @import 'components/slider__gallery';
 @import 'components/slider__in-article';
 @import 'components/slider__in-content';
+@import 'components/slider__in-explore';
 @import 'components/slider__numbered-list';
 @import 'components/slider__transporter';
 @import 'components/tags';

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -33,7 +33,7 @@
       <div class="grid grid--no-gutters">
         <div class="{{ {s: 4, m: 8, l: 12, xl: 12} | gridClasses }}">
           {% set asyncContentEndpoint = '/series-transporter/' + latestDigitalStory %}
-          {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter' } %}
+          {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-explore": true}' } %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What's the purpose of this?
This is a:
- [x] fix

which adds value by…
Decoupling a few more things on the image slider - there will be more of a follow up on this again.

This came up when trying to do some work on the preformatted text which shows that things are a little to coupled.

# Q & A
## Has this been demoed this to the relevant people?
- [X] Yes

## Is this introducing code complexity?
- [X] No

## Is this PR labelled and assigned?
- [x] Yes

## Is this A11y tested `npm run test:accessibility <URL>`?
- [x] Yes

## Is this browser tested `npm run test:browsers <URL>`?
- [x] Yes

## Does this work without JS in the client?
- [x] Yes

## Is there a screenshot attached?
- [x] Yes

![fix-transportertreg](https://cloud.githubusercontent.com/assets/31692/26626724/18dbe886-45f0-11e7-9e78-c5a318a5b9eb.png)
![fix-article-gallery](https://cloud.githubusercontent.com/assets/31692/26626730/1cd27f72-45f0-11e7-9c03-2c9f9ae3e81b.png)
![fix-explore](https://cloud.githubusercontent.com/assets/31692/26626732/20d8dd0a-45f0-11e7-98c3-2a7c79cf377a.png)

You can see this article to see how it's out of whack:
/articles/eels-and-feels

