### PR TITLE
Show copyright on standalone images

### DIFF
--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -33,7 +33,7 @@
               {% set sizes ='(min-width: 1340px) 579px, (min-width: 960px) calc(58.33vw - 100px), (min-width: 600px) calc(75vw - 63px), calc(100vw - 36px)' %}
             {% endif %}
             <div class="{{wrapperClasses}}">
-              {% componentV2 'captioned-image', bodyPart.value, {'has-border-bottom': bodyPart.value.caption}, {sizesQueries: sizes} %}
+              {% componentV2 'captioned-image', bodyPart.value, {'has-border-bottom': bodyPart.value.caption}, {sizesQueries: sizes, showCopyright: true} %}
             </div>
           {% elif bodyPart.type === 'video-embed' %}
             {% componentV2 'iframed-video', bodyPart.value %}


### PR DESCRIPTION
## Type
🐛  Bugfix  

## Value
Displays TASL information on standalone images

## Screenshot
![screen shot 2017-09-26 at 18 17 44](https://user-images.githubusercontent.com/1394592/30874012-09a52b12-a2e7-11e7-9d2c-ef82810fdd06.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
