### PR TITLE
allow subtitles on image lists

### DIFF
--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -171,7 +171,8 @@ export function convertContentToBodyParts(content) {
             const image = prismicImageToPicture(item);
             const description = RichText.asHtml(item.description);
             const title = asText(item.title);
-            return { title, image, description };
+            const subtitle = asText(item.subtitle);
+            return { title, subtitle, image, description };
           })
         };
 

--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -52,7 +52,20 @@
             <ul class="plain-list no-margin no-padding">
               {% for item in bodyPart.value %}
                 <li>
-                  <h2>{{ loop.index }}. {{ item.title }}</h2>
+                  <h2>
+                    <div class="flex">
+                      <div class="{{ {s: 1} | spacingClasses({margin: ['right']}) }}">{{ loop.index }}.</div>
+                      <div>
+                        <div>
+                          {{ item.title }}
+                        </div>
+                        {% if item.subtitle %}
+                          <div>
+                            {{ item.subtitle }}
+                          </div>
+                        {% endif %}
+                      </div>
+                  </h2>
                   {% componentV2 'captioned-image', item.image, {'has-border-bottom': item.image.caption}, {showCopyright: true} %}
                   {{item.description | safe}}
                 </li>


### PR DESCRIPTION
## Type
🎩 Content test

Adding subtitles to image lists as a test to see how editorial are using them.

The image lists are still a WIP, so the markup is too (although nicely with what we have I didn't need any more CSS).

![screen shot 2017-08-31 at 11 26 03](https://user-images.githubusercontent.com/31692/29919071-c4daa0b8-8e3f-11e7-8b78-9400473cfdb5.png)

