### PR TITLE
use scroll:auto for reformatted text

### DIFF
--- a/client/scss/components/_pre.scss
+++ b/client/scss/components/_pre.scss
@@ -1,5 +1,5 @@
 .pre {
   @include font('LR3');
-  overflow: scroll;
+  overflow: auto;
   margin: 0;
 }


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
🔧 Fix  

## Value
<!-- how does this add value? -->
Makes things look nicer when you don't need to scroll.

## Screenshot
<!-- drag screenshot here -->
### Before
<img width="1061" alt="screen shot 2017-06-06 at 11 27 55" src="https://cloud.githubusercontent.com/assets/31692/26824989/40461f58-4aab-11e7-85a6-72623233ee44.png">

### After
<img width="1078" alt="screen shot 2017-06-06 at 11 27 45" src="https://cloud.githubusercontent.com/assets/31692/26824988/4030d904-4aab-11e7-953b-17f183b7e289.png">


## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
