### PR TITLE
separate 500 and 404 error handline

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -4,7 +4,7 @@ import serve from 'koa-static';
 import {router} from './routes';
 import render from './view/render';
 import setCacheControl from './middleware/set-cache-control';
-import error from './middleware/error';
+import {serverError, notFound} from './middleware/error';
 import {determineFeaturesCohort} from './middleware/features-cohort';
 import {intervalCache} from './middleware/interval-cache';
 
@@ -20,7 +20,8 @@ app.use(determineFeaturesCohort());
 app.use(render(config.views.path, globals));
 // `error` is only after `intervalCache` and `render` as there's a dependency chain there
 // TODO: remove dependency chain
-app.use(error());
+app.use(serverError(globals.beaconError));
+app.use(notFound());
 app.use(setCacheControl(config.cacheControl));
 app.use(serve(config.static.path));
 app.use(serve(config.favicon.path));

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -5,10 +5,12 @@ const config = {
   },
   globals: {
     development: {
-      rootDomain: ''
+      rootDomain: '',
+      beaconErrors: false
     },
     production: {
-      rootDomain: 'https://wellcomecollection.org'
+      rootDomain: 'https://wellcomecollection.org',
+      beaconErrors: true
     }
   },
   server: {


### PR DESCRIPTION
## Type
🐛 Bugfix  

I noticed sentry errors weren't coming through.
I've created a new sentry project called `node-app` (I'd like to standardise these names).

Before we were making koa treat 404s and 500s the same, which made it a little hard to fathom as to when errors etc would beacon.

Now, on application error, we beacon, else we wait for no response from the other middleware, and respond with a 404 page.