### PR TITLE
redirect next. to root URL

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -83,6 +83,12 @@ http {
   }
 
   server {
+    listen 80;
+    server_name next.wellcomecollection.org;
+    return 301 https://wellcomecollection.org$request_uri;
+  }
+
+  server {
     listen      80 default_server;
     server_name _;
     add_header  'X-wc-nginx-proxy' 'true';


### PR DESCRIPTION
🚑 Health

Push all `next.` traffic to root domain.
This should hopefully help with duplicate content across Google.