### PR TITLE
Throw 404

### DIFF
--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -29,6 +29,7 @@ export function notFound() {
   return async (ctx, next) => {
     await next();
     if (404 === ctx.response.status && !ctx.response.body) {
+      ctx.throw(404);
 
       ctx.render('pages/error', {
         errorStatus: ctx.status,

--- a/server/test/app/app.js
+++ b/server/test/app/app.js
@@ -23,3 +23,8 @@ test('/series/:id', async t => {
   const res = await request.get('/series/a-drop-in-the-ocean');
   t.is(res.status, 200);
 });
+
+test('404', async t => {
+  const res = await request.get('/exhibitions/medicine-man');
+  t.is(res.status, 404);
+});


### PR DESCRIPTION
## Type
🐛 Bugfix  

Annoyingly even though the koa status is 404, if you don't throw it explicitly, it keeps the header as 200.