### PR TITLE
Dont force 200

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -51,7 +51,7 @@ http {
       proxy_set_header           Host $host;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
       proxy_intercept_errors     on;
-      error_page 404 =200 @v2;
+      error_page 404 = @v2;
     }
 
     location @v2 {


### PR DESCRIPTION
## Type
🐛 Bugfix  

Currently we force a `200` (my lack of understanding thought it would 200, then inherit the new location's code) - this will inherit whatever code v2 responds with.