### PR TITLE
Add two authors to article as single person (hack)

### DIFF
--- a/server/data/people.js
+++ b/server/data/people.js
@@ -163,3 +163,10 @@ export const wendyMoore: Person = {
                '& Nicolson. Her research was supported by a Wellcome Trust Medical Humanities Research grant.',
   twitterHandle: 'wendymoore99'
 };
+
+// FIXME: double author hack
+export const nicolaCookAndLoesjaVigour: Person = {
+  givenName: 'Nicola/Loesja',
+  familyName: 'Cook/Vigour',
+  name: 'Nicola Cook and Loesja Vigour'
+};

--- a/server/services/author-lookup.js
+++ b/server/services/author-lookup.js
@@ -57,5 +57,6 @@ export const authorMap: { [key: string]: Person } = {
   'sharing-nature-emotion': people.helenBabbs,
   'animal-doctors': people.helenBabbs,
   '10-reasons-to-wear-sunglasses': people.lalitaKaplish,
-  'sharing-nature-relationships': people.dannyBirchall
+  'sharing-nature-relationships': people.dannyBirchall,
+  'six-personal-health-zines-that-might-change-your-life': people.nicolaCookAndLoesjaVigour
 };


### PR DESCRIPTION
## Type
🚑 Health

## Value
Adds Nicola Cook and Loesja Vigour as authors for the article, 'six-personal-health-zines-that-might-change-your-life'.

Uses a single `Person` model because WP can't handle the truth.
