### PR TITLE
Enable tracking of external links in GA

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -1,6 +1,7 @@
 /* global Raven */
 import 'core-js/fn/object/assign';
 import 'core-js/fn/promise';
+import 'core-js/fn/map';
 import 'whatwg-fetch';
 import lazysizes from 'lazysizes';
 

--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -1,3 +1,5 @@
+/* global ga */
+
 import { on } from './util';
 import { trackEvent } from './utils/track-event';
 
@@ -15,3 +17,29 @@ export default {
     });
   }
 };
+
+function trackOutboundLink(url) {
+  ga('send', 'event', 'outbound', 'click', url, {
+    'transport': 'beacon',
+    'hitCallback': () => {
+      document.location = url;
+    }
+  });
+};
+
+function getDomain(url) {
+  return url.replace('http://', '').replace('https://', '').split('/')[0];
+}
+
+function isExternal(url) {
+  return getDomain(document.location.href) !== getDomain(url);
+}
+
+on('body', 'click', 'a', ({ target }) => {
+  const anchor = target.closest('a');
+  const url = anchor.href;
+
+  if (isExternal(url)) {
+    trackOutboundLink(url);
+  }
+});


### PR DESCRIPTION
## Type
✨ Feature  

## Value
Will allow us to see what the destination URL is from an exit page in GA.

## Screenshot
🔍

## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
