### PR TITLE
Delegate access for billing view to platform account

### DIFF
--- a/infra/terraform/templates/iam.tf
+++ b/infra/terraform/templates/iam.tf
@@ -62,9 +62,27 @@ data "aws_iam_policy_document" "ecs_service_policy" {
   }
 }
 
-# Platform team account access delegation
+# Platform team ecs access delegation
 resource "aws_iam_role" "platform_team_assume_role" {
   name = "platform-team-assume-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Principal": {
+      "AWS": "arn:aws:iam::${var.platform_team_account_id}:root"
+    },
+    "Action": "sts:AssumeRole"
+  }
+}
+EOF
+}
+
+# Platform team grafana access delegation
+resource "aws_iam_role" "platform_team_grafana_assume_role" {
+  name = "platform-team-grafana-assume-role"
 
   assume_role_policy = <<EOF
 {
@@ -93,8 +111,33 @@ data "aws_iam_policy_document" "allow_ecs_admin" {
   }
 }
 
+data "aws_iam_policy_document" "allow_billing_usage_view" {
+  statement {
+    actions = [
+      "aws-portal:ViewBilling",
+      "aws-portal:ViewUsage",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
 resource "aws_iam_role_policy" "platform_team_ecs_admin" {
   name   = "platform_team_ecs_admin"
   role   = "${aws_iam_role.platform_team_assume_role.name}"
   policy = "${data.aws_iam_policy_document.allow_ecs_admin.json}"
+}
+
+resource "aws_iam_role_policy" "platform_team_billing_view" {
+  name   = "platform_team_billing_view"
+  role   = "${aws_iam_role.platform_team_assume_role.name}"
+  policy = "${data.aws_iam_policy_document.allow_billing_usage_view.json}"
+}
+
+resource "aws_iam_role_policy" "platform_team_grafana_billing" {
+  name   = "platform_team_grafana_billing_view"
+  role   = "${aws_iam_role.platform_team_grafana_assume_role.name}"
+  policy = "${data.aws_iam_policy_document.allow_billing_usage_view.json}"
 }

--- a/infra/terraform/templates/iam.tf
+++ b/infra/terraform/templates/iam.tf
@@ -130,12 +130,6 @@ resource "aws_iam_role_policy" "platform_team_ecs_admin" {
   policy = "${data.aws_iam_policy_document.allow_ecs_admin.json}"
 }
 
-resource "aws_iam_role_policy" "platform_team_billing_view" {
-  name   = "platform_team_billing_view"
-  role   = "${aws_iam_role.platform_team_assume_role.name}"
-  policy = "${data.aws_iam_policy_document.allow_billing_usage_view.json}"
-}
-
 resource "aws_iam_role_policy" "platform_team_grafana_billing" {
   name   = "platform_team_grafana_billing_view"
   role   = "${aws_iam_role.platform_team_grafana_assume_role.name}"


### PR DESCRIPTION
## Type
✨ Feature  

## Value
Provide visibility on experience team costs alongside platform team costs on the shared dashboard.

## Screenshot
💻 

This change adds an extra role for `grafana` in order to reduce the scope of `grafana` access. 

In addition account owners will need to enable the IAM billing option described here: https://aws.amazon.com/blogs/security/dont-forget-to-enable-access-to-the-billing-console/