### PR TITLE
Use cursor: pointer for copy url link

### DIFF
--- a/server/views/components/copy-url/copy-url.njk
+++ b/server/views/components/copy-url/copy-url.njk
@@ -3,7 +3,7 @@
 <button
   data-copy-text="{{ model.url }}"
   data-track-event='{"category": "component", "action": "copy-url:click", "label": "id:{{ model.id }}"}'
-  class="{{ {s:2} | spacingClasses({margin: ['top']}) }} {{ {s:'HNM5' , m:'HNM4'} | fontClasses }} plain-button font-elf-green is-hidden js-copy-url">
+  class="{{ {s:2} | spacingClasses({margin: ['top']}) }} {{ {s:'HNM5' , m:'HNM4'} | fontClasses }} plain-button font-elf-green is-hidden js-copy-url pointer">
   {% icon 'actions/link', null, ['icon--elf-green'] %}
   Copy link
 </button>


### PR DESCRIPTION
Fixes #1446 

## Type
🐛  Bugfix  

## Value
Makes it clearer that 'copy link' is clickable.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged