### PR TITLE
Override min-width: 100% for comics

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -44,6 +44,7 @@
     .image {
       max-height: 95vh;
       width: auto;
+      min-width: auto;
       margin: 0 auto;
     }
   }


### PR DESCRIPTION
Fixes/Closes/References #

## Type  
🔧 Fix  

## Value
Fixes regression where comic image could stretch the full width of the viewport while having a constrained height.

## Screenshot
before:
![screen shot 2017-06-09 at 12 08 08](https://user-images.githubusercontent.com/1394592/26973037-5846b168-4d0c-11e7-950f-7f1326ecd38b.png)

after:
![screen shot 2017-06-09 at 12 07 57](https://user-images.githubusercontent.com/1394592/26973042-5c91a3ae-4d0c-11e7-9b0c-8acbf2446ac1.png)

## Checklist
### All
- [ ] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
