### PR TITLE
use title as description on twitter cards if description doesn't exist

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,9 +5,9 @@
   "main": "app.js",
   "scripts": {
     "app:build": "babel . -d .dist --ignore=node_modules --copy-files",
-    "app:dev":    "nodemon -e js,njk,json --exec babel-node run.js",
+    "app:dev": "nodemon -e js,njk,json --exec babel-node run.js",
     "app:docker": "pm2-docker --json pm2.yml",
-    "app:run":    "pm2 start pm2.yml",
+    "app:run": "pm2 start pm2.yml",
     "optimise:svg": "node ./optimise-svgs.js",
     "test": "ava",
     "test:accessibility": "pa11y",
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "ava": "^0.17.0",
-    "babel-cli": "^6.18.0",
+    "babel-cli": "^6.26.0",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-env": "^1.1.8",
     "entities": "^1.1.1",
@@ -41,10 +41,10 @@
     "parse5": "^3.0.1",
     "pm2": "^2.1.5",
     "prismic-dom": "^1.2.6",
-    "prismic-javascript": "^1.1.4",
-    "raven": "^1.2.0",
+    "prismic-javascript": "^1.3.0",
+    "raven": "^2.1.2",
     "rimraf": "^2.6.1",
-    "superagent": "^3.3.1",
+    "superagent": "^3.6.0",
     "supertest": "^3.0.0",
     "wellcomecollection-config": "file:../config"
   },
@@ -56,7 +56,7 @@
     "flow-typed": "^2.1.5",
     "nodemon": "^1.10.2",
     "open": "0.0.5",
-    "pa11y": "^4.2.0",
+    "pa11y": "^4.12.1",
     "svgo": "^0.7.2"
   },
   "ava": {

--- a/server/views/components/twitter-card/twitter-card.njk
+++ b/server/views/components/twitter-card/twitter-card.njk
@@ -2,6 +2,6 @@
 <meta name="twitter:url" content="{{ pageConfig.organization.url }}{{ metaContent.url }}" />
 <meta name="twitter:site" content="{{ pageConfig.organization.twitterHandle }}" />
 <meta name="twitter:title" content="{{ metaContent.title }}" />
-<meta name="twitter:description" content="{{ metaContent.description | striptags | safe | truncate(200) }}" />
+<meta name="twitter:description" content="{{ (metaContent.description | striptags | safe | truncate(200)) or metaContent.title }}" />
 <meta name="twitter:image" content="{{ metaContent.image }}?w=600&h=322&crop=1" />
 {#<meta name="twitter:image:alt" content=" {{ article.thumbnailAlt }}" />#}{# TODO not available from wordpress #}

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -7,7 +7,7 @@
     title: work.title,
     image: work.imgLink | replace('WIDTH', 1200),
     url: pageConfig.path,
-    description: work.description
+    description: work.description or work.title
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}


### PR DESCRIPTION
Fixes #1420 

## Type
🐛 Bugfix  

Twitter doesn't consider a card valid without a description.
I'm passing the title in for now, but wonder if something more like, "one of 53,000 image to explore from the Wellcome Collection" <= @jennpb?

![screen shot 2017-08-31 at 10 26 52](https://user-images.githubusercontent.com/31692/29916632-3d94053e-8e37-11e7-8ce1-f40cfdbe4cd1.png)
