### PR TITLE
Use contentType to set search promo type classes

### DIFF
--- a/server/views/components/promo/promo.njk
+++ b/server/views/components/promo/promo.njk
@@ -13,10 +13,12 @@
   {% set titleFontSizes = {s:'WB7'} %}
 {% elif model.modifiers and model.modifiers | contains('standalone') %}
   {% set titleFontSizes = {s:'WB6', m:'WB4', l:'WB6', xl:'WB4'} %}
-{% elif model.modifiers and model.modifiers | contains('work') %}
-  {% set titleFontSizes = {s:'HNL5'} %}
 {% else %}
   {% set titleFontSizes = {s:'WB6'} %}
+{% endif %}
+
+{% if model.contentType and model.contentType === 'work' %}
+  {% set titleFontSizes = {s:'HNL5'} %}
 {% endif %}
 
 {% if model.modifiers and model.modifiers | contains('transporter-child') %}


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
We were incorrectly checking the modifiers instead of the contentType to determine whether or not to display Helvetica instead of Wellcome Bold.

## Screenshot
![screen shot 2017-07-18 at 15 16 15](https://user-images.githubusercontent.com/1394592/28321805-1b32c418-6bcc-11e7-841d-ebee21ce3a60.png)
