### PR TITLE
removed alert banner

### DIFF
--- a/client/scss/benched.scss
+++ b/client/scss/benched.scss
@@ -1,0 +1,1 @@
+@import 'components/new_site_notice';

--- a/client/scss/critical.scss
+++ b/client/scss/critical.scss
@@ -32,7 +32,6 @@
 @import 'components/header';
 @import 'components/interview';
 @import 'components/lazyload';
-@import 'components/new_site_notice';
 @import 'components/numbered_list';
 @import 'components/page_description';
 @import 'components/promo';

--- a/client/scss/styleguide.scss
+++ b/client/scss/styleguide.scss
@@ -1,3 +1,4 @@
 @import 'critical';
 @import 'non-critical';
+@import 'benched';
 @import 'styleguide/styleguide';

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -55,9 +55,6 @@
     ] %}
     {% component 'header', { navLinks: navLinks } %}
 
-    {% block siteNotice %}
-      {% component 'new-site-notice', {showLink: true} %}
-    {% endblock %}
     <div id="main" class="main" role="main">
       {% block body %}
       {% endblock %}


### PR DESCRIPTION
References #910

## Type
✨ Feature (less)

## Value
The banner took up space and kept people from recognising that they're in 'Explore' section

## Screenshot
![screen shot 2017-06-15 at 11 29 38](https://user-images.githubusercontent.com/6051896/27177347-f77426f2-51bd-11e7-9926-22b624b04859.png)

