### PR TITLE
Add audio element to article body parts

### DIFF
--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -280,6 +280,15 @@ export function convertContentToBodyParts(content) {
           }
         };
 
+      case 'audio':
+        return {
+          type: 'audio',
+          value: {
+            title: slice.value.name,
+            url: slice.value.url
+          }
+        };
+
       default:
         break;
     }

--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -94,6 +94,8 @@
             </ul>
           {% elif bodyPart.type === 'iframe' %}
             {% componentV2 'iframe', bodyPart.value %}
+          {% elif bodyPart.type === 'audio' %}
+            {% componentV2 'audio', bodyPart.value %}
           {% else %}
             {{ bodyPart.value | safe }}
           {% endif %}

--- a/server/views/components/audio/audio.config.js
+++ b/server/views/components/audio/audio.config.js
@@ -1,0 +1,5 @@
+export const context = {
+  model: {
+    url: 'https://wellcomecollection.files.wordpress.com/2017/05/rtms-poem-read-by-sarah-james.mp3'
+  }
+};

--- a/server/views/components/audio/audio.njk
+++ b/server/views/components/audio/audio.njk
@@ -1,0 +1,6 @@
+<audio class="audio"
+  preload="none"
+  controls>
+  <source type="audio/mpeg" src="{{ model.url }}">
+  <a href="{{ model.url }}">{{ model.title }}</a>
+</audio>


### PR DESCRIPTION
Closes #1524 

## Type
✨  Feature  

## Value
Displays an (unstyled) html5 audio element to play any audio uploaded to Prismic articles.

## Screenshot
![screen shot 2017-09-18 at 16 07 01](https://user-images.githubusercontent.com/1394592/30548956-71642224-9c8b-11e7-9946-2bb5523fee8f.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
