### PR TITLE
refresh prismic API every minute

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -1,5 +1,5 @@
 import Prismic from 'prismic-javascript';
-import {prismicApiV2} from '../services/prismic-api';
+import {prismicApi} from '../services/prismic-api';
 import {getContent, getPreviewContent} from '../services/prismic-content';
 import {createPageConfig} from '../model/page-config';
 
@@ -49,7 +49,7 @@ export async function setContentPreviewSession(ctx, next) {
 }
 
 async function getPreviewSession(token) {
-  const prismic = await prismicApiV2();
+  const prismic = await prismicApi();
 
   return new Promise((resolve, reject) => {
     prismic.previewSession(token, (doc) => {

--- a/server/services/prismic-api.js
+++ b/server/services/prismic-api.js
@@ -1,27 +1,29 @@
-import Prismic from 'prismic.io';
-import PrismicV2 from 'prismic-javascript';
+import Prismic from 'prismic-javascript';
 
-// This is so only the first request to the app once started has to make this request.
+const oneMinute = 1000 * 60;
+const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
+
 let memoizedPrismic;
+
+function periodicallyUpdatePrismic() {
+  setInterval(async() => {
+    console.info('refreshing prismic');
+    memoizedPrismic = await Prismic.getApi(apiUri);
+  }, oneMinute);
+}
+
 export async function prismicApi() {
   if (!memoizedPrismic) {
-    memoizedPrismic = await Prismic.api('https://wellcomecollection.prismic.io/api');
+    console.info('memoizing prismic');
+    memoizedPrismic = await Prismic.getApi(apiUri);
+  } else {
+    console.info('returning memoized prismic');
   }
 
   return memoizedPrismic;
 }
-
-// TODO: Setup interval to update this every now and then.
-const apiV2Uri = 'https://wellcomecollection.prismic.io/api/v2';
-let memoizedPrismicV2;
-export async function prismicApiV2() {
-  if (!memoizedPrismicV2) {
-    memoizedPrismicV2 = await PrismicV2.getApi(apiV2Uri);
-  }
-
-  return memoizedPrismicV2;
-}
+periodicallyUpdatePrismic();
 
 export async function prismicPreviewApi(req) {
-  return await PrismicV2.getApi(apiV2Uri, {req});
+  return await Prismic.getApi(apiUri, {req});
 }

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -2,7 +2,7 @@ import type {Article} from '../model/article';
 import type {Picture} from '../model/picture';
 import Prismic from 'prismic-javascript';
 import {RichText, Date as PrismicDate} from 'prismic-dom';
-import {prismicApiV2, prismicPreviewApi} from './prismic-api';
+import {prismicApi, prismicPreviewApi} from './prismic-api';
 
 export async function getPreviewContent(id: string, req) {
   const prismic = await prismicPreviewApi(req);
@@ -10,7 +10,7 @@ export async function getPreviewContent(id: string, req) {
 }
 
 export async function getContent(id: string) {
-  const prismic = await prismicApiV2();
+  const prismic = await prismicApi();
   return getParsedContent(prismic, id);
 }
 


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
🔧 Fix  

## Value
We make sure we return the latest version of the article.

If we only load the Prismic API on app launch, and then update the master ref (essentially the master branch of our content), we will be retrieving an old value.

I could setup a webhook on Prismic but that's feels a little to decoupled, but might if this causes problems, which I can't imagine it will.

