### PR TITLE
fallback to v2 for 404 articles, exhibitions, and events

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -39,7 +39,17 @@ http {
     server_name      wellcomecollection.org;
     add_header       'X-wc-nginx-proxy' 'true';
 
-    location ~ ^/assets|async|explore|works {
+    location ~ ^/assets|/async|/explore|/works {
+      proxy_set_header Host $host;
+      proxy_pass       http://wellcomecollection:3000;
+    }
+
+    location ~ ^/articles|/exhibitions|/events {
+      proxy_intercept_errors on;
+      error_page 404 =200 @v2;
+    }
+
+    location @v2 {
       proxy_set_header Host $host;
       proxy_pass       http://wellcomecollection:3000;
     }


### PR DESCRIPTION
## Type
✨ Feature  

If we hit a 404 on `/articles`, `/events`, or `/exhibitions` - we `proxy_pass` to  V2.