### PR TITLE
Use the new identifierScheme in the API

### DIFF
--- a/server/model/work.js
+++ b/server/model/work.js
@@ -11,8 +11,7 @@ export type Work = {|
   creators: Array<string>;
   type: string;
   identifiers?: ?Array<{
-    source: string,
-    name: string,
+    identifierScheme: string,
     value: string,
     type: string
   }>;

--- a/server/test/mocks/wellcomecollection-api.json
+++ b/server/test/mocks/wellcomecollection-api.json
@@ -5,15 +5,15 @@
 "identifiers": [
 {
 "label": "V0006724",
-"authority": "MIRO"
+"identifierScheme": "miro-image-number"
 },
 {
 "label": "ICV No 6939",
-"authority": "Videodisk"
+"identifierScheme": "Videodisk"
 },
 {
 "label": "b11579328",
-"authority": "Sierra"
+"identifierScheme": "Sierra"
 }
 ],
 "title": "A lecture on pneumatics at the Royal Institution, London. Co",
@@ -78,7 +78,7 @@
 "identifiers": [
 {
 "label": "V0006724",
-"authority": "MIRO"
+"identifierScheme": "miro-image-number"
 }
 ],
 "status": "Open"


### PR DESCRIPTION
See https://github.com/wellcometrust/platform-api/issues/334

We’ve changed the way identifiers are represented in the API.

Before:

```json
"identifiers": [
  {
    "source": "Miro",
    "name": "MiroID",
    "value": "V0042826ER",
    "type": "Identifier"
  }
],
```

After:

```json
"identifiers": [
  {
    "identifierScheme": "miro-image-number",
    "value": "V0042826ER",
    "type": "Identifier"
  }
],
```

The code that looks up identifiers for choosing images isn't affected by this change -- this just brings your models and examples into line with the new API.