### PR TITLE
Shim icon component with a canvas element to keep svg aspect ratio

### DIFF
--- a/client/scss/base/_icons.scss
+++ b/client/scss/base/_icons.scss
@@ -1,42 +1,55 @@
 .icon {
-  height: $v-spacing-unit * 2;
+  display: inline-block;
+  height: 1em;
+  position: relative;
+  user-select: none;
+}
+
+.icon__canvas {
+  display: block;
+  height: 100%;
+  visibility: hidden;
+}
+
+.icon__svg {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
 }
 
 .icon--2x {
-  height: $v-spacing-unit * 4;
+  height: 2em;
 }
 
-.icon--huge {
-  height: $v-spacing-unit * 16;
+.icon--4x {
+  height: 4em;
 }
 
-.icon--match-text {
-  height: 1em;
-}
-
-.icon--fill {
+.icon--fill svg {
   fill: color('black');
 }
 
 @each $color-key, $color-value in $colors {
-  .icon--#{$color-key} {
+  .icon--#{$color-key} svg {
     fill: nth($color-value, 1);
   }
 }
 
-.icon--stroke {
+.icon--stroke svg {
   stroke: color('black');
 }
 
-.icon--fill-negative {
+.icon--fill-negative svg {
   fill: color('white');
 }
 
-.icon--stroke-negative {
+.icon--stroke-negative svg {
   stroke: color('white');
 }
 
-.icon--action {
+.icon--action svg {
   fill: color('mint');
 }
 

--- a/client/scss/components/_author.scss
+++ b/client/scss/components/_author.scss
@@ -66,8 +66,6 @@
   color: color('seaweed');
 
   .icon {
-    width: 2em;
-    height: 2em;
     margin-right: 0.2em;
   }
 

--- a/client/scss/components/_buttons.scss
+++ b/client/scss/components/_buttons.scss
@@ -38,8 +38,6 @@
 
   .icon {
     display: inline-block;
-    width: 26px; //width and height should be same aspect ratio as the icon's viewbox, to avoid excess whitespace in the svg
-    height: 26px;
     vertical-align: middle;
     margin-right: 10px;
   }

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -63,9 +63,7 @@
 
   .icon {
     vertical-align: top;
-    width: 1.3em;
     height: 1.3em;
-    min-width: 1.3em;
     margin-right: 0.8em;
     float: left;
   }

--- a/client/scss/components/_cookie_notification.scss
+++ b/client/scss/components/_cookie_notification.scss
@@ -14,9 +14,7 @@
   transition: opacity 600ms ease, z-index 0ms 600ms;
 
   .icon {
-    width: 1.3em;
     height: 1.3em;
-    min-width: 1.3em;
   }
 
   .icon__shape {

--- a/client/scss/components/_find_us.scss
+++ b/client/scss/components/_find_us.scss
@@ -22,10 +22,7 @@
 
   .icon {
     position: relative;
-    width: 0.875em;
     height: 1.25em;
-    margin-right: 1em;
-    margin-top: 0.2em;
   }
 
   .icon__shape {

--- a/client/scss/components/_footer.scss
+++ b/client/scss/components/_footer.scss
@@ -64,7 +64,6 @@ $footer-strap-width: 220px;
   }
 
   .icon {
-    width: 2.6rem;
     height: 2.6rem;
     margin-right: 0.6rem;
   }
@@ -83,8 +82,6 @@ $footer-strap-width: 220px;
   display: flex;
 
   .icon {
-    width: 1.5rem;
-    height: 1.5rem;
     margin-right: 0.5rem;
   }
 
@@ -190,11 +187,6 @@ $footer-strap-width: 220px;
 
     @include respond-to('xlarge') {
       padding-right: 0;
-    }
-
-    .icon {
-      width: 1em;
-      height: 1em;
     }
 
     .icon__shape {

--- a/client/scss/components/_footer_nav.scss
+++ b/client/scss/components/_footer_nav.scss
@@ -5,12 +5,6 @@
   margin-bottom: 2 * $vertical-space-unit;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-
-  .icon {
-    fill: color('white');
-    width: 10rem;
-    height: 3.33333rem;
-  }
 }
 
 .footer-nav__brand {

--- a/client/scss/components/_footer_social.scss
+++ b/client/scss/components/_footer_social.scss
@@ -48,9 +48,6 @@
   }
 
   .icon {
-    position: relative;
-    width: 2em;
-    height: 2em;
     margin-right: 1.4em;
   }
 

--- a/client/scss/components/_gif_video.scss
+++ b/client/scss/components/_gif_video.scss
@@ -46,9 +46,7 @@
 
   .icon {
     vertical-align: top;
-    width: 1.3em;
     height: 1.3em;
-    min-width: 1.3em;
     margin-right: 0.8em;
     float: left;
   }

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -228,7 +228,6 @@ $tweakpoints: (
   }
 
   .icon {
-    width: 1.3em;
     height: 1.3em;
     transition: transform 200ms ease;
 
@@ -287,7 +286,6 @@ $tweakpoints: (
   z-index: 1;
 
   .icon {
-    width: 1rem;
     height: 1rem;
     transition: transform 600ms ease;
   }

--- a/client/scss/components/_instagram_thumbnail.scss
+++ b/client/scss/components/_instagram_thumbnail.scss
@@ -3,8 +3,6 @@
   position: relative;
 
   .icon {
-    width: 1em;
-    height: 1em;
     margin-right: 0.2em;
   }
 

--- a/client/scss/components/_more_info_link.scss
+++ b/client/scss/components/_more_info_link.scss
@@ -4,14 +4,6 @@
   text-decoration: none;
   align-items: center;
   margin-top: $spacing-unit * 3;
-
-  .icon {
-    // The icon's viewBox is 0 0 12 13 so x=12 y=13
-    // Default icon height is (2 * $v-spacing-unit)
-    // TODO: find a way that we don't have to set
-    // both svg height and width for IE -- this is silly/brittle.
-    width: 12 / 13 * (2 * $v-spacing-unit);
-  }
 }
 
 .more-info-link__text {

--- a/client/scss/components/_new_site_notice.scss
+++ b/client/scss/components/_new_site_notice.scss
@@ -7,11 +7,6 @@ $mega-w-size: 400px;
 .new-site-notice {
   position: relative;
   overflow: hidden;
-
-  .icon {
-    width: 2.142857em; //30/14
-    height: 1.571428em; //22/14
-  }
 }
 
 .new-site-notice:before {

--- a/client/scss/components/_page_description.scss
+++ b/client/scss/components/_page_description.scss
@@ -22,7 +22,6 @@
   margin-left: -0.06em;
 
   .icon {
-    width: 0.8em;
     height: 0.8em;
   }
 }
@@ -51,7 +50,6 @@
 
   .icon {
     margin-right: 0.5em;
-    width: 1.3em;
     height: 1.3em;
   }
 }

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -19,10 +19,6 @@
     padding-bottom: 0;
     margin-bottom: 3 * $v-spacing-unit;;
   }
-
-  .icon {
-    vertical-align: middle;
-  }
 }
 
 @include image-zoom ($interactionElement: '.promo', $containerElement: '.promo__image-container:not(.promo__image-container--constrained)', $zoomElement: '.image:not(.promo__image-container--constrained .image)');
@@ -161,6 +157,11 @@
   bottom: 0;
   left: 0;
   padding: map-get($gutter-width, 'small')/2;
+
+  .icon {
+    vertical-align: middle;
+    height: 1.6em;
+  }
 
   @include respond-to('medium') {
     padding: map-get($gutter-width, 'medium')/2;
@@ -307,27 +308,6 @@
       flex-basis: 60%;
       padding-right: 20%;
     }
-  }
-}
-
-.promo--gallery {
-  .icon { // aspect ratio: 24 x 19
-    width: (24/19) * 1.6em;
-    height: (19/19) * 1.6em;
-  }
-}
-
-.promo--audio {
-  .icon { // aspect ratio: 27 x 22
-    width: (27/22) * 1.6em;
-    height: (22/22) * 1.6em;
-  }
-}
-
-.promo--video {
-  .icon { // aspect ratio: 17 x 19
-    width: (17/19) * 1.6em;
-    height: (19/19) * 1.6em;
   }
 }
 

--- a/client/scss/components/_search_box.scss
+++ b/client/scss/components/_search_box.scss
@@ -9,9 +9,4 @@
 .search-box__button {
   position: absolute;
   right: 0.6em;
-
-  .icon {
-    width: 1em;
-    height: 1em;
-  }
 }

--- a/client/scss/components/_social_media_block.scss
+++ b/client/scss/components/_social_media_block.scss
@@ -1,7 +1,6 @@
 .social-media-block__intro {
   .icon {
     margin-right: 0.5em;
-    width: 1.4em;
     height: 1.4em;
   }
 }

--- a/client/scss/components/_sort_search.scss
+++ b/client/scss/components/_sort_search.scss
@@ -10,14 +10,11 @@
 }
 
 .sort-search__sort-icon {
-  width: 1.5em;
   height: 1.5em;
 }
 
 .sort-search__close-icon {
   display: none;
-  width: 1em;
-  height: 1em;
 
   .is-sort-search-active & {
     display: block;

--- a/client/scss/components/_transporter.scss
+++ b/client/scss/components/_transporter.scss
@@ -7,28 +7,3 @@
     max-width: 50%;
   }
 }
-
-.transporter__link {
-  position: relative;
-  padding-left: ((12/12) * 0.8) + 0.5em;
-
-  &:hover,
-  &:focus {
-    cursor: pointer;
-    text-decoration: underline;
-  }
-
-  .icon { // aspect ratio: 12 x 13
-    width: (12/12) * 0.8em;
-    height: (13/12) * 0.8em;
-    transform: rotate(270deg);
-    position: absolute;
-    left: 0;
-    top: 50%;
-    margin-top: -(13/12) * 0.4em;
-  }
-
-  .icon__shape {
-    fill: currentColor;
-  }
-}

--- a/client/scss/styleguide/_styleguide.scss
+++ b/client/scss/styleguide/_styleguide.scss
@@ -9,8 +9,7 @@
   width: 140px;
 
   .icon {
-    width: 80px;
-    height: 80px;
+    max-width: 80px;
   }
 }
 

--- a/server/filters/get-viewbox.js
+++ b/server/filters/get-viewbox.js
@@ -1,0 +1,9 @@
+export default (attrs) => {
+  const viewBox = attrs.find(attr => attr.name === 'viewBox');
+  const values = viewBox.value.split(' ');
+
+  return {
+    width: values[2],
+    height: values[3]
+  };
+};

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -5,6 +5,7 @@ import getIconForContentType from './get-icon-for-content-type';
 import getPrincipleMainMedia from './get-principle-main-media';
 import getCommissionedSeries from './get-commissioned-series';
 import getSeriesTitle from './get-series-title';
+import getViewBox from './get-viewbox';
 import gridClasses from './grid-classes';
 import spacingClasses from './spacing-classes';
 import fontClasses from './font-classes';
@@ -27,6 +28,7 @@ export default Map({
   getPrincipleMainMedia,
   getCommissionedSeries,
   getSeriesTitle,
+  getViewBox,
   gridClasses,
   spacingClasses,
   fontClasses,

--- a/server/views/components/author/author.njk
+++ b/server/views/components/author/author.njk
@@ -12,7 +12,7 @@
           <a href="https://twitter.com/{{ twitterHandle }}"
             class="author__link"
             aria-label="{{ name }} (screen name: {{ twitterHandle }})">
-            {% icon 'social/twitter' %} @{{ twitterHandle }}
+            {% icon 'social/twitter', null, ['icon--2x'] %} @{{ twitterHandle }}
           </a>
         </span>
       {% endif %}

--- a/server/views/components/button-button/button-button.config.js
+++ b/server/views/components/button-button/button-button.config.js
@@ -5,6 +5,6 @@ export const context = {
   modifierClasses: 'btn--light',
   attributes: 'disabled',
   icon: 'actions/download-1',
-  iconExtraClasses: ['icon--fill'],
+  iconExtraClasses: ['icon--fill', 'icon--2x'],
   text: 'this is a disabled button'
 };

--- a/server/views/components/button-link/button-link.config.js
+++ b/server/views/components/button-link/button-link.config.js
@@ -11,7 +11,7 @@ export const variants = [{
   name: 'with-icon',
   context: {
     icon: 'actions/download-1',
-    iconExtraClasses: ['icon--fill'],
+    iconExtraClasses: ['icon--fill', 'icon--2x'],
     text: 'this is a link with an icon'
   }
 }, {
@@ -28,7 +28,7 @@ export const variants = [{
   context: {
     modifierClasses: 'btn--dark',
     icon: 'actions/download-1',
-    iconExtraClasses: ['icon--fill'],
+    iconExtraClasses: ['icon--fill', 'icon--2x'],
     text: 'this is a link'
   }
 }];

--- a/server/views/components/footer-social/footer-social.njk
+++ b/server/views/components/footer-social/footer-social.njk
@@ -2,7 +2,7 @@
   {% for item in items %}
     <div class="footer-social__cell">
       <a class="footer-social__link {{ {s:'HNM6'} | fontClasses }}" href="{{ item.url }}">
-        {% icon item.icon %}
+        {% icon item.icon, null, ['icon--2x'] %}
         <span class="footer-social__title">{{ item.title }}</span>
         <span class="footer-social__service">{{ item.service }}</span>
       </a>

--- a/server/views/components/footer/footer.njk
+++ b/server/views/components/footer/footer.njk
@@ -28,8 +28,8 @@
         </div>
         <div class="footer__licensing {{ {s:'HNM6'} | fontClasses }} {{ {l:2} | spacingClasses({padding: ['right']}, false) }}">
           <div class="footer__licensing-icons">
-            {% icon 'other/cc_logo' %}
-            {% icon 'other/cc_attribution' %}
+            {% icon 'other/cc_logo', null, ['icon--2x'] %}
+            {% icon 'other/cc_attribution', null, ['icon--2x'] %}
           </div>
           <p class="footer__licensing-copy">Except where otherwise noted, content on this site is licenced under a <a class="footer__licensing-link" href="https://creativecommons.org/licenses/by/4.0/"> Creative Commons Attribution 4.0 International License</a></p>
         </div>

--- a/server/views/components/icon/icon.njk
+++ b/server/views/components/icon/icon.njk
@@ -1,8 +1,15 @@
-<svg class="icon{% for class in extraClasses %} {{ class }}{% endfor %}"
+<div class="icon {% for class in extraClasses %}{{ class }} {% endfor %}">
+  {% set viewBox = attrs | getViewBox %}
+  <canvas class="icon__canvas" height="{{ viewBox.height }}" width="{{ viewBox.width }}"></canvas>
+  <svg class="icon__svg"
     {% if title %} role="img"{% else %} aria-hidden="true"{% endif %}
     {% for attr in attrs %}
-        {{ attr.name }}="{{ attr.value }}"
+      {{ attr.name }}="{{ attr.value }}"
     {% endfor %}>
-  {% if title %}<title>{{ title }}</title>{% endif %}
-  {{ pathData|safe }}
-</svg>
+
+    {% if title %}
+      <title>{{ title }}</title>
+    {% endif %}
+    {{ pathData | safe }}
+  </svg>
+</div>

--- a/server/views/components/new-site-notice/new-site-notice.njk
+++ b/server/views/components/new-site-notice/new-site-notice.njk
@@ -4,7 +4,7 @@
       <div class="{{ {} | gridClasses }}">
         <div class="new-site-notice__inner {{ {s:'HNL7', m:'HNL6'} | fontClasses }}">
           <p class="new-site-notice__msg">
-            <span class="new-site-notice__device-ico">{% icon 'other/devices' %}</span>
+            <span class="new-site-notice__device-ico">{% icon 'other/devices', null, ['icon--2x'] %}</span>
             <span class="new-site-notice__text">Welcome to the new reading experience for stories and articles. {% if showLink %}<span class="new-site-notice__cta {{ {s:'HNM6', m:'HNM5'} | fontClasses }}"><a href="/">Find out more</a>.</span>{% endif %}</span>
           </p>
         </div>

--- a/server/views/components/transporter/transporter.njk
+++ b/server/views/components/transporter/transporter.njk
@@ -19,9 +19,6 @@
     {% endfor %}
   </div>
   {% if themeUrl %}
-  <a class="transporter__link font--seaweed plain-link {{ {s:'HNM5'} | fontClasses }}" href="{{ themeUrl }}">
-    {% icon 'actions/arrow-small' %}
-    Full theme
-  </a>
+    {% componentV2 'more-info-link', {name: 'Full theme', url: themeUrl} %}
   {% endif %}
 </section>

--- a/server/views/global/icons.config.js
+++ b/server/views/global/icons.config.js
@@ -16,7 +16,7 @@ function walk(dir) {
       return acc.concat(walk(dirOrFile));
     } else if (path.extname(dirOrFile) === '.svg') {
       return acc.concat({
-        extraClasses: ['icon--fill'],
+        extraClasses: ['icon--fill', 'icon--4x'],
         icon: path.join(path.basename(dir), path.basename(dirOrFile, '.svg'))
       });
     }

--- a/server/views/pages/event.njk
+++ b/server/views/pages/event.njk
@@ -87,7 +87,7 @@
               <div class="flex">
                 <div class="{{ {s:6, m:6, l:6} | spacingClasses({margin: ['right']}) }}">
                   {% if accessStatement.title === ' British Sign Language tour' %}
-                    {% icon 'a11y/sign_language', "British Sign Language tour", ['icon--huge'] %}
+                    {% icon 'a11y/sign_language', "British Sign Language tour", ['icon--4x'] %}
                   {% endif %}
                 </div>
                 <div>


### PR DESCRIPTION
Fixes #1191

## Type
🐛 Bugfix  

## Value
Simplifies how we size svgs and ensures they look good on IE9–11.

## Screenshot
✨
![screen shot 2017-07-18 at 12 56 18](https://user-images.githubusercontent.com/1394592/28315951-8db10ad6-6bb8-11e7-8f99-1e004756d605.png)

## Checklist
### All
- [x] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
