### PR TITLE
Use plural 'exhibitions' (with updated type in Prismic)

### DIFF
--- a/server/content-model/content-blocks.js
+++ b/server/content-model/content-blocks.js
@@ -4,8 +4,7 @@ import type {Person} from '../model/person';
 import type {Picture} from '../model/picture';
 import {List} from 'immutable';
 
-// TODO: should these be plural or not?
-type ContentBlockType = 'events' | 'webcomics' | 'articles' | 'exhibition'
+type ContentBlockType = 'events' | 'webcomics' | 'articles' | 'exhibitions'
 
 type ContentBlock = {|
   blockType: ContentBlockType,

--- a/server/services/exhibitions.js
+++ b/server/services/exhibitions.js
@@ -18,7 +18,7 @@ export async function getExhibition(id: string): Promise<?Exhibition> {
   const featuredImage = prismicImageToPicture({image: exhibition.data.featuredImage});
 
   return ({
-    blockType: 'exhibition',
+    blockType: 'exhibitions',
     id: exhibition.id,
     title: RichText.asText(exhibition.data.title),
     start: exhibition.data.start,

--- a/server/views/templates/exhibition.config.js
+++ b/server/views/templates/exhibition.config.js
@@ -17,7 +17,7 @@ export const handle = 'exhibition-template';
 export const context = {
   pageConfig: createPageConfig({inSection: 'whatson'}),
   event: getEvent('WXmdTioAAJWWjZdH'),
-  exhibition: getExhibition('WYH6Px8AAH9Ic4Mf'),
+  exhibition: getExhibition('WZQhjSoAAJqjjuw1'),
   articlePromos: getFourArticlePromos(),
   tags: {
     id: 'cardigan-exhibition',


### PR DESCRIPTION
## Type
🚑  Health

## Value
Uses correct (plural) naming convention for exhibitions content type.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
