### PR TITLE
Don't hide slider controls when images fit in viewport

### DIFF
--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -126,7 +126,7 @@ const contentSlider = (el, options) => {
         } else {
           positionArray = positionArrayByContainer;
         }
-        toggleControlsVisibility(slidesCombinedWidth, containerWidth, sliderElements.sliderControls);
+
         updatePosition(setSlideIndexes(slidesWidthArray, containerWidth, sliderElements, indexAttr) || positionIndex, positionArray);
       });
     });
@@ -231,14 +231,6 @@ const contentSlider = (el, options) => {
     positionArrayByContainer.push(slidesWidth - containerWidth);
     return positionArrayByContainer;
   };
-
-  function toggleControlsVisibility(slidesCombinedWidth, containerWidth, controls) {
-    if (slidesCombinedWidth <= containerWidth) {
-      controls.style.visibility = 'hidden';
-    } else {
-      controls.style.removeProperty('visibility');
-    }
-  }
 
   function changeCurrentItemsStatus(items, n, className, positionArrayBySlide, positionArray, slidesWidthArray, containerWidth) {
     const positionValue = positionArray[n];


### PR DESCRIPTION
Fixes #1353 

## Type
🐛  Bugfix  

- [ ] Demoed to @jamesgorrie 

## Value
Prevents slider controls from being hidden while they're still useful.

## Screenshot
![screen shot 2017-08-17 at 14 31 25](https://user-images.githubusercontent.com/1394592/29414795-ca7b91ae-8358-11e7-9706-36e3f1c7b7c4.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
