### PR TITLE
Get original image size so we don't request images that are larger

### DIFF
--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -17,6 +17,9 @@ function imageUrlFromMiroId(id, useIiif) {
   }
 }
 
+// Hackety Hack, to deal with the fact we get broken images if we request an image that is larger than the original
+// We either need the iiif API to return the largest image possible in this case: https://github.com/wellcometrust/platform-api/issues/698
+// Or have the image dimensions available in the wellcomecollection API
 async function imageWidthFromMiroId(id) {
   return await superagent.get(`https://iiif.wellcomecollection.org/image/${id}.jpg/info.json`)
   .then((request) => {

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -20,7 +20,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s:12, m:12, l:10, xl:10, shiftL:1, shiftXl:1} | gridClasses }}">
-          {% componentV2 'main-media-work', {contentUrl: work.imgLink, caption: work.description, width: 2048, isIiif: true}, {'fit-vh': true}, {sizesQueries: '(min-width: 1420px) 1218px, (min-width: 600px) 87.75vw, calc(100vw - 36px)'} %}
+          {% componentV2 'main-media-work', {contentUrl: work.imgLink, caption: work.description, width: work.imgWidth, isIiif: true}, {'fit-vh': true}, {sizesQueries: '(min-width: 1420px) 1218px, (min-width: 600px) 87.75vw, calc(100vw - 36px)'} %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
References https://github.com/wellcometrust/platform-api/issues/698

At present, trying to get an image from Loris that is larger than its original resolution returns a 404 and so we're getting broken images on some pages.

This fixes that by getting the original image size from the iiif API, so we don't request anything larger. Does mean another API call though :(, but probably ok for now

## Type
🐛 Bugfix  

## Value
This doesn't happen anymore:

<img width="726" alt="screen shot 2017-07-24 at 17 15 10" src="https://user-images.githubusercontent.com/6051896/28533296-7607bdf4-7094-11e7-9ef3-e320d55b5f0a.png">

This does:

<img width="665" alt="screen shot 2017-07-24 at 17 21 48" src="https://user-images.githubusercontent.com/6051896/28533357-aedd572e-7094-11e7-826a-75e975e29fbb.png">


