### PR TITLE
Add manky background to non-alt-texted images in previews

### DIFF
--- a/client/scss/components/_is_preview.scss
+++ b/client/scss/components/_is_preview.scss
@@ -1,0 +1,6 @@
+.is-preview {
+  [alt=''] {
+    background: repeating-linear-gradient(-45deg, color('orange-graphics'), color('orange-graphics') 10px, color('teal') 10px, color('teal') 20px);
+    padding: 50px;
+  }
+}

--- a/client/scss/non-critical.scss
+++ b/client/scss/non-critical.scss
@@ -16,6 +16,7 @@
 @import 'components/iframe_container';
 @import 'components/image_gallery';
 @import 'components/instagram_thumbnail';
+@import 'components/is_preview';
 @import 'components/more_info_link';
 @import 'components/opening_hours';
 @import 'components/pre';

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -35,7 +35,8 @@ export const renderArticle = async(ctx, next) => {
           category: 'editorial',
           canonicalUri: `${ctx.globals.rootDomain}/articles/${id}`
         }), getEditorialAnalyticsInfo(article)),
-        article: article
+        article: article,
+        isPreview: preview
       });
     }
   }
@@ -118,7 +119,8 @@ export async function renderExhibition(ctx, next, overrideId) {
           contentType: 'exhibitions',
           canonicalUri: `${ctx.globals.rootDomain}/exhibitions/${exhibition.id}`
         }),
-        exhibition: exhibition
+        exhibition: exhibition,
+        isPreview: preview
       });
     }
   }

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -20,8 +20,8 @@ export const renderArticle = async(ctx, next) => {
   const path = ctx.request.url;
   // We rehydrate the `W` here as we take it off when we have the route.
   const id = `W${ctx.params.id}`;
-  const preview = Boolean(ctx.params.preview);
-  const article = await getArticle(id, preview ? ctx.request : null);
+  const isPreview = Boolean(ctx.params.preview);
+  const article = await getArticle(id, isPreview ? ctx.request : null);
 
   if (article) {
     if (format === 'json') {
@@ -36,7 +36,7 @@ export const renderArticle = async(ctx, next) => {
           canonicalUri: `${ctx.globals.rootDomain}/articles/${id}`
         }), getEditorialAnalyticsInfo(article)),
         article: article,
-        isPreview: preview
+        isPreview: isPreview
       });
     }
   }
@@ -101,8 +101,8 @@ export async function renderEvent(ctx, next) {
 
 export async function renderExhibition(ctx, next, overrideId) {
   const id = overrideId || `${ctx.params.id}`;
-  const preview = Boolean(ctx.params.preview);
-  const exhibition = await getExhibition(id, preview ? ctx.request : null);
+  const isPreview = Boolean(ctx.params.preview);
+  const exhibition = await getExhibition(id, isPreview ? ctx.request : null);
   const format = ctx.request.query.format;
   const path = ctx.request.url;
 
@@ -120,7 +120,7 @@ export async function renderExhibition(ctx, next, overrideId) {
           canonicalUri: `${ctx.globals.rootDomain}/exhibitions/${exhibition.id}`
         }),
         exhibition: exhibition,
-        isPreview: preview
+        isPreview: isPreview
       });
     }
   }

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -142,7 +142,6 @@ function parseArticleAsArticle(prismicArticle) {
   const description = promo && asText(promo.primary.caption); // TODO: Do not use description
   const contributors = getContributors(prismicArticle);
 
-
   const series = prismicArticle.data.series.length > 0 && prismicArticle.data.series.map(prismicSeries => {
     const seriesData = prismicSeries.primary.series.data;
     // TODO: Support commissionedLength and positionInSeries

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -34,7 +34,7 @@
       <link rel="canonical" href="{{ pageConfig.canonicalUri }}" />
     {% endif %}
   </head>
-  <body>
+  <body {% if isPreview %}class="is-preview"{% endif %}>
     {% component 'skip-link' %}
 
     {% set navLinks = [


### PR DESCRIPTION
## Type
🚑  Health

- [x] Demoed to Helen

## Value
Alerts content editors to the fact that alt text hasn't been added to images by displaying them on a disgusting background.

## Screenshot
![screen shot 2017-09-19 at 17 40 21](https://user-images.githubusercontent.com/1394592/30604464-de55813e-9d62-11e7-974a-39391721722c.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
