### PR TITLE
Update remaining CC-BYs to CC BY

### DIFF
--- a/server/views/components/license/license.config.js
+++ b/server/views/components/license/license.config.js
@@ -15,15 +15,15 @@ export const context = { model: license };
 export const variants = [
   {
     name: 'CC BY',
-    context: { model: Object.assign({}, license, {licenseType: 'CC-BY'}) }
+    context: { model: Object.assign({}, license, {licenseType: 'CC BY'}) }
   },
   {
     name: 'CC BY NC',
-    context: { model: Object.assign({}, license, {licenseType: 'CC-BY-NC'}) }
+    context: { model: Object.assign({}, license, {licenseType: 'CC BY-NC'}) }
   },
   {
     name: 'CC BY NC ND',
-    context: { model: Object.assign({}, license, {licenseType: 'CC-BY-NC-ND'}) }
+    context: { model: Object.assign({}, license, {licenseType: 'CC BY-NC-ND'}) }
   },
   {
     name: 'PDM',


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Uses correct (non-hyphenated) 'CC BY' attribution in Cardigan (already changed elsewhere).
