### PR TITLE
Truncate text

### DIFF
--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -197,6 +197,21 @@
   }
 }
 
+.text--truncate {
+  max-height: 80px;
+  overflow: hidden;
+
+  &:after {
+    position: absolute;
+    top: 45px;
+    content: '';
+    display: block;
+    width: 100%;
+    height: 35px;
+    background: linear-gradient(color('transparent'), color('white'));
+  }
+}
+
 .border-left {
   border-left: 5px solid color('black');
 }

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -208,7 +208,7 @@
     display: block;
     width: 100%;
     height: 35px;
-    background: linear-gradient(color('transparent'), color('white'));
+    background: linear-gradient(rgba(255, 255, 255 , 0.001), color('white')); // Safari doesn't like transparent (shows as grey), so giving a value very close to transparent.
   }
 }
 

--- a/server/views/components/promo/promo.njk
+++ b/server/views/components/promo/promo.njk
@@ -100,12 +100,12 @@
                     {% endif %}
                   </span>
                 {% endif %}
-                  <{{ headingLevel or 'h2'}} class="promo__title{{ ' promo__title--lead' if model.weight === 'lead' }} {{ titleFontSizes | fontClasses }}">
+                  <{{ headingLevel or 'h2'}} class="promo__title{{ ' promo__title--lead' if model.weight === 'lead' }} {{ titleFontSizes | fontClasses }}{%if model.contentType == 'work'%} text--truncate {% endif %}">
                     {{ model.title if model.url else 'Coming soon…' }}
                   </{{ headingLevel or 'h2'}}>
               </div>
               {% if model.datePublished and model.contentType == 'work' %}
-                <p class="promo {{ dateFontSizes | fontClasses }} text--meta">{{ model.datePublished }}</p>
+                <p class="promo {{ dateFontSizes | fontClasses }} text--meta relative">{{ model.datePublished }}</p>
               {% endif %}
               {% if model.description %}
                 <span class="promo__copy">{{ model.description | striptags | safe | truncate(140) }}</span>


### PR DESCRIPTION
Fixes #1184

## Type
✨ Feature  

## Value
Prevents titles from taking up too much space, enabling user to scan results quickly

## Screenshot
<img width="1261" alt="screen shot 2017-08-07 at 13 47 56" src="https://user-images.githubusercontent.com/6051896/29027653-78a8298c-7b79-11e7-9861-5c4fd7ef8202.png">

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
