### PR TITLE
remove imgix completely and related feature flag code

### DIFF
--- a/server/filters/convert-image-uri.js
+++ b/server/filters/convert-image-uri.js
@@ -6,13 +6,11 @@ const imageMap = {
   },
   prismic: {
     root: 'https://prismic-io.s3.amazonaws.com/wellcomecollection/',
-    imigixRoot: 'https://wellcomecollection-prismic.imgix.net',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/prismic:',
     iiifOriginRoot: 'https://iiif-origin.wellcomecollection.org/image/prismic:'
   },
   miro: {
     root: 'https://s3-eu-west-1.amazonaws.com/miro-images-public/',
-    imigixRoot: 'https://wellcomecollection-miro-images.imgix.net',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/',
     iiifOriginRoot: 'https://iiif-origin.wellcomecollection.org/image/'
   },
@@ -53,17 +51,13 @@ function convertPathToWordpressUri(originalUriPath, size) {
   return originalUriPath + `?w=${size}`;
 }
 
-function convertPathToImgixUri(originalUriPath, imgixRoot, size) {
-  return `${imgixRoot}/${originalUriPath}?w=${size}`;
-}
-
 function convertPathToIiifUri(originalUriPath, iiifRoot, size) {
   const isFullSize = size === 'full';
   const format = determineFinalFormat(originalUriPath);
   return `${iiifRoot}${originalUriPath}/full/${size}${isFullSize ? '' : ','}/0/default.${format}`;
 }
 
-export default function convertImageUri(originalUri, requiredSize, useIiif, useIiifOrigin) {
+export default function convertImageUri(originalUri, requiredSize, useIiifOrigin) {
   if (originalUri) {
     const imageSrc = determineSrc(originalUri);
     const isGif = determineIfGif(originalUri);
@@ -71,18 +65,16 @@ export default function convertImageUri(originalUri, requiredSize, useIiif, useI
     if (imageSrc === 'unknown') {
       return originalUri;
     } else {
-      if (useIiif && !isGif) {
+      if (!isGif) {
         const imagePath = imageSrc === 'miro' ? originalUri.split(imageMap[imageSrc].root)[1].split('/', 2)[1] : imageSrc === 'iiif' ? originalUri.split(imageMap[imageSrc].root)[1].split('/', 2)[0] : originalUri.split(imageMap[imageSrc].root)[1];
         const iiifRoot = useIiifOrigin ? imageMap[imageSrc].iiifOriginRoot : imageMap[imageSrc].iiifRoot;
 
         return convertPathToIiifUri(imagePath, iiifRoot, requiredSize);
       } else {
-        if (imageSrc === 'iiif') { // we have to use the iiif uri as that is all we have
-          return originalUri;
-        } else if (imageSrc === 'wordpress') {
+        if (imageSrc === 'wordpress') {
           return convertPathToWordpressUri(originalUri, requiredSize);
         } else {
-          return convertPathToImgixUri(originalUri.split(imageMap[imageSrc].root)[1], imageMap[imageSrc].imigixRoot, requiredSize);
+          return originalUri;
         }
       }
     }

--- a/server/views/components/image/image.njk
+++ b/server/views/components/image/image.njk
@@ -1,5 +1,4 @@
 {% set sizes = model | getImageSizesFor %}
-{% set useIiif = featuresCohort | isFlagEnabled('useIiif', featureFlags) %}
 {% set useIiifOrigin = featuresCohort | isFlagEnabled('imagesFromOrigin', featureFlags) %}
 
 {% set comma = joiner() %}
@@ -10,7 +9,7 @@
   {% set loop = [1] %}
 {% endif %}
 <noscript>
-  <img width="{{model.width}}" height="{{model.height}}" class="image" src="{{ model.contentUrl | convertImageUri(320, useIiif, useIiifOrigin) }}"
+  <img width="{{model.width}}" height="{{model.height}}" class="image" src="{{ model.contentUrl | convertImageUri(320, useIiifOrigin) }}"
 alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{ model.caption | striptags() }}{% endif %}" />
 </noscript>
 
@@ -21,10 +20,10 @@ alt="{% if model.alt %} {{ model.alt | striptags() }}{% elif model.caption %} {{
     promo__image-mask {{data.clipPathClass}}
   {% endif %}
   "
-  src="{{ model.contentUrl | convertImageUri(defaultSize, useIiif, useIiifOrigin) }}"
+  src="{{ model.contentUrl | convertImageUri(defaultSize, useIiifOrigin) }}"
   data-srcset="
   {%- for size in sizes -%}
-    {{ comma() }}{{ model.contentUrl | convertImageUri(size, useIiif, useIiifOrigin) }} {{ size }}w
+    {{ comma() }}{{ model.contentUrl | convertImageUri(size, useIiifOrigin) }} {{ size }}w
   {%- endfor %}"
   {% if data.sizesQueries %}
     sizes="{{ data.sizesQueries }}"

--- a/server/views/components/picture/picture.njk
+++ b/server/views/components/picture/picture.njk
@@ -1,4 +1,3 @@
-{% set useIiif = featuresCohort | isFlagEnabled('useIiif', featureFlags) %}
 {% set useIiifOrigin = featuresCohort | isFlagEnabled('imagesFromOrigin', featureFlags) %}
 {% set comma = joiner() %}
 
@@ -9,12 +8,12 @@
       {% if data.lazyload %}
         data-srcset="
         {%- for size in sizes -%}
-          {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiif, useIiifOrigin) }} {{ size }}w
+          {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiifOrigin) }} {{ size }}w
         {%- endfor %}"
       {% else %}
         srcset="
         {%- for size in sizes -%}
-          {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiif, useIiifOrigin) }} {{ size }}w
+          {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiifOrigin) }} {{ size }}w
         {%- endfor %}"
       {% endif %}>
 
@@ -24,9 +23,9 @@
         width="{{ image.width }}"
         class="image {{ 'lazy-image lazyload' if data.lazyload }}"
         {% if data.lazyload %}
-          data-src="{{ image.contentUrl | convertImageUri(image.width, useIiif, useIiifOrigin) }}"
+          data-src="{{ image.contentUrl | convertImageUri(image.width, useIiifOrigin) }}"
         {% else %}
-          src="{{ image.contentUrl | convertImageUri(image.width, useIiif, useIiifOrigin) }}"
+          src="{{ image.contentUrl | convertImageUri(image.width, useIiifOrigin) }}"
         {% endif %}
         alt="{{ image.alt }}" />
     {% endif %}


### PR DESCRIPTION
Closes #1136

## Type
🚑 Health

## Value
We've been using iiif images from Loris for a while now, but it's been wrapped in a feature flag/imgix safety blanket. Platform team is happy for us to rely on Loris now, so removing imgix related stuff.
