### PR TITLE
fix server sentry errors and send URL over correctly

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -11,6 +11,7 @@ import {intervalCache} from './middleware/interval-cache';
 
 const app = new Koa();
 
+app.use(error());
 app.use(enforceSSL());
 app.use(setCacheControl(config.cacheControl));
 app.use(intervalCache());
@@ -19,6 +20,5 @@ app.use(serve(config.favicon.path));
 app.use(determineFeaturesCohort());
 app.use(render(config.views.path));
 app.use(router);
-app.use(error());
 
 export default app;

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -9,7 +9,7 @@ export default function() {
       if (404 === ctx.response.status && !ctx.response.body) ctx.throw(404);
     } catch (err) {
       if (404 !== err.status) {
-        Raven.captureException(err, {url: ctx.request.url});
+        Raven.captureException(err, {extra: {url: ctx.request.url}});
       }
 
       ctx.status = err.status || 500;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -17,6 +17,9 @@ const r = new Router({
 r.get('/', index);
 r.get('/healthcheck', healthcheck);
 r.get('/flags', featureFlags);
+r.get('/kaboom', (ctx, next) => {
+  ctx.throw('Error Message', 500);
+});
 
 // Content
 r.get('/editorial/(W):id', renderEditorial);


### PR DESCRIPTION

## Type
🐛 Bugfix  

## Value
<!-- how does this add value? -->
Errors are actually sent over to sentry (I don't know why I thought that errors should be at the bottom us the `use` chain).

We also send over the URL correctly:
https://docs.sentry.io/clients/javascript/usage/#raven-js-additional-context

