### PR TITLE
Improve search button size/alignment

### DIFF
--- a/client/scss/components/_search_box.scss
+++ b/client/scss/components/_search_box.scss
@@ -9,4 +9,5 @@
 .search-box__button {
   position: absolute;
   right: 0.6em;
+  height: 1em;
 }

--- a/server/views/components/search-box/search-box.njk
+++ b/server/views/components/search-box/search-box.njk
@@ -1,6 +1,6 @@
 <form class="search-box" action="{{ model.action }}">
   {% componentV2 'input', {id: model.id, type: 'text', name: model.name, value: model.query, placeholder: 'Search image collections', autofocus: model.autofocus}, null, {isLabelHidden: true} %}
-  <button class="search-box__button plain-button v-center {{ {s:0} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}">
+  <button class="search-box__button plain-button v-center {{ {s:0} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }} {{ {s:'HNL3', m:'HNL2'} | fontClasses }}">
     {% icon 'actions/search', 'Search' %}
   </button>
 </form>


### PR DESCRIPTION
## Type
🐛 Bugfix  

- [x] Demoed to @Norvard 

## Value
Improves the size/alignment of the search icon (button)

## Screenshot
![screen shot 2017-07-27 at 17 15 49](https://user-images.githubusercontent.com/1394592/28681811-b03ded4e-72f2-11e7-954e-4469ac17a229.png)


## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
