### PR TITLE
Remove info button animation

### DIFF
--- a/client/scss/components/_scroll_to_info.scss
+++ b/client/scss/components/_scroll_to_info.scss
@@ -1,18 +1,3 @@
-@keyframes scroll-to-info-animate-icons {
-  0% {
-    transform: translateY(0);
-  }
-
-  50% {
-    transform: translateY(-20px);
-  }
-}
-
 .scroll-to-info--work {
-  transform: translateY(0);
   bottom: 4 * $spacing-unit;
-
-  .icon {
-    animation: scroll-to-info-animate-icons 2s ease-in-out 3 forwards;
-  }
 }


### PR DESCRIPTION
References #1141

## Type
🚑 Health

## Value
Removes the 3s wobbling animation from the info button in advance of A/B testing the info button's usefulness.

If it turns out to be useful/necessary, then a further A/B test of it with/without animation could be done.

