### PR TITLE
Https throughout

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -54,7 +54,7 @@ resource "aws_cloudfront_distribution" "next" {
     origin_id   = "${var.alb_id}"
 
     custom_origin_config {
-      origin_protocol_policy = "http-only"
+      origin_protocol_policy = "https-only"
       http_port              = "80"
       https_port             = "443"
       origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]

--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -76,7 +76,7 @@ resource "aws_cloudfront_distribution" "next" {
     max_ttl                = 86400
 
     forwarded_values {
-      headers                 = ["Host", "HTTP_X_FORWARDED_PROTO"]
+      headers                 = ["Host"]
       query_string            = true
       query_string_cache_keys = ["page", "current", "q", "format", "query", "cohort", "uri"]
 

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -51,8 +51,6 @@ http {
       proxy_pass                 http://prev.wellcomecollection.org;
       proxy_set_header           Host $host;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-      proxy_set_header           X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header           X-Url-Scheme $scheme;
       proxy_intercept_errors     on;
       error_page 404 = @v2;
     }

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -42,7 +42,6 @@ http {
     # These are the locations we know exist solely on v2
     location ~ ^/assets|/async|/explore|/works|/series|/preview {
       proxy_set_header Host $host;
-      proxy_set_header HTTP_X_FORWARDED_PROTO https;
       proxy_pass       http://wellcomecollection:3000;
     }
 
@@ -57,7 +56,6 @@ http {
 
     location @v2 {
       proxy_set_header Host $host;
-      proxy_set_header HTTP_X_FORWARDED_PROTO https;
       proxy_pass       http://wellcomecollection:3000;
     }
   }


### PR DESCRIPTION
Moving back to a more peeled back attempt at stoping Drupal redirect loop traffic.

I recon it's the fact that we had the `origin_protocol_policy` set to `http` - so I'm going to try that in isolation.