### PR TITLE
Use 'preview' verbatim in route handler

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -39,11 +39,12 @@ r.get('/download', (ctx, next) => {
 });
 
 // Content
-r.get('/:preview?/articles/(W):id', renderArticle);
+
+r.get('/(preview)?/articles/(W):id', renderArticle);
 r.get('/explore', renderExplore);
 r.get('/preview', setPreviewSession);
-r.get('/:preview?/events/:id', renderEvent);
-r.get('/:preview?/exhibitions/:id', renderExhibition);
+r.get('/(preview)?/events/:id', renderEvent);
+r.get('/(preview)?/exhibitions/:id', renderExhibition);
 r.get('/eventbrite-event-embed/:id', renderEventbriteEmbed);
 
 // Vanity URLs - should redirect


### PR DESCRIPTION
## Type
🐛 Bugfix  

- [x] Demoed to @gestchild 

## Value
We're getting `500` errors from urls like `/exhibitionsandevents/events/WTX053590.htm`. This is because the current route handler allows for an optional `preview` segment in the url, but that segment is set as a variable (`:preview`) rather than the actual word, 'preview'.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
