### PR TITLE
Only copy origin and pathname from URL

### DIFF
--- a/client/js/components/copy-url.js
+++ b/client/js/components/copy-url.js
@@ -3,10 +3,11 @@ export default (el) => {
 
   el.addEventListener('click', () => {
     const textarea = document.createElement('textarea');
+    const { origin, pathname } = window.location;
 
     textarea.setAttribute('style', 'position: fixed; left: -9999px;');
     el.parentNode.insertBefore(textarea, el.nextSibling);
-    textarea.innerHTML = window.location.href;
+    textarea.innerHTML = `${origin}${pathname}`;
     textarea.select();
 
     try {


### PR DESCRIPTION
References #1312

## Type
🐛 Bugfix  

- [ ] Demoed to @

## Value
Only copies the url to the work, rather than the work + any other (e.g. query) parameters
