### PR TITLE
add version 1 vs 2 testing to nginx

### DIFF
--- a/infra/terraform/cloudfront/cloudfront.tf
+++ b/infra/terraform/cloudfront/cloudfront.tf
@@ -82,7 +82,13 @@ resource "aws_cloudfront_distribution" "next" {
 
       cookies {
         forward           = "whitelist"
-        whitelisted_names = ["WC_wpAuthToken", "WC_featuresCohort", "*SESS*"]
+        whitelisted_names = [
+          "WC_wpAuthToken",
+          "WC_featuresCohort",
+          "*SESS*",
+          # A/B tests
+          "WC_graphicdesign"
+        ]
       }
     }
   }

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -2,10 +2,11 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
+  # Wordpress Blog deprecation
   server {
     listen      80;
     server_name blog.wellcomecollection.org;
-    add_header  'X-wc-nginx-proxy' 'true';
+    add_header  x-wc-nginx-proxy true;
 
     location ~* \/feed\/?$ {
       # we send the traffic over to the Wordpress servers, and the host, they then resolve correctly,
@@ -33,17 +34,48 @@ http {
     }
   }
 
+  # v1 vs v2 testing
+  split_clients "version${remote_addr}${http_user_agent}${date_gmt}" $version_split {
+    50% 1;
+    50% 2;
+  }
+  map $cookie_WC_version $version {
+    default $cookie_WC_version;
+    ""      $version_split;
+  }
+  upstream v1 {
+    server prev.wellcomecollection.org;
+  }
+  upstream v2 {
+    server wellcomecollection:3000;
+  }
+  map $version $upstream_name {
+    1 v1;
+    2 v2;
+  }
+
   server {
     listen           80;
     listen           443 ssl;
-    server_name      wellcomecollection.org;
-    add_header       'X-wc-nginx-proxy' 'true';
+    server_name      wellcomecollection.org dev-wellcomecollection.org;
+    add_header       x-wc-nginx-proxy true;
 
     gzip on;
     gzip_types text/css application/javascript;
     # See: http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
     gzip_min_length 860;
     gzip_proxied any;
+
+    # v1 vs v2 testing
+    location ~ ^/graphicdesign {
+      # TODO: Maybe we make v an a/b testing flag
+      add_header Set-Cookie   "WC_version=$version;Path=/;Max-Age=86400";
+
+      proxy_set_header        HTTP_X_FORWARDED_PROTO https;
+      proxy_set_header        Host $host;
+
+      proxy_pass              http://$upstream_name;
+    }
 
     # These are the locations we know exist solely on v2
     location ~ ^/assets|/async|/explore|/works|/series|/preview {
@@ -91,7 +123,7 @@ http {
   server {
     listen      80 default_server;
     server_name _;
-    add_header  'X-wc-nginx-proxy' 'true';
+    add_header  x-wc-nginx-proxy true;
 
     gzip on;
     gzip_types text/css application/javascript;

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -35,19 +35,19 @@ http {
   }
 
   # v1 vs v2 testing
-  split_clients "graphicdesign${remote_addr}${http_user_agent}${date_gmt}" $graphicdesign_split {
-    50% 1;
-    50% 2;
-  }
-  map $cookie_WC_graphicdesign $graphicdesign {
-    default $cookie_WC_graphicdesign;
-    ""      $graphicdesign_split;
-  }
   upstream v1 {
     server prev.wellcomecollection.org;
   }
   upstream v2 {
     server wellcomecollection:3000;
+  }
+  split_clients "graphicdesign${remote_addr}${http_user_agent}${date_gmt}" $graphicdesign_split {
+    50% 1;
+    50% 2;
+  }
+  map $cookie_WC_graphicdesign $graphicdesign {
+    ""      $graphicdesign_split;
+    default $cookie_WC_graphicdesign;
   }
   map $graphicdesign $upstream_name {
     1 v1;
@@ -68,8 +68,8 @@ http {
 
     # v1 vs v2 testing
     location ~ ^/graphicdesign {
-      # TODO: Maybe we make v an a/b testing flag
       add_header Set-Cookie   "WC_graphicdesign=$graphicdesign;Path=/;Max-Age=86400";
+      add_header x-wc-gd      $graphicdesign;
 
       proxy_set_header        HTTP_X_FORWARDED_PROTO https;
       proxy_set_header        Host $host;

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -35,13 +35,13 @@ http {
   }
 
   # v1 vs v2 testing
-  split_clients "version${remote_addr}${http_user_agent}${date_gmt}" $version_split {
+  split_clients "graphicdesign${remote_addr}${http_user_agent}${date_gmt}" $graphicdesign_split {
     50% 1;
     50% 2;
   }
-  map $cookie_WC_version $version {
-    default $cookie_WC_version;
-    ""      $version_split;
+  map $cookie_WC_graphicdesign $graphicdesign {
+    default $cookie_WC_graphicdesign;
+    ""      $graphicdesign_split;
   }
   upstream v1 {
     server prev.wellcomecollection.org;
@@ -49,7 +49,7 @@ http {
   upstream v2 {
     server wellcomecollection:3000;
   }
-  map $version $upstream_name {
+  map $graphicdesign $upstream_name {
     1 v1;
     2 v2;
   }
@@ -69,7 +69,7 @@ http {
     # v1 vs v2 testing
     location ~ ^/graphicdesign {
       # TODO: Maybe we make v an a/b testing flag
-      add_header Set-Cookie   "WC_version=$version;Path=/;Max-Age=86400";
+      add_header Set-Cookie   "WC_graphicdesign=$graphicdesign;Path=/;Max-Age=86400";
 
       proxy_set_header        HTTP_X_FORWARDED_PROTO https;
       proxy_set_header        Host $host;

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -98,8 +98,8 @@ export async function renderEvent(ctx, next) {
   }
 }
 
-export async function renderExhibition(ctx, next) {
-  const id = `${ctx.params.id}`;
+export async function renderExhibition(ctx, next, overrideId) {
+  const id = overrideId || `${ctx.params.id}`;
   const preview = Boolean(ctx.params.preview);
   const exhibition = await getExhibition(id, preview ? ctx.request : null);
   const format = ctx.request.query.format;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -41,6 +41,11 @@ r.get('/events/:id', renderEvent);
 r.get('/:preview?/exhibitions/:id', renderExhibition);
 r.get('/eventbrite-event-embed/:id', renderEventbriteEmbed);
 
+// Vanity URLs - should redirect
+r.get('/graphicdesign', async (ctx, next) => {
+  return renderExhibition(ctx, next, 'WZwh4ioAAJ3usf86');
+});
+
 // API
 r.get('/works', search);
 r.get('/works/:id', work);


### PR DESCRIPTION
## Type
<!-- delete as appropriate -->
✨ Feature  

This allows us to split traffic between V1 and V2.
At first we're doing it for `/graphicdesign` only (potentially not, maybe `/visit-us`).

the process is:
* Assign a version, 1 or 2, to a user on visit
* if you land on a designated URL, `/graphicdesign` form example, you get stuck in your group.
* We can then measure through Google Analytics.

@jennpb @hthair I'd like to discuss which method, this or optimise, would be better for testing v1 vs v2 content.