### PR TITLE
don't include delisted articles in lists

### DIFF
--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -273,7 +273,8 @@ export async function getArticleList(documentTypes = ['articles', 'webcomics']) 
   ];
   const prismic = await prismicApi();
   const articlesList = await prismic.query([
-    Prismic.Predicates.any('document.type', documentTypes)
+    Prismic.Predicates.any('document.type', documentTypes),
+    Prismic.Predicates.not('document.tags', ['delist'])
   ], {fetchLinks});
 
   const articlesAsArticles = articlesList.results.map(result => {


### PR DESCRIPTION
## Type
✨ Feature

Allows us to publish content that isn't automatically listed.