### PR TITLE
 Fix input zoom in iOS

### DIFF
--- a/client/scss/components/_input.scss
+++ b/client/scss/components/_input.scss
@@ -101,7 +101,7 @@
 .input--text {
   display: flex;
   width: 100%;
-  padding: 0.8em;
+  padding: 0.4em;
   border: 1px solid color('pumice');
 
   &:focus {

--- a/server/views/components/input/input.njk
+++ b/server/views/components/input/input.njk
@@ -1,6 +1,6 @@
 <label class="input__label flex flex--v-center" for="{{ model.id }}">
   <input id="{{ model.id }}"
-    class="input input--{{ model.type }}"
+    class="input input--{{ model.type }} {{ {s:'HNL2'} | fontClasses }}"
     type="{{ model.type }}"
     name="{{ model.name }}"
     value="{{ model.value }}"


### PR DESCRIPTION
If font size is less than 16px, [iOS will automatically zoom the field](https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone) . This fix has the added benefit of aligning the font size with the header input field (which is already larger than 16px).

Fixes #1245

## Type
🐛 Bugfix  

