### PR TITLE
Use the uri query parameter to distinguish cached URLs

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -78,7 +78,7 @@ resource "aws_cloudfront_distribution" "next" {
     forwarded_values {
       headers                 = ["Host"]
       query_string            = true
-      query_string_cache_keys = ["page", "current", "q", "format", "query", "cohort"]
+      query_string_cache_keys = ["page", "current", "q", "format", "query", "cohort", "uri"]
 
       cookies {
         forward           = "whitelist"


### PR DESCRIPTION
I haven’t demoed or tried this – I don’t think I have access to your AWS account? But this is my best guess for what’s causing #1394, so hopefully resolves that (when applied).