### PR TITLE
Fix header height from medium breakpoint

### DIFF
--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -5,6 +5,16 @@ $tweakpoints: (
   'small': map-get($breakpoints, 'small')
 );
 
+.header {
+  // Setting this allows us to use calc() in order to e.g. fill
+  // the rest of the viewport with a work image
+  .enhanced & {
+    @include respond-to('medium') {
+      height: $header-height-fixed;
+    }
+  }
+}
+
 .header__upper {
   padding-top: $vertical-space-unit;
   padding-bottom: $vertical-space-unit;

--- a/client/scss/components/_header.scss
+++ b/client/scss/components/_header.scss
@@ -10,7 +10,11 @@ $tweakpoints: (
   // the rest of the viewport with a work image
   .enhanced & {
     @include respond-to('medium') {
-      height: $header-height-fixed;
+      height: $header-height-fixed-small;
+    }
+
+    @include respond-to('header-medium') {
+      height: $header-height-fixed-large;
     }
   }
 }

--- a/client/scss/components/_work_media.scss
+++ b/client/scss/components/_work_media.scss
@@ -3,7 +3,7 @@
   height: 80vh;
 
   @include respond-to('medium') {
-    height: 90vh;
+    height: calc(100vh - #{$header-height-fixed});
   }
 
   .image {
@@ -16,7 +16,7 @@
     padding: 10 * $spacing-unit;
 
     @include respond-to('medium') {
-      max-height: 90vh;
+      max-height: calc(100vh - #{$header-height-fixed});
     }
 
     .enhanced & {

--- a/client/scss/components/_work_media.scss
+++ b/client/scss/components/_work_media.scss
@@ -1,9 +1,17 @@
+$tweakpoints: (
+  'header-medium': 825px,
+);
+
 .work-media {
   position: relative;
   height: 80vh;
 
   @include respond-to('medium') {
-    height: calc(100vh - #{$header-height-fixed});
+    height: calc(100vh - #{$header-height-fixed-small});
+  }
+
+  @include respond-to('header-medium') {
+    height: calc(100vh - #{$header-height-fixed-large});
   }
 
   .image {
@@ -16,7 +24,11 @@
     padding: 10 * $spacing-unit;
 
     @include respond-to('medium') {
-      max-height: calc(100vh - #{$header-height-fixed});
+      max-height: calc(100vh - #{$header-height-fixed-small});
+    }
+
+    @include respond-to('header-medium') {
+      max-height: calc(100vh - #{$header-height-fixed-large});
     }
 
     .enhanced & {

--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -202,7 +202,10 @@ $spacing-unit: 6px;
 $article-top-space: 2 * $vertical-space-unit;
 $border-radius-unit: 6px;
 $spacing-directions: ('top', 'right', 'bottom', 'left');
-$header-height-fixed: 87px; // The calculated value, i.e. the height the header would be even if this wasn't set
+
+// The calculated values, i.e. the heights the header would be even if this wasn't set
+$header-height-fixed-small: 73px;
+$header-height-fixed-large: 87px;
 
 $container-padding-s: map-get($container-padding, 'small');
 $container-padding-m: map-get($container-padding, 'medium');

--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -202,6 +202,7 @@ $spacing-unit: 6px;
 $article-top-space: 2 * $vertical-space-unit;
 $border-radius-unit: 6px;
 $spacing-directions: ('top', 'right', 'bottom', 'left');
+$header-height-fixed: 87px; // The calculated value, i.e. the height the header would be even if this wasn't set
 
 $container-padding-s: map-get($container-padding, 'small');
 $container-padding-m: map-get($container-padding, 'medium');


### PR DESCRIPTION
## Type
🐛 Bugfix  

- [ ] Demoed to @

## Value
Lets us ensure the work image always fills all of the available space that isn't taken up by the header.

I'm not sure about this (it feels slightly messy), but thought I'd put it up for posterity/see if we have any other ideas.

## Screenshot
![screen shot 2017-07-27 at 18 23 58](https://user-images.githubusercontent.com/1394592/28683563-ef98af0a-72f8-11e7-956f-326dfb1abad1.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
