### PR TITLE
Add tracking to header nav links for explore vs. magazine A/B test

### DIFF
--- a/server/views/components/header/header.njk
+++ b/server/views/components/header/header.njk
@@ -21,6 +21,7 @@
             <li class="header__item {{ 'header__item--is-current' if navLink.isCurrent }}">
               <a href="{{ navLink.href }}"
                 class="header__link js-header-nav-link"
+                data-track-event='{"category": "A/B", "action": "nav-link:click", "label": "url:{{ navLink.href }}"}'
                 {%- if navLink.isCurrent %}
                   aria-current="true"
                 {%- endif %}>{{ navLink.title }}</a>


### PR DESCRIPTION
## Type
✨ Feature  

- [x] Demoed to @gestchild 

## Value
Tracks nav links, initially to A/B test Explore vs. Magazine
