### PR TITLE
Delegate ECS/ECR access to platform team

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -49,20 +49,20 @@ resource "aws_cloudfront_distribution" "cardigan" {
 }
 
 resource "aws_cloudfront_distribution" "next" {
-
   origin {
     domain_name = "${var.dns_name}"
     origin_id   = "${var.alb_id}"
+
     custom_origin_config {
       origin_protocol_policy = "http-only"
-      http_port = "80"
-      https_port = "443"
-      origin_ssl_protocols = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      http_port              = "80"
+      https_port             = "443"
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
     }
   }
 
-  enabled             = true
-  is_ipv6_enabled     = true
+  enabled         = true
+  is_ipv6_enabled = true
 
   aliases = ["${var.website_uri}", "wellcomecollection.org"]
 
@@ -76,11 +76,11 @@ resource "aws_cloudfront_distribution" "next" {
     max_ttl                = 86400
 
     forwarded_values {
-      query_string = true
+      query_string            = true
       query_string_cache_keys = ["page", "current", "q", "format", "query"]
 
       cookies {
-        forward = "whitelist"
+        forward           = "whitelist"
         whitelisted_names = ["WC_wpAuthToken", "WC_featuresCohort"]
       }
     }
@@ -99,7 +99,7 @@ resource "aws_cloudfront_distribution" "next" {
 
     forwarded_values {
       query_string = true
-      headers = ["*"]
+      headers      = ["*"]
 
       cookies {
         forward = "all"
@@ -119,13 +119,14 @@ resource "aws_cloudfront_distribution" "next" {
 
     forwarded_values {
       query_string = true
-      headers = ["*"]
+      headers      = ["*"]
 
       cookies {
         forward = "all"
       }
     }
   }
+
   cache_behavior {
     target_origin_id       = "${var.alb_id}"
     path_pattern           = "/preview"
@@ -138,7 +139,7 @@ resource "aws_cloudfront_distribution" "next" {
 
     forwarded_values {
       query_string = true
-      headers = ["*"]
+      headers      = ["*"]
 
       cookies {
         forward = "all"

--- a/infra/terraform/dev/wellcomecollection.tf
+++ b/infra/terraform/dev/wellcomecollection.tf
@@ -4,7 +4,11 @@ variable "aws_profile" {}
 variable "wellcomecollection_key_path" {}
 variable "wellcomecollection_key_name" {}
 variable "wellcomecollection_ssl_cert_arn" {}
-variable "website_uri" { default = "next.dev-wellcomecollection.org" }
+
+variable "website_uri" {
+  default = "next.dev-wellcomecollection.org"
+}
+
 variable "container_tag" {}
 
 provider "aws" {
@@ -26,6 +30,7 @@ module "wellcomecollection" {
   wellcomecollection_ssl_cert_arn = "${var.wellcomecollection_ssl_cert_arn}"
   website_uri                     = "${var.website_uri}"
   container_tag                   = "${var.container_tag}"
+  platform_team_account_id        = "${var.platform_team_account_id}"
 }
 
 output "ami_id" {

--- a/infra/terraform/prod/wellcomecollection.tf
+++ b/infra/terraform/prod/wellcomecollection.tf
@@ -1,16 +1,20 @@
 variable "aws_access_key" {}
 variable "aws_secret_key" {}
-variable "aws_profile" {}
 variable "wellcomecollection_key_path" {}
 variable "wellcomecollection_key_name" {}
 variable "wellcomecollection_ssl_cert_arn" {}
-variable "website_uri" { default = "next.wellcomecollection.org" }
+
+variable "website_uri" {
+  default = "next.wellcomecollection.org"
+}
+
 variable "container_tag" {}
+
+variable "platform_team_account_id" {}
 
 provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
-  profile    = "${var.aws_profile}"
   region     = "eu-west-1"
 }
 
@@ -26,15 +30,16 @@ module "wellcomecollection" {
   wellcomecollection_ssl_cert_arn = "${var.wellcomecollection_ssl_cert_arn}"
   website_uri                     = "${var.website_uri}"
   container_tag                   = "${var.container_tag}"
+  platform_team_account_id        = "${var.platform_team_account_id}"
 }
 
 module "wellcomecollection_cardigan" {
-  source = "../website-bucket"
+  source      = "../website-bucket"
   website_uri = "cardigan.wellcomecollection.org"
 }
 
 module "wellcomecollection_cloudformation" {
-  source = "../cloudfront"
+  source                          = "../cloudfront"
   wellcomecollection_ssl_cert_arn = "${var.wellcomecollection_ssl_cert_arn}"
   website_uri                     = "${var.website_uri}"
   dns_name                        = "${module.wellcomecollection.dns_name}"

--- a/infra/terraform/templates/alb.tf
+++ b/infra/terraform/templates/alb.tf
@@ -1,17 +1,19 @@
 data "aws_acm_certificate" "star_wellcomecollection_org" {
-  domain = "${var.ssl_cert_name}"
+  domain   = "${var.ssl_cert_name}"
   statuses = ["ISSUED"]
 }
 
 resource "aws_alb" "wellcomecollection_alb" {
-  name            = "wellcomecollection-alb"
-  subnets         = ["${aws_subnet.public_a.id}", "${aws_subnet.public_b.id}"]
+  name    = "wellcomecollection-alb"
+  subnets = ["${aws_subnet.public_a.id}", "${aws_subnet.public_b.id}"]
+
   security_groups = [
     "${aws_security_group.https.id}",
     "${aws_security_group.http.id}",
     "${aws_security_group.node_app_port.id}",
-    "${aws_security_group.docker.id}"
+    "${aws_security_group.docker.id}",
   ]
+
   access_logs {
     bucket = "${aws_s3_bucket.alb_log_bucket.bucket}"
     prefix = "dotorg-alb"
@@ -101,16 +103,16 @@ resource "aws_sns_topic" "wellcomecollection_alb_500_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "wellcomecollection_alb_500" {
-  alarm_description = "Monitoring any 500 errors from the ALB"
-  alarm_name = "wellcomecollection-alb-500"
-  alarm_actions = ["${aws_sns_topic.wellcomecollection_alb_500_alarm.arn}"]
+  alarm_description   = "Monitoring any 500 errors from the ALB"
+  alarm_name          = "wellcomecollection-alb-500"
+  alarm_actions       = ["${aws_sns_topic.wellcomecollection_alb_500_alarm.arn}"]
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods = "1"
-  metric_name = "HTTPCode_Target_5XX_Count"
-  namespace = "AWS/ApplicationELB"
-  period = "120"
-  statistic = "Sum"
-  threshold = "0"
+  evaluation_periods  = "1"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = "120"
+  statistic           = "Sum"
+  threshold           = "0"
 
   dimensions {
     LoadBalancer = "${replace("${aws_alb.wellcomecollection_alb.arn}", "/arn:.*?:loadbalancer\\/(.*)/", "$1")}"

--- a/infra/terraform/templates/ecs.tf
+++ b/infra/terraform/templates/ecs.tf
@@ -19,28 +19,28 @@ resource "aws_ecs_cluster" "wellcomecollection" {
 }
 
 resource "aws_ecs_task_definition" "wellcomecollection" {
-  family = "wellcomecollection"
+  family                = "wellcomecollection"
   container_definitions = "${data.template_file.container_definitions.rendered}"
 }
 
 resource "aws_ecs_service" "wellcomecollection" {
-  name = "wellcomecollection"
-  cluster = "${aws_ecs_cluster.wellcomecollection.id}"
-  task_definition = "${aws_ecs_task_definition.wellcomecollection.arn}"
-  desired_count = 2
+  name                               = "wellcomecollection"
+  cluster                            = "${aws_ecs_cluster.wellcomecollection.id}"
+  task_definition                    = "${aws_ecs_task_definition.wellcomecollection.arn}"
+  desired_count                      = 2
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent = 200
-  iam_role = "${aws_iam_role.ecs_service_role.arn}"
+  deployment_maximum_percent         = 200
+  iam_role                           = "${aws_iam_role.ecs_service_role.arn}"
 
   placement_strategy {
-    type = "spread"
+    type  = "spread"
     field = "instanceId"
   }
 
   load_balancer {
     target_group_arn = "${aws_alb_target_group.wellcomecollection.id}"
-    container_name = "nginx-proxy"
-    container_port = 80
+    container_name   = "nginx-proxy"
+    container_port   = 80
   }
 
   depends_on = [
@@ -50,28 +50,28 @@ resource "aws_ecs_service" "wellcomecollection" {
 }
 
 resource "aws_ecs_task_definition" "thumbor" {
-  family = "thumbor"
+  family                = "thumbor"
   container_definitions = "${data.template_file.container_definitions_thumbor.rendered}"
 }
 
 resource "aws_ecs_service" "thumbor" {
-  name = "thumbor"
-  cluster = "${aws_ecs_cluster.wellcomecollection.id}"
-  task_definition = "${aws_ecs_task_definition.thumbor.arn}"
-  desired_count = 1
+  name                               = "thumbor"
+  cluster                            = "${aws_ecs_cluster.wellcomecollection.id}"
+  task_definition                    = "${aws_ecs_task_definition.thumbor.arn}"
+  desired_count                      = 1
   deployment_minimum_healthy_percent = 50
-  deployment_maximum_percent = 200
-  iam_role = "${aws_iam_role.ecs_service_role.arn}"
+  deployment_maximum_percent         = 200
+  iam_role                           = "${aws_iam_role.ecs_service_role.arn}"
 
   placement_strategy {
-    type = "spread"
+    type  = "spread"
     field = "instanceId"
   }
 
   load_balancer {
     target_group_arn = "${aws_alb_target_group.thumbor.id}"
-    container_name = "thumbor"
-    container_port = 8000
+    container_name   = "thumbor"
+    container_port   = 8000
   }
 
   depends_on = [

--- a/infra/terraform/templates/iam.tf
+++ b/infra/terraform/templates/iam.tf
@@ -1,6 +1,7 @@
 # TODO convert EOF strings to data
 resource "aws_iam_role" "wellcomecollection_instance" {
   name = "wellcomecollection-instance"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -16,37 +17,39 @@ EOF
 # ECS
 resource "aws_iam_policy_attachment" "ecs_service_ec2_role" {
   # This is the default name used by amazon
-  name = "ecsInstanceRole"
-  roles = ["${aws_iam_role.wellcomecollection_instance.name}"]
+  name       = "ecsInstanceRole"
+  roles      = ["${aws_iam_role.wellcomecollection_instance.name}"]
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_role" "ecs_service_role" {
-  name = "ecs-service-role"
+  name               = "ecs-service-role"
   assume_role_policy = "${data.aws_iam_policy_document.ecs_service_role.json}"
 }
 
 data "aws_iam_policy_document" "ecs_service_role" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["sts:AssumeRole"]
+
     principals {
-      type = "Service"
+      type        = "Service"
       identifiers = ["ecs.amazonaws.com"]
     }
   }
 }
 
 resource "aws_iam_role_policy" "ecs_service_policy" {
-  name = "ecs-service-policy"
-  role = "${aws_iam_role.ecs_service_role.id}"
+  name   = "ecs-service-policy"
+  role   = "${aws_iam_role.ecs_service_role.id}"
   policy = "${data.aws_iam_policy_document.ecs_service_policy.json}"
 }
 
 data "aws_iam_policy_document" "ecs_service_policy" {
   statement {
-    effect = "Allow"
+    effect    = "Allow"
     resources = ["*"]
+
     actions = [
       "elasticloadbalancing:Describe*",
       "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
@@ -54,7 +57,44 @@ data "aws_iam_policy_document" "ecs_service_policy" {
       "elasticloadbalancing:DeregisterTargets",
       "elasticloadbalancing:RegisterTargets",
       "ec2:Describe*",
-      "ec2:AuthorizeSecurityGroupIngress"
+      "ec2:AuthorizeSecurityGroupIngress",
     ]
   }
+}
+
+# Platform team account access delegation
+resource "aws_iam_role" "platform_team_assume_role" {
+  name = "platform-team-assume-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {
+      "AWS": "arn:aws:iam::${var.platform_team_account_id}:root"
+    },
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+data "aws_iam_policy_document" "allow_ecs_admin" {
+  statement {
+    actions = [
+      "ecs:*",
+      "ecr:*",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "platform_team_ecs_admin" {
+  name   = "platform_team_ecs_admin"
+  role   = "${aws_iam_role.platform_team_assume_role.name}"
+  policy = "${data.aws_iam_policy_document.allow_ecs_admin.json}"
 }

--- a/infra/terraform/templates/launch.tf
+++ b/infra/terraform/templates/launch.tf
@@ -4,57 +4,65 @@ resource "aws_key_pair" "wellcomecollection" {
 }
 
 resource "aws_iam_instance_profile" "wellcomecollection" {
-  name = "wellcomecollection-app"
+  name  = "wellcomecollection-app"
   roles = ["${aws_iam_role.wellcomecollection_instance.name}"]
 
-  lifecycle { create_before_destroy = true }
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Launch through ECS
 data "aws_ami" "ecs_optimized" {
   most_recent = true
-  owners = ["amazon"]
+  owners      = ["amazon"]
 
   filter {
-    name = "name"
+    name   = "name"
     values = ["amzn-ami-*-amazon-ecs-optimized"]
   }
 }
 
 resource "aws_launch_configuration" "wellcomecollection_ecs" {
-  name_prefix            = "wellcomecollection-ecs-instance-"
-  key_name               = "${aws_key_pair.wellcomecollection.id}"
-  image_id               = "${data.aws_ami.ecs_optimized.id}"
-  instance_type          = "t2.small"
-  iam_instance_profile   = "${aws_iam_instance_profile.wellcomecollection.id}"
-  security_groups        = [
+  name_prefix          = "wellcomecollection-ecs-instance-"
+  key_name             = "${aws_key_pair.wellcomecollection.id}"
+  image_id             = "${data.aws_ami.ecs_optimized.id}"
+  instance_type        = "t2.small"
+  iam_instance_profile = "${aws_iam_instance_profile.wellcomecollection.id}"
+
+  security_groups = [
     "${aws_security_group.ssh_in.id}",
     "${aws_security_group.http.id}",
     "${aws_security_group.https.id}",
     "${aws_security_group.node_app_port.id}",
-    "${aws_security_group.docker.id}"
+    "${aws_security_group.docker.id}",
   ]
+
   user_data = <<EOF
 #!/bin/bash
 echo ECS_CLUSTER=wellcomecollection >> /etc/ecs/ecs.config
 EOF
 
-  connection { user = "ubuntu" }
-  lifecycle { create_before_destroy = true }
+  connection {
+    user = "ubuntu"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_autoscaling_group" "wellcomecollection_ecs_asg" {
-  name = "wellcomecollection-cluster-instances"
-  desired_capacity = 3
-  min_size         = 3
-  max_size         = 6
-  health_check_type         = "EC2"
-  launch_configuration      = "${aws_launch_configuration.wellcomecollection_ecs.id}"
-  vpc_zone_identifier       = ["${aws_subnet.public_a.id}", "${aws_subnet.public_b.id}"]
-  target_group_arns         = ["${aws_alb_target_group.wellcomecollection.id}"]
+  name                 = "wellcomecollection-cluster-instances"
+  desired_capacity     = 3
+  min_size             = 3
+  max_size             = 6
+  health_check_type    = "EC2"
+  launch_configuration = "${aws_launch_configuration.wellcomecollection_ecs.id}"
+  vpc_zone_identifier  = ["${aws_subnet.public_a.id}", "${aws_subnet.public_b.id}"]
+  target_group_arns    = ["${aws_alb_target_group.wellcomecollection.id}"]
 }
 
 output "ami_id" {
   value = "${data.aws_ami.ecs_optimized.id}"
 }
-

--- a/infra/terraform/templates/s3.tf
+++ b/infra/terraform/templates/s3.tf
@@ -4,17 +4,19 @@ resource "aws_s3_bucket" "alb_log_bucket" {
 
 data "aws_iam_policy_document" "alb_log_bucket_policy_document" {
   statement {
-    sid = ""
-    effect = "Allow"
+    sid     = ""
+    effect  = "Allow"
     actions = ["s3:PutObject"]
+
     resources = [
-        "${aws_s3_bucket.alb_log_bucket.arn}/${var.alb_log_prefix}/AWSLogs/*"
+      "${aws_s3_bucket.alb_log_bucket.arn}/${var.alb_log_prefix}/AWSLogs/*",
     ]
 
     principals {
       // Comes from here:
       // http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html#w28aac15b9c15b8c15b3b5b3
       identifiers = ["arn:aws:iam::156460612806:root"]
+
       type = "AWS"
     }
   }

--- a/infra/terraform/templates/sg.tf
+++ b/infra/terraform/templates/sg.tf
@@ -1,56 +1,58 @@
 resource "aws_security_group" "http" {
-  name = "allow-http"
+  name        = "allow-http"
   description = "Allow http traffic"
-  vpc_id = "${aws_vpc.wellcomecollection.id}"
+  vpc_id      = "${aws_vpc.wellcomecollection.id}"
 
   # HTTP
   ingress {
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   egress {
-    from_port = 80
-    to_port = 80
-    protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
 resource "aws_security_group" "docker" {
-  name = "docker"
+  name        = "docker"
   description = "Allow all docker ports"
-  vpc_id = "${aws_vpc.wellcomecollection.id}"
+  vpc_id      = "${aws_vpc.wellcomecollection.id}"
 
   # HTTP
   ingress {
-    from_port = 32768
-    to_port = 61000
-    protocol = "tcp"
+    from_port   = 32768
+    to_port     = 61000
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   egress {
-    from_port = 32768
-    to_port = 61000
-    protocol = "tcp"
+    from_port   = 32768
+    to_port     = 61000
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
-
 resource "aws_security_group" "https" {
-  name = "allow-http-s"
+  name        = "allow-http-s"
   description = "Allow https traffic"
-  vpc_id = "${aws_vpc.wellcomecollection.id}"
+  vpc_id      = "${aws_vpc.wellcomecollection.id}"
 
   # HTTPS
   ingress {
-    from_port = 443
-    to_port = 443
-    protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   egress {
     from_port   = 443
     to_port     = 443
@@ -59,23 +61,23 @@ resource "aws_security_group" "https" {
   }
 }
 
-
 resource "aws_security_group" "node_app_port" {
-  name = "allow-3000"
+  name        = "allow-3000"
   description = "Allow node app (:3000) traffic"
-  vpc_id = "${aws_vpc.wellcomecollection.id}"
+  vpc_id      = "${aws_vpc.wellcomecollection.id}"
 
   # Our apps run on port 3000
   ingress {
-    from_port = 3000
-    to_port = 3000
-    protocol = "tcp"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   egress {
-    from_port = 3000
-    to_port = 3000
-    protocol = "tcp"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/infra/terraform/templates/vars.tf
+++ b/infra/terraform/templates/vars.tf
@@ -8,4 +8,9 @@ variable "container_definitions" {}
 variable "container_definitions_thumbor" {}
 variable "ssl_cert_name" {}
 variable "alb_log_bucket" {}
-variable "alb_log_prefix" { default = "dotorg-alb" }
+
+variable "alb_log_prefix" {
+  default = "dotorg-alb"
+}
+
+variable "platform_team_account_id" {}

--- a/infra/terraform/templates/vpc.tf
+++ b/infra/terraform/templates/vpc.tf
@@ -1,6 +1,6 @@
 resource "aws_vpc" "wellcomecollection" {
   # 172.20.0.0 - 172.20.255.255
-  cidr_block = "172.20.0.0/16"
+  cidr_block           = "172.20.0.0/16"
   enable_dns_hostnames = true
 
   tags {
@@ -11,7 +11,9 @@ resource "aws_vpc" "wellcomecollection" {
 resource "aws_internet_gateway" "wellcomecollection" {
   vpc_id = "${aws_vpc.wellcomecollection.id}"
 
-  tags { Name = "wellcomecollection-igw" }
+  tags {
+    Name = "wellcomecollection-igw"
+  }
 }
 
 resource "aws_route" "public_a" {
@@ -19,6 +21,7 @@ resource "aws_route" "public_a" {
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = "${aws_internet_gateway.wellcomecollection.id}"
 }
+
 resource "aws_route" "public_b" {
   route_table_id         = "${aws_route_table.public_b.id}"
   destination_cidr_block = "0.0.0.0/0"
@@ -30,16 +33,23 @@ resource "aws_route" "public_b" {
 # Public
 resource "aws_subnet" "public_a" {
   vpc_id                  = "${aws_vpc.wellcomecollection.id}"
-  cidr_block              = "172.20.0.0/20" # 172.20.0.0 - 172.20.15.255
+  cidr_block              = "172.20.0.0/20"                    # 172.20.0.0 - 172.20.15.255
   availability_zone       = "eu-west-1a"
   map_public_ip_on_launch = true
 
-  tags { Name = "wellcomecollection-public-a" }
+  tags {
+    Name = "wellcomecollection-public-a"
+  }
 }
+
 resource "aws_route_table" "public_a" {
   vpc_id = "${aws_vpc.wellcomecollection.id}"
-  tags { Name = "wellcomecollection-public-a" }
+
+  tags {
+    Name = "wellcomecollection-public-a"
+  }
 }
+
 resource "aws_route_table_association" "public_a" {
   subnet_id      = "${element(aws_subnet.public_a.*.id, count.index)}"
   route_table_id = "${aws_route_table.public_a.id}"
@@ -48,20 +58,28 @@ resource "aws_route_table_association" "public_a" {
 # Private
 resource "aws_subnet" "private_a" {
   vpc_id                  = "${aws_vpc.wellcomecollection.id}"
-  cidr_block              = "172.20.16.0/20" # 172.20.16.0 - 172.20.31.255
+  cidr_block              = "172.20.16.0/20"                   # 172.20.16.0 - 172.20.31.255
   availability_zone       = "eu-west-1a"
   map_public_ip_on_launch = false
 
-  tags { Name = "wellcomecollection-private-a" }
+  tags {
+    Name = "wellcomecollection-private-a"
+  }
 }
+
 resource "aws_route_table" "private_a" {
   vpc_id = "${aws_vpc.wellcomecollection.id}"
-  tags { Name = "wellcomecollection-private-a" }
+
+  tags {
+    Name = "wellcomecollection-private-a"
+  }
 }
+
 resource "aws_route_table_association" "private_a" {
   subnet_id      = "${element(aws_subnet.private_a.*.id, count.index)}"
   route_table_id = "${aws_route_table.private_a.id}"
 }
+
 # 172.20.32.0/20 Potential data layer
 # 172.20.48.0/20 Spare
 
@@ -69,16 +87,23 @@ resource "aws_route_table_association" "private_a" {
 # Public
 resource "aws_subnet" "public_b" {
   vpc_id                  = "${aws_vpc.wellcomecollection.id}"
-  cidr_block              = "172.20.64.0/20" # 172.20.64.0 - 172.20.127.255
+  cidr_block              = "172.20.64.0/20"                   # 172.20.64.0 - 172.20.127.255
   availability_zone       = "eu-west-1b"
   map_public_ip_on_launch = true
 
-  tags { Name = "wellcomecollection-public-b" }
+  tags {
+    Name = "wellcomecollection-public-b"
+  }
 }
+
 resource "aws_route_table" "public_b" {
   vpc_id = "${aws_vpc.wellcomecollection.id}"
-  tags { Name = "wellcomecollection-public-b" }
+
+  tags {
+    Name = "wellcomecollection-public-b"
+  }
 }
+
 resource "aws_route_table_association" "public_b" {
   subnet_id      = "${element(aws_subnet.public_b.*.id, count.index)}"
   route_table_id = "${aws_route_table.public_b.id}"
@@ -87,22 +112,31 @@ resource "aws_route_table_association" "public_b" {
 # Private
 resource "aws_subnet" "private_b" {
   vpc_id                  = "${aws_vpc.wellcomecollection.id}"
-  cidr_block              = "172.20.80.0/20" # 172.20.80.0 - 172.20.95.255
+  cidr_block              = "172.20.80.0/20"                   # 172.20.80.0 - 172.20.95.255
   availability_zone       = "eu-west-1b"
   map_public_ip_on_launch = false
 
-  tags { Name = "wellcomecollection-private-b" }
+  tags {
+    Name = "wellcomecollection-private-b"
+  }
 }
+
 resource "aws_route_table" "private_b" {
   vpc_id = "${aws_vpc.wellcomecollection.id}"
-  tags { Name = "wellcomecollection-private-b" }
+
+  tags {
+    Name = "wellcomecollection-private-b"
+  }
 }
+
 resource "aws_route_table_association" "private_b" {
   subnet_id      = "${element(aws_subnet.private_b.*.id, count.index)}"
   route_table_id = "${aws_route_table.private_b.id}"
 }
+
 # 172.20.96.0/20 Potential data layer
 # 172.20.112.0/20 Spare
+
 
 # For zone c
 # 172.20.128.0/20 Public App
@@ -110,4 +144,6 @@ resource "aws_route_table_association" "private_b" {
 # 172.20.160.0/20 Data
 # 172.20.176.0/20 Spare
 
+
 # 172.20.192.0/18 Completely Spare
+

--- a/infra/terraform/website-bucket/website-bucket.tf
+++ b/infra/terraform/website-bucket/website-bucket.tf
@@ -10,7 +10,7 @@ data "template_file" "website_policy" {
 
 resource "aws_s3_bucket" "website_bucket" {
   bucket = "${var.website_uri}"
-  acl = "public-read"
+  acl    = "public-read"
   policy = "${data.template_file.website_policy.rendered}"
 
   website {


### PR DESCRIPTION
Adds an `aws_iam_role` and associated policy and role policy to delegate ECS and ECR access to the platform team account root, from where it can be further distributed to devs.

This is in order that platform team members have visibility of experience team infrastructure and to provide for emergency infra changes.

It's also mixed in with a `terraform fmt` because I do not git correctly.