### PR TITLE
Tweak the social media preview for the root search page

### DIFF
--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -5,6 +5,8 @@
   {% set metaTitle = 'Wellcome Collection search: ' + query %}
 {% endif %}
 
+{% set description = 'Explore 53,000 Artworks and Photos' %}
+
 {% block pageMeta %}
   {% set metaContent = {
     type: 'website',
@@ -15,7 +17,11 @@
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
 
+  {% if query %}
   <meta name="description" content="A Wellcome Collection search for '{{ query }}'" />
+  {% else %}
+  <meta name="description" content="{{ description }}">
+  {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -28,7 +34,7 @@
         <div class="{{ {s:12, m:10, l:8, xl:8} | gridClasses }}">
           {% if not query %}
             <span class="font-turquoise-text caps {{ {s:'WB7', l:'WB6'} | fontClasses }}">New</span>
-            <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }} {{ {s:0} | spacingClasses({margin: ['top']}) }}">Explore 53,000 Artworks and Photos</h2>
+            <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }} {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{ description }}</h2>
           {% endif %}
           {% componentV2 'search-box', {id: 'search-works', action: '', name: 'query', query: query, autofocus: true} %}
           {% if not query %}


### PR DESCRIPTION
This tweaks the social media preview on the root search page – where currently it says _A Wellcome Collection search for ''_, now it says _Explore 53,000 Artworks and Photos_. I saw this in Slack this afternoon and it was annoying me, so I changed it. Views for search result pages are unchanged.

Before:

![screen shot 2017-08-24 at 19 21 24](https://user-images.githubusercontent.com/301220/29682039-85376ccc-8901-11e7-8ecb-f0fd2325ba2f.png)

After:

![screen shot 2017-08-24 at 19 21 45](https://user-images.githubusercontent.com/301220/29682038-83a866d6-8901-11e7-86b5-f7bb3fecb823.png)

(I don’t feel strongly about the new wording, but it feels like an improvement on the current state of affairs.)