### PR TITLE
If viewing a preview then prevent the browser from caching it

### DIFF
--- a/server/middleware/set-cache-control.js
+++ b/server/middleware/set-cache-control.js
@@ -4,11 +4,18 @@ export default (options = {}) => {
 
   return function setCacheControl(ctx, next) {
     return next().then(() => {
-      cacheControl.forEach((config) => {
-        if (config.contentType === ctx.response.type) {
-          ctx.response.set('Cache-Control', `max-age=${config.maxAge || year}`);
-        }
-      });
+      const isPreview = /^\/preview\//.test(ctx.request.path);
+      const isHtml = ctx.response.type === 'text/html';
+      if(isPreview && isHtml) {
+        ctx.response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+        ctx.set('Pragma', 'no-cache');
+      } else {
+        cacheControl.forEach((config) => {
+          if (config.contentType === ctx.response.type) {
+            ctx.response.set('Cache-Control', `max-age=${config.maxAge || year}`);
+          }
+        });
+      }
     });
   };
 }


### PR DESCRIPTION
## Type
✨ Feature  

## Value
Prevents browsers from caching preview pages, so that previews update without the need to refresh