### PR TITLE
Make exhibition promos momentum-scrolly on iOS

### DIFF
--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -206,7 +206,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="container container--scroll">
+        <div class="container container--scroll touch-scroll">
           <div class="grid grid--scroll">
             {% for promo in promoList %}
               <div class="{{ gridSizes | gridClasses }}">


### PR DESCRIPTION
## Type
🐛  Bugfix  

## Value
Makes the exhibition page promos scroll nicely on iOS
