### PR TITLE
remove works-search component and associated feature flag code

### DIFF
--- a/server/views/components/header/header.njk
+++ b/server/views/components/header/header.njk
@@ -28,15 +28,7 @@
           {% endfor %}
         </ul>
       </nav>
-      {% if featureFlags and featuresCohort %}
-        {% if featuresCohort | isFlagEnabled('searchWorks', featureFlags) %}
-          {% componentV2 'works-search' %}
-        {% else %}
-          {% componentV2 'search' %}
-        {% endif %}
-      {% else %}
-        {% componentV2 'search' %}
-      {% endif %}
+      {% componentV2 'search' %}
     </div>
   </div>
 </div>

--- a/server/views/components/works-search/works-search.config.js
+++ b/server/views/components/works-search/works-search.config.js
@@ -1,1 +1,0 @@
-export const hidden = true;


### PR DESCRIPTION
References #1372

## Type
🚑 Health

## Value
Removes unnecessary code. The header search will no longer be needed as a way to access the image search, once the images link is present.

N.B. Once deployed we should delete the searchWorks flag from Prismic.
