### PR TITLE
Add font-at-breakpoint classes

### DIFF
--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -14,6 +14,24 @@
   }
 }
 
+@each $font-key, $font-value in $fonts {
+  @each $breakpoint-key, $breakpoint-value in $grid-config {
+    $breakpoint-respond: map-get($breakpoint-value, 'respond');
+
+    .font-#{$font-key}-#{$breakpoint-key} {
+      @if (length($breakpoint-respond) > 1) {
+        @include respond-between(nth($breakpoint-respond, 1), nth($breakpoint-respond, 2)) {
+          @include font($font-key);
+        }
+      } @else {
+        @include respond-to($breakpoint-respond) {
+          @include font($font-key);
+        }
+      }
+    }
+  }
+}
+
 .is-hidden {
   display: none;
 }

--- a/server/filters/font-classes.js
+++ b/server/filters/font-classes.js
@@ -1,0 +1,5 @@
+export default function fontClasses(sizes) {
+  return Object.keys(sizes).map(key => {
+    return `font-${sizes[key]}-${key}`;
+  }).join(' ');
+}

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -7,6 +7,7 @@ import getCommissionedSeries from './get-commissioned-series';
 import getSeriesTitle from './get-series-title';
 import gridClasses from './grid-classes';
 import spacingClasses from './spacing-classes';
+import fontClasses from './font-classes';
 import componentClasses from './component-classes';
 import concat from './concat';
 import contains from './contains';
@@ -27,6 +28,7 @@ export default Map({
   getSeriesTitle,
   gridClasses,
   spacingClasses,
+  fontClasses,
   concat,
   contains,
   componentClasses,


### PR DESCRIPTION
## Type
🚑 Health

## Value
We have a set of 24 possible typography styles and 4 breakpoints. This adds a font-at-breakpoint class for each combination (e.g. `.font-HNM3-s`).

The end goal is that we could do away with any font-family declarations within components and handle them in the markup (using  a `fontClasses()` filter, à la `spacingClasses()`).

Updating each component to use these classes in the markup will be a fairly tedious bit of grunt work if we want to do it. Reckons?
