### PR TITLE
Add drawer containing opening hours to top of exhibition page

### DIFF
--- a/client/scss/components/_opening_hours.scss
+++ b/client/scss/components/_opening_hours.scss
@@ -5,8 +5,16 @@
   margin-bottom: 2 * $vertical-space-unit;
 }
 
+.opening-hours--light {
+  color: color('pewter');
+}
+
 .opening-hours__tablist {
   border-bottom: 1px solid color('charcoal');
+
+  .opening-hours--light & {
+    border-bottom-color: color('pewter');
+  }
 }
 
 .opening-hours__tabitem {
@@ -18,6 +26,10 @@
 
   @include respond-to('medium') {
     padding: 0 0.6em;
+
+    .opening-hours--compressed & {
+      padding: 0;
+    }
   }
 
   &:first-child {
@@ -34,6 +46,12 @@
     color: color('silver');
     border-color: color('charcoal');
     border-bottom-color: color('dark-black');
+
+    .opening-hours--light & {
+      color: color('black');
+      border-color: color('pewter');
+      border-bottom-color: color('white');
+    }
   }
 }
 
@@ -43,9 +61,17 @@
   padding: 0.5em;
   transition: color 200ms ease;
 
+  .opening-hours--compressed & {
+    padding: $spacing-unit;
+  }
+
   &:hover,
   &:focus {
     color: color('mint');
+
+    .opening-hours--light & {
+      color: color('black');
+    }
   }
 
   .opening-hours__tabitem:first-child & {
@@ -57,6 +83,10 @@
   color: color('silver');
   width: 100%;
   margin-bottom: 2 * $vertical-space-unit;
+
+  .opening-hours--light & {
+    color: color('black');
+  }
 
   .enhanced & {
     display: flex;
@@ -95,11 +125,19 @@
   display: flex;
   justify-content: space-between;
   border-bottom: 1px solid color('charcoal');
+
+  .opening-hours--light & {
+    border-bottom-color: color('pewter');
+  }
 }
 
 .opening-hours__td {
   padding: 1em 0;
   display: block;
+
+  .opening-hours--compressed & {
+    padding: $spacing-unit 0;
+  }
 
   &:last-child {
     text-align: right;

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -114,6 +114,10 @@
   justify-content: space-between;
 }
 
+.pointer {
+  cursor: pointer;
+}
+
 .pointer-events-none {
   pointer-events: none;
 }

--- a/server/views/components/footer/footer.config.js
+++ b/server/views/components/footer/footer.config.js
@@ -4,6 +4,6 @@ export const status = 'graduated';
 export const preview = '@preview-no-container';
 export const context = {
   navLinks: '@footer-nav.navLinks',
-  openingHours: '@opening-hours',
+  openingHours: '@opening-hours.model',
   footerSocial: '@footer-social'
 };

--- a/server/views/components/footer/footer.njk
+++ b/server/views/components/footer/footer.njk
@@ -10,7 +10,7 @@
       </div>
       <div class="{{ {s:12, l:6, xl:6} | gridClasses }}">
         <h3 class="footer__heading {{ {s:'HNL5'} | fontClasses }}">Opening times:</h3>
-        {% component 'opening-hours', {places: openingHours.places} %}
+        {% componentV2 'opening-hours', {places: openingHours.places} %}
       </div>
     </div>
     <div class="grid">

--- a/server/views/components/opening-hours/opening-hours.config.js
+++ b/server/views/components/opening-hours/opening-hours.config.js
@@ -5,5 +5,7 @@ export const label = 'opening-hours';
 export const status = 'graduated';
 export const hidden = true;
 export const context = {
-  places: defaultPlacesOpeningHours
+  model: {
+    places: defaultPlacesOpeningHours
+  }
 };

--- a/server/views/components/opening-hours/opening-hours.njk
+++ b/server/views/components/opening-hours/opening-hours.njk
@@ -1,12 +1,12 @@
-<div class="opening-hours js-opening-hours js-tabs">
+<div class="opening-hours {{ 'opening-hours' | componentClasses(modifiers) }} js-opening-hours js-tabs">
   <ul class="plain-list opening-hours__tablist {{ {s:'HNM6'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'left', 'bottom', 'right'], padding: ['top', 'left', 'bottom', 'right']}) }} js-tablist">
-    {% for place in places %}
+    {% for place in model.places %}
       <li class="opening-hours__tabitem js-tabitem">
         <a class="opening-hours__tablink js-tablink" href="#{{ place.id }}">{{ place.name }}</a>
       </li>
     {% endfor %}
   </ul>
-  {% for place in places %}
+  {% for place in model.places %}
     <table id="panel-{{ place.id }}" class="opening-hours__table {{ {s:'HNL5'} | fontClasses }} js-tabpanel">
       <caption id="{{ place.id }}" class="opening-hours__caption js-tabfocus">{{ place.name }}</caption>
       <thead class="opening-hours__thead">

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -38,11 +38,17 @@
   <div class="row {{ {s:10} | spacingClasses({padding: ['bottom']}) }}">
     <div class="container">
       <div class="grid">
-        <div class="{{ {s:12, m:10, shiftM:1, l:7, xl:7} | gridClasses }} {{ {s:'HNL3', m:'HNL2'} | fontClasses}}">
+        <div class="{{ {s:12, m:10, shiftM:1, l:7, xl:7} | gridClasses }} {{ {s:'HNL3', m:'HNL2'} | fontClasses}} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
           {% block exhibitionDescription %}{% endblock %}
         </div>
         <div class="{{ {s:12, m:10, shiftM:1, l:5, xl:5} | gridClasses }}">
-
+          <div class="drawer js-show-hide">
+            <button class="plain-button no-padding pointer js-show-hide-trigger font-elf-green {{ {s:4} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">{% icon 'actions/more-2', null, ['icon--elf-green'] %}Opening times</button>
+            <div class="drawer__body js-show-hide-drawer">
+              {% componentV2 'opening-hours', {places: pageConfig.openingHours}, {'light': true, 'compressed': true} %}
+            </div>
+          </div>
+          <hr class="divider divider--keyline divider--pumice {{ {s:2} | spacingClasses({margin: ['bottom']}) }}" />
           {% block accessStatements %}
             {% for statement in exhibition.accessStatements %}
               <div class="flex {{ {s:1} | spacingClasses({margin: ['top', 'bottom']}) }} {{ {s:'HNL4'} | fontClasses}}">
@@ -58,7 +64,6 @@
 
 
           <hr class="divider divider--pumice divider--keyline" />
-          {% block social %}{% endblock %}
         </div>
       </div>
     </div>

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -43,7 +43,7 @@
         </div>
         <div class="{{ {s:12, m:10, shiftM:1, l:5, xl:5} | gridClasses }}">
           <div class="drawer js-show-hide">
-            <button class="plain-button no-padding pointer js-show-hide-trigger font-elf-green {{ {s:4} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">{% icon 'actions/more-2', null, ['icon--elf-green'] %}Opening times</button>
+            <button data-component-name="Opening times drawer" data-component-id="exhibition" data-track-click='{}' class="plain-button no-padding pointer js-show-hide-trigger font-elf-green {{ {s:4} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">{% icon 'actions/more-2', null, ['icon--elf-green'] %}Opening times</button>
             <div class="drawer__body js-show-hide-drawer">
               {% componentV2 'opening-hours', {places: pageConfig.openingHours}, {'light': true, 'compressed': true} %}
             </div>


### PR DESCRIPTION
## Type
✨ Feature  
- [ ] Demoed to @

## Value
Adds in-page opening times to the exhibition page ( aUX recommendation as a result of user research).

## Screenshot
![aug-21-2017 12-36-04](https://user-images.githubusercontent.com/1394592/29517771-90f1dca4-866e-11e7-9be2-7c36b2ac9dd9.gif)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
