### PR TITLE
Add cache-control header for html docs

### DIFF
--- a/server/config/index.js
+++ b/server/config/index.js
@@ -18,9 +18,22 @@ const config = {
   session: {
     secretKey: 'myKoajsSecretKey'
   },
-  cacheControl: {
-    files: ['text/css', 'application/javascript', 'application/font-woff', 'application/font-woff2']
-  }
+  cacheControl: [{
+    contentType: 'text/css'
+  },
+  {
+    contentType: 'application/javascript'
+  },
+  {
+    contentType: 'application/font-woff'
+  },
+  {
+    contentType: 'application/font-woff2'
+  },
+  {
+    contentType: 'text/html',
+    maxAge: 1800
+  }]
 };
 
 export default config;

--- a/server/middleware/set-cache-control.js
+++ b/server/middleware/set-cache-control.js
@@ -1,12 +1,14 @@
 export default (options = {}) => {
-  const files = options.files || '';
-  const maxAge = options.maxAge || 31536000; // 60*60*24*365, i.e. 1 year
+  const cacheControl = options || '';
+  const year = 60*60*24*365;
 
   return function setCacheControl(ctx, next) {
     return next().then(() => {
-      if (files.indexOf(ctx.response.type) > -1) {
-        ctx.response.set('Cache-Control', `max-age=${maxAge}`);
-      }
+      cacheControl.forEach((config) => {
+        if (config.contentType === ctx.response.type) {
+          ctx.response.set('Cache-Control', `max-age=${config.maxAge || year}`);
+        }
+      });
     });
   };
 }


### PR DESCRIPTION
## Type
🚑 Health

## Value
Sets cache-control header to 30 mins for html pages, potentially speeding up users experience.
(Allowa different maxAges for different content types)