### PR TITLE
exclude content from explore when flag is off

### DIFF
--- a/server/controllers/lists.js
+++ b/server/controllers/lists.js
@@ -10,9 +10,9 @@ export async function explore(ctx, next) {
   // TODO: Remove WP content
   const [flags] = ctx.intervalCache.get('flags');
   const prismicArticlesOnExploreFlag = isFlagEnabled(ctx.featuresCohort, 'prismicArticlesOnExplore', flags);
-  const curatedListPromise = prismicArticlesOnExploreFlag ? getCuratedList('explore') : Promise.resolve([]);
+  const contentListPromise = prismicArticlesOnExploreFlag ? getContentList() : Promise.resolve([]);
 
-  const listRequests = [curatedListPromise, getArticleStubs(10), getContentList()];
+  const listRequests = [getCuratedList('explore'), getArticleStubs(10), contentListPromise];
   const [curatedList, articleStubs, contentList] = await Promise.all(listRequests);
 
   const wpPromos = articleStubs.data.map(PromoFactory.fromArticleStub);


### PR DESCRIPTION

<!-- delete as appropriate -->
🐛 Bugfix  

## Value
<!-- how does this add value? -->
Messed the order up a little, content lists are meant to be excluded, not the curatedLists.

