### PR TITLE
Limit height of image on work page (as with comic)

### DIFF
--- a/client/scss/base/_row.scss
+++ b/client/scss/base/_row.scss
@@ -4,6 +4,10 @@
   background: color('dark-black');
 }
 
+.row--black {
+  background: color('black');
+}
+
 .row--cream {
   background: color('cream');
 }

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -37,7 +37,7 @@
   }
 }
 
-.captioned-image--comic {
+.captioned-image--fit-vh {
   @include respond-to('large') {
     background: color('black');
 

--- a/server/views/components/captioned-image/captioned-image.config.js
+++ b/server/views/components/captioned-image/captioned-image.config.js
@@ -15,6 +15,7 @@ const image: Picture = createPicture({
 
 export const context = { model: image, modifiers: [] };
 export const variants = [
-  { name: 'full', context: { model: image, modifiers: ['full'] } },
-  { name: 'bleed', context: { model: image, modifiers: ['bleed'] } }
+  {name: 'full', context: {model: image, modifiers: {'full': true}}},
+  {name: 'bleed', context: {model: image, modifiers: {'bleed': true}}},
+  {name: 'fit viewport height', context: {model: image, modifiers: {'fit-vh': true}}}
 ];

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -12,14 +12,7 @@
   {% endif %}
   </div>
   {% block figcaption %}
-    {# TODO: separate licensing info from the fact that the content type is 'comic' #}
-    {% if data.contentType === 'comic' %}
-      <figcaption class="captioned-image__caption {{ {s:'LR3', m:'LR2'} | fontClasses }}">
-        {% icon 'other/picture', {}, ['float-l', 'margin-right-s2', 'margin-right-m2', 'margin-right-l2', 'margin-right-xl2'] %}
-        {% componentV2 'license', {subject: model.contentUrl, licenseType: 'CC-BY-NC'} %}
-        {{ model.caption | safe }}
-      </figcaption>
-    {% elif model.caption %}
+    {% if model.caption %}
       <figcaption class="captioned-image__caption {{ {s:'LR3', m:'LR2'} | fontClasses }}">
         {% icon 'other/picture', {}, ['float-l', 'margin-right-s2', 'margin-right-m2', 'margin-right-l2', 'margin-right-xl2'] %}
         <div class="captioned-image__caption-text{{ ' js-truncate-text' if data.truncateCaption }}" tabindex="0">

--- a/server/views/components/main-media-work/main-media-work.njk
+++ b/server/views/components/main-media-work/main-media-work.njk
@@ -1,0 +1,2 @@
+{% extends 'components/captioned-image/captioned-image.njk' %}
+{% block figcaption %}{% endblock %}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -41,7 +41,7 @@
     } %}
     {% if (article.mainMedia.length > 0) %}
       {% if (article.contentType === 'comic') %}
-        {% componentV2 'main-media-comic', article.mainMedia | getPrincipleMainMedia, {full: true, comic: true}, mainMediaData %}
+        {% componentV2 'main-media-comic', article.mainMedia | getPrincipleMainMedia, {full: true, 'fit-vh': true}, mainMediaData %}
       {% elif (article.contentType === 'video') %}
         {% componentV2 'main-media-video', article.mainMedia | getPrincipleMainMedia, {full: true}, mainMediaData %}
       {% else %}

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -4,7 +4,7 @@
 
 {% block body %}
   {% if queryString %}
-    <div class="row row--dark-black {{ {s:5, m:5, l:5, xl: 5} | spacingClasses({padding: ['top', 'bottom']}) }}">
+    <div class="row row--black {{ {s:2, m:2, l:2, xl: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
       <div class="container">
         <div class="grid">
           <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
@@ -14,11 +14,11 @@
       </div>
     </div>
   {% endif %}
-  <div class="row {{ {s:10, m:10, l:10, xl: 10} | spacingClasses({padding: ['top']}) }}">
+  <div class="row row--black {% if not queryString %}{{ {s:8, m:8, l:8, xl: 8} | spacingClasses({padding: ['top']}) }}{% endif %}">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
-          {% componentV2 'captioned-image', {contentUrl: work.imgLink, caption: work.description, width: 2048}, {}, {sizesQueries: '(min-width: 1420px) 1218px, (min-width: 600px) 87.75vw, calc(100vw - 36px)'} %}
+        <div class="{{ {s:12, m:12, l:10, xl:10, shiftL:1, shiftXl:1} | gridClasses }}">
+          {% componentV2 'main-media-work', {contentUrl: work.imgLink, caption: work.description, width: 2048}, {'fit-vh': true}, {sizesQueries: '(min-width: 1420px) 1218px, (min-width: 600px) 87.75vw, calc(100vw - 36px)'} %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
References #1116

## Type
🚑 Health

## Value
Limits the height of the work `main-media` image such that it covers maximum 95% of the viewport height (and shares this logic between the work page and where it was previously being used on the articles with `contentType` 'comic').

## Screenshot
![screen shot 2017-07-19 at 14 33 48](https://user-images.githubusercontent.com/1394592/28369394-5684b774-6c8f-11e7-9a93-dd484ad34272.png)

## Checklist
### All
- [ ] Demoed to the relevant people
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
