### PR TITLE
Use background image instead of linear gradient to fix retina rendering

### DIFF
--- a/client/scss/components/_divider.scss
+++ b/client/scss/components/_divider.scss
@@ -32,5 +32,6 @@
 
 .divider--dashed {
   height: 10px;
-  background: repeating-linear-gradient(90deg, color('black'), color('black') 1px, color('transparent') 1px, color('transparent') 5px);
+  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20viewBox%3D%220%200%205%2010%22%3E%0A%09%3Cline%20fill%3D%22none%22%20stroke%3D%22%23000000%22%20class%3D%22st0%22%20x1%3D%220.5%22%20y1%3D%2210%22%20x2%3D%220.5%22%20y2%3D%220%22%20/%3E%0A%3C/svg%3E%0A');
+  background-repeat: repeat;
 }


### PR DESCRIPTION
Fixes #1025

## Type
🔧 Fix  

## Value
Stops the dashed divider looking weird on high pixel density screens.

## Screenshot
![img_0778](https://user-images.githubusercontent.com/1394592/27387867-d2f39190-5691-11e7-8290-51ae9cbc3a1e.PNG)


## Checklist
### All
- [ ] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
