### PR TITLE
Add Rob Bidder as author of pundit comic

### DIFF
--- a/server/services/author-lookup.js
+++ b/server/services/author-lookup.js
@@ -27,6 +27,7 @@ export const authorMap: { [key: string]: Person } = {
   'body-squabbles-thirst': people.robertBidder,
   'body-squabbles-teeth': people.robertBidder,
   'body-squabbles-keyholes': people.robertBidder,
+  'body-squabbles-pundit': people.robertBidder,
   'museums-in-context-the-birth-of-the-public-museum': people.elissavetNtoulia,
   'the-electric-age': people.lalitaKaplish,
   'electric-age-the-electrified-garden': people.lalitaKaplish,


### PR DESCRIPTION
Fixes/Closes/References #

## Type
🔧 Fix  

## Value
Adds Rob as author of _Pundit_ comic.

## Screenshot
![screen shot 2017-06-13 at 14 10 28](https://user-images.githubusercontent.com/1394592/27083969-3020c118-5042-11e7-9f36-2b1ea1652341.png)


## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
