### PR TITLE
Slider controls

### DIFF
--- a/client/js/components/content-slider.js
+++ b/client/js/components/content-slider.js
@@ -42,6 +42,8 @@ const contentSlider = (el, options) => {
   const sliderModifiers = setModifiers('slider');
   const slidesContainerModifiers = setModifiers('slides-container');
   const sliderControlsModifiers = setModifiers('slider-controls');
+  const inContent = settings.modifiers.indexOf('in-content') > -1;
+  const flushRightClass = inContent ? 'flush-container-right' : '';
 
   // Generate classes for slider elements
   const classes = {
@@ -50,7 +52,7 @@ const contentSlider = (el, options) => {
     slidesContainer: `slides-container`,
     sliderItem: `slide-item`,
     currentItem: `slide-item--current`,
-    sliderControls: `slider-controls  ${sliderControlsModifiers}`,
+    sliderControls: `slider-controls  ${sliderControlsModifiers} ${flushRightClass}`,
     prevControl: `slider-control--prev`,
     nextControl: `slider-control--next`,
     sliderControlInactive: `slider-control--inactive`

--- a/client/scss/components/_slider__gallery.scss
+++ b/client/scss/components/_slider__gallery.scss
@@ -58,8 +58,3 @@
     }
   }
 }
-
-.slider-controls--gallery {
-  top: -15 * $spacing-unit;
-  position: relative;
-}

--- a/client/scss/components/_slider__in-article.scss
+++ b/client/scss/components/_slider__in-article.scss
@@ -17,3 +17,9 @@
     }
   }
 }
+
+.slider-controls--in-article {
+  @include respond-to('xlarge') {
+    margin-right: ($container-width-max / 12) * 1;
+  }
+}

--- a/client/scss/components/_slider__in-content.scss
+++ b/client/scss/components/_slider__in-content.scss
@@ -36,6 +36,8 @@ $slider-control-margin: 18px;
 }
 
 .slider-controls--in-content {
+  bottom: $spacing-unit * 6;
+
   /* stylelint-disable plugin/selector-bem-pattern */
   .control-arrow {
     width: 16px;
@@ -54,14 +56,6 @@ $slider-control-margin: 18px;
     cursor: pointer;
     outline: none;
     overflow: hidden;
-    position: relative;
-    margin-left: calc(100% - (2 * #{$slider-control-size} + #{$slider-control-margin}));
-
-    // this calculation is related to the gallery appearing in the article template
-    @include respond-to('xlarge') {
-      margin-left: 50%;
-      left: -(($container-width-max - (map-get($container-padding, 'large') * 2)) / 2) * (-5/6) - ((2 * $slider-control-size) + $slider-control-margin);
-    }
 
     &:focus {
       background: color('smoke');

--- a/client/scss/components/_slider__transporter.scss
+++ b/client/scss/components/_slider__transporter.scss
@@ -5,4 +5,3 @@
     padding-top: 0;
   }
 }
-

--- a/client/scss/components/_slider__transporter.scss
+++ b/client/scss/components/_slider__transporter.scss
@@ -1,5 +1,6 @@
 .slider--transporter {
   margin-top: 0;
+  padding-bottom: 5 * $spacing-unit;
 
   .slider-inner {
     padding-top: 0;

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -119,7 +119,7 @@
             <div class="grid grid--no-gutters">
               <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
                 <div class="body-part body-part--full-width">
-                  <div class="{{ {s:10} | spacingClasses({padding: ['bottom']}) }} relative">
+                  <div class="{{ {s:8} | spacingClasses({padding: ['bottom']}) }}">
                     <div class="wobbly-edge wobbly-edge--white wobbly-edge--small js-wobbly-edge" data-is-static="true"></div>
                     {% set asyncContentEndpoint = '/series-transporter/' + series.url + '?current=' + article.url %}
                     {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-article": true}' } %}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -114,14 +114,16 @@
   {% block transporters %}
     {% for series in article.series %}
       {% if series.commissionedLength %}
-        <div class="row {{ {s:10} | spacingClasses({padding: ['top']}) }} {{ {s:5} | spacingClasses({padding: ['bottom']}) }}">
+        <div class="row {{ {s:10} | spacingClasses({padding: ['top']}) }}">
           <div class="container digital-story-transporter">
             <div class="grid grid--no-gutters">
               <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">
                 <div class="body-part body-part--full-width">
-                  <div class="wobbly-edge wobbly-edge--white wobbly-edge--small js-wobbly-edge" data-is-static="true"></div>
-                  {% set asyncContentEndpoint = '/series-transporter/' + series.url + '?current=' + article.url %}
-                  {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-article": true}' } %}
+                  <div class="{{ {s:10} | spacingClasses({padding: ['bottom']}) }} relative">
+                    <div class="wobbly-edge wobbly-edge--white wobbly-edge--small js-wobbly-edge" data-is-static="true"></div>
+                    {% set asyncContentEndpoint = '/series-transporter/' + series.url + '?current=' + article.url %}
+                    {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-article": true}' } %}
+                  </div>
                 </div>
               </div>
             </div>

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -46,7 +46,7 @@
       {% if section.value.data.commissionedLength %}
         {# Digital stories #}
         <div class="row {{ {s:2} | spacingClasses({padding:['top']}) }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }} relative">
-          <div class="container container--scroll-xl {{ {s:6} | spacingClasses({padding: ['bottom']}) }}">
+          <div class="container container--scroll-xl">
             <div class="grid grid--no-gutters">
               <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | gridClasses }}">
                 {% set asyncContentEndpoint = '/series-transporter/' + section.value.data.wordpressSlug %}

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -45,8 +45,8 @@
     {% if section.slice_type === 'series' %}
       {% if section.value.data.commissionedLength %}
         {# Digital stories #}
-        <div class="row {{ {s:2} | spacingClasses({padding:['top']}) }}">
-          <div class="container container--scroll-xl">
+        <div class="row {{ {s:2} | spacingClasses({padding:['top']}) }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }} relative">
+          <div class="container container--scroll-xl {{ {s:6} | spacingClasses({padding: ['bottom']}) }}">
             <div class="grid grid--no-gutters">
               <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | gridClasses }}">
                 {% set asyncContentEndpoint = '/series-transporter/' + section.value.data.wordpressSlug %}
@@ -56,7 +56,7 @@
           </div>
           <div class="{{ {s:4} | spacingClasses({margin:['top']}) }}">
             <div class="container container--no-collapse">
-              {% componentV2 'divider', null, {'thick': true, 'black': true}, {extraClasses: [{s:5} | spacingClasses({margin: ['bottom']})]} %}
+              {% componentV2 'divider', null, {'thick': true, 'black': true} %}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Type
🐛  Bugfix  

## Value
Currently, only the top half of '+more' links under images in galleries is clickable – the bottom half is obscured by the slider controls. This fixes that issue, by using a pre-existing helper class.

It has the side-benefit of aligning the controls beneath the transporter on the explore page correctly (at present they're too far to the left).

## Screenshot
![more](https://user-images.githubusercontent.com/1394592/29714841-c7129f36-899c-11e7-8e3c-54a6a3acaa09.gif)

![screen shot 2017-08-25 at 13 50 05](https://user-images.githubusercontent.com/1394592/29714847-cca288bc-899c-11e7-9be3-ac3962fb1be2.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
