### PR TITLE
Only show quote footer if there is content for it

### DIFF
--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -182,7 +182,7 @@ function convertContentToBodyParts(content) {
           weight: 'default',
           value: {
             body: RichText.asHtml(slice.primary.quote),
-            footer: `${slice.primary.citation} - ${slice.primary.source}`,
+            footer: slice.primary.citation && slice.primary.source ? `${slice.primary.citation} - ${slice.primary.source}` : null,
             quote: RichText.asHtml(slice.primary.quote),
             citation: `${slice.primary.citation} - ${slice.primary.source}`
           }


### PR DESCRIPTION
## Type
🐛 Bugfix 

## Value
stops null appearing on the page, when the citation and source fields are empty
