### PR TITLE
GA exclusion

### DIFF
--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -2,23 +2,38 @@
 
 import { on } from './util';
 
-export default {
-  init: () => {
-    // GA events
-    on('body', 'click', '[data-track-event]', ({ target }) => {
-      const el = target.closest('[data-track-event]');
-      trackGaEvent(JSON.parse(el.getAttribute('data-track-event')));
-    });
+const maybeTrackEvent = (hasAnalytics) => {
+  if (hasAnalytics) {
+    const actuallyTrackEvent = ({category, action, label}) => {
+      ga('send', {
+        hitType: 'event',
+        eventCategory: category,
+        eventAction: action,
+        eventLabel: label
+      });
+    };
+    return actuallyTrackEvent;
+  } else {
+    const noop = () => {};
+    return noop;
   }
 };
 
-function trackOutboundLink(url) {
-  ga('send', 'event', 'outbound', 'click', url, {
-    'transport': 'beacon',
-    'hitCallback': () => {
-      document.location = url;
-    }
-  });
+const maybeTrackOutboundLinks = (hasAnalytics) => {
+  if (hasAnalytics) {
+    const actuallyTrackLinks = (url) => {
+      ga('send', 'event', 'outbound', 'click', url, {
+        'transport': 'beacon',
+        'hitCallback': () => {
+          document.location = url;
+        }
+      });
+    };
+    return actuallyTrackLinks;
+  } else {
+    const noop = () => {};
+    return noop;
+  }
 };
 
 function getDomain(url) {
@@ -29,20 +44,25 @@ function isExternal(url) {
   return getDomain(document.location.href) !== getDomain(url);
 }
 
-export function trackGaEvent({category, action, label}) {
-  ga('send', {
-    hitType: 'event',
-    eventCategory: category,
-    eventAction: action,
-    eventLabel: label
-  });
-}
+export const trackGaEvent = maybeTrackEvent(window.ga);
 
-on('body', 'click', 'a', ({ target }) => {
-  const anchor = target.closest('a');
-  const url = anchor.href;
+export const trackOutboundLink = maybeTrackOutboundLinks(window.ga);
 
-  if (isExternal(url)) {
-    trackOutboundLink(url);
+export default {
+  init: () => {
+    // GA events
+    on('body', 'click', '[data-track-event]', ({ target }) => {
+      const el = target.closest('[data-track-event]');
+      trackGaEvent(JSON.parse(el.getAttribute('data-track-event')));
+    });
+
+    on('body', 'click', 'a', ({ target }) => {
+      const anchor = target.closest('a');
+      const url = anchor.href;
+      if (isExternal(url)) {
+        trackOutboundLink(url);
+      }
+    });
   }
-});
+};
+

--- a/client/libs/ga-scroll-depth.js
+++ b/client/libs/ga-scroll-depth.js
@@ -1,27 +1,37 @@
 // Simplified/rewritten from https://github.com/leighmcculloch/gascrolldepth.js
 import { getWindowHeight } from '../js/util';
-
 import { onWindowScrollDebounce$ } from '../js/utils/dom-events';
+
 const startTime = new Date().getTime();
 const getElHeight = el => el.offsetHeight + el.offsetTop;
 
-const sendEvent = (distance, timing) => {
-  window.ga('send', {
-    hitType: 'event',
-    eventCategory: 'Scroll Depth',
-    eventAction: 'Percentage',
-    eventLabel: distance,
-    eventValue: 1,
-    eventNonInteraction: true
-  });
+const maybeSendEvent = (hasAnalytics) => {
+  if (hasAnalytics) {
+    const actuallySendEvent = (distance, timing) => {
+      window.ga('send', {
+        hitType: 'event',
+        eventCategory: 'Scroll Depth',
+        eventAction: 'Percentage',
+        eventLabel: distance,
+        eventValue: 1,
+        eventNonInteraction: true
+      });
 
-  window.ga('send', {
-    hitType: 'timing',
-    timingCategory: 'Scroll Timing',
-    timingVar: `Scrolled ${distance}`,
-    timingValue: timing
-  });
+      window.ga('send', {
+        hitType: 'timing',
+        timingCategory: 'Scroll Timing',
+        timingVar: `Scrolled ${distance}`,
+        timingValue: timing
+      });
+    };
+    return actuallySendEvent;
+  } else {
+    const noop = () => {};
+    return noop;
+  }
 };
+
+const sendEvent = maybeSendEvent(window.ga);
 
 const calculateMarks = (elHeight) => {
   return {

--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -1,3 +1,4 @@
+{% if featuresCohort | isFlagEnabled('includeGA', featureFlags) %}
 <style>.async-hide .header__nav{ opacity: 0 !important} </style>
 <script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
 h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
@@ -34,4 +35,5 @@ if ('{{ pageConfig.contentType }}') {
 ga('require', 'GTM-NXMJ6D9');
 ga('send', 'pageview');
 </script>
-
+{# what about ga code we use, will be undefined? #}
+{% endif %}

--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -35,5 +35,4 @@ if ('{{ pageConfig.contentType }}') {
 ga('require', 'GTM-NXMJ6D9');
 ga('send', 'pageview');
 </script>
-{# what about ga code we use, will be undefined? #}
 {% endif %}


### PR DESCRIPTION
Fixes #1464

## Type
✨ Feature 

## Value
Gives cleaner usage data through Google Analytics, by allowing us to exclude staff use while working from home/on the road.

If someone goes to  wellcomecollection.org/flags and joins the wellcomeUser cohort - analytics data won't be sent

