### PR TITLE
add a way of previewing webcomics

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -5,7 +5,6 @@ import {work, search} from '../controllers/work';
 import {index, article, articles, preview, series} from '../controllers'; // Deprecated
 import {
   renderArticle,
-  renderArticlePreview,
   setPreviewSession,
   renderEvent,
   renderEventbriteEmbed,
@@ -26,11 +25,11 @@ r.get('/kaboom', (ctx, next) => {
 });
 
 // Content
-r.get('/articles/(W):id', renderArticle);
-r.get('/webcomics/:id', renderWebcomic);
+//
+r.get('/:preview?/articles/(W):id', renderArticle);
+r.get('/:preview?/webcomics/:id', renderWebcomic);
 r.get('/explore', renderExplore);
 r.get('/preview', setPreviewSession);
-r.get('/preview/:id', renderArticlePreview);
 r.get('/events/:id', renderEvent);
 r.get('/eventbrite-event-embed/:id', renderEventbriteEmbed);
 

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -5,17 +5,6 @@ import {RichText, Date as PrismicDate} from 'prismic-dom';
 import {prismicApi, prismicPreviewApi} from './prismic-api';
 import moment from 'moment';
 
-export async function getArticlePreview(id: string, req) {
-  const prismic = await prismicPreviewApi(req);
-  return getArticleAsArticle(prismic, id);
-}
-
-export async function getArticle(id: string) {
-  const prismic = await prismicApi();
-
-  return getArticleAsArticle(prismic, id);
-}
-
 function getContributors(doc) {
   // TODO: Support creator's role
   return doc.data.contributors
@@ -31,7 +20,9 @@ function getContributors(doc) {
     });
 }
 
-async function getArticleAsArticle(prismic, id: string) {
+export async function getArticle(id: string, req: Request) {
+  const prismic = req ? await prismicPreviewApi(req) : await prismicApi();
+
   const fetchLinks = [
     'people.name', 'people.image', 'people.twitterHandle', 'people.description',
     'books.title', 'books.title', 'books.author', 'books.isbn', 'books.publisher', 'books.link', 'books.cover',
@@ -287,8 +278,8 @@ export async function getEvent(id) {
   return article;
 }
 
-export async function getWebcomic(id) {
-  const prismic = await prismicApi();
+export async function getWebcomic(id: string, req: Request) {
+  const prismic = req ? await prismicPreviewApi(req) : await prismicApi();
   const fetchLinks = [
     'people.name', 'people.image', 'people.twitterHandle', 'people.description',
     'access-statements.title', 'access-statements.description',


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
🐛 Bugfix 

## Value
The editorial team can preview `webcomics`.
Not massively elegant, but allows editorial to keep on keeping on.
There'll probably be some more abstractions as we go on.

