### PR TITLE
Articles archive

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -19,12 +19,6 @@ http {
       # articles
       rewrite ^/\d+\/\d+\/\d+\/(.*)/?$ https://wellcomecollection.org/articles/$1 permanent;
 
-      # categories
-      rewrite ^/category\/(.*)/?$ https://wellcomecollection.org/articles?q=categories:$1 permanent;
-
-      # tags
-      rewrite ^/tag\/(.*)/?$ https://wellcomecollection.org/articles?q=tags:$1 permanent;
-
       # pages
       rewrite ^/about/?$ https://wellcomecollection.org/what-we-do/about-wellcome-collection permanent;
       rewrite ^/about/terms-and-conditions/?$ https://wellcome.ac.uk/about-us/terms-use permanent;

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -200,7 +200,7 @@ export async function renderArticlesList(ctx, next) {
   const promoList = PromoListFactory.fromSeries(series);
   const pagination = PaginationFactory.fromList(promoList.items, promoList.total, parseInt(page, 10) || 1);
   const path = ctx.request.url;
-  const moreLink = articlesList.totalPages === 1 ? '/articles?format=archive' : null;
+  const moreLink = articlesList.totalPages === 1 || articlesList.currentPage === articlesList.totalPages ? '/articles?format=archive' : null;
 
   ctx.render('pages/list', {
     pageConfig: createPageConfig({

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -13,6 +13,8 @@ import {
 } from '../services/prismic-content';
 import {getEvent} from '../services/events';
 import {getExhibition} from '../services/exhibitions';
+import {PromoListFactory} from '../model/promo-list';
+import {PaginationFactory} from '../model/pagination';
 
 export const renderArticle = async(ctx, next) => {
   const format = ctx.request.query.format;
@@ -152,7 +154,7 @@ export async function renderExplore(ctx, next) {
   const listRequests = [getCuratedList('explore'), contentListPromise];
   const [curatedList, contentList] = await Promise.all(listRequests);
 
-  const contentPromos = contentList.map(PromoFactory.fromArticleStub);
+  const contentPromos = contentList.results.map(PromoFactory.fromArticleStub);
   const promos = List(contentPromos.map((promo, index) => {
     // First promo on Explore page is treated differently
     if (index === 0) {
@@ -178,6 +180,38 @@ export async function renderExplore(ctx, next) {
     curatedList,
     collectorsPromo, // TODO: Remove this, make it automatic
     latestTweets
+  });
+
+  return next();
+}
+
+export async function renderArticlesList(ctx, next) {
+  // TODO: Remove WP content
+  const {page} = ctx.request.query;
+  const articlesList = await getArticleList(['articles', 'webcomics'], 96, page);
+  const contentPromos = List(articlesList.results);
+
+  const series: Series = {
+    url: '/articles',
+    name: 'Articles',
+    items: contentPromos,
+    total: articlesList.totalResults
+  };
+  const promoList = PromoListFactory.fromSeries(series);
+  const pagination = PaginationFactory.fromList(promoList.items, promoList.total, parseInt(page, 10) || 1);
+  const path = ctx.request.url;
+  const moreLink = articlesList.totalPages === 1 ? '/articles?format=archive' : null;
+
+  ctx.render('pages/list', {
+    pageConfig: createPageConfig({
+      path: path,
+      title: 'Articles',
+      inSection: 'explore',
+      category: 'list'
+    }),
+    list: promoList,
+    pagination,
+    moreLink
   });
 
   return next();

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -43,7 +43,7 @@ export const articles = async(ctx, next) => {
     total: articleStubsResponse.total
   };
   const promoList = PromoListFactory.fromSeries(series);
-  const pagination = PaginationFactory.fromList(promoList.items, promoList.total, parseInt(page, 10) || 1);
+  const pagination = PaginationFactory.fromList(promoList.items, promoList.total, parseInt(page, 10) || 1, 32, { format: 'archive' });
 
   ctx.render('pages/list', {
     pageConfig: createPageConfig({

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -3,14 +3,15 @@ import request from 'superagent';
 import {healthcheck, featureFlags} from '../controllers/utils';
 import {seriesNav, seriesTransporter, latestInstagramPosts, seriesContainerPromoList} from '../controllers/async-controllers';
 import {work, search} from '../controllers/work';
-import {index, article, articles, preview, series} from '../controllers'; // Deprecated
+import {index, article, preview, series, articles} from '../controllers'; // Deprecated
 import {
   renderArticle,
   setPreviewSession,
   renderEvent,
   renderExhibition,
   renderEventbriteEmbed,
-  renderExplore
+  renderExplore,
+  renderArticlesList
 } from '../controllers/content';
 
 const r = new Router({
@@ -60,7 +61,15 @@ r.get('/works/:id', work);
 r.get('/articles/:slug', article);
 r.get('/articles/preview/:id', preview);
 r.get('/series/:id', series);
-r.get('/articles', articles);
+r.get('/articles', async (ctx, next) => {
+  const format = ctx.query.format;
+
+  if (format === 'archive') {
+    return articles(ctx, next);
+  } else {
+    return renderArticlesList(ctx, next);
+  }
+});
 
 // Async
 r.get('/async/series-nav/:id', seriesNav);

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -278,11 +278,12 @@ export function convertContentToBodyParts(content) {
   }).filter(_ => _);
 }
 
-export async function getArticleList(documentTypes = ['articles', 'webcomics'], pageSize = 10) {
+export async function getArticleList(documentTypes = ['articles', 'webcomics'], pageSize = 10, page = 1) {
   const fetchLinks = [
     'people.name', 'people.image', 'people.twitterHandle', 'people.description',
     'series.name', 'series.description', 'series.color', 'series.commissionedLength'
   ];
+  // TODO: This order is not really doing what we expect it to do.
   const orderings = '[document.first_publication_date desc, my.articles.publishDate desc, my.webcomics.publishDate desc]';
   const prismic = await prismicApi();
   const articlesList = await prismic.query([
@@ -296,7 +297,15 @@ export async function getArticleList(documentTypes = ['articles', 'webcomics'], 
       case 'webcomics': return parseWebcomicAsArticle(result);
     }
   });
-  return articlesAsArticles;
+
+  // This shape matches the works API
+  return {
+    currentPage: page,
+    results: articlesAsArticles,
+    pageSize: articlesList.results_per_page,
+    totalResults: articlesList.total_results_size,
+    totalPages: articlesList.total_pages
+  };
 }
 
 export function asText(maybeContent) {

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -65,11 +65,19 @@
 
   <div class="row {{ {s:2, m:2, l:2} | spacingClasses({padding: ['top']}) }} {{ {s:3, m:3, l:3} | spacingClasses({padding: ['bottom']}) }} ">
     <div class="container">
-      <div class="grid">
-        <div class="grid__cell">
-          {% componentV2 'pagination', pagination %}
+      {% if moreLink %}
+        <div class="grid">
+          <div class="grid__cell" style="text-align: right">
+            <a href="{{moreLink}}">More articles from the archive</a>
+          </div>
         </div>
-      </div>
+      {% else %}
+        <div class="grid">
+          <div class="grid__cell">
+            {% componentV2 'pagination', pagination %}
+          </div>
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Type
🚑 Health

- [ ] Demo to @jennpb 

Adding the ability to list all of our Prismic articles and also make sure that we link through to our WP content.

The thinking here is that having a link, for SEO more than anything given the analytics, should be linking through to our new articles with an option to link through to the WP articles until migration.

I'd like to demo to @jennpb, but here's a screenshot for now:
<img width="843" alt="screen shot 2017-09-26 at 08 21 14" src="https://user-images.githubusercontent.com/31692/30847582-f33e66f2-a293-11e7-88a1-024b8de18d41.png">

Analytics over 3 months:
![analytics](https://user-images.githubusercontent.com/31692/30849056-f5a8dc10-a298-11e7-9839-475efa503277.png)
