### PR TITLE
Copy url

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -28,6 +28,7 @@ import backToTop from './components/back-to-top';
 import toggleShowHide from './components/toggle-show-hide';
 import scrollToInfo from './components/scroll-to-info';
 import workMediaControls from './components/work-media-controls';
+import copyUrl from './components/copy-url';
 
 const init = () => {
   polyfills.init();
@@ -56,6 +57,9 @@ const init = () => {
   const toggleShowHideEls = document.querySelectorAll('.js-show-hide');
   const scrollToInfoEls = document.querySelectorAll('.js-scroll-to-info');
   const workMediaEls = document.querySelectorAll('.js-work-media');
+  const copyUrlEls = document.querySelectorAll('.js-copy-url');
+
+  nodeList(copyUrlEls).forEach(copyUrl);
 
   nodeList(workMediaEls).forEach(workMediaControls);
 

--- a/client/js/components/copy-url.js
+++ b/client/js/components/copy-url.js
@@ -16,6 +16,6 @@ export default (el) => {
       el.innerHTML = 'Copy failed';
     }
 
-    textarea.blur();
+    el.focus();
   });
 };

--- a/client/js/components/copy-url.js
+++ b/client/js/components/copy-url.js
@@ -3,11 +3,19 @@ export default (el) => {
 
   el.addEventListener('click', () => {
     const textarea = document.createElement('textarea');
+
     textarea.setAttribute('style', 'position: fixed; left: -9999px;');
-    document.body.appendChild(textarea);
+    el.parentNode.insertBefore(textarea, el.nextSibling);
     textarea.innerHTML = window.location.href;
     textarea.select();
-    el.innerHTML = 'Copied to clipboard';
-    document.execCommand('copy');
+
+    try {
+      document.execCommand('copy');
+      el.innerHTML = 'Copied to clipboard';
+    } catch (err) {
+      el.innerHTML = 'Copy failed';
+    }
+
+    textarea.blur();
   });
 };

--- a/client/js/components/copy-url.js
+++ b/client/js/components/copy-url.js
@@ -1,4 +1,6 @@
 export default (el) => {
+  el.classList.remove('is-hidden'); // Hidden until JS fires
+
   el.addEventListener('click', () => {
     const textarea = document.createElement('textarea');
     textarea.setAttribute('style', 'position: fixed; left: -9999px;');

--- a/client/js/components/copy-url.js
+++ b/client/js/components/copy-url.js
@@ -1,0 +1,11 @@
+export default (el) => {
+  el.addEventListener('click', () => {
+    const textarea = document.createElement('textarea');
+    textarea.setAttribute('style', 'position: fixed; left: -9999px;');
+    document.body.appendChild(textarea);
+    textarea.innerHTML = window.location.href;
+    textarea.select();
+    el.innerHTML = 'Copied to clipboard';
+    document.execCommand('copy');
+  });
+};

--- a/server/views/components/copy-url/copy-url.njk
+++ b/server/views/components/copy-url/copy-url.njk
@@ -1,1 +1,1 @@
-<button class="btn btn--dark is-hidden js-copy-url">Copy URL</button>
+<button data-component-name="Copy URL button" data-component-id="{{ model.id }}" data-track-click="{}" class="btn btn--dark is-hidden js-copy-url">Copy URL</button>

--- a/server/views/components/copy-url/copy-url.njk
+++ b/server/views/components/copy-url/copy-url.njk
@@ -1,1 +1,1 @@
-<button class="btn btn--dark js-copy-url">Copy URL</button>
+<button class="btn btn--dark is-hidden js-copy-url">Copy URL</button>

--- a/server/views/components/copy-url/copy-url.njk
+++ b/server/views/components/copy-url/copy-url.njk
@@ -1,0 +1,1 @@
+<button class="btn btn--dark js-copy-url">Copy URL</button>

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -44,6 +44,8 @@
           {% if work.lettering.length > 0 %}
             {% componentV2 'meta-unit', {headingText: 'Lettering', content: work.lettering, includeDivider: false} %}
           {% endif %}
+
+          {% componentV2 'copy-url' %}
         </div>
       </div>
     </div>

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -45,7 +45,7 @@
             {% componentV2 'meta-unit', {headingText: 'Lettering', content: work.lettering, includeDivider: false} %}
           {% endif %}
 
-          {% componentV2 'copy-url' %}
+          {% componentV2 'copy-url', {id: 'work'} %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes/Closes/References #

## Type
✨ Feature  

- [ ] Demoed to @

## Value
Allows a user to copy a url at the click of a button

## Screenshot
![copy](https://user-images.githubusercontent.com/1394592/28962203-caed8f86-78fc-11e7-935d-bb981857abb1.gif)


## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client __(won't display)__
- [x] Relevant tracking/monitoring has been considered
