### PR TITLE
Pass query parameter

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "next" {
 
     forwarded_values {
       query_string = true
-      query_string_cache_keys = ["page", "current", "q", "format"]
+      query_string_cache_keys = ["page", "current", "q", "format", "query"]
 
       cookies {
         forward = "whitelist"


### PR DESCRIPTION
🔧 Fix  

## Value
Stops search params being ignored by Cloudfront
