### PR TITLE
Make drawer css critical

### DIFF
--- a/client/scss/critical.scss
+++ b/client/scss/critical.scss
@@ -29,6 +29,7 @@
 @import 'components/captioned_image';
 @import 'components/chapter_indicator';
 @import 'components/cookie_notification';
+@import 'components/drawer';
 @import 'components/event_promo';
 @import 'components/exhibition_hero';
 @import 'components/header';

--- a/client/scss/non-critical.scss
+++ b/client/scss/non-critical.scss
@@ -7,7 +7,6 @@
 @import 'components/book-promo';
 @import 'components/buttons';
 @import 'components/divider';
-@import 'components/drawer';
 @import 'components/feature_flags';
 @import 'components/find_us';
 @import 'components/footer';


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Contents of `drawer` components should be hidden until opened (unless no JS). Making the drawer css 'critical' makes sure this happens.

Prevents the flash of unstyled opening hours on the v2 exhibition page.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
