### PR TITLE
Switch to using the v1 Catalogue API

### DIFF
--- a/server/services/wellcomecollection-api.js
+++ b/server/services/wellcomecollection-api.js
@@ -2,7 +2,7 @@
 import superagent from 'superagent';
 import type {Work} from '../model/work';
 
-const version = 'v0';
+const version = 'v1';
 const baseUri = `https://api.wellcomecollection.org/catalogue/${version}`;
 
 export async function getWork(id: string): Promise<Work> {

--- a/server/test/mocks/wellcomecollection-api.json
+++ b/server/test/mocks/wellcomecollection-api.json
@@ -1,5 +1,5 @@
 {
-"@context": "https://api.wellcomecollection.org/catalogue/v0/context.json",
+"@context": "https://api.wellcomecollection.org/catalogue/v1/context.json",
 "id": "watu9tbc",
 "type": "Work",
 "identifiers": [


### PR DESCRIPTION
Related: https://github.com/wellcometrust/platform/issues/582

## Type

🚑 Health

## Value

The V1 API comes with shiny guarantees of uptime and us not making backward-compatible changes to the data model. This is the “production-ready” Catalogue API.

Currently we’re running both v0 and v1, so it should be possible to deploy this at any time without disruption to the Collection site. But once it’s done, we plan to shut down the v0 API – so please tell us when you’ve deployed this patch. :-)

I’ve tested this change locally.