### PR TITLE
add headers to send to drupal to prevent https 301 loop

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -76,7 +76,7 @@ resource "aws_cloudfront_distribution" "next" {
     max_ttl                = 86400
 
     forwarded_values {
-      headers                 = ["Host"]
+      headers                 = ["Host", "HTTP_X_FORWARDED_PROTO"]
       query_string            = true
       query_string_cache_keys = ["page", "current", "q", "format", "query", "cohort", "uri"]
 

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -42,6 +42,7 @@ http {
     # These are the locations we know exist solely on v2
     location ~ ^/assets|/async|/explore|/works|/series|/preview {
       proxy_set_header Host $host;
+      proxy_set_header HTTP_X_FORWARDED_PROTO https;
       proxy_pass       http://wellcomecollection:3000;
     }
 
@@ -50,12 +51,15 @@ http {
       proxy_pass                 http://prev.wellcomecollection.org;
       proxy_set_header           Host $host;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
+      proxy_set_header           X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header           X-Url-Scheme $scheme;
       proxy_intercept_errors     on;
       error_page 404 = @v2;
     }
 
     location @v2 {
       proxy_set_header Host $host;
+      proxy_set_header HTTP_X_FORWARDED_PROTO https;
       proxy_pass       http://wellcomecollection:3000;
     }
   }


### PR DESCRIPTION
Adding some headers that _might_ be needed for Drupal to not send us in a loop when traffic is coming from CloudFront.