### PR TITLE
only set the mega proxy buffers for drupal admin

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -67,12 +67,6 @@ http {
     gzip_min_length 860;
     gzip_proxied any;
 
-    # Added for supporting the Drupal adminstration functions.
-    proxy_buffer_size         512k;
-    proxy_buffers             8 256k;
-    client_body_buffer_size   512k;
-    client_max_body_size      200M;
-
     # v1 vs v2 testing
     location ~ ^/graphicdesign {
       add_header Set-Cookie   "WC_graphicdesign=$graphicdesign;Path=/;Max-Age=86400";
@@ -96,6 +90,18 @@ http {
       proxy_pass              http://wellcomecollection:3000;
       proxy_intercept_errors  on;
       error_page 404 = @v1;
+    }
+
+    location ~ ^/admin.* {
+      # Added for supporting the Drupal adminstration functions.
+      proxy_buffer_size       512k;
+      proxy_buffers           8 256k;
+      client_body_buffer_size 512k;
+      client_max_body_size    200M;
+
+      proxy_pass              http://prev.wellcomecollection.org;
+      proxy_set_header        Host $host;
+      proxy_set_header        HTTP_X_FORWARDED_PROTO https;
     }
 
     # Everything else - if we 404 on v1, we fallback to v2


### PR DESCRIPTION
## Type
🚑 Health

Setting the huge buffersize only on admin routes.

Realised the standard size for this is actually 4/8k - looking at our CloudWatch graphs this might be the cause.