### PR TITLE
add nocache to preview and fix promise function names

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -86,9 +86,49 @@ resource "aws_cloudfront_distribution" "next" {
     }
   }
 
+  # TODO: Deprecate
   cache_behavior {
     target_origin_id       = "${var.alb_id}"
     path_pattern           = "/articles/preview/*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${var.alb_id}"
+    path_pattern           = "/preview/*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+  cache_behavior {
+    target_origin_id       = "${var.alb_id}"
+    path_pattern           = "/preview"
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -58,9 +58,9 @@ async function getPreviewSession(token) {
       }
     }, '/', (err, redirectUrl) => {
       if (err) {
-        resolve(err);
+        reject(err);
       } else {
-        reject(redirectUrl);
+        resolve(redirectUrl);
       }
     });
   });


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
🔧 Fix  

## Value
<!-- how does this add value? -->
Makes the redirect service work.
* Fixed mixed promise function names (`resolve` and `reject`).
* Also does't use the cache for `/preview` and `/preview/*`. 

### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
