### PR TITLE
get tasl from prismic

### DIFF
--- a/server/filters/get-tasl-markup.js
+++ b/server/filters/get-tasl-markup.js
@@ -1,6 +1,6 @@
 import getLicenseInfo from './get-license-info';
 
-function setTitle(title, author, sourceLink) {
+function getTitleHtml(title, author, sourceLink) {
   if (!title) return '';
 
   const byAuthor = author ? `, by ${author}` : '';
@@ -12,7 +12,7 @@ function setTitle(title, author, sourceLink) {
   }
 }
 
-function setSource(sourceName, sourceLink) {
+function getSourceHtml(sourceName, sourceLink) {
   if (!sourceName) return '';
 
   if (sourceLink) {
@@ -22,22 +22,22 @@ function setSource(sourceName, sourceLink) {
   }
 }
 
-function setCopyright(copyrightHolder, copyrightLink) {
+function getCopyrightHtml(copyrightHolder, copyrightLink) {
   if (!copyrightHolder) return '';
 
   if (copyrightLink) {
-    return `Copyright: <a href="${copyrightLink}">${copyrightHolder}</a>. `;
+    return `&copy; <a href="${copyrightLink}">${copyrightHolder}</a>. `;
   } else {
-    return `Copyright: ${copyrightHolder}. `;
+    return `&copy; ${copyrightHolder}. `;
   }
 }
 
 export default function({title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink}) {
-  const titleMarkup = setTitle(title, author, sourceLink);
-  const sourceMarkup = setSource(sourceName, sourceLink);
+  const titleHtml = getTitleHtml(title, author, sourceLink);
+  const sourceHtml = getSourceHtml(sourceName, sourceLink);
   const licenseInfo = license && getLicenseInfo(license);
-  const copyrightMarkup = setCopyright(copyrightHolder, copyrightLink);
-  const licenseMarkup = licenseInfo ? `<a rel="license" href="${licenseInfo.url}">${licenseInfo.text}</a>.` : '';
+  const copyrightHtml = getCopyrightHtml(copyrightHolder, copyrightLink);
+  const licenseHtml = licenseInfo ? `<a rel="license" href="${licenseInfo.url}">${licenseInfo.text}</a>.` : '';
 
-  return `${titleMarkup}${sourceMarkup}${copyrightMarkup}${licenseMarkup}`;
+  return `${titleHtml}${sourceHtml}${copyrightHtml}${licenseHtml}`;
 }

--- a/server/filters/get-tasl-markup.js
+++ b/server/filters/get-tasl-markup.js
@@ -1,10 +1,43 @@
 import getLicenseInfo from './get-license-info';
 
-export default function({title, author, source, license}) {
-  const titleMarkup = source ? `<a rel="cc:attributionURL" property="dc:title" href="${source}">${title || source}</a>. ` : `<span property="dc:title">${title}.</span> `;
-  const authorMarkup = author ? `Credit: <span property="cc:attributionName">${author}.</span> ` : '';
+function setTitle(title, author, sourceLink) {
+  if (!title) return '';
+
+  const byAuthor = author ? `, by ${author}` : '';
+
+  if (sourceLink) {
+    return `<a href="${sourceLink}" property="dc:title" rel="cc:attributionURL">${title}${byAuthor}</a>. `;
+  } else {
+    return `<span property="dc:title">${title}${byAuthor}.</span> `;
+  }
+}
+
+function setSource(sourceName, sourceLink) {
+  if (!sourceName) return '';
+
+  if (sourceLink) {
+    return `Source: <a href="${sourceLink}" rel="cc:attributionURL">${sourceName}</a>. `;
+  } else {
+    return `Source: ${sourceName}. `;
+  }
+}
+
+function setCopyright(copyrightHolder, copyrightLink) {
+  if (!copyrightHolder) return '';
+
+  if (copyrightLink) {
+    return `Copyright: <a href="${copyrightLink}">${copyrightHolder}</a>. `;
+  } else {
+    return `Copyright: ${copyrightHolder}. `;
+  }
+}
+
+export default function({title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink}) {
+  const titleMarkup = setTitle(title, author, sourceLink);
+  const sourceMarkup = setSource(sourceName, sourceLink);
   const licenseInfo = license && getLicenseInfo(license);
+  const copyrightMarkup = setCopyright(copyrightHolder, copyrightLink);
   const licenseMarkup = licenseInfo ? `<a rel="license" href="${licenseInfo.url}">${licenseInfo.text}</a>.` : '';
 
-  return `${titleMarkup}${authorMarkup}${licenseMarkup}`;
+  return `${titleMarkup}${sourceMarkup}${copyrightMarkup}${licenseMarkup}`;
 }

--- a/server/filters/get-tasl-markup.js
+++ b/server/filters/get-tasl-markup.js
@@ -1,0 +1,10 @@
+import getLicenseInfo from './get-license-info';
+
+export default function({title, author, source, license}) {
+  const titleMarkup = source ? `<a rel="cc:attributionURL" property="dc:title" href="${source}">${title || source}</a>. ` : `<span property="dc:title">${title}.</span> `;
+  const authorMarkup = author ? `Credit: <span property="cc:attributionName">${author}.</span> ` : '';
+  const licenseInfo = license && getLicenseInfo(license);
+  const licenseMarkup = licenseInfo ? `<a rel="license" href="${licenseInfo.url}">${licenseInfo.text}</a>.` : '';
+
+  return `${titleMarkup}${authorMarkup}${licenseMarkup}`;
+}

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -32,6 +32,7 @@ import {
   formatAndDedupeOnTime
 } from './format-date';
 import getLicenseInfo from './get-license-info';
+import getTaslMarkup from './get-tasl-markup';
 
 export default Map({
   youtubeEmbedUrl,
@@ -65,5 +66,6 @@ export default Map({
   getLinkObjects,
   prettyDump,
   prismicAsHtml,
-  getLicenseInfo
+  getLicenseInfo,
+  getTaslMarkup
 });

--- a/server/model/license.js
+++ b/server/model/license.js
@@ -1,6 +1,7 @@
 // @flow
+export type LicenseType = | 'CC0' | 'CC-BY' | 'CC-BY-NC' | 'CC-BY-NC-ND' | 'PDM' | 'copyright-not-cleared';
 export type License = {|
   subject?: string;
-  licenseType: 'CC0' | 'CC-BY' | 'CC-BY-NC' | 'CC-BY-NC-ND' | 'PDM' | 'copyright-not-cleared';
+  licenseType: LicenseType;
 |};
 // Need to clarify what the API will deliver, 2 examples currently show CC BY-4.0 and CC BY-NC

--- a/server/model/picture.js
+++ b/server/model/picture.js
@@ -10,10 +10,9 @@ export type Picture = {|
   alt?: ?string;
   copyright?: ?string;
   author?: string;
-  copyrightHolder?: string;
   fileFormat?: string;
   url?: ?string;
-  attribute?: {title: ?string, author: ?string, source: ?string, license: LicenseType};
+  attribute?: {title: ?string, author: ?string, sourceName: ?string, sourceLink: ?string, license: LicenseType, copyrightHolder: ?string, copyrightLink: ?string};
 |}
 
 export function createPicture(data: Picture): Picture {

--- a/server/model/picture.js
+++ b/server/model/picture.js
@@ -1,4 +1,5 @@
 // @flow
+import type {LicenseType} from './license';
 export type Picture = {|
   type: 'picture';
   contentUrl: ?string;
@@ -12,6 +13,7 @@ export type Picture = {|
   copyrightHolder?: string;
   fileFormat?: string;
   url?: ?string;
+  attribute?: {title: ?string, author: ?string, source: ?string, license: LicenseType};
 |}
 
 export function createPicture(data: Picture): Picture {

--- a/server/model/picture.js
+++ b/server/model/picture.js
@@ -12,7 +12,11 @@ export type Picture = {|
   author?: string;
   fileFormat?: string;
   url?: ?string;
-  attribute?: {title: ?string, author: ?string, sourceName: ?string, sourceLink: ?string, license: LicenseType, copyrightHolder: ?string, copyrightLink: ?string};
+  title?: ?string;
+  author?: ?string;
+  source?: ?{name?: ?string, link?: ?string};
+  license?: ?string;
+  copyright?: ?{holder?: string, link?: string};
 |}
 
 export function createPicture(data: Picture): Picture {

--- a/server/model/picture.js
+++ b/server/model/picture.js
@@ -15,7 +15,7 @@ export type Picture = {|
   title?: ?string;
   author?: ?string;
   source?: ?{name?: ?string, link?: ?string};
-  license?: ?string;
+  license?: ?LicenseType;
   copyright?: ?{holder?: string, link?: string};
 |}
 

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -44,6 +44,8 @@ export function getFeaturedMediaFromBody(doc): ?Picture {
 
 export function prismicImageToPicture(captionedImage) {
   const image = isEmptyObj(captionedImage.image) ? null : captionedImage.image;
+  const attribute = image && image.copyright && getTaslFromCopyright(image.copyright);
+
   return ({
     type: 'picture',
     contentUrl: image && convertPrismicToImgIxUri(image.url), // TODO: Send this through the img.wc.org
@@ -51,8 +53,22 @@ export function prismicImageToPicture(captionedImage) {
     height: image && image.dimensions.height,
     caption: captionedImage.caption && captionedImage.caption.length !== 0 && asHtml(captionedImage.caption),
     alt: image && image.alt,
-    copyrightHolder: image && image.copyright
+    copyrightHolder: image && image.copyright,
+    attribute
   }: Picture);
+}
+
+function getTaslFromCopyright(copyright) {
+  // We expect a string of title\author\source\license
+  // e.g. \Rob Bidder\\CC-BY-NC
+  const list = copyright.split('\\');
+  const v = list
+    .concat(Array(4 - list.length))
+    .map(v => !v ? null : v.trim());
+
+  const [title, author, source, license] = v;
+
+  return {title, author, source, license};
 }
 
 export async function getArticle(id: string, previewReq: ?Request) {

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -44,7 +44,7 @@ export function getFeaturedMediaFromBody(doc): ?Picture {
 
 export function prismicImageToPicture(captionedImage) {
   const image = isEmptyObj(captionedImage.image) ? null : captionedImage.image;
-  const attribute = image && image.copyright && getTaslFromCopyright(image.copyright);
+  const tasl = image && image.copyright && getTaslFromCopyright(image.copyright);
 
   return ({
     type: 'picture',
@@ -53,7 +53,17 @@ export function prismicImageToPicture(captionedImage) {
     height: image && image.dimensions.height,
     caption: captionedImage.caption && captionedImage.caption.length !== 0 && asHtml(captionedImage.caption),
     alt: image && image.alt,
-    attribute
+    title: tasl && tasl.title,
+    author: tasl && tasl.author,
+    source: {
+      name: tasl && tasl.sourceName,
+      link: tasl && tasl.sourceLink
+    },
+    license: tasl && tasl.license,
+    copyright: {
+      holder: tasl && tasl.copyrightHolder,
+      link: tasl && tasl.copyrightLink
+    }
   }: Picture);
 }
 

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -53,22 +53,21 @@ export function prismicImageToPicture(captionedImage) {
     height: image && image.dimensions.height,
     caption: captionedImage.caption && captionedImage.caption.length !== 0 && asHtml(captionedImage.caption),
     alt: image && image.alt,
-    copyrightHolder: image && image.copyright,
     attribute
   }: Picture);
 }
 
 function getTaslFromCopyright(copyright) {
-  // We expect a string of title|author|source|license
-  // e.g. |Rob Bidder||CC-BY-NC
+  // We expect a string of title|author|sourceName|sourceLink|license|copyrightHolder|copyrightLink
+  // e.g. Self|Rob Bidder|||CC-BY-NC
   const list = copyright.split('|');
   const v = list
-    .concat(Array(4 - list.length))
+    .concat(Array(7 - list.length))
     .map(v => !v.trim() ? null : v);
 
-  const [title, author, source, license] = v;
+  const [title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink] = v;
 
-  return {title, author, source, license};
+  return {title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink};
 }
 
 export async function getArticle(id: string, previewReq: ?Request) {

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -59,12 +59,12 @@ export function prismicImageToPicture(captionedImage) {
 }
 
 function getTaslFromCopyright(copyright) {
-  // We expect a string of title\author\source\license
-  // e.g. \Rob Bidder\\CC-BY-NC
-  const list = copyright.split('\\');
+  // We expect a string of title|author|source|license
+  // e.g. |Rob Bidder||CC-BY-NC
+  const list = copyright.split('|');
   const v = list
     .concat(Array(4 - list.length))
-    .map(v => !v ? null : v.trim());
+    .map(v => !v.trim() ? null : v);
 
   const [title, author, source, license] = v;
 

--- a/server/util/prismic-parser.js
+++ b/server/util/prismic-parser.js
@@ -123,7 +123,7 @@ function createPrismicImageWithCaption(image: Picture) {
           y: 0
         }
       },
-      credits: image.attribute.copyrightHolder,
+      credits: image.copyright.holder,
       alt: image.alt,
       thumbnails: {}
     }

--- a/server/util/prismic-parser.js
+++ b/server/util/prismic-parser.js
@@ -123,7 +123,7 @@ function createPrismicImageWithCaption(image: Picture) {
           y: 0
         }
       },
-      credits: image.copyrightHolder,
+      credits: image.attribute.copyrightHolder,
       alt: image.alt,
       thumbnails: {}
     }

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -14,7 +14,7 @@
           {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
         {% endif %}
     {% endif %}
-    {% if (model.attribute and data.showCopyright) %}
+    {% if ((model.title or model.source.name or model.copyright.name or model.license) and data.showCopyright) %}
       <div
         data-component-name="Image credit drawer"
         data-component-id="image-credit"
@@ -26,7 +26,17 @@
           </span>
         </button>
         <div class="drawer__body js-show-hide-drawer bg-white {{ {s:1} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}">
-          {{ model.attribute | getTaslMarkup | safe }}
+          {% set tasl = {
+            title: model.title,
+            author: model.author,
+            sourceName: model.source.name,
+            sourceLink: model.source.link,
+            license: model.license,
+            copyrightHolder: model.copyright.holder,
+            copyrightLink: model.copyright.link
+          } %}
+
+          {{ tasl | getTaslMarkup | safe }}
         </div>
       </div>
     {% endif %}

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -14,7 +14,7 @@
           {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
         {% endif %}
     {% endif %}
-    {% if (model.copyrightHolder and data.showCopyright) %}
+    {% if (model.attribute and data.showCopyright) %}
       <div
         data-component-name="Image credit drawer"
         data-component-id="image-credit"
@@ -26,7 +26,7 @@
           </span>
         </button>
         <div class="drawer__body js-show-hide-drawer bg-white {{ {s:1} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}">
-          Credit: {{ model.copyrightHolder }}
+          {{ model.attribute | getTaslMarkup | safe }}
         </div>
       </div>
     {% endif %}

--- a/server/views/templates/article.config.js
+++ b/server/views/templates/article.config.js
@@ -34,17 +34,18 @@ const gifVideoPoster = createPicture({
 const smallPicture = createPicture({
   contentUrl: 'https://placehold.it/400x225',
   caption: 'Copyright Holder',
-  author: `Author's name`,
   width: 400,
   height: 225,
-  attribute: {
-    title: 'A Work',
-    author: 'Jo Bloggs',
-    sourceName: 'Wellcome Collection',
-    sourceLink: 'https://next.wellcomecollection.org/works/wygx8v4v',
-    license: 'CC-BY',
-    copyrightHolder: 'Wellcome Collection',
-    copyrightLink: 'http://wellcomecollection.org'
+  title: 'A Work',
+  author: 'Jo Bloggs',
+  source: {
+    name: 'Wellcome Collection',
+    link: 'https://next.wellcomecollection.org/works/wygx8v4v'
+  },
+  license: 'CC-BY',
+  copyright: {
+    holder: 'Wellcome Collection',
+    link: 'http://wellcomecollection.org'
   },
   fileFormat: 'png'
 });

--- a/server/views/templates/article.config.js
+++ b/server/views/templates/article.config.js
@@ -37,7 +37,15 @@ const smallPicture = createPicture({
   author: `Author's name`,
   width: 400,
   height: 225,
-  copyrightHolder: 'copyright holder',
+  attribute: {
+    title: 'A Work',
+    author: 'Jo Bloggs',
+    sourceName: 'Wellcome Collection',
+    sourceLink: 'https://next.wellcomecollection.org/works/wygx8v4v',
+    license: 'CC-BY',
+    copyrightHolder: 'Wellcome Collection',
+    copyrightLink: 'http://wellcomecollection.org'
+  },
   fileFormat: 'png'
 });
 


### PR DESCRIPTION
References #1404 

# Type
✨ Feature  
🐛 Bugfix  

## Value
We can start attributing images correctly.
https://wiki.creativecommons.org/wiki/Best_practices_for_attribution#Title.2C_Author.2C_Source.2C_License

This is a hack, but it's one until Prismic decide on what they're going to do with this.

## Example front-end with different data
__with all information__
![screen shot 2017-08-30 at 17 23 58](https://user-images.githubusercontent.com/1394592/29883765-26be210c-8da9-11e7-88ae-4f03d6410574.png)

__without author__
![screen shot 2017-08-30 at 17 24 49](https://user-images.githubusercontent.com/1394592/29883782-32878942-8da9-11e7-8717-f86bedf33ddc.png)

__without copyright or source link__
![screen shot 2017-08-30 at 17 25 42](https://user-images.githubusercontent.com/1394592/29883800-4241677c-8da9-11e7-872d-6d332325fd21.png)
