### PR TITLE
Articles webcomics uri

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -11,8 +11,7 @@ import {collectorsPromo} from '../data/series';
 import {
   getArticle,
   getArticleList,
-  getEvent,
-  getWebcomic
+  getEvent
 } from '../services/prismic-content';
 
 export const renderArticle = async(ctx, next) => {

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -37,27 +37,6 @@ export const renderArticle = async(ctx, next) => {
   }
 };
 
-export async function renderWebcomic(ctx, next) {
-  const format = ctx.request.query.format;
-  const id = ctx.params.id;
-  const preview = Boolean(ctx.params.preview);
-  const webcomic = await getWebcomic(id, preview ? ctx.request : null);
-
-  if (webcomic) {
-    if (format === 'json') {
-      ctx.body = webcomic;
-    } else {
-      ctx.render('pages/article', {
-        pageConfig: createPageConfig({
-          title: webcomic.title,
-          inSection: 'explore'
-        }),
-        article: webcomic
-      });
-    }
-  }
-}
-
 export async function setPreviewSession(ctx, next) {
   const {token} = ctx.request.query;
   ctx.cookies.set(Prismic.previewCookie, token, {
@@ -77,7 +56,7 @@ async function getPreviewSession(token) {
     prismic.previewSession(token, (doc) => {
       switch (doc.type) {
         case 'articles': return `/preview/articles/${doc.id}`;
-        case 'webcomics': return `/preview/webcomics/${doc.id}`;
+        case 'webcomics': return `/preview/articles/${doc.id}`;
       }
     }, '/', (err, redirectUrl) => {
       if (err) {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,8 +8,7 @@ import {
   setPreviewSession,
   renderEvent,
   renderEventbriteEmbed,
-  renderExplore,
-  renderWebcomic
+  renderExplore
 } from '../controllers/content';
 
 const r = new Router({
@@ -27,7 +26,6 @@ r.get('/kaboom', (ctx, next) => {
 // Content
 //
 r.get('/:preview?/articles/(W):id', renderArticle);
-r.get('/:preview?/webcomics/:id', renderWebcomic);
 r.get('/explore', renderExplore);
 r.get('/preview', setPreviewSession);
 r.get('/events/:id', renderEvent);

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -285,18 +285,6 @@ export async function getEvent(id) {
   return article;
 }
 
-export async function getWebcomic(id: string, req: Request) {
-  const prismic = req ? await prismicPreviewApi(req) : await prismicApi();
-  const fetchLinks = [
-    'people.name', 'people.image', 'people.twitterHandle', 'people.description',
-    'series.name', 'series.description', 'series.color', 'series.commissionedLength'
-  ];
-  const webcomics = await prismic.query(Prismic.Predicates.at('document.id', id), {fetchLinks});
-  const webcomic = webcomics.total_results_size === 1 ? webcomics.results[0] : null;
-
-  return parseWebcomicAsArticle(webcomic);
-}
-
 // TODO: There's some abstracting to do here
 function parseWebcomicAsArticle(prismicDoc) {
   // TODO : construct this not from strings


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
🐛 Bugfix  

## Value
As much as I can see this is an abstraction, I'd probably like to bring it back in once we have answered the couple questions below.

Now using the same URLs for `/webcomics` and `/articles`.

This has two reasons:
* So we don't have to think about URIs just yet
* I can hijack Wordpresses email / RSS functionality until we figure out what to do with the followers on that platform.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
