### PR TITLE
embed eventbrite widget via proxy

### DIFF
--- a/server/controllers/async-controllers.js
+++ b/server/controllers/async-controllers.js
@@ -1,9 +1,9 @@
-import { getSeries } from '../services/wordpress';
-import { PromoListFactory } from '../model/promo-list';
-import { getForwardFill, getUnpublishedSeries } from '../model/series';
-import { getSeriesColor } from '../data/series';
-import { createNumberedList } from '../model/numbered-list';
-import { getLatestInstagramPosts } from '../services/instagram';
+import {getSeries} from '../services/wordpress';
+import {PromoListFactory} from '../model/promo-list';
+import {getForwardFill, getUnpublishedSeries} from '../model/series';
+import {getSeriesColor} from '../data/series';
+import {createNumberedList} from '../model/numbered-list';
+import {getLatestInstagramPosts} from '../services/instagram';
 
 export const seriesNav = async(ctx, next) => {
   const {id} = ctx.params;
@@ -107,4 +107,3 @@ export const seriesContainerPromoList = async(ctx, next) => {
 
   return next();
 };
-

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -2,6 +2,7 @@ import Prismic from 'prismic-javascript';
 import {prismicApi} from '../services/prismic-api';
 import {getEditorial, getEditorialPreview, getEvent} from '../services/prismic-content';
 import {createPageConfig} from '../model/page-config';
+import {getEventbriteEventEmbed} from '../services/eventbrite';
 
 export const renderEditorial = async(ctx, next) => {
   const format = ctx.request.query.format;
@@ -85,3 +86,11 @@ export async function renderEvent(ctx, next) {
     }
   }
 }
+
+export const renderEventbriteEmbed = async(ctx, next) => {
+  const {id} = ctx.params;
+  const eventEmbedHtml = await getEventbriteEventEmbed(id);
+  ctx.body = eventEmbedHtml;
+
+  return next();
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,7 +1,10 @@
 import Router from 'koa-router';
 import {healthcheck, featureFlags} from '../controllers/utils';
 import {seriesNav, seriesTransporter, latestInstagramPosts, seriesContainerPromoList} from '../controllers/async-controllers';
-import {renderEditorial, renderEditorialPreview, setPreviewSession, renderEvent} from '../controllers/content';
+import {
+  renderEditorial, renderEditorialPreview, setPreviewSession, renderEvent,
+  renderEventbriteEmbed
+} from '../controllers/content';
 import {explore} from '../controllers/lists';
 import {work, search} from '../controllers/work';
 import {index, article, articles, preview, series} from '../controllers'; // Deprecated
@@ -38,5 +41,6 @@ r.get('/latest-instagram-posts', latestInstagramPosts);
 r.get('/series-container-promos-list/:id', seriesContainerPromoList);
 
 r.get('/events/:id', renderEvent);
+r.get('/eventbrite-event-embed/:id', renderEventbriteEmbed);
 
 export const router = r.middleware();

--- a/server/services/eventbrite.js
+++ b/server/services/eventbrite.js
@@ -1,0 +1,7 @@
+// @flow
+import superagent from 'superagent';
+
+export async function getEventbriteEventEmbed(id: string) {
+  const iframeContent = await superagent.get(`https://eventbrite.com/tickets-external?eid=${id}&ref=etckt`);
+  return iframeContent.text;
+}

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -248,7 +248,7 @@ export async function getEvent(id) {
   const author = person && {
     name: person.name,
     twitterHandle: person.twitterHandle,
-    image: person.image.url,
+    image: person.image && person.image.url,
     description: RichText.asText(person.description)
   };
 

--- a/server/views/pages/event.njk
+++ b/server/views/pages/event.njk
@@ -104,6 +104,20 @@
             </div>
           {% endfor %}
 
+          <div class="{{ {s:6, m:6, l:6} | spacingClasses({padding: ['top']}) }}">
+            {% if (article.eventbriteId) %}
+              <iframe id="eventbrite-iframe-{{ eventbriteId }}" src="/eventbrite-event-embed/{{ article.eventbriteId }}" frameborder="0" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe>
+              <script>
+                (function() {
+                  var iframe = document.getElementById('eventbrite-iframe-{{ eventbriteId }}');
+                  iframe.addEventListener('load', function() {
+                    iframe.height = iframe.contentWindow.document.body.scrollHeight;
+                  });
+                })();
+              </script>
+            {% endif %}
+            <p>This event is <b>FREE</b>. <a href="https://wellcomecollection.org/visit-us/tickets">Find out more about events</a>.</p>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
✨ Feature  

## Value
<!-- how does this add value? -->
Shows users the eventbrite widget so they can buy tickets.

We use a proxy here as EB have a crappy bug that means the iframe doesn't resize and we can't read the document dimensions as it's cross domain. This way we can.

Having it this way also means we don't need to say when the tickets go on sale (which isn't available on the EB public API) as the widget tells you.

## Screenshot
![eventbrite](https://user-images.githubusercontent.com/31692/28030081-279c4afe-659a-11e7-961b-3692430634d4.png)


## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
