### PR TITLE
Error handling

### DIFF
--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -11,17 +11,18 @@ export const article = async(ctx, next) => {
   const slug = ctx.params.slug;
   const format = ctx.request.query.format;
   const article = await getArticle(`slug:${slug}`);
-  const editorialAnalyticsInfo = getEditorialAnalyticsInfo(article);
-  const pageConfig = createPageConfig(Object.assign({}, {
-    title: article.headline,
-    inSection: 'explore',
-    category: 'editorial'
-  }, editorialAnalyticsInfo));
 
   if (article) {
     if (format === 'json') {
       ctx.body = article;
     } else {
+      const editorialAnalyticsInfo = getEditorialAnalyticsInfo(article);
+      const pageConfig = createPageConfig(Object.assign({}, {
+        title: article.headline,
+        inSection: 'explore',
+        category: 'editorial'
+      }, editorialAnalyticsInfo));
+
       ctx.render('pages/article', {pageConfig, article});
     }
   }

--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -38,6 +38,7 @@ export const work = async(ctx, next) => {
   const id = ctx.params.id;
   const queryString = ctx.search;
   const singleWork = await getWork(id);
+
   const miroId = singleWork.identifiers[0].value;
   const imgWidth = '2048';
   const imgLink = imageUrlFromMiroId(miroId, shouldUseIiif(ctx));

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -13,11 +13,11 @@ export default function() {
       }
       console.error(err)
       ctx.status = err.status || 500;
-      console.error(err);
 
       ctx.render('pages/error', {
+        errorStatus: ctx.status,
         pageConfig: createPageConfig({
-          title: `We did a ${err.status} oopsy`
+          title: `${err.status} error`
         })
       });
     }

--- a/server/services/wellcomecollection-api.js
+++ b/server/services/wellcomecollection-api.js
@@ -8,11 +8,7 @@ const baseUri = `https://api.wellcomecollection.org/catalogue/${version}`;
 export async function getWork(id: string): Promise<Work> {
   return await superagent.get(`${baseUri}/works/${id}`)
     .query({includes: 'identifiers'})
-    .then((request) => {
-      return request.body;
-    }).catch((error) => {
-      return { error };
-    });
+    .then((request) => request.body);
 }
 
 export async function getWorks(query: string, page: string): Promise<Work> {

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -1,5 +1,5 @@
 {% extends 'layout/default.njk' %}
 
 {% block body %}
-  {% componentV2 'page-description', { title: '😊Oopsy something is amiss😊' } %}
+  {% componentV2 'page-description', { title: errorStatus + '' } %}
 {% endblock %}


### PR DESCRIPTION

## Type
<!-- delete as appropriate -->
🐛 Bugfix  

404 when we should 404 - `catch`ing promises is no longer really necessary with `async`.

This just sends the API error to the client, which isn't great, but at least prevents other programatic errors further down the chain.