### PR TITLE
Trim pieces of TASL to prevent unwanted space/make sure license renders

### DIFF
--- a/server/filters/get-tasl-markup.js
+++ b/server/filters/get-tasl-markup.js
@@ -3,12 +3,12 @@ import getLicenseInfo from './get-license-info';
 function getTitleHtml(title, author, sourceLink) {
   if (!title) return '';
 
-  const byAuthor = author ? `, by ${author.trim()}` : '';
+  const byAuthor = author ? `, by ${author}` : '';
 
   if (sourceLink) {
-    return `<a href="${sourceLink.trim()}" property="dc:title" rel="cc:attributionURL">${title.trim()}${byAuthor}</a>. `;
+    return `<a href="${sourceLink}" property="dc:title" rel="cc:attributionURL">${title}${byAuthor}</a>. `;
   } else {
-    return `<span property="dc:title">${title.trim()}${byAuthor}.</span> `;
+    return `<span property="dc:title">${title}${byAuthor}.</span> `;
   }
 }
 
@@ -16,9 +16,9 @@ function getSourceHtml(sourceName, sourceLink) {
   if (!sourceName) return '';
 
   if (sourceLink) {
-    return `Source: <a href="${sourceLink.trim()}" rel="cc:attributionURL">${sourceName.trim()}</a>. `;
+    return `Source: <a href="${sourceLink}" rel="cc:attributionURL">${sourceName}</a>. `;
   } else {
-    return `Source: ${sourceName.trim()}. `;
+    return `Source: ${sourceName}. `;
   }
 }
 
@@ -26,16 +26,16 @@ function getCopyrightHtml(copyrightHolder, copyrightLink) {
   if (!copyrightHolder) return '';
 
   if (copyrightLink) {
-    return `&copy; <a href="${copyrightLink.trim()}">${copyrightHolder.trim()}</a>. `;
+    return `&copy; <a href="${copyrightLink}">${copyrightHolder}</a>. `;
   } else {
-    return `&copy; ${copyrightHolder.trim()}. `;
+    return `&copy; ${copyrightHolder}. `;
   }
 }
 
 export default function({title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink}) {
   const titleHtml = getTitleHtml(title, author, sourceLink);
   const sourceHtml = getSourceHtml(sourceName, sourceLink);
-  const licenseInfo = license && getLicenseInfo(license.trim());
+  const licenseInfo = license && getLicenseInfo(license);
   const copyrightHtml = getCopyrightHtml(copyrightHolder, copyrightLink);
   const licenseHtml = licenseInfo ? `<a rel="license" href="${licenseInfo.url}">${licenseInfo.text}</a>.` : '';
 

--- a/server/filters/get-tasl-markup.js
+++ b/server/filters/get-tasl-markup.js
@@ -3,12 +3,12 @@ import getLicenseInfo from './get-license-info';
 function getTitleHtml(title, author, sourceLink) {
   if (!title) return '';
 
-  const byAuthor = author ? `, by ${author}` : '';
+  const byAuthor = author ? `, by ${author.trim()}` : '';
 
   if (sourceLink) {
-    return `<a href="${sourceLink}" property="dc:title" rel="cc:attributionURL">${title}${byAuthor}</a>. `;
+    return `<a href="${sourceLink.trim()}" property="dc:title" rel="cc:attributionURL">${title.trim()}${byAuthor}</a>. `;
   } else {
-    return `<span property="dc:title">${title}${byAuthor}.</span> `;
+    return `<span property="dc:title">${title.trim()}${byAuthor}.</span> `;
   }
 }
 
@@ -16,9 +16,9 @@ function getSourceHtml(sourceName, sourceLink) {
   if (!sourceName) return '';
 
   if (sourceLink) {
-    return `Source: <a href="${sourceLink}" rel="cc:attributionURL">${sourceName}</a>. `;
+    return `Source: <a href="${sourceLink.trim()}" rel="cc:attributionURL">${sourceName.trim()}</a>. `;
   } else {
-    return `Source: ${sourceName}. `;
+    return `Source: ${sourceName.trim()}. `;
   }
 }
 
@@ -26,16 +26,16 @@ function getCopyrightHtml(copyrightHolder, copyrightLink) {
   if (!copyrightHolder) return '';
 
   if (copyrightLink) {
-    return `&copy; <a href="${copyrightLink}">${copyrightHolder}</a>. `;
+    return `&copy; <a href="${copyrightLink.trim()}">${copyrightHolder.trim()}</a>. `;
   } else {
-    return `&copy; ${copyrightHolder}. `;
+    return `&copy; ${copyrightHolder.trim()}. `;
   }
 }
 
 export default function({title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink}) {
   const titleHtml = getTitleHtml(title, author, sourceLink);
   const sourceHtml = getSourceHtml(sourceName, sourceLink);
-  const licenseInfo = license && getLicenseInfo(license);
+  const licenseInfo = license && getLicenseInfo(license.trim());
   const copyrightHtml = getCopyrightHtml(copyrightHolder, copyrightLink);
   const licenseHtml = licenseInfo ? `<a rel="license" href="${licenseInfo.url}">${licenseInfo.text}</a>.` : '';
 

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -98,7 +98,7 @@ function getTaslFromCopyright(copyright) {
   const list = copyright.split('|');
   const v = list
     .concat(Array(7 - list.length))
-    .map(v => !v.trim() ? null : v);
+    .map(v => !v.trim() ? null : v.trim());
 
   const [title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink] = v;
 


### PR DESCRIPTION
Fixes/Closes/References #

## Type
🐛 Bugfix  

## Value
Trims off excess whitespace between `|` characters in the TASL. This prevents unwanted gaps before any punctuation in the TASL information, and ensures the correct license information is displayed.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
