### PR TITLE
Componentise divider

### DIFF
--- a/client/scss/components/_divider.scss
+++ b/client/scss/components/_divider.scss
@@ -29,3 +29,8 @@
 .divider--thick {
   height: 22px;
 }
+
+.divider--dashed {
+  height: 2 * $spacing-unit;
+  background: repeating-linear-gradient(90deg, color('black'), color('black') 1px, color('transparent') 1px, color('transparent') $spacing-unit);
+}

--- a/server/views/components/divider/index.config.js
+++ b/server/views/components/divider/index.config.js
@@ -1,0 +1,12 @@
+export const name = 'divider';
+export const collated = true;
+export const context = {
+  modifiers: {}
+};
+export const variants = [
+  {name: 'stub', context: {modifiers: {'black': true, 'stub': true}}},
+  {name: 'keyline', context: {modifiers: {'pumice': true, 'keyline': true}}},
+  {name: 'thin', context: {modifiers: {'black': true, 'thin': true}}},
+  {name: 'thick', context: {modifiers: {'pumice': true, 'thick': true}}},
+  {name: 'dashed', context: {modifiers: {'dashed': true}}}
+];

--- a/server/views/components/divider/index.njk
+++ b/server/views/components/divider/index.njk
@@ -1,0 +1,1 @@
+<hr class="divider {{ 'divider' | componentClasses(modifiers) }} {% for class in data.extraClasses %}{{ class }} {% endfor %}" />

--- a/server/views/components/series-container/index.njk
+++ b/server/views/components/series-container/index.njk
@@ -50,7 +50,7 @@
     </div>
   </div>
   <div class="container container--no-collape">
-    <hr class="divider divider--thick divider--black {{ {s:5, m:5, l:5} | spacingClasses({margin: ['bottom']}) }}" />
+    {% componentV2 'divider', {}, {'thick': true, 'black': true}, {extraClasses: [{s:5, m:5, l:5} | spacingClasses({margin: ['bottom']})]} %}
   </div>
 </div>
 

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -37,7 +37,7 @@
   <div class="row row--cream">
     <div class="container">
       <div class="{{ {s:6, m:6, l:6} | spacingClasses({padding: ['top']}) }}">
-        <hr class="divider divider--pumice divider--keyline" />
+        {% componentV2 'divider', null, {'pumice': true, 'keyline': true} %}
       </div>
     </div>
   </div>
@@ -70,7 +70,7 @@
               } %}
             {% endif %}
 
-            <hr class="divider divider--stub divider--black {{ {s:4, m:4, l:4} | spacingClasses({margin: ['top']}) }} {{ {s:1, m:1, l:1} | spacingClasses({margin: ['bottom']}) }}" />
+            {% componentV2 'divider', null, {'stub': true, 'black': true}, {extraClasses: [{s:4, m:4, l:4} | spacingClasses({margin: ['top']})]} %}
 
             {% if article.tags.length > 0 %}
               {% component 'tags', { tags: article.tags } %}

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -12,7 +12,7 @@
     </div>
     <div class="row__wobbly-background"></div>
     <div class="container">
-      <hr class="divider divider--keyline divider--pumice {{ {s:3, m:3, l:3} | spacingClasses({margin: ['bottom']}) }}" />
+      {% componentV2 'divider', null, {'keyline': true, 'pumice': true}, {extraClasses: [{s:3, m:3, l:3} | spacingClasses({margin: ['bottom']})]} %}
     </div>
     <div class="container container--scroll container--scroll-cream touch-scroll">
       <div class="grid grid--dividers grid--scroll">
@@ -24,7 +24,7 @@
       </div>
     </div>
     <div class="container container--no-collapse">
-      <hr class="divider divider--thick divider--black {{ {s:5, m:5, l:5} | spacingClasses({margin: ['bottom']}) }}" />
+      {% componentV2 'divider', null, {'thick': true, 'black': true}, {extraClasses: [{s:5, m:5, l:5} | spacingClasses({margin: ['bottom']})]} %}
     </div>
   </div>
 
@@ -39,7 +39,7 @@
     </div>
     <div class="{{ {s:4, m:4, l:4} | spacingClasses({margin:['top']}) }}">
       <div class="container container--no-collapse">
-        <hr class="divider divider--thick divider--black {{ {s:5, m:5, l:5} | spacingClasses({margin: ['bottom']}) }}" />
+        {% componentV2 'divider', null, {'thick': true, 'black': true}, {extraClasses: [{s:5, m:5, l:5} | spacingClasses({margin: ['bottom']})]} %}
       </div>
     </div>
   </div>

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -33,7 +33,7 @@
           </div>
         </div>
       </div>
-      <hr class="divider divider--keyline divider--pumice" />
+      {% componentV2 'divider', null, {'keyline': true, 'pumice': true} %}
     </div>
   </div>
 

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -16,7 +16,7 @@
     <div class="wobbly-edge wobbly-edge--rotated wobbly-edge--cream wobbly-edge--small js-wobbly-edge"></div>
     <div class="container">
       {% component 'transporter', transporter %}
-      <hr class="divider divider--thin" />
+      {% componentV2 'divider', null, {'thin': true} %}
     </div>
   </div>
 
@@ -41,7 +41,7 @@
       </div>
     </div>
     <div class="container container--no-collapse">
-      <hr class="divider divider--thin" />
+      {% componentV2 'divider', null, {'thin': true} %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
References #670.

## Type
<!-- delete as appropriate -->
✨ Feature  

## Value
<!-- how does this add value? -->
Adding a dashed divider (in preparation for use with #670) and componentising the divider.

## Screenshot
<!-- drag screenshot here -->
![screen shot 2017-05-31 at 14 59 24](https://cloud.githubusercontent.com/assets/1394592/26635480/caf2e4c2-4611-11e7-9287-ebb8aa24bbe7.png)

## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
