### PR TITLE
'determineFeaturesCohort' before 'render'

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -12,6 +12,7 @@ import {intervalCache} from './middleware/interval-cache';
 const app = new Koa();
 
 app.use(intervalCache());
+app.use(determineFeaturesCohort());
 app.use(render(config.views.path));
 // `error` is only after `intervalCache` and `render` as there's a dependency chain there
 // TODO: remove dependency chain
@@ -20,7 +21,6 @@ app.use(enforceSSL());
 app.use(setCacheControl(config.cacheControl));
 app.use(serve(config.static.path));
 app.use(serve(config.favicon.path));
-app.use(determineFeaturesCohort());
 app.use(router);
 
 export default app;


### PR DESCRIPTION
Fixes/Closes/References #

## Type
🐛 Bugfix  

## Value
We were rendering the page before determining the cohort the user belongs to, thus breaking feature flags and stopping the search from showing. Now we're not
