### PR TITLE
Series nav border

### DIFF
--- a/client/scss/components/_slider__numbered-list.scss
+++ b/client/scss/components/_slider__numbered-list.scss
@@ -4,6 +4,7 @@
 
   @include respond-to('medium') {
     border-width: 1px;
+    border-top: 0;
   }
 }
 
@@ -21,7 +22,7 @@
 
   @include respond-to('medium') {
     flex-direction: column;
-    border-width: 1px 1px 1px 0;
+    border-width: 0 1px 1px 0;
   }
 
   .numbered-list--horizontal-narrow & {

--- a/server/data/series.js
+++ b/server/data/series.js
@@ -45,7 +45,7 @@ export const series = List([
     items: List([
       ({
         contentType: 'article',
-        headline: 'The stranger who sparked an epidemic',
+        headline: 'The stranger who started an epidemic',
         // url: 'the-stranger',
         url: '',
         description: '',


### PR DESCRIPTION
## Type
🔧 Fix  

## Value
Removes the doubled-up border that resulted from removing the new site notice.

## Screenshot
![screen shot 2017-06-15 at 14 39 00](https://user-images.githubusercontent.com/1394592/27183946-6ad4a878-51d8-11e7-9bdb-c3fe7f1dd601.png)


## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
