### PR TITLE
Don't hide controls when they're hovered

### DIFF
--- a/client/js/components/work-media-controls.js
+++ b/client/js/components/work-media-controls.js
@@ -7,11 +7,15 @@ export default (el) => {
   const controls = container.querySelectorAll('.js-work-media-control');
 
   function showHideControls() {
+    const activeControl = container.classList.contains('is-control-active');
+
     clearTimeout(timeout);
 
     fastdom.mutate(() => {
       container.classList.add('is-active');
     });
+
+    if (activeControl) return;
 
     timeout = setTimeout(() => {
       fastdom.mutate(() => {
@@ -24,6 +28,16 @@ export default (el) => {
 
   nodeList(controls).forEach(control => {
     control.addEventListener('keyup', showHideControls);
+    control.addEventListener('mouseenter', () => {
+      fastdom.mutate(() => {
+        container.classList.add('is-control-active');
+      });
+    });
+    control.addEventListener('mouseleave', () => {
+      fastdom.mutate(() => {
+        container.classList.remove('is-control-active');
+      });
+    });
   });
 
   showHideControls();


### PR DESCRIPTION
Fixes/Closes/References #

## Type
🚑  Health

- [ ] Demoed to @Heesoomoon 

## Value
Prevents the 'return to results' and scroll-down-to-main controls from being hidden if they are under the cursor.

