### PR TITLE
Get the miro id, when there is more than one identifier from API

### DIFF
--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -24,7 +24,10 @@ export const work = async(ctx, next) => {
   const queryString = ctx.search;
   const singleWork = await getWork(id);
   const truncatedTitle = getTruncatedTitle(singleWork.title);
-  const miroId = singleWork.identifiers[0].value;
+  const miroIdObject = singleWork.identifiers.find(identifier => {
+    return identifier.identifierScheme === 'miro-image-number';
+  });
+  const miroId = miroIdObject && miroIdObject.value;
   const imgWidth = '2048';
   const imgLink = imageUrlFromMiroId(miroId);
 


### PR DESCRIPTION
## Type
🐛 Bugfix    
🚑 Health

## Value
This prepares for an API change (see below) that would break our works page.

"We’re planning to roll out a change in the next day or so that adds a second identifier to the `identifiers` field in API responses (specifically, the _sierra-system-number_). Previously it just contained _miro-image-number_." - @alexwlchan 
