### PR TITLE
Display license description and CC info on separate lines

### DIFF
--- a/server/views/components/license/license.njk
+++ b/server/views/components/license/license.njk
@@ -1,18 +1,22 @@
 {% set licenseInfo = model.licenseType | getLicenseInfo %}
 {% set iconClasses = ['icon--2x', 'v-align-middle'] %}
 
-{% if licenseInfo.description %}
-  <p class="{{ {s:'HNL5' , m:'HNL4'} | fontClasses }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }}">{{ licenseInfo.description }}</p>
-{% endif %}
-<span class="{{ {s:'LR2'} | fontClasses }}"{% if model.subject %} about="{{model.subject}}{% endif %}">
-  {% if licenseInfo.url %}
-    <a class="plain-link {{ {s:'LR2'} | fontClasses }}" rel="license" href="{{ licenseInfo.url }}">
-  {% else %}
-    <span class="{{ {s:'LR2'} | fontClasses }}">
+<div>
+  {% if licenseInfo.description %}
+    <div class="{{ {s:2} | spacingClasses({margin: ['bottom']}) }}">
+      <p class="{{ {s:'HNL5' , m:'HNL4'} | fontClasses }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }}">{{ licenseInfo.description }}</p>
+    </div>
   {% endif %}
-    {% for icon in licenseInfo.icons %}
-      {% icon 'other/' + icon, null, iconClasses %}
-    {% endfor %}
-    <span class="{{ 'link-underline' if licenseInfo.url }}">{{ licenseInfo.text }}</a>
-  </{{ 'a' if licenseInfo.url else 'span' }}>
-</span>
+  <span class="{{ {s:'LR2'} | fontClasses }}"{% if model.subject %} about="{{model.subject}}{% endif %}">
+    {% if licenseInfo.url %}
+      <a class="plain-link {{ {s:'LR2'} | fontClasses }}" rel="license" href="{{ licenseInfo.url }}">
+    {% else %}
+      <span class="{{ {s:'LR2'} | fontClasses }}">
+    {% endif %}
+      {% for icon in licenseInfo.icons %}
+        {% icon 'other/' + icon, null, iconClasses %}
+      {% endfor %}
+      <span class="{{ 'link-underline' if licenseInfo.url }}">{{ licenseInfo.text }}</a>
+    </{{ 'a' if licenseInfo.url else 'span' }}>
+  </span>
+</div>


### PR DESCRIPTION
Fixes #1404

## Type
🐛  Bugfix  

- [ ] Demoed to @jennpb 

## Value
Stops license looking broken on webcomics (puts the description and the CC info/icons on separate lines – consistent with work page).

## Screenshot
![screen shot 2017-09-05 at 18 31 45](https://user-images.githubusercontent.com/1394592/30074407-581a12a0-9269-11e7-81b1-442292aee856.png)


## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
