### PR TITLE
Hide main media work in Cardigan

### DIFF
--- a/server/views/components/main-media-work/main-media-work.config.js
+++ b/server/views/components/main-media-work/main-media-work.config.js
@@ -1,0 +1,1 @@
+export const hidden = true;


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Prevents `main-media-work` displaying in Cardigan as a standalone component.
