### PR TITLE
Grid refactor

### DIFF
--- a/client/scss/components/_grid_placeholder.scss
+++ b/client/scss/components/_grid_placeholder.scss
@@ -9,11 +9,11 @@
   color: color('white');
 
   // Example used in grids.njk
-  @include container-query(('s': ('1'))) {
+  @include container-query(('s': ('3'))) {
     background: color('red-graphics');
 
     &:before {
-      content: 's1';
+      content: 's3';
     }
   }
 

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -9,7 +9,7 @@
     padding-bottom: 5 * $v-spacing-unit;
   }
 
-  @include container-query(('m': ('8'), 'l': ('8', '12'))) {
+  @include container-query(('m': ('12'), 'l': ('8', '12'))) {
     display: flex;
     align-items: flex-start;
   }
@@ -60,19 +60,19 @@
     margin-bottom: 0;
   }
 
-  @include container-query(('m': ('8'), 'l': ('8', '12'))) {
+  @include container-query(('m': ('12'), 'l': ('8', '12'))) {
     order: 1;
     width: percentage(2 / 3);
     margin-bottom: 0;
   }
 
   .promo--transporter-child & {
-    @include container-query(('s': ('4'))) {
+    @include container-query(('s': ('12'))) {
       width: percentage(118 / 316);
       margin-bottom: 0;
     }
 
-    @include container-query(('m': ('8'))) {
+    @include container-query(('m': ('12'))) {
       order: 0;
       width: percentage(1 / 3);
     }
@@ -275,16 +275,16 @@
     padding-right: map-get($gutter-width, 'large');
   }
 
-  @include container-query(('m': ('8'))) {
+  @include container-query(('m': ('12'))) {
     padding-right: map-get($gutter-width, 'medium');
   }
 
   .promo--transporter-child & {
-    @include container-query(('s': ('4'))) {
+    @include container-query(('s': ('12'))) {
       padding-left: map-get($gutter-width, 'small');
     }
 
-    @include container-query(('m': ('8'))) {
+    @include container-query(('m': ('12'))) {
       padding-right: 0;
       padding-left: map-get($gutter-width, 'medium');
     }
@@ -343,7 +343,7 @@
 }
 
 .promo--transporter-child {
-  @include container-query(('s': ('4'))) {
+  @include container-query(('s': ('12'))) {
     display: flex;
     align-items: flex-start;
     padding-bottom: $vertical-space-unit;
@@ -359,7 +359,7 @@
   .promo__title {
     @include font('WB7');
 
-    @include container-query(('s': ('4'))) {
+    @include container-query(('s': ('12'))) {
       @include font('HNM5');
     }
   }
@@ -384,12 +384,12 @@
 }
 
 .promo--slider-transporter-child {
-  @include container-query(('m': ('8'), 'l': ('8', '12'))) {
+  @include container-query(('m': ('12'), 'l': ('8', '12'))) {
     display: block;
   }
 
   .promo__image-container {
-    @include container-query(('m': ('8'), 'l': ('8', '12'))) {
+    @include container-query(('m': ('12'), 'l': ('8', '12'))) {
       width: 100%;
       margin-bottom: 2 * $spacing-unit;
     }

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -36,14 +36,13 @@
   $to-list: null;
   $between-list: null;
 
-  @each $sizes in $cq-list {
-    $size-key: nth($sizes, 1);
+  @each $size-key, $sizes-value in $cq-list {
 
     $size: map-get($grid-config, $size-key);
     $respond: map-get($size, 'respond');
 
     @if (length($respond) > 1) {
-      @each $cols in nth($sizes, 2) {
+      @each $cols in $sizes-value {
         $between-list: $between-list, unquote('[class*="grid__cell--#{$size-key}#{$cols}"] &');
       }
       // stylelint-disable plugin/declaration-block-order
@@ -53,7 +52,7 @@
         }
       }
     } @else {
-      @each $cols in nth($sizes, 2) {
+      @each $cols in $sizes-value {
         $to-list: $to-list, unquote('[class*="grid__cell--#{$size-key}#{$cols}"] &');
       }
 

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -36,13 +36,13 @@
   $to-list: null;
   $between-list: null;
 
-  @each $size-key, $sizes-value in $cq-list {
+  @each $size-key, $size-value in $cq-list {
 
     $size: map-get($grid-config, $size-key);
     $respond: map-get($size, 'respond');
 
     @if (length($respond) > 1) {
-      @each $cols in $sizes-value {
+      @each $cols in $size-value {
         $between-list: $between-list, unquote('[class*="grid__cell--#{$size-key}#{$cols}"] &');
       }
       // stylelint-disable plugin/declaration-block-order
@@ -52,7 +52,7 @@
         }
       }
     } @else {
-      @each $cols in $sizes-value {
+      @each $cols in $size-value {
         $to-list: $to-list, unquote('[class*="grid__cell--#{$size-key}#{$cols}"] &');
       }
 

--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -207,35 +207,31 @@ $gutter-width: (
   'large': 30px
 );
 
-$total-columns: (
-  'small': 4,
-  'medium': 8,
-  'large': 12
-);
+$total-columns: 12;
 
 $grid-config: (
   's': (
     'padding': map-get($container-padding, 'small'),
     'gutter': map-get($gutter-width, 'small'),
-    'columns': map-get($total-columns, 'small'),
+    'columns': $total-columns,
     'respond': ('small', 'medium')
   ),
   'm': (
     'padding': map-get($container-padding, 'medium'),
     'gutter': map-get($gutter-width, 'medium'),
-    'columns': map-get($total-columns, 'medium'),
+    'columns': $total-columns,
     'respond': ('medium', 'large')
   ),
   'l': (
     'padding': map-get($container-padding, 'large'),
     'gutter': map-get($gutter-width, 'large'),
-    'columns': map-get($total-columns, 'large'),
+    'columns': $total-columns,
     'respond': 'large'
   ),
   'xl': (
     'padding': map-get($container-padding, 'large'),
     'gutter': map-get($gutter-width, 'large'),
-    'columns': map-get($total-columns, 'large'),
+    'columns': $total-columns,
     'respond': 'xlarge'
   )
 );

--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -198,13 +198,15 @@ $border-radius-unit: 6px;
 $container-padding: (
   'small': 18px,
   'medium': 42px,
-  'large': 60px
+  'large': 60px,
+  'xlarge': 60px
 );
 
 $gutter-width: (
   'small': 18px,
   'medium': 24px,
-  'large': 30px
+  'large': 30px,
+  'xlarge': 30px
 );
 
 $total-columns: 12;
@@ -229,8 +231,8 @@ $grid-config: (
     'respond': 'large'
   ),
   'xl': (
-    'padding': map-get($container-padding, 'large'),
-    'gutter': map-get($gutter-width, 'large'),
+    'padding': map-get($container-padding, 'xlarge'),
+    'gutter': map-get($gutter-width, 'xlarge'),
     'columns': $total-columns,
     'respond': 'xlarge'
   )

--- a/server/views/components/footer/index.njk
+++ b/server/views/components/footer/index.njk
@@ -1,14 +1,14 @@
 <div class="footer row row--dark-black {{ {s:5, m:10, l:10} | spacingClasses({padding: ['top']}) }}">
   <div class="container">
     <div class="grid">
-      <div class="{{ {s:4, m:4, l:3} | gridClasses }}">
+      <div class="{{ {s:12, m:6, l:3} | gridClasses }}">
         {% component 'footer-nav', {navLinks: navLinks} %}
       </div>
-      <div class="{{ {s:4, m:4, l:3} | gridClasses }}">
+      <div class="{{ {s:12, m:6, l:3} | gridClasses }}">
         <h3 class="footer__heading">Finding us:</h3>
         {% componentV2 'find-us', address %}
       </div>
-      <div class="{{ {s:4} | gridClasses }}">
+      <div class="{{ {s:12} | gridClasses }}">
         <h3 class="footer__heading">Opening times:</h3>
         {% component 'opening-hours', {places: openingHours.places} %}
       </div>

--- a/server/views/components/main-media/index.njk
+++ b/server/views/components/main-media/index.njk
@@ -7,7 +7,7 @@
     <div class="row row--cream">
       <div class="container">
         <div class="grid">
-          <div class="{{ {m:6, xl:10, shiftM:1, shiftXl:1} | gridClasses }}">
+          <div class="{{ {m:10, xl:10, shiftM:1, shiftXl:1} | gridClasses }}">
             {{ super() }}
           </div>
         </div>
@@ -18,7 +18,7 @@
   <div class="row row--dark-black {{ {s:4, m:8, l:10} | spacingClasses({padding: ['top', 'bottom']}) }}">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:8, l:8, shiftL:2} | gridClasses }}">
+        <div class="{{ {s:12, m:12, l:8, shiftL:2} | gridClasses }}">
           {% componentV2 'iframed-video', {
             embedUrl: model.embedUrl
           } %}

--- a/server/views/components/page-description/index.njk
+++ b/server/views/components/page-description/index.njk
@@ -2,7 +2,7 @@
   <div class="row page-description__row {{ 'row--lead row--lead--l' if model.lead }}">
     <div class="container page-description__container">
       <div class="grid">
-        <div class="grid__cell grid__cell--s4 grid__cell--m6 grid__cell--shift-m1 {{ 'grid__cell--shift-l1 grid__cell--l11 grid__cell--xl10' if model.lead else 'grid__cell--l12 grid__cell--xl11' }}">
+        <div class="grid__cell grid__cell--s12 grid__cell--m10 grid__cell--shift-m1 {{ 'grid__cell--shift-l1 grid__cell--l11 grid__cell--xl10' if model.lead else 'grid__cell--l12 grid__cell--xl11' }}">
           {% if model.intro %}
             <span class="page-description__intro {{ {s:1, m:1, l:2} | spacingClasses({margin: ['bottom']}) }}">{{ model.intro }}</span>
           {% endif %}

--- a/server/views/components/promo/index.njk
+++ b/server/views/components/promo/index.njk
@@ -51,7 +51,7 @@
     <div class="row row--cream {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }} ">
       <div class="container">
         <div class="grid">
-          <div class="{{ {l:10, shiftL:1, m:6, shiftM:1, s:4} | gridClasses }}">
+          <div class="{{ {l:10, shiftL:1, m:10, shiftM:1, s:12} | gridClasses }}">
           {% endif %}
             <header class="promo__description">
               <div class="promo__heading">

--- a/server/views/components/series-container/index.njk
+++ b/server/views/components/series-container/index.njk
@@ -6,10 +6,10 @@
 <div class="row {{ {s:4, m:4, l:4} | spacingClasses({padding: ['top']}) }} ">
   <div class="container">
     <div class="grid">
-      <div class="{{ {s:4, m:8, l:12, xl: 12} | gridClasses }}">
+      <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
         <h2 class="heading--large {{ {s:0, m:0, l:0} | spacingClasses({margin: ['top', 'bottom']}) }}">{{ model.name }}</h2>
       </div>
-      <div class="{{ {s:4, m:8, l:8} | gridClasses }}">
+      <div class="{{ {s:12, m:12, l:8} | gridClasses }}">
         <p class="{{ {s:0, m:0, l:0} | spacingClasses({margin: ['top', 'bottom']}) }}">{{ model.description }}</p>
         {% componentV2 'more-info-link', model %}
       </div>

--- a/server/views/components/social-media-block/index.njk
+++ b/server/views/components/social-media-block/index.njk
@@ -13,20 +13,20 @@
       <div class="grid {{ {s:10, m:10, l:10} | spacingClasses({padding: ['bottom']}) }}">
         {% if model.service === 'Twitter' %}
           {% for post in model.posts %}
-            <div class="{{ {s:4, m:4, l:6, xl:3} | gridClasses }}">
+            <div class="{{ {s:12, m:6, l:6, xl:3} | gridClasses }}">
               {% componentV2 'tweet', post %}
             </div>
           {% endfor %}
         {% elif model.service === 'Instagram' %}
           {% for i in range(0, 4) %}
-            <div class="{{ {s:4, m:4, l:3, xl:3} | gridClasses }} {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }}">
+            <div class="{{ {s:12, m:6, l:3, xl:3} | gridClasses }} {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }}">
               {% componentV2 'instagram-thumbnail', model.posts[i], null, {sizes: '(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'} %}
             </div>
           {% endfor %}
 
           {% for i in range(4, 10) %}
             {% set post = model.posts[i] %}
-            <div class="{{ {s:2, m:4, l:2} | gridClasses }} {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }}">
+            <div class="{{ {s:6, m:6, l:2} | gridClasses }} {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }}">
               {% componentV2 'instagram-thumbnail', model.posts[i], null, {sizes: '(min-width: 1420px) 178px, (min-width: 960px) calc(14.32vw - 22px), (min-width: 600px) calc(50vw - 54px), calc(50vw - 27px)'} %}
             </div>
           {% endfor %}

--- a/server/views/components/transporter/index.njk
+++ b/server/views/components/transporter/index.njk
@@ -4,7 +4,7 @@
   {% endif %}
   <div class="grid grid--dividers">
     {% if type === 'theme' %}
-    <div class="{{ {s:4, m:8, l:3} | gridClasses }} transporter__item">
+    <div class="{{ {s:12, m:12, l:3} | gridClasses }} transporter__item">
       <p class="transporter__more">More from this theme</p>
       <h2 class="transporter__title">{{ title }}</h2>
       <p class="transporter__intro">{{ introCopy }}</p>
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% for promo in promos %}
-    <div class="{{ {s:4, m:8} | gridClasses }} transporter__item">
+    <div class="{{ {s:12, m:12} | gridClasses }} transporter__item">
       {% set modifiers = promo.modifiers.concat('large-text') if (promos.length <= 4) else promo.modifiers %}
       {% componentV2 'promo', promo | objectAssign({ modifiers: modifiers }) %}
     </div>

--- a/server/views/docs/visual-architecture.md
+++ b/server/views/docs/visual-architecture.md
@@ -3,9 +3,9 @@ title: Visual Architecture
 ---
 
 _Note: The below describes a few ideals that have not yet been implemented, but will give us and
-others direction moving forward_. 
+others direction moving forward_.
 
-The architecture we have composed consists of two parts. [Structure](#structure) & [Style](#style).  
+The architecture we have composed consists of two parts. [Structure](#structure) & [Style](#style).
 
 # Structure
 
@@ -27,7 +27,7 @@ The app shell may also contain [layouts](#layout-elements).
 The page is the content that is loaded dependant on the route requested by the client.
 e.g. `/explore`.
 
-The page can consist of one or more [layouts](#layout-elements). 
+The page can consist of one or more [layouts](#layout-elements).
 
 The page will rarely, if ever, have [style](#style)s.
 
@@ -36,9 +36,9 @@ The page will rarely, if ever, have [style](#style)s.
 
 A elements are intentionally stupid objects including:
 
-  * Rows: Allows styling of full width 
+  * Rows: Allows styling of full width
     * Containers: Constrains the contained content to a certain width or behavior.
-  
+
 Layout elements may contain [components](#components), but may not contain themselves.
 
 Layout elements will always manage their own [style](#style), but have access to
@@ -54,7 +54,7 @@ application. Components have 2 sub-types:
     be useful. e.g. image gallery
   * Atoms: These are the constituent parts of modules. They can be reused within modules, but do not
     make sense without the context of the module.
-    
+
 Components can be children of components, whether it be a module or atom.
 
 Components will always manage their own [style](#style), but have access to
@@ -75,7 +75,7 @@ Globally accessible, reusable styles are defined in
 The layout has a maximum width of 1338px.
 
 ## Breakpoints
-    
+
 The layout utilises 3 breakpoints:
 
 - Small: >= 0
@@ -83,9 +83,9 @@ The layout utilises 3 breakpoints:
 - Large: >= 960px
 - XLarge > 1338px
 
-## Grid columns/spacing (TODO: Implement 12 cols / break point)
+## Grid columns/spacing
 
-Breakpoints consist of 12 columns and determine the spacing between the columns, 
+The grid consists of 12 columns and breakpoints determine the spacing between the columns,
 i.e. gutters, and the space either side of the layout, i.e. margins.
 
 ### Small
@@ -98,7 +98,7 @@ i.e. gutters, and the space either side of the layout, i.e. margins.
 - Width of gutters: 24px
 - Width of margins: 42px
 
-### Large
+### Large and Extra large
 
 - Width of gutters: 30px
 - Width of margins: 60px

--- a/server/views/grid/aligning/aligning.njk
+++ b/server/views/grid/aligning/aligning.njk
@@ -1,36 +1,36 @@
 <div class="grid grid--justify-start">
-  <div class="grid__cell grid__cell--s2 grid__cell--m4 grid__cell--l6">
+  <div class="grid__cell grid__cell--s6 grid__cell--m6 grid__cell--l6">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 </div>
 
 <div class="grid grid--justify-center">
-  <div class="grid__cell grid__cell--s2 grid__cell--m4 grid__cell--l6">
+  <div class="grid__cell grid__cell--s6 grid__cell--m6 grid__cell--l6">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 </div>
 
 <div class="grid grid--justify-end">
-  <div class="grid__cell grid__cell--s2 grid__cell--m4 grid__cell--l6">
+  <div class="grid__cell grid__cell--s6 grid__cell--m6 grid__cell--l6">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 </div>
 
 <div class="grid grid--spaced">
-  <div class="grid__cell grid__cell--s1 grid__cell--m3 grid__cell--l5">
+  <div class="grid__cell grid__cell--s3 grid__cell--m4 grid__cell--l5">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 
-  <div class="grid__cell grid__cell--s1 grid__cell--m3 grid__cell--l5">
+  <div class="grid__cell grid__cell--s3 grid__cell--m4 grid__cell--l5">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 </div>
 
 <div class="grid">
-  <div class="grid__cell grid__cell--l5 grid__cell--shift-l1 grid__cell--m3 grid__cell--shift-m1 grid__cell--s1 grid__cell--shift-s1">
+  <div class="grid__cell grid__cell--l5 grid__cell--shift-l1 grid__cell--m4 grid__cell--shift-m1 grid__cell--s3 grid__cell--shift-s3">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
-  <div class="grid__cell grid__cell--l5 grid__cell--shift-l1 grid__cell--m3 grid__cell--shift-m1 grid__cell--s1 grid__cell--shift-s1">
+  <div class="grid__cell grid__cell--l5 grid__cell--shift-l1 grid__cell--m3 grid__cell--shift-m1 grid__cell--s3 grid__cell--shift-s1">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 </div>

--- a/server/views/grid/container_queries/README.md
+++ b/server/views/grid/container_queries/README.md
@@ -17,7 +17,7 @@ container-query(('s': ('1', '2'), 'm': ('4'), 'l': ('8', '12'))) {
 
 ## SCSS in the example on this page
 ```scss
-@include container-query(('s': ('1'))) {
+@include container-query(('s': ('3'))) {
   background: color('red-graphics');
 }
 

--- a/server/views/grid/container_queries/container_queries.njk
+++ b/server/views/grid/container_queries/container_queries.njk
@@ -1,5 +1,5 @@
 <div class="grid grid--justify-start">
-  <div class="{{ {s:1, m:5, l:3} | gridClasses }}">
+  <div class="{{ {s:3, m:8, l:3} | gridClasses }}">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 </div>

--- a/server/views/grid/container_queries/container_queries.njk
+++ b/server/views/grid/container_queries/container_queries.njk
@@ -1,5 +1,5 @@
 <div class="grid grid--justify-start">
-  <div class="{{ {s:3, m:8, l:3} | gridClasses }}">
+  <div class="{{ {s:3, m:5, l:3} | gridClasses }}">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
 </div>

--- a/server/views/grid/nesting/nesting.njk
+++ b/server/views/grid/nesting/nesting.njk
@@ -1,13 +1,13 @@
 <div class="grid">
-  <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
+  <div class="{{ {s:12, m:6, l:4} | gridClasses }}">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
   <div class="grid__cell">
     <div class="grid">
-      <div class="{{ {m:8} | gridClasses }}">
+      <div class="{{ {m:12} | gridClasses }}">
         {% include "views/grid/placeholder/placeholder.njk" %}
       </div>
-      <div class="{{ {m:8} | gridClasses }}">
+      <div class="{{ {m:12} | gridClasses }}">
         {% include "views/grid/placeholder/placeholder.njk" %}
       </div>
     </div>

--- a/server/views/grid/sizing/README.md
+++ b/server/views/grid/sizing/README.md
@@ -1,17 +1,16 @@
-Modifier classes can be used to determine exactly how many columns a cell will take up at a given breakpoint.
+The grid is composed of 12 columns.
 
-<small>__N.B. remember that there are different numbers of columns avaliable at each breakpoint:
-<br>small(s) - 4; medium(m) - 8; large(l) - 12. [See layout documentation for details](/docs/layout).__</small>
+Modifier classes can be used to determine exactly how many columns a cell will take up at a given breakpoint.
 
 Size modifier classes take the form `grid__cell--xy`, where `x` is either `s`, `m` or `l` and `y` is the number of columns the cell should span.  Applying a size modifier class to a `grid__cell` div will make the cell span the designated number of columns within the specified breakpoint only.
 
 ```html
 <div class="grid">
-  <div class="grid__cell grid__cell--s2 grid__cell--m2 grid__cell--l4">
+  <div class="grid__cell grid__cell--s6 grid__cell--m3 grid__cell--l4">
     {content goes here}
   </div>
 </div>
 ```
 
-In above example, the first cell will take up half the grid on small screens (2/4),
- a quarter on medium screens (2/8) and a a third on large screens (4/12).
+In above example, the first cell will take up half the grid on small screens (6/12),
+ a quarter on medium screens (3/12) and a third on large screens (4/12).

--- a/server/views/grid/sizing/sizing.njk
+++ b/server/views/grid/sizing/sizing.njk
@@ -1,5 +1,5 @@
 <div class="grid">
-  <div class="{{ {s:2, m:2, l:4} | gridClasses }}">
+  <div class="{{ {s:6, m:3, l:4} | gridClasses }}">
     {% include "views/grid/placeholder/placeholder.njk" %}
   </div>
   <div class="grid__cell">

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -45,7 +45,7 @@
   <div class="row row--cream {{ {s:4, m:4, l:4} | spacingClasses({padding: ['top', 'bottom']}) }} ">
     <div class="container">
       <div class="grid grid--no-gutters">
-        <div class="{{ {s: 4, m: 6, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
+        <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
           {% if article.author and article.bodyParts.length > 0  %}
             {% component 'author', {
               name: article.author.name,
@@ -89,7 +89,7 @@
       <div class="row {{ {s:8, m:8, l:8} | spacingClasses({padding: ['top', 'bottom']}) }}">
         <div class="container digital-story-transporter">
           <div class="grid grid--no-gutters">
-            <div class="{{ {s: 4, m: 6, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
+            <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
               <div class="body-part body-part--full-width">
                 <div class="wobbly-edge wobbly-edge--white wobbly-edge--small js-wobbly-edge" data-is-static="true"></div>
                 {% set asyncContentEndpoint = '/series-transporter/' + series.url + '?current=' + article.url %}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -1,5 +1,4 @@
 {% extends 'layout/default.njk' %}
-{% set gridCellClasses = 'grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4' %}
 
 {% block pageMeta %}
   {% component 'open-graph', { pageConfig: pageConfig, article: article } %}

--- a/server/views/pages/catalogue-item.njk
+++ b/server/views/pages/catalogue-item.njk
@@ -1,5 +1,4 @@
 {% extends 'layout/default.njk' %}
-{% set gridCellClasses = 'grid__cell grid__cell--xl6 grid__cell--shift-xl1 grid__cell--l7 grid__cell--m6 grid__cell--shift-m1 grid__cell--s4' %}
 
 {% block pageMeta %}{% endblock %}
 

--- a/server/views/pages/explore.njk
+++ b/server/views/pages/explore.njk
@@ -5,7 +5,7 @@
   <div class="row row--cream row--has-wobbly-background {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }}">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:8, l:12, xl:12} | gridClasses }}">
+        <div class="{{ {s:12, m:12, l:12, xl:12} | gridClasses }}">
           {% componentV2 'promo', topPromo, {}, {sizes: '(min-width: 1420px) 812px, (min-width: 600px) 58.5vw, calc(100vw - 36px)'} %}
         </div>
       </div>
@@ -31,7 +31,7 @@
   <div class="row {{ {s:2, m:2, l:2} | spacingClasses({padding:['top']}) }}">
     <div class="container container--scroll-xl">
       <div class="grid grid--no-gutters">
-        <div class="{{ {s: 4, m: 8, l: 12, xl: 12} | gridClasses }}">
+        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | gridClasses }}">
           {% set asyncContentEndpoint = '/series-transporter/' + latestDigitalStory %}
           {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-explore": true}' } %}
         </div>
@@ -50,10 +50,10 @@
   <div class="row">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:8, l:12, xl: 12} | gridClasses }}">
+        <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
           <h2 class="heading--large {{ {s:0, m:0, l:0} | spacingClasses({margin: ['top', 'bottom']}) }}">You may have missed</h2>
         </div>
-        <div class="{{ {s:4, m:8, l:8} | gridClasses }}">
+        <div class="{{ {s:12, m:12, l:8} | gridClasses }}">
           <a class="more-info-link" href="/articles">
             {% icon 'actions/arrow-small', null, ['icon--270', 'icon--action'] %}
             <span class="more-info-link__text">More articles</span>

--- a/server/views/pages/flags.njk
+++ b/server/views/pages/flags.njk
@@ -5,19 +5,19 @@
   <div class="row">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:8, l:12, xl: 12} | gridClasses }}">
+        <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
           <h2 class="feature-flags__title">Feature Flags</h2>
         </div>
       </div>
       <div class="grid">
-        <div class="{{ {s:4, m:4, l:4, xl: 4} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:4, xl: 4} | gridClasses }}">
             <p>You currently belong to the <span class="feature-flags__current-cohort">{{ featuresCohort  if featuresCohort else
              'default' }}</span> group.</p>
             {% for cohort in cohorts %}
               <button class="btn btn--light {{ {s:2, m:4, l:4, xl:4} | spacingClasses({margin: ['bottom']})}} js-cohort-button" data-cohort="{{cohort}}">Join the {{cohort}} group</button>
             {% endfor %}
         </div>
-        <div class="{{ {s:4, m:4, l:8, xl: 8} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:8, xl: 8} | gridClasses }}">
           {% for name, flag in featureFlags %}
           <table class="feature-flags__table {{ {s:2, m:4, l:4, xl:4} | spacingClasses({margin: ['bottom']})}}">
             <caption class="feature-flags__caption {{ {s:1, m:2, l:2, xl:2} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']})}}"><strong>{{name}}</strong></caption>

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -10,7 +10,7 @@
       </div>
 
       <div class="grid">
-        <div class="{{ {s: 4, m: 8, l: 8} | gridClasses }}">
+        <div class="{{ {s: 12, m: 12, l: 8} | gridClasses }}">
           <p class="{{ {s:2, m:2, l:2} | spacingClasses({margin: ['top']}) }} {{ {s:0, m:0, l:0} | spacingClasses({margin: ['bottom']}) }}">{{ list.description }}</p>
         </div>
       </div>
@@ -27,7 +27,7 @@
   <div class="row">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:8, l:12} | gridClasses }}">
+        <div class="{{ {s:12, m:12, l:12} | gridClasses }}">
           <div class="{{ {s:5, m:5, l:5} | spacingClasses({padding: ['top']}) }}  {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }} text--meta flex flex--v-center">
             {{ pagination.range.beginning }} - {{ pagination.range.end }}
           </div>
@@ -41,7 +41,7 @@
     <div class="container">
       <div class="grid">
         {% for promo in list.items.toJS() %}
-          <div class="{{ {s:4, m:4, l:3, xl:3} | gridClasses }}">
+          <div class="{{ {s:12, m:6, l:3, xl:3} | gridClasses }}">
             {% componentV2 'promo', promo, {}, {sizes: '(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'} %}
           </div>
         {% endfor %}

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -23,7 +23,7 @@
   <div class="row">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:8, l:12, xl: 12} | gridClasses }}">
+        <div class="{{ {s:12, m:8, l:12, xl: 12} | gridClasses }}">
           <h2 class="heading--large v-margin-0">Latest</h2>
         </div>
       </div>

--- a/server/views/templates/explore-landing.njk
+++ b/server/views/templates/explore-landing.njk
@@ -6,7 +6,7 @@
   <div class="row row--cream row--has-wobbly-background {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }}">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:8, l:12, xl:12} | gridClasses }}">
+        <div class="{{ {s:12, m:12, l:12, xl:12} | gridClasses }}">
           {% componentV2 'promo', comicPromo %}
         </div>
       </div>
@@ -17,15 +17,15 @@
   <div class="row row--cream">
     <div class="container container--scroll container--scroll-cream touch-scroll">
       <div class="grid grid--dividers grid--scroll">
-        <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:4} | gridClasses }}">
           {% componentV2 'promo', promo %}
         </div>
 
-        <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:4} | gridClasses }}">
           {% componentV2 'promo', comicPromo %}
         </div>
 
-        <div class="{{ {s:4, m:8, l:4} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:4} | gridClasses }}">
           {% componentV2 'promo', seriesArticlePromo %}
         </div>
       </div>
@@ -35,16 +35,16 @@
   <div class="row {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }}">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:4, m:4, l:12, xl:12} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:12, xl:12} | gridClasses }}">
           {% componentV2 'promo', promo %}
         </div>
-        <div class="{{ {s:4, m:4, l:8} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:8} | gridClasses }}">
           {% componentV2 'promo', promo %}
         </div>
-        <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:4} | gridClasses }}">
           {% componentV2 'promo', promo %}
         </div>
-        <div class="{{ {s:4, m:4, l:4} | gridClasses }}">
+        <div class="{{ {s:12, m:6, l:4} | gridClasses }}">
           {% component 'numbered-list', { numberedList: numberedList } %}
         </div>
       </div>


### PR DESCRIPTION
Fixes #992

🚑 Health

## Value
This simplifies the grid to use 12 columns at all breakpoints, making it easier reason about.

It will change the width of some components on medium screens, but not dramatically, and have run this passed Tomi.

### All
- [X] Demoed to the relevant people
- [X] PR labelled and assigned
- [X] Any introduced code complexity has been flagged