### PR TITLE
consume articles from prismic onto the explore page

### DIFF
--- a/server/controllers/lists.js
+++ b/server/controllers/lists.js
@@ -13,7 +13,7 @@ export async function explore(ctx, next) {
   const wpPromos = articleStubs.data.map(PromoFactory.fromArticleStub);
   const contentPromos = contentList.map(PromoFactory.fromArticleStub);
   const promos = wpPromos.concat(contentPromos).sort((a, b) => {
-    return a.datePublished.getTime() - b.datePublished.getTime()
+    return a.datePublished.getTime() - b.datePublished.getTime();
   }).reverse();
 
   // TODO: Remove this, make it automatic


### PR DESCRIPTION
Fixes #1033 
## Type
<!-- delete as appropriate -->
✨ Feature  

## Value
Consumes articles from Prismic and slams them onto the `/explore` page.
This means we can start producing Prismic articles, which will support things like multiple creators, footnotes, books, etc.

## Screenshot
![prismic yay](https://user-images.githubusercontent.com/31692/27492390-f9bf1882-583d-11e7-8a25-a2ae2c05d4da.png)

## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

