### PR TITLE
Only display author markup if there's an author

### DIFF
--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -64,12 +64,14 @@
           <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
             {% if article.bodyParts.length > 0  %}
               {% for author in article.author %}
-                {% component 'author', {
-                  name: author.name,
-                  twitterHandle: author.twitterHandle,
-                  modifiers: ['border-bottom'] if loop.last else [],
-                  image: author.image
-                } %}
+                {% if author %}
+                  {% component 'author', {
+                    name: author.name,
+                    twitterHandle: author.twitterHandle,
+                    modifiers: ['border-bottom'] if loop.last else [],
+                    image: author.image
+                  } %}
+                {% endif %}
               {% endfor %}
             {% endif %}
 
@@ -79,13 +81,15 @@
               {% endblock %}
 
               {% for author in article.author %}
-                {% component 'author', {
-                  name: author.name,
-                  twitterHandle: author.twitterHandle,
-                  modifiers: ['border-left'],
-                  description: author.description,
-                  image: author.image
-                } %}
+                {% if author %}
+                  {% component 'author', {
+                    name: author.name,
+                    twitterHandle: author.twitterHandle,
+                    modifiers: ['border-left'],
+                    description: author.description,
+                    image: author.image
+                  } %}
+                {% endif %}
               {% endfor %}
 
               {% componentV2 'divider', null, {'stub': true, 'black': true}, {extraClasses: [{s:4} | spacingClasses({margin: ['top']})]} %}


### PR DESCRIPTION
## Type
🐛 Bugfix  

- [ ] Demoed to @

## Value
Prevents unnecessary markup (and associated styles) being added to the page when there isn't an author for an article

## Screenshot
__Before:__
![screen shot 2017-08-02 at 12 33 45](https://user-images.githubusercontent.com/1394592/28871973-ec131caa-777e-11e7-88b2-7f68b753463a.png)

__After:__
![screen shot 2017-08-02 at 12 32 03](https://user-images.githubusercontent.com/1394592/28871950-c7613a4a-777e-11e7-9988-c600e1e72a3f.png)


## Checklist
### All
- [x] PR labelled and assigned
