### PR TITLE
Use up-to-date nav height data

### DIFF
--- a/client/js/components/shrink-stories-nav.js
+++ b/client/js/components/shrink-stories-nav.js
@@ -27,11 +27,15 @@ const shrinkStoriesNav = (el, dispatch) => {
       if (value && isScrolledEnough() && !getIsNarrow()) {
         el.classList.add('numbered-list--horizontal-narrow');
 
-        dispatch(setStickyNavHeight(height));
+        fastdom.measure(() => {
+          dispatch(setStickyNavHeight(el.offsetHeight));
+        });
       } else if (!value && getIsNarrow()) {
         el.classList.remove('numbered-list--horizontal-narrow');
 
-        dispatch(setStickyNavHeight(height));
+        fastdom.measure(() => {
+          dispatch(setStickyNavHeight(el.offsetHeight));
+        });
       }
     };
 


### PR DESCRIPTION
## Type
🔧 Fix  

## Value
Puts rail items in the correct position under the series nav.

## Screenshot
![screen shot 2017-06-15 at 12 26 33](https://user-images.githubusercontent.com/1394592/27179308-e700395c-51c5-11e7-86ed-412af0f8c5ad.png)

## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
