### PR TITLE
A11y font colours

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -190,19 +190,8 @@
 }
 
 .promo__type {
-  color: color('turquoise-text');
   display: block;
   text-transform: capitalize;
-  transition: color 400ms ease;
-
-  .promo--series & {
-    color: color('purple-text');
-  }
-
-  .promo:not(.promo--surrogate):hover &,
-  .promo:not(.promo--surrogate):focus & {
-    color: color('black');
-  }
 }
 
 .promo__title {

--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -190,7 +190,7 @@
 }
 
 .promo__type {
-  color: color('mint');
+  color: color('turquoise-text');
   display: block;
   text-transform: capitalize;
   transition: color 400ms ease;

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -179,28 +179,6 @@
   margin-right: auto;
 }
 
-.heading--large {
-  @include font('WB6');
-
-  @include respond-to('medium') {
-    @include font('WB5');
-  }
-
-  @include respond-to('large') {
-    @include font('WB4');
-  }
-}
-
-.text--meta {
-  @include font('LR3');
-
-  color: color('pewter');
-
-  @include respond-to('medium') {
-    @include font('LR2');
-  }
-}
-
 .text--truncate {
   max-height: 80px;
   overflow: hidden;

--- a/server/views/components/pagination/pagination.njk
+++ b/server/views/components/pagination/pagination.njk
@@ -1,4 +1,4 @@
-<div class="pagination float-r flex-inline flex--v-center text--meta">
+<div class="pagination float-r flex-inline flex--v-center font-pewter {{ {s:'LR3', m:'LR2'} | fontClasses }}">
   {% if (model.prevPage) %}
     <a href="{{ model.prevQueryString }}" rel="prev" class="{{ {s:2} | spacingClasses({margin: ['right']}) }}">
       <div class="icon-rounder flex flex--v-center">

--- a/server/views/components/promo/promo.njk
+++ b/server/views/components/promo/promo.njk
@@ -101,7 +101,7 @@
                   </{{ headingLevel or 'h2'}}>
               </div>
               {% if model.datePublished and model.contentType == 'work' %}
-                <p class="promo {{ dateFontSizes | fontClasses }} text--meta relative">{{ model.datePublished }}</p>
+                <p class="promo {{ dateFontSizes | fontClasses }}  font-pewter relative">{{ model.datePublished }}</p>
               {% endif %}
               {% if model.description %}
                 <span class="promo__copy">{{ model.description | striptags | safe | truncate(140) }}</span>

--- a/server/views/components/promo/promo.njk
+++ b/server/views/components/promo/promo.njk
@@ -86,7 +86,7 @@
             <header class="promo__description {{ {s:'HNL5'} | fontClasses }}">
               <div class="promo__heading">
                 {% if model.contentType %}
-                  <span class="promo__type {{ typeFontSizes | fontClasses }}" aria-hidden="true">
+                  <span class="promo__type font-charcoal {{ typeFontSizes | fontClasses }}" aria-hidden="true">
                     {% if commissionedSeries and model.positionInSeries %}
                       {{ commissionedSeries.name }}: Part {{ model.positionInSeries }}
                     {% elif seriesTitle %}

--- a/server/views/components/promo/promo.njk
+++ b/server/views/components/promo/promo.njk
@@ -86,7 +86,7 @@
             <header class="promo__description {{ {s:'HNL5'} | fontClasses }}">
               <div class="promo__heading">
                 {% if model.contentType %}
-                  <span class="promo__type font-charcoal {{ typeFontSizes | fontClasses }}" aria-hidden="true">
+                  <span class="promo__type font-charcoal {{ {s:1} | spacingClasses({margin: ['bottom']}) }} {{ typeFontSizes | fontClasses }}" aria-hidden="true">
                     {% if commissionedSeries and model.positionInSeries %}
                       {{ commissionedSeries.name }}: Part {{ model.positionInSeries }}
                     {% elif seriesTitle %}

--- a/server/views/components/series-container/series-container.njk
+++ b/server/views/components/series-container/series-container.njk
@@ -7,7 +7,7 @@
   <div class="container">
     <div class="grid">
       <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
-        <h2 class="heading--large {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">{{ model.data.name }}</h2>
+        <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">{{ model.data.name }}</h2>
       </div>
       <div class="{{ {s:12, m:12, l:8} | gridClasses }}">
         <p class="{{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">{{ model.data.description }}</p>

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -74,7 +74,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
-          <h2 class="heading--large {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">You may have missed</h2>
+          <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">You may have missed</h2>
         </div>
         <div class="{{ {s:12, m:12, l:8} | gridClasses }}">
           <a class="more-info-link {{ {s:'HNM6'} | fontClasses }}" href="/articles">

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -19,7 +19,7 @@
     <div class="container">
       <div class="grid">
         <div class="grid__cell">
-          <h1 class="heading--large {{ {s:0, m:0, l:0} | spacingClasses({margin: ['top']}) }} {{ {s:0, m:0, l:0} | spacingClasses({margin: ['bottom']}) }}">{{ list.name }}</h1>
+          <h1 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0, m:0, l:0} | spacingClasses({margin: ['top']}) }} {{ {s:0, m:0, l:0} | spacingClasses({margin: ['bottom']}) }}">{{ list.name }}</h1>
         </div>
       </div>
 
@@ -31,7 +31,7 @@
 
       <div class="grid">
         <div class="grid__cell">
-          <p class="text--meta {{ {s:2, m:2, l:2} | spacingClasses({margin: ['top']}) }} {{ {s:2, m:2, l:2} | spacingClasses({margin: ['bottom']}) }}">{{ list.total }} articles</p>
+          <p class="font-pewter {{ {s:'LR3', m:'LR2'} | fontClasses }} {{ {s:2, m:2, l:2} | spacingClasses({margin: ['top']}) }} {{ {s:2, m:2, l:2} | spacingClasses({margin: ['bottom']}) }}">{{ list.total }} articles</p>
         </div>
       </div>
 
@@ -42,7 +42,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s:12, m:12, l:12} | gridClasses }}">
-          <div class="{{ {s:5, m:5, l:5} | spacingClasses({padding: ['top']}) }}  {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }} text--meta flex flex--v-center">
+          <div class="{{ {s:5, m:5, l:5} | spacingClasses({padding: ['top']}) }}  {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }} flex flex--v-center font-pewter {{ {s:'LR3', m:'LR2'} | fontClasses }}">
             {{ pagination.range.beginning }} - {{ pagination.range.end }}
           </div>
         </div>

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -41,7 +41,7 @@
             <p class="{{ {s:'HNL5', m:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['top']}) }} {{ {s:1} | spacingClasses({margin: ['bottom']}) }}">Images are free to download and use under Creative Commons licences.</p>
             <p class="{{ {s:'HNL5', m:'HNL4'} | fontClasses }}">Visit <a class="font-elf-green" href="https://wellcomeimages.org/">Wellcome Images</a> to search all images from the collection.</p>
           {% else %}
-            <p class="text--meta {{ {s:2} | spacingClasses({margin: ['top']}) }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }}">
+            <p class="font-charcoal-text {{ {s:2} | spacingClasses({margin: ['top']}) }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'LR3', m:'LR2'} | fontClasses }}">
               {{ resultsList.totalResults if resultsList.totalResults > 0 else 'No' }} results for "{{ query }}"
             </p>
           {% endif %}
@@ -78,7 +78,7 @@
         <div class="grid">
           <div class="grid__cell">
             <div class="flex flex--h-space-between flex--v-center">
-              <div class="text--meta flex flex--v-center">
+              <div class="flex flex--v-center font-pewter {{ {s:'LR3', m:'LR2'} | fontClasses }}">
                 Showing {{ pagination.range.beginning }} - {{ pagination.range.end }}
               </div>
               {% componentV2 'pagination', pagination, null, {query: query} %}

--- a/server/views/templates/article.njk
+++ b/server/views/templates/article.njk
@@ -24,7 +24,7 @@
     <div class="container">
       <div class="grid">
         <div class="{{ {s:12, m:8, l:12, xl: 12} | gridClasses }}">
-          <h2 class="heading--large v-margin-0">Latest</h2>
+          <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} v-margin-0">Latest</h2>
         </div>
       </div>
     </div>


### PR DESCRIPTION
References #1442 and #606 

## Type
🐛  Bugfix  
🚑  Health

- [x] Demoed to @jennpb @Heesoomoon 

## Value
Corrects the a11y contrast issues referenced directly in #1442 (uses 'charcoal' for the promo 'type' label and the 'showing x results for y' text.

Also removes some unused css selectors.

This PR doesn't address the remaining issue in #606 of white-text-on-turquoise-background.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged