### PR TITLE
Don't add comma to URL for full iiif images

### DIFF
--- a/server/filters/convert-image-uri.js
+++ b/server/filters/convert-image-uri.js
@@ -58,8 +58,9 @@ function convertPathToImgixUri(originalUriPath, imgixRoot, size) {
 }
 
 function convertPathToIiifUri(originalUriPath, iiifRoot, size) {
+  const isFullSize = size === 'full';
   const format = determineFinalFormat(originalUriPath);
-  return `${iiifRoot}${originalUriPath}/full/${size},/0/default.${format}`;
+  return `${iiifRoot}${originalUriPath}/full/${size}${isFullSize ? '' : ','}/0/default.${format}`;
 }
 
 export default function convertImageUri(originalUri, requiredSize, useIiif, useIiifOrigin) {


### PR DESCRIPTION
Fixes #1483

## Type
🐛  Bugfix  

- [ ] Demoed to @gestchild 

## Value
Fixes full-size IIIF image downloads.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
