### PR TITLE
Add exhibition tag to exhibition page

### DIFF
--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -296,14 +296,6 @@
   border-radius: 50%;
 }
 
-.relative-s {
-  @include respond-to('small') {
-    position: relative;
-  }
-}
-
-.absolute-m {
-  @include respond-to('medium') {
-    position: absolute;
-  }
+.absolute {
+  position: absolute;
 }

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -19,7 +19,19 @@
 
 <article itemscope itemtype="http://schema.org/ExhibitionEvent">
   <div class="row relative">
-    {% block tags %}{% endblock %}
+    {# TODO: Tags will probably need to be passed in from the model. Just hard-coding a link to all exhibitions (fair to assume that should be on every exhibition page) for now  #}
+    {% set tags = {
+      id: 'exhibition-tags',
+      tags: [{
+        text: 'exhibition',
+        url: '/whats-on/exhibitions/all-exhibitions'
+      }]
+    } %}
+
+    <div class="flush-container-left absolute {{ {s:2} | spacingClasses({margin: ['top']}) }}">
+      {% componentV2 'tags', tags %}
+    </div>
+
     <div class="exhibition-hero">
       {% componentV2 'picture', {images: exhibition.featuredImages}, {}, {'lazyload': true, extraClasses: ['exhibition-hero__picture']} %}
 

--- a/server/views/templates/exhibition.njk
+++ b/server/views/templates/exhibition.njk
@@ -1,11 +1,5 @@
 {% extends 'pages/exhibition.njk' %}
 
-{% block tags %}
-  <div class="flush-container-left relative-s absolute-m {{ {s:2} | spacingClasses({margin: ['top']}) }}">
-    {% componentV2 'tags', tags %}
-  </div>
-{% endblock %}
-
 {% block exhibitionDescription %}
   <p class="no-margin">Our summer exhibition shines a light on how each of us connects with nature. We are displaying objects borrowed from members of the public that tell a story about their relationship with nature.</p>
 


### PR DESCRIPTION
References #1472 

## Type
✨  Feature  

## Value
Provides a link (tag) to all exhibitions from the exhibition page.

## Screenshot
![screen shot 2017-09-11 at 16 44 00](https://user-images.githubusercontent.com/1394592/30283617-749246ea-9710-11e7-958d-47b5a9d0be18.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged