### PR TITLE
Use config node module

### DIFF
--- a/server/filters/get-breakpoint.js
+++ b/server/filters/get-breakpoint.js
@@ -1,4 +1,4 @@
-import breakpoints from '../../config/breakpoints';
+import breakpoints from 'wellcomecollection-config/breakpoints';
 
 export default function(name) {
   return breakpoints[name];


### PR DESCRIPTION
## Type
🐛  Bugfix

## Value
The `getBreakpoints` filter is pointing at a file that isn't deployed wholesale (it is packaged as a node module instead). This PR points the filter to the node module version.
