### PR TITLE
Add image list as a content type

### DIFF
--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -23,27 +23,6 @@
     margin-top: 0;
   }
 
-  ul {
-    list-style: none;
-    margin: 0 0 2em;
-    padding: 0;
-
-    li {
-      list-style: none;
-
-      &:before {
-        content: '';
-        width: 0.35em;
-        height: 0.35em;
-        display: inline-block;
-        vertical-align: middle;
-        border-radius: 0.1em;
-        background: color('currentColor');
-        margin-right: 0.4em;
-      }
-    }
-  }
-
   *::selection {
     background: transparentize(color('turquoise-graphics'), 0.7);
   }
@@ -176,4 +155,25 @@ $scroller-offset: map-get($container-padding, 'large');
 
 .body-part__scroller {
   overflow: auto;
+}
+
+.body-content-list {
+  list-style: none;
+  margin: 0 0 2em;
+  padding: 0;
+}
+
+.body-content-list__item {
+  list-style: none;
+
+  &:before {
+    content: '';
+    width: 0.35em;
+    height: 0.35em;
+    display: inline-block;
+    vertical-align: middle;
+    border-radius: 0.1em;
+    background: color('currentColor');
+    margin-right: 0.4em;
+  }
 }

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -193,3 +193,10 @@
   background: color('white');
 }
 
+.no-margin {
+  margin: 0;
+}
+
+.no-padding {
+  margin: 0;
+}

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -95,6 +95,7 @@ function parseArticleAsArticle(prismicArticle) {
 }
 
 function convertContentToBodyParts(content) {
+  // TODO: Add these as ContentBlocks when the model is in
   return content.map(slice => {
     switch (slice.slice_type) {
       case 'standfirst':
@@ -129,6 +130,18 @@ function convertContentToBodyParts(content) {
             name: asText(slice.primary.heading),
             items: slice.items.map(prismicImageToPicture)
           }
+        };
+
+      case 'imageList':
+        return {
+          weight: 'default',
+          type: 'imageList',
+          value: slice.items.map(item => {
+            const image = prismicImageToPicture(item);
+            const description = RichText.asHtml(item.description);
+            const title = asText(item.title);
+            return { title, image, description };
+          })
         };
 
       case 'quote':

--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -47,6 +47,18 @@
             {% componentV2 'tweet', bodyPart.value %}
           {% elif bodyPart.type === 'instagramEmbed' %}
             {% componentV2 'instagram-embed', bodyPart.value %}
+          {% elif bodyPart.type === 'imageList' %}
+            {% if(bodyPart.value.length > 0) %}
+            <ul class="plain-list no-margin no-padding">
+              {% for item in bodyPart.value %}
+                <li>
+                  <h2>{{ loop.index }}. {{ item.title }}</h2>
+                  {% componentV2 'captioned-image', item.image, {'has-border-bottom': item.image.caption}, {showCopyright: true} %}
+                  {{item.description | safe}}
+                </li>
+              {% endfor %}
+            </ul>
+            {% endif %}
           {% elif bodyPart.type === 'quote' %}
             {% set fontStyles = {s:'HNL3'} %}
             {% componentV2 'quote', {body: bodyPart.value.body | safe, footer: bodyPart.value.footer | safe}, {'block': true}, {fontStyles: fontStyles} %}

--- a/server/views/components/list/list.njk
+++ b/server/views/components/list/list.njk
@@ -1,7 +1,7 @@
 <div itemscope itemtype="http://schema.org/ItemList">
-  <ul>
+  <ul class="body-content-list">
     {% for item in list.items %}
-      <li itemprop="itemListElement">{{ item | safe }}</li>
+      <li class="body-content-list__item" itemprop="itemListElement">{{ item | safe }}</li>
     {% endfor %}
   </ul>
 </div>


### PR DESCRIPTION
## Type
✨ Feature  

- [x] Demoed to Lalita.

## Value
Allows editors to create a semantically meaningful image list, aka, listicle.
I have limited it to images, as we haven't had the requirement to do anything more.

Here's the model, which is also up for scrutiny.
Once #1242 is in, I can start adding content blocks to this repo, negating the need for the other.

## Screenshot
![listicle](https://user-images.githubusercontent.com/31692/28631821-77427fe0-7226-11e7-879d-1824ee0e226f.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
