### PR TITLE
Decrease code preview size in Cardigan slightly

### DIFF
--- a/client/scss/styleguide/_styleguide.scss
+++ b/client/scss/styleguide/_styleguide.scss
@@ -168,12 +168,9 @@ html {
   }
 }
 
-.Status {
-  font-size: 0.7em;
-}
-
+.Status,
 .Code {
-  font-size: 0.8em;
+  font-size: 0.7em;
 }
 
 .Document {


### PR DESCRIPTION
## Type
🚑 Health

## Value
Makes the code preview look a little bit smaller/nicer in Cardigan (currently looks kind of childishly big).

## Screenshot
![screen shot 2017-07-07 at 10 36 31](https://user-images.githubusercontent.com/1394592/27952438-2f999eec-6300-11e7-97a6-8112dcb91678.png)
