### PR TITLE
remove async-hide styles

### DIFF
--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -1,4 +1,3 @@
-<style>.async-hide { opacity: 0 !important} </style>
 <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
 h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;


### PR DESCRIPTION
## Type
🚑 Health

## Value
The .async-hide style is being applied for Google Optimize, to ensure that users don't see the initial page content prior to it being modified by an experiment. However, this causes a noticeable delay in the rendering of the page.

Since we are only using Google Optimize to test the digital-story transporter, which appears way below the fold, this is pretty redundant and removing it will speed up page rendering.

In the future, if required, we could use the .async-hide class to more directly target page components, rather than hiding the whole page.
