### PR TITLE
Fix spacing at end of digital story page

### DIFF
--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -93,7 +93,6 @@ $center-width-xlarge: (6/6) * 100%;
   @include respond-to('large') {
     left: $center-width-large;
     margin-right: calc((#{$narrow-width} + #{map-get($gutter-width, 'large')}) * -1);
-    background-color: color('cream');
     padding: 0 map-get($container-padding, 'large');
     padding-top: $vertical-space-unit;
     margin-top: -$vertical-space-unit;

--- a/client/scss/components/_slider__transporter.scss
+++ b/client/scss/components/_slider__transporter.scss
@@ -4,12 +4,5 @@
   .slider-inner {
     padding-top: 0;
   }
-
-  .slide-item {
-    padding-bottom: 8 * $spacing-unit;
-  }
 }
 
-.slider-controls--transporter {
-  margin-top: -(8 * $spacing-unit);
-}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -41,7 +41,7 @@
     </div>
   </div>
 
-  <div class="row row--cream {{ {s:4, m:4, l:4} | spacingClasses({padding: ['top', 'bottom']}) }} ">
+  <div class="row row--cream {{ {s:8, m:8, l:8} | spacingClasses({padding: ['top', 'bottom']}) }} ">
     <div class="container">
       <div class="grid grid--no-gutters">
         <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
@@ -85,7 +85,7 @@
 {% block transporters %}
   {% for series in article.series %}
     {% if series.commissionedLength %}
-      <div class="row {{ {s:8, m:8, l:8} | spacingClasses({padding: ['top', 'bottom']}) }}">
+      <div class="row {{ {s:10, m:10, l:10} | spacingClasses({padding: ['top']}) }} {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }}">
         <div class="container digital-story-transporter">
           <div class="grid grid--no-gutters">
             <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">


### PR DESCRIPTION
Fixes #965

## Type
🔧 Fix  

## Value
Cleans up the spacings at the end of the digital story page.

## Screenshot
![screen shot 2017-06-21 at 15 40 15](https://user-images.githubusercontent.com/1394592/27390083-35608684-5698-11e7-9db7-c74ca37f2260.png)

## Checklist
### All
- [ ] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
