### PR TITLE
Track return-to-results link

### DIFF
--- a/server/views/components/work-media/work-media.njk
+++ b/server/views/components/work-media/work-media.njk
@@ -3,6 +3,7 @@
     {% if model.queryString %}
       <div class="flush-container-left {{ {s:2} | spacingClasses({padding: ['top']}) }}">
         <a href="/works{{ model.queryString }}#{{model.id}}"
+          data-track-event='{"category": "work", "action": "return-to-results", "label": "query:{{ model.queryString }}, id:{{model.id}}"}'
           class="flex flex--v-center {{ {s:'HNM6', m:'HNM5'} | fontClasses }} font-white plain-link pointer-events-all js-work-media-control">
           {% icon 'actions/arrow-small', null, ['icon--match-text', 'icon--white', 'icon--90', 'margin-right-s1', 'margin-right-m1', 'margin-right-l1', 'margin-right-xl1'] %}Return to results
         </a>

--- a/server/views/components/work-media/work-media.njk
+++ b/server/views/components/work-media/work-media.njk
@@ -3,7 +3,7 @@
     {% if model.queryString %}
       <div class="flush-container-left {{ {s:2} | spacingClasses({padding: ['top']}) }}">
         <a href="/works{{ model.queryString }}#{{model.id}}"
-          data-track-event='{"category": "work", "action": "return-to-results", "label": "query:{{ model.queryString }}, id:{{model.id}}"}'
+          data-track-event='{"category": "work", "action": "return-to-results", "label": "query:{{ model.queryString }}, id:{{ model.id }}"}'
           class="flex flex--v-center {{ {s:'HNM6', m:'HNM5'} | fontClasses }} font-white plain-link pointer-events-all js-work-media-control">
           {% icon 'actions/arrow-small', null, ['icon--match-text', 'icon--white', 'icon--90', 'margin-right-s1', 'margin-right-m1', 'margin-right-l1', 'margin-right-xl1'] %}Return to results
         </a>


### PR DESCRIPTION
References #1374

## Type
🚑  Health

- [x] Demoed to @hthair 

## Value
Adds GA tracking to the return-to-results link. When clicked, it will send the id of the work, and the query string that got the user to the work (i.e. the results page) to the 'work' category in GA.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged