### PR TITLE
wrap iiif image requests in feature flag

### DIFF
--- a/server/views/components/image-iiif/image-iiif.njk
+++ b/server/views/components/image-iiif/image-iiif.njk
@@ -7,7 +7,7 @@
   {% set loop = [1] %}
 {% endif %}
 <noscript>
-  <img width="{{model.width}}" height="{{model.height}}" class="image" src="{{ model.contentUrl | replace('WIDTH', 320) }}?w=320"
+  <img width="{{model.width}}" height="{{model.height}}" class="image" src="{{ model.contentUrl | replace('WIDTH', 320) }}"
 alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{ model.caption | striptags() }}{% endif %}" />
 </noscript>
 
@@ -17,7 +17,7 @@ alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{
     promo__image-mask {{data.clipPathClass}}
   {% endif %}
   "
-  src="{{ model.contentUrl | replace('WIDTH', 30) }}?w=30"
+  src="{{ model.contentUrl | replace('WIDTH', 30) }}"
   data-srcset="
   {%- for size in sizes -%}
     {{ comma() }}{{ model.contentUrl | replace('WIDTH', size) }} {{ size }}w


### PR DESCRIPTION
Closes #1289

## Type
✨ Feature 

## Value
Enables more accurate load testing of image search pages by using a feature flag to determine if images are requested from origin or CDN. 

The feature flag is currently enabled for the 'platformTeam' cohort, i.e. any page request sent with a cookie of WC_features_cohort = platformTeam, will have the flag enabled and receive images from the origin.

