### PR TITLE
Give templates access to request URL via pageConfig object

### DIFF
--- a/cardigan/fractal-app.js
+++ b/cardigan/fractal-app.js
@@ -22,7 +22,7 @@ const nunjucks = Nunjucks({
   filters: filters.toJS(),
   extensions: extensionsWithEnv.toJS(),
   globals: {
-    pageConfig: createPageConfig({ title: 'Cardigan', inSection: 'explore' })
+    pageConfig: createPageConfig({ title: 'Cardigan', inSection: 'explore', path: '/' })
   }
 });
 fractal.components.engine(nunjucks);

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -16,6 +16,7 @@ import {getExhibition} from '../services/exhibitions';
 
 export const renderArticle = async(ctx, next) => {
   const format = ctx.request.query.format;
+  const path = ctx.request.url;
   // We rehydrate the `W` here as we take it off when we have the route.
   const id = `W${ctx.params.id}`;
   const preview = Boolean(ctx.params.preview);
@@ -27,6 +28,7 @@ export const renderArticle = async(ctx, next) => {
     } else {
       ctx.render('pages/article', {
         pageConfig: Object.assign({}, createPageConfig({
+          path: path,
           title: article.title,
           inSection: 'explore',
           category: 'editorial'
@@ -73,6 +75,7 @@ export async function renderEvent(ctx, next) {
   const id = `${ctx.params.id}`;
   const event = await getEvent(id);
   const format = ctx.request.query.format;
+  const path = ctx.request.url;
 
   if (event) {
     if (format === 'json') {
@@ -80,6 +83,7 @@ export async function renderEvent(ctx, next) {
     } else {
       ctx.render('pages/event', {
         pageConfig: createPageConfig({
+          path: path,
           title: event.title,
           inSection: 'whatson',
           category: 'publicprograms',
@@ -96,6 +100,7 @@ export async function renderExhibition(ctx, next) {
   const preview = Boolean(ctx.params.preview);
   const exhibition = await getExhibition(id, preview ? ctx.request : null);
   const format = ctx.request.query.format;
+  const path = ctx.request.url;
 
   if (exhibition) {
     if (format === 'json') {
@@ -103,6 +108,7 @@ export async function renderExhibition(ctx, next) {
     } else {
       ctx.render('pages/exhibition', {
         pageConfig: createPageConfig({
+          path: path,
           title: exhibition.title,
           inSection: 'whatson',
           category: 'publicprograms',
@@ -151,9 +157,11 @@ export async function renderExplore(ctx, next) {
 
   // TODO: Remove this, make it automatic
   const latestTweets = ctx.intervalCache.get('tweets');
+  const path = ctx.request.url;
 
   ctx.render('pages/curated-lists', {
     pageConfig: createPageConfig({
+      path: path,
       title: 'Explore',
       inSection: 'explore',
       category: 'list'

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -11,6 +11,7 @@ export const article = async(ctx, next) => {
   const slug = ctx.params.slug;
   const format = ctx.request.query.format;
   const article = await getArticle(`slug:${slug}`);
+  const path = ctx.request.url;
 
   if (article) {
     if (format === 'json') {
@@ -18,6 +19,7 @@ export const article = async(ctx, next) => {
     } else {
       const editorialAnalyticsInfo = getEditorialAnalyticsInfo(article);
       const pageConfig = createPageConfig(Object.assign({}, {
+        path: path,
         title: article.headline,
         inSection: 'explore',
         category: 'editorial'
@@ -31,6 +33,7 @@ export const article = async(ctx, next) => {
 };
 
 export const articles = async(ctx, next) => {
+  const path = ctx.request.url;
   const {page, q} = ctx.request.query;
   const articleStubsResponse = await getArticleStubs(maxItemsPerPage, {page}, q);
   const series: Series = {
@@ -44,6 +47,7 @@ export const articles = async(ctx, next) => {
 
   ctx.render('pages/list', {
     pageConfig: createPageConfig({
+      path: path,
       title: 'Articles',
       inSection: 'explore',
       category: 'list'
@@ -58,6 +62,7 @@ export const articles = async(ctx, next) => {
 export const series = async(ctx, next) => {
   const {id, page} = ctx.params;
   const series = await getSeries(id, maxItemsPerPage, page);
+  const path = ctx.request.url;
 
   if (series) {
     const promoList = PromoListFactory.fromSeries(series);
@@ -65,6 +70,7 @@ export const series = async(ctx, next) => {
 
     ctx.render('pages/list', {
       pageConfig: createPageConfig({
+        path: path,
         title: series.name,
         inSection: 'explore',
         category: 'list',
@@ -79,7 +85,7 @@ export const series = async(ctx, next) => {
 };
 
 export const index = (ctx, next) => ctx.render('pages/index', {
-  pageConfig: createPageConfig({inSection: 'index'})
+  pageConfig: createPageConfig({inSection: 'index', path: '/'})
 }) && next();
 
 export const preview = async(ctx, next) => {
@@ -87,6 +93,7 @@ export const preview = async(ctx, next) => {
   const format = ctx.request.query.format;
   const authToken = ctx.cookies.get('WC_wpAuthToken');
   const article = await getArticle(id, authToken);
+  const path = ctx.request.url;
 
   if (article) {
     if (format === 'json') {
@@ -94,6 +101,7 @@ export const preview = async(ctx, next) => {
     } else {
       ctx.render('pages/article', {
         pageConfig: createPageConfig({
+          path: path,
           title: article.headline,
           inSection: 'explore'
         }),

--- a/server/controllers/utils.js
+++ b/server/controllers/utils.js
@@ -6,8 +6,10 @@ export const healthcheck = (ctx, next) => {
 };
 
 export const featureFlags = (ctx, next) => {
+  const path = ctx.request.url;
+
   ctx.render('pages/flags', {
-    pageConfig: createPageConfig({inSection: 'index'})
+    pageConfig: createPageConfig({inSection: 'index', path: path})
   });
   return next();
 };

--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -50,6 +50,7 @@ export const work = async(ctx, next) => {
     requestHost,
     requestPath,
     pageConfig: createPageConfig({
+      path: requestPath,
       title: 'Work',
       inSection: 'explore',
       category: 'collections'
@@ -94,10 +95,12 @@ export const search = async (ctx, next) => {
     totalPages,
     totalResults
   });
+  const path = ctx.request.url;
 
   const pagination = PaginationFactory.fromList(List(resultsWithImages), parseInt(totalResults, 10) || 1, parseInt(page, 10) || 1, pageSize || 1, ctx.query);
   ctx.render('pages/search', {
     pageConfig: createPageConfig({
+      path: path,
       inSection: 'index'
     }),
     resultsList,

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -11,12 +11,14 @@ export default function() {
       if (404 !== err.status) {
         Raven.captureException(err, {extra: {url: ctx.request.href}});
       }
+      const path = ctx.request.url;
       console.error(err)
       ctx.status = err.status || 500;
 
       ctx.render('pages/error', {
         errorStatus: ctx.status,
         pageConfig: createPageConfig({
+          path: path,
           title: `${err.status} error`
         })
       });

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -6,6 +6,7 @@ import {wellcomeCollection} from './organization';
 
 // TODO: Make this a strict object, but then we have problems with Object.assign...
 export type PageConfig = {
+  path: string;
   title: string;
   inSection?: string;
   openingHours?: PlacesOpeningHours;

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -5,7 +5,7 @@
     type: 'article',
     title: article.headline,
     image: article.thumbnail.contentUrl,
-    url: article.url,
+    url: pageConfig.path,
     description: article.description
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -5,7 +5,7 @@
     type: 'website',
     title: pageConfig.title,
     image: promos.first().image.contentUrl,
-    url: '/explore'
+    url: pageConfig.path
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/server/views/pages/event.njk
+++ b/server/views/pages/event.njk
@@ -5,7 +5,7 @@
     type: 'website',
     title: event.title,
     image: event.promo.media.contentUrl,
-    url: '/events/' + event.id
+    url: pageConfig.path
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -5,7 +5,7 @@
     type: 'website',
     title: exhibition.title,
     image: exhibition.featuredImage.contentUrl,
-    url: '/exhibitions/' + exhibition.id
+    url: pageConfig.path
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -5,7 +5,7 @@
     type: 'website',
     title: list.name,
     image: list.items.first().image.contentUrl,
-    url: '/series/' + list.url,
+    url: pageConfig.path,
     description: list.description
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -10,7 +10,7 @@
     type: 'website',
     title: metaTitle,
     image: resultsList.results[0].imgLink | replace('WIDTH', 1200),
-    url: '/search' + queryString
+    url: pageConfig.path
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -5,7 +5,7 @@
     type: 'website',
     title: work.title,
     image: work.imgLink | replace('WIDTH', 1200),
-    url: '/works/' + work.id,
+    url: pageConfig.path,
     description: work.description
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/server/views/templates/event.config.js
+++ b/server/views/templates/event.config.js
@@ -14,7 +14,7 @@ export const name = 'event';
 export const handle = 'event-template';
 
 export const context = {
-  pageConfig: createPageConfig({inSection: 'whatson'}),
+  pageConfig: createPageConfig({inSection: 'whatson', path: '/cardigan/event'}),
   articlePromos: getFourArticlePromos(),
   event: getEvent('WXmdTioAAJWWjZdH'),
   tags: '@tags.model',

--- a/server/views/templates/exhibition.config.js
+++ b/server/views/templates/exhibition.config.js
@@ -15,7 +15,7 @@ export const name = 'exhibition';
 export const handle = 'exhibition-template';
 
 export const context = {
-  pageConfig: createPageConfig({inSection: 'whatson'}),
+  pageConfig: createPageConfig({inSection: 'whatson', path: '/cardigan/exhibition'}),
   event: getEvent('WXmdTioAAJWWjZdH'),
   exhibition: getExhibition('WZQhjSoAAJqjjuw1'),
   articlePromos: getFourArticlePromos(),


### PR DESCRIPTION
## Type
🚑  Health

## Value
Gives every template access to the requested URL (i.e. the path being rendered) via the `pageConfig` object. Useful for e.g. consistently passing the shareable URL along with Twitter card and Open Graph data.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
