### PR TITLE
Use helvetica medium for strong and b elements in body

### DIFF
--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -56,6 +56,11 @@
       box-shadow: inset 0 -0.2em 0 0 color('seaweed');
     }
   }
+
+  strong,
+  b {
+    font-family: $helvetica-neue-medium;
+  }
 }
 
 $narrow-width: (5/7) * 100%; // calculates the narrow column width as a percentage of the main column.


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
🐛 Bugfix  

## Value
<!-- how does this add value? -->
We can now see bold.
I didn't use the `include font('BLAH')` as I want it to inherit the body sizes.

## Screenshot
<!-- drag screenshot here -->
💪 

## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
