### PR TITLE
Ask Loris for PNG images if the source is PNG

### DIFF
--- a/server/filters/convert-image-uri.js
+++ b/server/filters/convert-image-uri.js
@@ -41,6 +41,14 @@ function determineIfGif(originalUriPath) {
   return originalUriPath.slice(-4) === '.gif';
 }
 
+function determineFinalFormat(originalUriPath) {
+  if (originalUriPath.slice(-4) === '.png') {
+    return 'png';
+  } else {
+    return 'jpg';
+  }
+}
+
 function convertPathToWordpressUri(originalUriPath, size) {
   return originalUriPath + `?w=${size}`;
 }
@@ -50,7 +58,8 @@ function convertPathToImgixUri(originalUriPath, imgixRoot, size) {
 }
 
 function convertPathToIiifUri(originalUriPath, iiifRoot, size) {
-  return `${iiifRoot}${originalUriPath}/full/${size},/0/default.jpg`;
+  const format = determineFinalFormat(originalUriPath);
+  return `${iiifRoot}${originalUriPath}/full/${size},/0/default.${format}`;
 }
 
 export default function convertImageUri(originalUri, requiredSize, useIiif, useIiifOrigin) {


### PR DESCRIPTION
In the vein of #1429.

Right now, you’re asking Loris for a JPEG regardless of what the source format is, which gets you URLs like this: https://iiif.wellcomecollection.org/image/wordpress:2017/04/head-apaprt-from-body-1.png/full/282,/0/default.jpg

Following that URL will give you a 500 error  and a sad message from Loris:

> Server Side Error: cannot write mode RGBA as JPEG 
>
> This is likely a permissions problem, though it's possible that there was a problem with the source file (/mnt/loris/resolver_cache/wordpress/fb/f26/a4f/a92/6bf/c3b/958/a04/e7f/313/3de/loris_cache.png). (500)

You get a broken link, the user doesn't see their image, we get an alarm from Loris. Everybody is sad. 😭 

If you ask Loris to convert PNG to PNG, all it has to do is a resize, which works fine (e.g. https://iiif.wellcomecollection.org/image/wordpress:2017/04/head-apaprt-from-body-1.png/full/282,/0/default.png). So if the original image was a PNG, ask Loris for a PNG as well. Working links, visible images, no alarms. 👌 