### PR TITLE
try to intercept 404 errors from prev.wc.org

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -45,7 +45,10 @@ http {
     }
 
     location ~ ^/articles|/exhibitions|/events {
-      proxy_intercept_errors on;
+      proxy_pass                 http://prev.wellcomecollection.org;
+      proxy_set_header           Host $host;
+      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
+      proxy_intercept_errors     on;
       error_page 404 =200 @v2;
     }
 


### PR DESCRIPTION
## Type
🐛 Bugfix  

I forgot to actually send the site to prev, so we were hitting 404 for everything.