### PR TITLE
only reference event once we know it exists

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -80,19 +80,19 @@ export async function renderEvent(ctx, next) {
   const isPreview = Boolean(ctx.params.preview);
   const event = await getEvent(id, isPreview ? ctx.request : null);
   const path = ctx.request.url;
-  // TODO: add the `Part of:` tag, we don't have a way of doing this in the model
-  const tags = [{
-    text: 'Event',
-    url: 'https://wellcomecollection.org/whats-on/events/all-events'
-  }].concat(event.format ? [{
-    text: event.format.title
-    // TODO: link through to others of this type?
-  }] : []);
 
   if (event) {
     if (format === 'json') {
       ctx.body = event;
     } else {
+      // TODO: add the `Part of:` tag, we don't have a way of doing this in the model
+      const tags = [{
+        text: 'Event',
+        url: 'https://wellcomecollection.org/whats-on/events/all-events'
+      }].concat(event.format ? [{
+        text: event.format.title
+        // TODO: link through to others of this type?
+      }] : []);
       ctx.render('pages/event', {
         pageConfig: createPageConfig({
           path: path,


### PR DESCRIPTION
## Type
🐛 Bugfix  

If the event isn't defined, this errors.
I hate not having types.