### PR TITLE
Move article hero copyright to top of image

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -128,8 +128,19 @@
 
   .enhanced & {
     position: absolute;
-    bottom: 0;
     width: 100%;
+  }
+}
+
+.captioned-image__copyright-holder--bottom {
+  .enhanced & {
+    bottom: 0;
+  }
+}
+
+.captioned-image__copyright-holder--top {
+  .enhanced & {
+    top: 0;
   }
 }
 

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -11,14 +11,16 @@
       {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
     {% endif %}
     {% if ((model.title or model.source.name or model.copyright.name or model.license) and data.showCopyright) %}
-      <div class="captioned-image__copyright-holder {{ {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses }} drawer js-show-hide"
+      <div class="captioned-image__copyright-holder {% if modifiers.full %}captioned-image__copyright-holder--top{% else %}captioned-image__copyright-holder--bottom{% endif %} {{ {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses }} drawer js-show-hide"
         data-track-action="toggle-image-credit",
         data-track-label="image:{{ model.contentUrl }}">
-        <button class="plain-button js-show-hide-trigger">
-          <span class="captioned-image__icon flex flex--v-center flex--h-center">
-            {% icon 'actions/information', 'information', ['icon--white', 'icon--2x'] %}
-          </span>
-        </button>
+        {% if not modifiers.full %}
+          <button class="plain-button js-show-hide-trigger">
+            <span class="captioned-image__icon flex flex--v-center flex--h-center">
+              {% icon 'actions/information', 'information', ['icon--white', 'icon--2x'] %}
+            </span>
+          </button>
+        {% endif %}
         <div class="drawer__body js-show-hide-drawer bg-white {{ {s:1} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}">
           {% set tasl = {
             title: model.title,
@@ -32,6 +34,13 @@
 
           {{ tasl | getTaslMarkup | safe }}
         </div>
+        {% if modifiers.full %}
+          <button class="plain-button js-show-hide-trigger">
+            <span class="captioned-image__icon flex flex--v-center flex--h-center">
+              {% icon 'actions/information', 'information', ['icon--white', 'icon--2x'] %}
+            </span>
+          </button>
+        {% endif %}
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
Fixes #1563

## Type
🐛 Bugfix  

## Value
Ensures hero image copyright info is visible. Not proposing that this should be how it ends up, but it's better than what we've got.

## Screenshot
![screen shot 2017-09-25 at 14 45 05](https://user-images.githubusercontent.com/1394592/30812120-dd61997c-a201-11e7-9e85-eb2696bd80bb.png)


## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
