### PR TITLE
explicitly set the root domain in config

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -14,7 +14,7 @@ const app = new Koa();
 app.proxy = true;
 app.use(intervalCache());
 app.use(determineFeaturesCohort());
-app.use(render(config.views.path));
+app.use(render(config.views.path, config.globals[app.env]));
 // `error` is only after `intervalCache` and `render` as there's a dependency chain there
 // TODO: remove dependency chain
 app.use(error());

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -3,6 +3,16 @@ const config = {
     name: 'wellcomecollection.org',
     version: '0.0.1'
   },
+  globals: {
+    development: {
+      rootDomain: '',
+      nextDomain: ''
+    },
+    production: {
+      rootDomain: 'https://wellcomecollection.org',
+      nextDomain: 'https://next.wellcomecollection.org'
+    }
+  },
   server: {
     port: 3000
   },

--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -42,14 +42,10 @@ export const work = async(ctx, next) => {
   const miroId = singleWork.identifiers[0].value;
   const imgWidth = '2048';
   const imgLink = imageUrlFromMiroId(miroId, shouldUseIiif(ctx));
-  const requestHost = `${ctx.request.protocol}://${ctx.request.host}`;
-  const requestPath = ctx.request.path;
 
   ctx.render('pages/work', {
     id,
     queryString,
-    requestHost,
-    requestPath,
     pageConfig: createPageConfig({
       title: 'Work',
       inSection: 'explore',

--- a/server/package.json
+++ b/server/package.json
@@ -5,9 +5,9 @@
   "main": "app.js",
   "scripts": {
     "app:build": "babel . -d .dist --ignore=node_modules --copy-files",
-    "app:dev": "nodemon -e js,njk,json --exec babel-node run.js",
+    "app:dev":    "nodemon -e js,njk,json --exec babel-node run.js",
     "app:docker": "pm2-docker --json pm2.yml",
-    "app:run": "pm2 start ./.dist/run.js --name 'wellcomecollection.org'",
+    "app:run":    "pm2 start pm2.yml",
     "optimise:svg": "node ./optimise-svgs.js",
     "test": "ava",
     "test:accessibility": "pa11y",

--- a/server/pm2.yml
+++ b/server/pm2.yml
@@ -2,3 +2,5 @@ apps:
   - script   : './.dist/run.js'
     name     : 'wellcomecollection.org'
     instances: 1
+    env:
+      NODE_ENV: "production"

--- a/server/run.js
+++ b/server/run.js
@@ -2,4 +2,4 @@ import config from './config';
 import app from './app';
 
 app.listen(config.server.port);
-console.info(`Server up and running on http://localhost:${config.server.port}`);
+console.info(`Server up and running on http://localhost:${config.server.port} in ${app.env}`);

--- a/server/view/render.js
+++ b/server/view/render.js
@@ -3,14 +3,14 @@ import {getEnvWithGlobalsExtensionsAndFilters} from './env-utils';
 import markdown from 'nunjucks-markdown';
 import marked from 'marked';
 
-export default function render(root) {
+export default function render(root, extraGlobals) {
   return (ctx, next) => {
     const [flags, cohorts] = ctx.intervalCache.get('flags');
-    const globals = Map({
+    const globals = Map(Object.assign({}, extraGlobals, {
       featuresCohort: ctx.featuresCohort,
       featureFlags: flags,
       cohorts: cohorts
-    });
+    }));
     const env = getEnvWithGlobalsExtensionsAndFilters(root, globals);
     ctx.render = (relPath, templateData) => ctx.body = env.render(`${relPath}.njk`, templateData);
     markdown.register(env, marked);

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -1,4 +1,6 @@
 {% extends 'layout/default.njk' %}
+{# TODO: Maybe set this on the actual work? #}
+{% set canonicalUri = rootDomain + '/works/' + work.id %}
 
 {% block pageMeta %}
   {% set metaContent = {
@@ -12,7 +14,7 @@
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
 
   <meta name="description" content="{{ work.description }}" />
-  <link rel="canonical" href="{{ requestHost }}{{ requestPath }}" />
+  <link rel="canonical" href="{{ canonicalUri }}" />
 {% endblock %}
 
 {% block body %}
@@ -95,7 +97,7 @@
               {{ {s:1} | spacingClasses({margin: ['bottom']}) }}">
                 Share
             </h2>
-            {% componentV2 'copy-url', {id: work.id, url: requestHost + requestPath} %}
+            {% componentV2 'copy-url', {id: work.id, url: canonicalUri} %}
           </div>
         </div>
       </div>

--- a/server/views/templates/work.config.js
+++ b/server/views/templates/work.config.js
@@ -8,8 +8,6 @@ export const context = {
   // temp license, img, etc. data until we know how this is coming from the API
   work: Object.assign({}, mockJson, {
     license: 'CC BY-NC',
-    requestHost: 'https://next.wellcomecollection.org',
-    requestPath: '/works/a22au6yn',
     imgLink: 'https://wellcomecollection-miro-images.imgix.net/V0047000/V0047696.jpg',
     imgWidth: 1000,
     moreInfo: [


### PR DESCRIPTION
Alternative to #1384

## Type
🚑 Health

By explicitly setting the path - it is no longer a contextual variable which could cause trouble with cache e.g. Someone hits the site using another request URL (the origin perhaps) - this could get cached and then served with the wrong domain to someone visiting from the normal domain.

I'd also like to use this as an opportunity to start using the root wc.org domain, this way we make sure we're getting all the SEO juice to the same place (#1387 #1388 #1389 helps with this).

@jennpb ^ in regards to this - it would be good to see if we can get the Editorial team to start sharing from the root too - let's chat.