### PR TITLE
defer ordering of articles to API query and remove WP articles from explore

### DIFF
--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -286,17 +286,17 @@ export function convertContentToBodyParts(content) {
   }).filter(_ => _);
 }
 
-export async function getArticleList(documentTypes = ['articles', 'webcomics']) {
+export async function getArticleList(documentTypes = ['articles', 'webcomics'], pageSize = 10) {
   const fetchLinks = [
     'people.name', 'people.image', 'people.twitterHandle', 'people.description',
     'series.name', 'series.description', 'series.color', 'series.commissionedLength'
   ];
-  const orderings = '[my.articles.publishDate desc, document.first_publication_date desc, my.webcomics.publishDate desc]';
+  const orderings = '[document.first_publication_date desc, my.articles.publishDate desc, my.webcomics.publishDate desc]';
   const prismic = await prismicApi();
   const articlesList = await prismic.query([
     Prismic.Predicates.any('document.type', documentTypes),
     Prismic.Predicates.not('document.tags', ['delist'])
-  ], {fetchLinks, orderings});
+  ], {fetchLinks, orderings, pageSize});
 
   const articlesAsArticles = articlesList.results.map(result => {
     switch (result.type) {

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -26,6 +26,7 @@ export function getContributors(doc): List<Person> {
 }
 
 export function getPublishedDate(doc) {
+  // This is because we need to have a separeate `publishDate` for articles imported from WP
   return PrismicDate(doc.data.publishDate || doc.first_publication_date || Date.now());
 }
 
@@ -290,11 +291,12 @@ export async function getArticleList(documentTypes = ['articles', 'webcomics']) 
     'people.name', 'people.image', 'people.twitterHandle', 'people.description',
     'series.name', 'series.description', 'series.color', 'series.commissionedLength'
   ];
+  const orderings = '[my.articles.publishDate desc, document.first_publication_date desc, my.webcomics.publishDate desc]';
   const prismic = await prismicApi();
   const articlesList = await prismic.query([
     Prismic.Predicates.any('document.type', documentTypes),
     Prismic.Predicates.not('document.tags', ['delist'])
-  ], {fetchLinks});
+  ], {fetchLinks, orderings});
 
   const articlesAsArticles = articlesList.results.map(result => {
     switch (result.type) {


### PR DESCRIPTION
Fixes/Closes/References #

## Type
🐛 Bugfix  

Removing all the junk logic from when we had to deal with WP / Prismic content on `/explore`.
Should hopefully speed the page up.