### PR TITLE
Remove orange background from the exhibition hero

### DIFF
--- a/client/scss/components/_exhibition_hero.scss
+++ b/client/scss/components/_exhibition_hero.scss
@@ -3,9 +3,6 @@
   margin: 0 auto;
 
   @include respond-to('medium') {
-    // TODO: this colour maybe going to be per-exhibition configurable
-    // decide if we're going to have class themes, or inline-styles
-    background: color('orange-graphics');
     display: flex;
   }
 }


### PR DESCRIPTION
## Type
🐛  Bugfix  

## Value
Prevents the flash of orange when the exhibition page loads
