### PR TITLE
Remove Hammer.js

### DIFF
--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -1,5 +1,4 @@
 import debounce from 'lodash.debounce';
-import Hammer from 'hammerjs';
 import { nodeList, setPropertyPrefixed, featureTest, addClassesToElements, removeClassesFromElements, addAttrToElements, removeAttrFromElements } from '../util';
 import { trackEvent } from '../utils/track-event';
 import fastdom from '../utils/fastdom-promise';
@@ -57,7 +56,6 @@ const contentSlider = (el, options) => {
     sliderControlInactive: `slider-control--inactive`
   };
   // Define vars
-  const sliderTouch = new Hammer(sliderElements.slidesContainer);
   const indexAttr = 'data-slide-index'; // Added to slide items to help with tabbing
   const id = sliderElements.slidesContainer.getAttribute('id');
   let slidesWidthArray;
@@ -362,10 +360,6 @@ const contentSlider = (el, options) => {
       });
     });
   }
-
-  // Handle touch
-  sliderTouch.on('swiperight', prevSlide);
-  sliderTouch.on('swipeleft', nextSlide);
 
   // Handle slider width changes
   window.addEventListener('resize', debounce(onWidthChange, 500));

--- a/client/package.json
+++ b/client/package.json
@@ -39,7 +39,6 @@
     "core-js": "^2.4.1",
     "fastdom": "^1.0.6",
     "fontfaceobserver": "^2.0.9",
-    "hammerjs": "^2.0.8",
     "lazysizes": "^3.0.0",
     "lodash.debounce": "^4.0.8",
     "redux": "^3.6.0",


### PR DESCRIPTION
Fixes #1178

## Type
🐛 Bugfix  

## Value
Allows content-slider caption text to be selectable (Hammer was hijacking those events). Also shaves 20k off our JS.
