### PR TITLE
Allow feature flags cohort to be passed as url parameter

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -77,7 +77,7 @@ resource "aws_cloudfront_distribution" "next" {
 
     forwarded_values {
       query_string            = true
-      query_string_cache_keys = ["page", "current", "q", "format", "query"]
+      query_string_cache_keys = ["page", "current", "q", "format", "query", "cohort"]
 
       cookies {
         forward           = "whitelist"

--- a/server/middleware/features-cohort.js
+++ b/server/middleware/features-cohort.js
@@ -1,6 +1,6 @@
 export function determineFeaturesCohort() {
   return (ctx, next) => {
-    ctx.featuresCohort = ctx.cookies.get('WC_featuresCohort') || 'default';
+    ctx.featuresCohort = ctx.request.query.cohort || ctx.cookies.get('WC_featuresCohort') || 'default';
     return next();
   };
 }


### PR DESCRIPTION
## Type
✨ Feature  

## Value
Will help with getting worst case performance metrics for search in Speedtracker, by allowing us to request images from origin rather than CDN