### PR TITLE
only add autofocus attribute if there is no query in the search box

### DIFF
--- a/server/views/components/input/input.njk
+++ b/server/views/components/input/input.njk
@@ -6,7 +6,7 @@
     value="{{ model.value }}"
     placeholder="{{ model.placeholder }}"
     {{ 'disabled' if model.disabled }}
-    {{ 'autofocus' if model.autofocus  }} />
+    {{ 'autofocus' if model.autofocus and not model.value }} />
   {% if ['radio', 'checkbox'] | contains(model.type) %}
     <span class="input__control-indicator input__control-indicator--{{ model.type }}"></span>
   {% endif %}


### PR DESCRIPTION
Fixes #1376

## Type
✨ Feature  
🐛 Bugfix  

## Value
As oer @jamesgorrie 's suggestion, this takes care of the issue in Chrome, where autofocus overrides the link target. 

Assumes we only want autofocus when the search input is empty, which seems reasonable.
