### PR TITLE
Move image gallery slider buttons up

### DIFF
--- a/client/scss/components/_slider__gallery.scss
+++ b/client/scss/components/_slider__gallery.scss
@@ -60,6 +60,6 @@
 }
 
 .slider-controls--gallery {
-  top: -60px;
+  top: -15 * $spacing-unit;
   position: relative;
 }


### PR DESCRIPTION
Fixes #1011

## Type
🔧 Fix  

## Value
Moves the gallery slider buttons up.

## Screenshot
![screen shot 2017-06-21 at 13 58 13](https://user-images.githubusercontent.com/1394592/27385204-b2361f7a-5689-11e7-9c09-72315e456839.png)

## Checklist
### All
- [ ] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
