### PR TITLE
Add status codes/descriptions to Cardigan docs

### DIFF
--- a/cardigan/config/statuses.js
+++ b/cardigan/config/statuses.js
@@ -1,0 +1,27 @@
+export default {
+  wip: {
+    label: 'WIP',
+    description: 'Work in progress',
+    color: '#ad4e00'
+  },
+  testing: {
+    label: 'Testing',
+    description: 'Being tested',
+    color: '#895791'
+  },
+  graduated: {
+    label: 'Graduated',
+    description: 'Implemented',
+    color: '#367378'
+  },
+  deprecated: {
+    label: 'Deprecated',
+    description: 'Deprecated',
+    color: '#c72e3d'
+  },
+  benched: {
+    label: 'Benched',
+    description: 'Has previously been used, but is not currently; maybe be used in future',
+    color: '#006272'
+  }
+};

--- a/cardigan/fractal-app.js
+++ b/cardigan/fractal-app.js
@@ -7,6 +7,7 @@ import filters from '../server/filters';
 import extensions from '../server/extensions';
 import {getEnvWithGlobalsExtensionsAndFilters} from '../server/view/env-utils';
 import {createPageConfig} from '../server/model/page-config';
+import statuses from './config/statuses';
 
 const fractal = Fractal.create();
 const root = serverDir('views');
@@ -29,33 +30,7 @@ fractal.components.engine(nunjucks);
 fractal.set('project.title', 'pattern library');
 
 fractal.components.set('path', root);
-fractal.components.set('statuses', {
-  wip: {
-    label: 'WIP',
-    description: 'Work in progress',
-    color: '#ad4e00'
-  },
-  testing: {
-    label: 'Testing',
-    description: 'Being tested',
-    color: '#895791'
-  },
-  graduated: {
-    label: 'Graduated',
-    description: 'Implemented',
-    color: '#367378'
-  },
-  deprecated: {
-    label: 'Deprecated',
-    description: 'Deprecated',
-    color: '#c72e3d'
-  },
-  benched: {
-    label: 'Benched',
-    desciption: 'Has previously been used, but is not currently; maybe be used in future',
-    color: '#006272'
-  }
-});
+fractal.components.set('statuses', statuses);
 fractal.components.set('default.status', 'wip');
 fractal.components.set('ext', '.njk');
 fractal.components.set('default.preview', '@preview');

--- a/server/filters/array-from-object.js
+++ b/server/filters/array-from-object.js
@@ -1,0 +1,6 @@
+export function arrayFromObject(object) {
+  return Object.keys(object)
+    .map(key => {
+      return object[key];
+    });
+}

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -15,6 +15,7 @@ import jsonLd from './json-ld';
 import {formatDate, formatDateWithComingSoon} from './format-date';
 import {isFlagEnabled} from '../util/flag-status';
 import {objectAssign} from './object-assign';
+import {arrayFromObject} from './array-from-object';
 import {groupBodyParts} from './group-body-parts';
 
 export default Map({
@@ -35,5 +36,6 @@ export default Map({
   formatDateWithComingSoon,
   isFlagEnabled,
   objectAssign,
+  arrayFromObject,
   groupBodyParts
 });

--- a/server/views/docs/index.config.js
+++ b/server/views/docs/index.config.js
@@ -1,4 +1,7 @@
+import statuses from '../../../cardigan/config/statuses';
+
 export const context = {
+  statuses,
   pageDescription: {
     intro: 'Wellcome Collection pattern library',
     title: 'Cardigan',

--- a/server/views/docs/index.njk
+++ b/server/views/docs/index.njk
@@ -13,5 +13,18 @@
     <li><a href="https://github.com/wellcometrust/wellcomecollection.org">GitHub Repository</a></li>
     <li><a href="https://circleci.com/gh/wellcometrust/wellcomecollection.org">CIrcleCi build</a></li>
   </ul>
+
+  <h2>Status codes</h2>
+  <p>Components and their variants have been given statuses reflecting their state of completion. The available statuses are listed below.</p>
+  <table>
+    <tbody>
+      {% for status in statuses | arrayFromObject %}
+        <tr>
+          <td><span style="background: {{ status.color }}; display: inline-block; padding: 0.2em 0.5em; border-radius: 6px; color: #fff; font-family: 'Wellcome Bold Web'">{{ status.label }}</span></td>
+          <td>{{ status.description }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 {% endblock %}
 


### PR DESCRIPTION
## Type
🚑 Health

## Value
Adds a table of our component status codes to the front of the docs, for clarity (as seen on/cribbed from the [Perch UI pattern library](http://patterns.perchcms.com/)).

## Screenshot
![screen shot 2017-07-06 at 12 20 40](https://user-images.githubusercontent.com/1394592/27908886-eaa3838a-6245-11e7-8492-6bf6f465c540.png)


## Checklist
### All
- [ ] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
