### PR TITLE
Allow iframe to be supporting/standalone

### DIFF
--- a/content-model/articles.json
+++ b/content-model/articles.json
@@ -23,6 +23,13 @@
             "name" : "standalone",
             "display" : "Standalone"
           } ],
+          "iframeSrc" : [ {
+            "name" : "supporting",
+            "display" : "Supporting"
+          }, {
+            "name" : "standalone",
+            "display" : "Standalone"
+          } ],
           "imageList" : [ {
             "name" : "featured",
             "display" : "Featured"

--- a/server/services/prismic-content.js
+++ b/server/services/prismic-content.js
@@ -280,6 +280,7 @@ export function convertContentToBodyParts(content) {
       case 'iframeSrc':
         return {
           type: 'iframe',
+          weight: slice.slice_label,
           value: {
             src: slice.value
           }


### PR DESCRIPTION
## Type
✨ Feature  

## Value
Allows us to display iframed content in the same way as editorial images – full grid width, or in the right-hand rail.

## Screenshot
![screen shot 2017-10-04 at 14 47 18](https://user-images.githubusercontent.com/1394592/31179108-e7992410-a912-11e7-8977-5e7331d01c26.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged