### PR TITLE
Rename 'label' to 'title' for results from the updated Catalogue API

### DIFF
--- a/server/model/work.js
+++ b/server/model/work.js
@@ -2,7 +2,7 @@
 
 export type Work = {|
   id: string;
-  label: string;
+  title: string;
   description: string;
   createdDate: {
     label: string,

--- a/server/model/work.js
+++ b/server/model/work.js
@@ -2,6 +2,7 @@
 
 export type Work = {|
   id: string;
+  label: string,
   title: string;
   description: string;
   createdDate: {

--- a/server/test/mocks/wellcomecollection-api.json
+++ b/server/test/mocks/wellcomecollection-api.json
@@ -16,7 +16,7 @@
 "authority": "Sierra"
 }
 ],
-"label": "A lecture on pneumatics at the Royal Institution, London. Co",
+"title": "A lecture on pneumatics at the Royal Institution, London. Co",
 "description": "A lecture on pneumatics at the Royal Institution, London. Coloured etching by J. Gillray, 1802.",
 "lettering": "Scientific researches! -New discoveries in pneumaticks! -or- an experimental lecture on the powers of air.- Js. Gillray inv. & fect.",
 "creators": [

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -43,7 +43,7 @@
             {% set img = {contentUrl: result.imgLink, width: 300, height: 300} %}
             {% set type = result.type | lower %}
             {% set url = '/works/' + result.id + queryString %}
-            {% componentV2 'promo', {contentType: type, title: result.title, url: url, image: img | objectAssign({ isIiif: true }), datePublished: result.createdDate.label}, {}, {isConstrained: true, sizes: '(min-width: 1340px) 178px, (min-width: 960px) calc(25vw - 52px), (min-width: 600px) calc(33.24vw - 43px), calc(50vw - 27px)'} %}
+            {% componentV2 'promo', {contentType: type, title: result.title or result.label, url: url, image: img | objectAssign({ isIiif: true }), datePublished: result.createdDate.label}, {}, {isConstrained: true, sizes: '(min-width: 1340px) 178px, (min-width: 960px) calc(25vw - 52px), (min-width: 600px) calc(33.24vw - 43px), calc(50vw - 27px)'} %}
           </div>
           {% endfor %}
         </div>

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -43,7 +43,7 @@
             {% set img = {contentUrl: result.imgLink, width: 300, height: 300} %}
             {% set type = result.type | lower %}
             {% set url = '/works/' + result.id + queryString %}
-            {% componentV2 'promo', {contentType: type, title: result.label, url: url, image: img | objectAssign({ isIiif: true }), datePublished: result.createdDate.label}, {}, {isConstrained: true, sizes: '(min-width: 1340px) 178px, (min-width: 960px) calc(25vw - 52px), (min-width: 600px) calc(33.24vw - 43px), calc(50vw - 27px)'} %}
+            {% componentV2 'promo', {contentType: type, title: result.title, url: url, image: img | objectAssign({ isIiif: true }), datePublished: result.createdDate.label}, {}, {isConstrained: true, sizes: '(min-width: 1340px) 178px, (min-width: 960px) calc(25vw - 52px), (min-width: 600px) calc(33.24vw - 43px), calc(50vw - 27px)'} %}
           </div>
           {% endfor %}
         </div>

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -13,7 +13,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s: 12, m: 6, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
-          <h1 id="work-info" class="{{ {s:'HNM3', m:'HNM2', l:'HNM1'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{work.title}}</h1>
+          <h1 id="work-info" class="{{ {s:'HNM3', m:'HNM2', l:'HNM1'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{work.title or work.label}}</h1>
           {% if work.license.length > 0 %}
             <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
               {% componentV2 'license', {subject: work.imgLink, licenseType: work.license} %} {# - license from API #}

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -13,7 +13,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s: 12, m: 6, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
-          <h1 id="work-info" class="{{ {s:'HNM3', m:'HNM2', l:'HNM1'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{work.label}}</h1>
+          <h1 id="work-info" class="{{ {s:'HNM3', m:'HNM2', l:'HNM1'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{work.title}}</h1>
           {% if work.license.length > 0 %}
             <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
               {% componentV2 'license', {subject: work.imgLink, licenseType: work.license} %} {# - license from API #}


### PR DESCRIPTION
There’s a pending change to the Catalogue API which makes changes the data model to use "title" instead of "label" (https://github.com/wellcometrust/platform-api/issues/751). You can see what the new API will look like at https://api-stage.wellcomecollection.org/catalogue/v0/works

This patch prepares the Collection site for this change – now it can pick up a "title" or a "label" field. I’ve tested it against both the new and the old API, and behaves correctly in both cases.

When we flip the switch, this interim code will need to be removed, but this is good to go now.

~This patch flips the Collection site to use the updated field name, and I’ve tested it against the staging API.~

~We’ll need to make sure we both flip the switch at the same time, or the Collection site doesn't show any titles. 😢~