### PR TITLE
Use the whole iframe src (enables private embeds)

### DIFF
--- a/content-model/articles.json
+++ b/content-model/articles.json
@@ -264,10 +264,10 @@
             "type" : "Slice",
             "fieldset" : "SoundCloud embed",
             "non-repeat" : {
-              "number" : {
-                "type" : "Number",
+              "iframeSrc" : {
+                "type" : "Text",
                 "config" : {
-                  "label" : "Track ID"
+                  "label" : "iframe src"
                 }
               }
             }

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -263,7 +263,7 @@ export function convertContentToBodyParts(content) {
         return {
           type: 'soundcloudEmbed',
           value: {
-            trackId: slice.primary.number
+            iframeSrc: slice.primary.iframeSrc
           }
         };
 

--- a/server/views/components/soundcloud-embed/soundcloud-embed.njk
+++ b/server/views/components/soundcloud-embed/soundcloud-embed.njk
@@ -1,8 +1,8 @@
-<div class="soundcloud-embed">
+<div class="soundcloud-embed {{ {s:2} | spacingClasses({margin: ['bottom']}) }}">
   <iframe
     width="100%"
     height="20"
     scrolling="no"
     frameborder="no"
-    src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/{{ model.trackId }}&amp;color=%23ff5500&amp;inverse=false&amp;show_user=true"></iframe>
+    src="{{ model.iframeSrc }}"></iframe>
 </div>


### PR DESCRIPTION
## Type
✨ Feature  

Third time lucky. If the track is private, a secret is added to the SoundCloud iframe src, so we need the whole thing rather than just the ID.
