### PR TITLE
use hyphen over camel case for curated lists

### DIFF
--- a/server/services/prismic-curated-lists.js
+++ b/server/services/prismic-curated-lists.js
@@ -7,8 +7,8 @@ export async function getCuratedList(id: string) {
   ];
   const prismic = await prismicApi();
   const curatedLists = await prismic.query([
-    Prismic.Predicates.at('my.curatedLists.uid', id),
-    Prismic.Predicates.at('document.type', 'curatedLists')
+    Prismic.Predicates.at('my.curated-lists.uid', id),
+    Prismic.Predicates.at('document.type', 'curated-lists')
   ], {fetchLinks});
 
   const curatedList = curatedLists.results.length > 0 && curatedLists.results[0];


### PR DESCRIPTION
It was annoying me - this will be inline with the platform team.