### PR TITLE
Default to v2 and fallback to v1 for /exhibitions urls

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -41,22 +41,38 @@ http {
 
     # These are the locations we know exist solely on v2
     location ~ ^/assets|/async|/explore|/works|/series|/preview {
-      proxy_set_header Host $host;
-      proxy_pass       http://wellcomecollection:3000;
+      proxy_set_header        Host $host;
+      proxy_pass              http://wellcomecollection:3000;
+    }
+
+    # For exhibitions, we efault to v2 and fallback to v1
+    # This is because drupal considers /exhibitions/anything/goes
+    # to be a valid request
+    location ~ ^/exhibitions/.* {
+      proxy_set_header        Host $host;
+      proxy_pass              http://wellcomecollection:3000;
+      proxy_intercept_errors  on;
+      error_page 404 = @v1;
     }
 
     # Everything else - if we 404 on v1, we fallback to v2
     location / {
-      proxy_pass                 http://prev.wellcomecollection.org;
-      proxy_set_header           Host $host;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-      proxy_intercept_errors     on;
+      proxy_pass              http://prev.wellcomecollection.org;
+      proxy_set_header        Host $host;
+      proxy_set_header        HTTP_X_FORWARDED_PROTO https;
+      proxy_intercept_errors  on;
       error_page 404 = @v2;
     }
 
+    location @v1 {
+      proxy_pass              http://prev.wellcomecollection.org;
+      proxy_set_header        Host $host;
+      proxy_set_header        HTTP_X_FORWARDED_PROTO https;
+    }
+
     location @v2 {
-      proxy_set_header Host $host;
-      proxy_pass       http://wellcomecollection:3000;
+      proxy_set_header        Host $host;
+      proxy_pass              http://wellcomecollection:3000;
     }
   }
 

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -45,7 +45,7 @@ http {
       proxy_pass              http://wellcomecollection:3000;
     }
 
-    # For exhibitions, we efault to v2 and fallback to v1
+    # For exhibitions, we default to v2 and fallback to v1
     # This is because drupal considers /exhibitions/anything/goes
     # to be a valid request
     location ~ ^/exhibitions/.* {


### PR DESCRIPTION
## Type
✨ Feature  

For /exhibitions/.* we will go to v1 and fallback to v2.
This to get around the fact that `/exhibitions/say/wat` is invalid, but returns a 200, which unfortunately also includes https://wellcomecollection.org/exhibitions/WZwh4ioAAJ3usf86

