### PR TITLE
Change promo descrption font colour to charcoal

### DIFF
--- a/client/scss/components/_promo.scss
+++ b/client/scss/components/_promo.scss
@@ -236,7 +236,7 @@
 
 .promo__description {
   align-items: center;
-  color: color('pewter');
+  color: color('charcoal');
   min-width: 0;
   flex: 1;
   position: relative;


### PR DESCRIPTION
References #1442

## Type
🐛  Bugfix  


## Value
Fixes a11y font colour issue for promo description on cream bg

## Screenshot
![screen shot 2017-09-08 at 09 55 09](https://user-images.githubusercontent.com/1394592/30203994-d88a1fc0-947b-11e7-86a2-f49097f91573.png)
