### PR TITLE
Added item id to ‘back to results' link

### DIFF
--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -46,6 +46,7 @@ export const work = async(ctx, next) => {
   const requestPath = ctx.request.path;
 
   ctx.render('pages/work', {
+    id,
     queryString,
     requestHost,
     requestPath,

--- a/server/views/components/promo/promo.njk
+++ b/server/views/components/promo/promo.njk
@@ -48,7 +48,7 @@
   {% endif %}
 {% endif %}
 
-<{{ 'a' if model.url else 'span' }}
+<{{ 'a' if model.url else 'span' }} id="{{model.id}}"
   {% if model.url %}href="{{ model.url }}"{% endif %}
   class="promo {% for modifier in model.modifiers %}promo--{{ modifier }} {% endfor %} promo--{{ model.contentType }} {{ 'promo--surrogate' if not model.url }}">
     <div class="promo__image-container {% if data.isConstrained %} promo__image-container--constrained {% endif %}">

--- a/server/views/components/work-media/work-media.njk
+++ b/server/views/components/work-media/work-media.njk
@@ -2,7 +2,7 @@
   <div class="work-media__controls js-work-media-controls pointer-events-none">
     {% if model.queryString %}
       <div class="flush-container-left {{ {s:2} | spacingClasses({padding: ['top']}) }}">
-        <a href="/search{{ model.queryString }}"
+        <a href="/search{{ model.queryString }}#{{model.id}}"
           class="flex flex--v-center {{ {s:'HNM6', m:'HNM5'} | fontClasses }} font-white plain-link pointer-events-all js-work-media-control">
           {% icon 'actions/arrow-small', null, ['icon--match-text', 'icon--white', 'icon--90', 'margin-right-s1', 'margin-right-m1', 'margin-right-l1', 'margin-right-xl1'] %}Return to results
         </a>

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -90,7 +90,7 @@
             {% set img = {contentUrl: result.imgLink, width: 300, height: 300} %}
             {% set type = result.type | lower %}
             {% set url = '/works/' + result.id + queryString %}
-            {% componentV2 'promo', {contentType: type, title: result.title, url: url, image: img | objectAssign({ isIiif: true }), datePublished: result.createdDate.label}, {}, {isConstrained: true, sizes: '(min-width: 1340px) 178px, (min-width: 960px) calc(25vw - 52px), (min-width: 600px) calc(33.24vw - 43px), calc(50vw - 27px)'} %}
+            {% componentV2 'promo', {id: result.id, contentType: type, title: result.title, url: url, image: img | objectAssign({ isIiif: true }), datePublished: result.createdDate.label}, {}, {isConstrained: true, sizes: '(min-width: 1340px) 178px, (min-width: 960px) calc(25vw - 52px), (min-width: 600px) calc(33.24vw - 43px), calc(50vw - 27px)'} %}
           </div>
           {% endfor %}
         </div>

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -18,7 +18,7 @@
 {% block body %}
   {% set iiifModel = {contentUrl: work.imgLink, caption: work.description, width: work.imgWidth} %}
   {% set iiifData = {lazyload: true, sizesQueries: '(min-width: 1420px) 1218px, (min-width: 600px) 87.75vw, calc(100vw - 36px)'} %}
-  {% componentV2 'work-media', {queryString: queryString, iiifModel: iiifModel, iiifData: iiifData} %}
+  {% componentV2 'work-media', {id: id, queryString: queryString, iiifModel: iiifModel, iiifData: iiifData} %}
 
   <div class="row {{ {s:3, m:3, l:3, xl: 3} | spacingClasses({padding: ['top', 'bottom']}) }}">
     <div class="container">


### PR DESCRIPTION
Fixes #1376

## Type
✨ Feature 

## Value
Positions page at appropriate search result, when using 'back to results link' - so people can quickly pick up where they left off

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
