### PR TITLE
Highlight correct section in Cardigan for events/exhibitions templates

### DIFF
--- a/server/views/templates/event.config.js
+++ b/server/views/templates/event.config.js
@@ -1,9 +1,11 @@
+import {createPageConfig} from '../../model/page-config';
 import {getEvent} from '../../services/events';
 
 export const name = 'event';
 export const handle = 'event-template';
 
 export const context = {
+  pageConfig: createPageConfig({inSection: 'whatson'}),
   event: getEvent('WXmdTioAAJWWjZdH'),
   tags: '@tags.model',
   video: {

--- a/server/views/templates/exhibition.config.js
+++ b/server/views/templates/exhibition.config.js
@@ -1,3 +1,4 @@
+import {createPageConfig} from '../../model/page-config';
 import {getExhibition} from '../../services/exhibitions';
 import {getEvent} from '../../services/events';
 
@@ -5,6 +6,7 @@ export const name = 'exhibition';
 export const handle = 'exhibition-template';
 
 export const context = {
+  pageConfig: createPageConfig({inSection: 'whatson'}),
   event: getEvent('WXmdTioAAJWWjZdH'),
   exhibition: getExhibition('WYH6Px8AAH9Ic4Mf'),
   tags: '@tags.model',


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Highlights the correct navigation link ('What's on') when the Event/Exhibition templates are viewed in Cardigan.

## Screenshot
![screen shot 2017-08-03 at 12 47 21](https://user-images.githubusercontent.com/1394592/28920488-091b4338-784a-11e7-8139-645fa227bcbc.png)


## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
