### PR TITLE
Use min-width instead of width (fixes iOS, supported everywhere)

### DIFF
--- a/client/scss/components/_tweet.scss
+++ b/client/scss/components/_tweet.scss
@@ -5,7 +5,7 @@
 
   /* stylelint-disable */
   .twitter-tweet {
-    width: 100% !important;
+    min-width: 100% !important;
   }
 
   twitterwidget::shadow .EmbeddedTweet {


### PR DESCRIPTION
Fixes #975

## Type
🔧 Fix  

## Value
Removes the horizontal scrollbar that can occur on iOS as a result of `width` not being honoured for iOS iFrames.

## Screenshot
![screen shot 2017-06-07 at 10 37 14](https://user-images.githubusercontent.com/1394592/26872117-4f591348-4b6d-11e7-9a7c-d4cbf990931d.png)


## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
