### PR TITLE
add copyright holder to images (from prismic)

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -133,3 +133,9 @@
     display: none;
   }
 }
+
+.captioned-image__copyright-holder {
+  text-align: right;
+  // TODO: This needs design
+}
+

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -13,6 +13,8 @@ export default function() {
       }
 
       ctx.status = err.status || 500;
+      console.error(err);
+
       ctx.render('pages/error', {
         pageConfig: createPageConfig({
           title: `We did a ${err.status} oopsy`

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -52,7 +52,7 @@ function parseEditorialAsArticle(prismicArticle) {
   // TODO: Don't convert this into thumbnail
   const promo = prismicArticle.data.promo.find(slice => slice.slice_type === 'editorialImage');
   const thumbnail = promo && prismicImageToPicture(promo.primary);
-  const description = asText(promo.primary.caption); // TODO: Do not use description
+  const description = promo && asText(promo.primary.caption); // TODO: Do not use description
 
   // TODO: Support more than 1 author
   // TODO: Support creator's role
@@ -207,7 +207,7 @@ function prismicImageToPicture(prismicImage) {
     contentUrl: convertPrismicToImgIxUri(prismicImage.image.url), // TODO: Send this through the img.wc.org
     width: prismicImage.image.dimensions.width,
     height: prismicImage.image.dimensions.height,
-    caption: asText(prismicImage.caption), // TODO: Support HTML
+    caption: prismicImage.caption.length !== 0 ? asText(prismicImage.caption) : prismicImage.image.alt, // TODO: Support HTML
     alt: prismicImage.image.alt,
     copyrightHolder: prismicImage.image.copyright
   }: Picture);

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -1,15 +1,22 @@
 <figure class="{{ 'captioned-image' | componentClasses(modifiers) }}">
   <div class="captioned-image__image-container">
-  {% if data.positionInSeries and data.series.commissionedLength and data.series.color and data.contentType === 'article' %}
-    {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries, clipPathClass: 'promo__clip-path--chapters-third'} %}
-    {% set chapterIndicatorModel = {
-      position: data.positionInSeries,
-      series: data.series
-    } %}
-    {% componentV2 'chapter-indicator', chapterIndicatorModel %}
-  {% else %}
-    {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
-  {% endif %}
+    {% if data.positionInSeries and data.series.commissionedLength and data.series.color and data.contentType === 'article' %}
+      {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries, clipPathClass: 'promo__clip-path--chapters-third'} %}
+      {% set chapterIndicatorModel = {
+        position: data.positionInSeries,
+        series: data.series
+      } %}
+      {% componentV2 'chapter-indicator', chapterIndicatorModel %}
+    {% else %}
+      {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
+    {% endif %}
+    {% if (model.copyrightHolder) %}
+      <div class="captioned-image__copyright-holder
+        {{ {s:1, m:1, l:1} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}
+        {{ {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses }}">
+        Credit: {{ model.copyrightHolder }}
+      </div>
+    {% endif %}
   </div>
   {% block figcaption %}
     {# TODO: separate licensing info from the fact that the content type is 'comic' #}


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
✨ Feature  

## Value
<!-- how does this add value? -->
First bash at putting copyright info on images.
A step towards using Prismic over WP.

The design isn't done, but we don't publish live from Prismic, so no wakkas.

## Screenshot
![credidrecit](https://user-images.githubusercontent.com/31692/28208619-8ee50e32-6886-11e7-8567-dbbae11b50b3.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
