### PR TITLE
Update Open Graph/Twitter cards for works, events and exhibitions

### DIFF
--- a/server/views/components/open-graph/open-graph.njk
+++ b/server/views/components/open-graph/open-graph.njk
@@ -1,8 +1,7 @@
 <meta property="og:type" content="{{ metaContent.type }}" />
 <meta property="og:title" content="{{ metaContent.title }}" />
-<meta property="og:image" content="{{ metaContent.image }}?w=1200&h=630&crop=1" />
-<meta property="og:image:width" content="630" />
-<meta property="og:image:height" content="1200" />
+<meta property="og:image" content="{{ metaContent.image }}?w=1200&crop=1" />
+<meta property="og:image:width" content="1200" />
 <meta property="og:url" content="{{ pageConfig.organization.url }}{{ metaContent.url }}" />
 <meta property="og:description" content="{{ metaContent.description | striptags | safe | truncate(200) }}" />
 <meta property="og:article:author" content="{{ metaContent.author.name }}" />

--- a/server/views/components/open-graph/open-graph.njk
+++ b/server/views/components/open-graph/open-graph.njk
@@ -3,8 +3,20 @@
 <meta property="og:image" content="{{ metaContent.image }}?w=1200&crop=1" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:url" content="{{ pageConfig.organization.url }}{{ metaContent.url }}" />
-<meta property="og:description" content="{{ metaContent.description | striptags | safe | truncate(200) }}" />
-<meta property="og:article:author" content="{{ metaContent.author.name }}" />
-<meta property="og:article:published_time" content="{{ metaContent.datePublished }}" />
 <meta property="og:site_name" content="{{ pageConfig.organization.name }}" />
-{#<meta property="og:video" content=" " />#}{# TODO not available from wordpress #}
+
+{% if metaContent.description %}
+  <meta property="og:description" content="{{ metaContent.description | striptags | safe | truncate(200) }}" />
+{% endif %}
+
+{% if metaContent.author.name %}
+  <meta property="og:article:author" content="{{ metaContent.author.name }}" />
+{% endif %}
+
+{% if metaContent.datePublished %}
+  <meta property="og:article:published_time" content="{{ metaContent.datePublished }}" />
+{% endif %}
+
+{% if metaContent.video %}
+  <meta property="og:video" content="{{ metaContent.video }}" />
+{% endif %}

--- a/server/views/components/open-graph/open-graph.njk
+++ b/server/views/components/open-graph/open-graph.njk
@@ -1,11 +1,11 @@
-<meta property="og:type" content="{{ article.type }}" />
-<meta property="og:title" content="{{ article.headline }}" />
-<meta property="og:image" content="{{ article.thumbnail.contentUrl }}?w=1200&h=630&crop=1" />
+<meta property="og:type" content="{{ metaContent.type }}" />
+<meta property="og:title" content="{{ metaContent.title }}" />
+<meta property="og:image" content="{{ metaContent.image }}?w=1200&h=630&crop=1" />
 <meta property="og:image:width" content="630" />
 <meta property="og:image:height" content="1200" />
-<meta property="og:url" content="{{ pageConfig.organization.alternateUrl }}{{ article.url }}" />
-<meta property="og:description" content="{{ article.description | striptags | safe | truncate(200) }}" />
-<meta property="og:article:author" content="{{ article.author.name }}" />
-<meta property="og:article:published_time" content="{{ article.datePublished }}" />
+<meta property="og:url" content="{{ pageConfig.organization.url }}{{ metaContent.url }}" />
+<meta property="og:description" content="{{ metaContent.description | striptags | safe | truncate(200) }}" />
+<meta property="og:article:author" content="{{ metaContent.author.name }}" />
+<meta property="og:article:published_time" content="{{ metaContent.datePublished }}" />
 <meta property="og:site_name" content="{{ pageConfig.organization.name }}" />
 {#<meta property="og:video" content=" " />#}{# TODO not available from wordpress #}

--- a/server/views/components/twitter-card/twitter-card.njk
+++ b/server/views/components/twitter-card/twitter-card.njk
@@ -1,7 +1,7 @@
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:url" content="{{ pageConfig.organization.alternateUrl }}{{ article.url }}" />
+<meta name="twitter:url" content="{{ pageConfig.organization.url }}{{ metaContent.url }}" />
 <meta name="twitter:site" content="{{ pageConfig.organization.twitterHandle }}" />
-<meta name="twitter:title" content="{{ article.headline }}" />
-<meta name="twitter:description" content="{{ article.description | striptags | safe | truncate(200) }}" />
-<meta name="twitter:image" content="{{ article.thumbnail.contentUrl }}?w=600&h=322&crop=1" />
+<meta name="twitter:title" content="{{ metaContent.title }}" />
+<meta name="twitter:description" content="{{ metaContent.description | striptags | safe | truncate(200) }}" />
+<meta name="twitter:image" content="{{ metaContent.image }}?w=600&h=322&crop=1" />
 {#<meta name="twitter:image:alt" content=" {{ article.thumbnailAlt }}" />#}{# TODO not available from wordpress #}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -1,13 +1,19 @@
 {% extends 'layout/default.njk' %}
 
 {% block pageMeta %}
-  {% component 'open-graph', { pageConfig: pageConfig, article: article } %}
-  {% component 'twitter-card', { pageConfig: pageConfig, article: article } %}
+  {% set metaContent = {
+    type: 'article',
+    title: article.headline,
+    image: article.thumbnail.contentUrl,
+    url: article.url,
+    description: article.description
+  } %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
   <meta name="description" content="{{ article.description | safe | striptags }}" />
 {% endblock %}
 
 {% block body %}
-
   {% block seriesNavigation %}
     {% for series in article.series %}
       {% if series.commissionedLength %}

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -1,6 +1,15 @@
 {% extends 'layout/default.njk' %}
 
 {% block pageMeta %}
+  {% set metaContent = {
+    type: 'website',
+    title: pageConfig.title,
+    image: promos.first().image.contentUrl,
+    url: '/explore'
+  } %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
+
   <meta name="description" content="Exploration for the incurably curious" />
 {% endblock %}
 

--- a/server/views/pages/event.njk
+++ b/server/views/pages/event.njk
@@ -2,7 +2,7 @@
 
 {% block pageMeta %}
   {% set metaContent = {
-    type: 'wellcome:event' + '.' + event.format,
+    type: 'website',
     title: event.title,
     image: event.promo.media.contentUrl,
     url: '/events/' + event.id

--- a/server/views/pages/event.njk
+++ b/server/views/pages/event.njk
@@ -1,8 +1,14 @@
 {% extends 'layout/default.njk' %}
 
 {% block pageMeta %}
-  {% component 'open-graph', { pageConfig: pageConfig, article: event } %}
-  {% component 'twitter-card', { pageConfig: pageConfig, article: event } %}
+  {% set metaContent = {
+    type: 'wellcome:event' + '.' + event.format,
+    title: event.title,
+    image: event.promo.media.contentUrl,
+    url: '/events/' + event.id
+  } %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
   <meta name="description" content="{{ event.description | safe | striptags }}" />
 {% endblock %}
 
@@ -14,8 +20,6 @@
 
 </style>
 <article itemscope itemtype="http://schema.org/Event">
-
-
   <div class="row {{ {s:4} | spacingClasses({padding: ['top', 'bottom']}) }}">
     <div class="container">
       <div class="grid">

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -1,8 +1,14 @@
 {% extends 'layout/default.njk' %}
 
 {% block pageMeta %}
-  {% component 'open-graph', { pageConfig: pageConfig, article: exhibition } %}
-  {% component 'twitter-card', { pageConfig: pageConfig, article: exhibition } %}
+  {% set metaContent = {
+    type: 'wellcome:exhibition',
+    title: exhibition.title,
+    image: exhibition.featuredImage.contentUrl,
+    url: '/exhibitions/' + exhibition.id
+  } %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
   {# <meta name="description" content="{{ exhibition.description | safe | striptags }}" /> #}
 {% endblock %}
 

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -2,7 +2,7 @@
 
 {% block pageMeta %}
   {% set metaContent = {
-    type: 'wellcome:exhibition',
+    type: 'website',
     title: exhibition.title,
     image: exhibition.featuredImage.contentUrl,
     url: '/exhibitions/' + exhibition.id

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -1,5 +1,19 @@
 {% extends 'layout/default.njk' %}
 
+{% block pageMeta %}
+  {% set metaContent = {
+    type: 'website',
+    title: list.name,
+    image: list.items.first().image.contentUrl,
+    url: '/series/' + list.url,
+    description: list.description
+  } %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
+
+  <meta name="description" content="{{ list.description }}" />
+{% endblock %}
+
 {% block body %}
   <div class="row bg-cream  {{ {s:3, m:5, l:5} | spacingClasses({padding: ['top']}) }} }}">
     <div class="container">

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -1,5 +1,23 @@
 {% extends 'layout/default.njk' %}
 
+{% set metaTitle = 'Wellcome Collection search' %}
+{% if query %}
+  {% set metaTitle = 'Wellcome Collection search: ' + query %}
+{% endif %}
+
+{% block pageMeta %}
+  {% set metaContent = {
+    type: 'website',
+    title: metaTitle,
+    image: resultsList.results[0].imgLink | replace('WIDTH', 1200),
+    url: '/search' + queryString
+  } %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
+
+  <meta name="description" content="A Wellcome Collection search for '{{ query }}'" />
+{% endblock %}
+
 {% block body %}
   {% componentV2 'page-description', { title: 'Search' }, {'hidden': true} %}
   <div class="row bg-cream

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -1,6 +1,15 @@
 {% extends 'layout/default.njk' %}
 
 {% block pageMeta %}
+  {% set metaContent = {
+    type: 'wellcome:work',
+    title: work.title,
+    image: work.imgLink | replace('WIDTH', 1200),
+    url: '/works/' + work.id,
+    description: work.description
+  } %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
   <link rel="canonical" href="{{ requestHost }}{{ requestPath }}" />
 {% endblock %}
 

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -2,7 +2,7 @@
 
 {% block pageMeta %}
   {% set metaContent = {
-    type: 'wellcome:work',
+    type: 'website',
     title: work.title,
     image: work.imgLink | replace('WIDTH', 1200),
     url: '/works/' + work.id,
@@ -10,6 +10,8 @@
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
+
+  <meta name="description" content="{{ work.description }}" />
   <link rel="canonical" href="{{ requestHost }}{{ requestPath }}" />
 {% endblock %}
 


### PR DESCRIPTION
References #1310

## Type
🚑  Health

- [ ] Demoed to @

## Value
Adds Open Graph/Twitter card meta data to `work`, `event` and `exhibition` pages.

## Screenshot
<img width="260" alt="screen shot 2017-08-21 at 17 40 27" src="https://user-images.githubusercontent.com/1394592/29529819-13304230-8699-11e7-920d-6e37f2c7d08a.png">


## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
