### PR TITLE
Work image hover

### DIFF
--- a/client/scss/components/_back-to-top.scss
+++ b/client/scss/components/_back-to-top.scss
@@ -37,7 +37,7 @@ $tweakpoints: (
 
 .back-to-top--visible {
   .enhanced & {
-    opacity: 0.7;
+    opacity: 1;
     transform: scale(1) translateX($link-dimension / 2);
 
     @include respond-to('back-to-top-xlarge') {

--- a/client/scss/components/_buttons.scss
+++ b/client/scss/components/_buttons.scss
@@ -75,7 +75,7 @@
   @include secondary;
   color: color('white');
   border-color: color('transparent');
-  background-color: rgba(color('black'), 0.61);
+  background-color: color('transparent-black');
 
   &:not([disabled]):hover,
   &:not([disabled]):focus {

--- a/client/scss/components/_buttons.scss
+++ b/client/scss/components/_buttons.scss
@@ -15,7 +15,7 @@
   padding: 10px 30px;
   color: color('white');
   background-color: color('seaweed');
-  border: 1px solid color('seaweed');
+  border: 2px solid color('seaweed');
   border-radius: $border-radius-unit;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -68,6 +68,19 @@
   &:not([disabled]):focus {
     color: color('java');
     border-color: color('java');
+  }
+}
+
+.btn--transparent-black {
+  @include secondary;
+  color: color('white');
+  border-color: color('transparent');
+  background-color: rgba(color('black'), 0.61);
+
+  &:not([disabled]):hover,
+  &:not([disabled]):focus {
+    border-color: color('transparent');
+    background-color: color('black');
   }
 }
 

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -147,6 +147,5 @@
     width: $icon-dimension;
     height: $icon-dimension;
     border-radius: 50%;
-    background: rgba(color('black'), 0.5);
   }
 }

--- a/client/scss/components/_work_media.scss
+++ b/client/scss/components/_work_media.scss
@@ -24,7 +24,6 @@
 }
 
 .work-media__controls {
-  background: linear-gradient(color('black'), color('transparent') 15%, color('transparent') 85%, color('black'));
   position: absolute;
   top: 0;
   right: 0;

--- a/client/scss/critical.scss
+++ b/client/scss/critical.scss
@@ -26,6 +26,7 @@
 @import 'components/article';
 @import 'components/author';
 @import 'components/body_content';
+@import 'components/buttons';
 @import 'components/captioned_image';
 @import 'components/chapter_indicator';
 @import 'components/cookie_notification';

--- a/client/scss/non-critical.scss
+++ b/client/scss/non-critical.scss
@@ -5,7 +5,6 @@
 @import 'base/fonts';
 @import 'components/back-to-top';
 @import 'components/book-promo';
-@import 'components/buttons';
 @import 'components/divider';
 @import 'components/feature_flags';
 @import 'components/find_us';

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -270,8 +270,7 @@
 }
 
 .bg-transparent-black {
-  background: rgba(color('black'), 0.61);
-  // Opacity value explanation; We use this class to provide a background to white text which overlays a variety of images (therefore unknown colour contrast).  This opacity is the lightest we can go, while still providing sufficient contrast to pass WCAG guidlines, when it is displayed above a white background, i.e. worst case scenario.
+  background: color('transparent-black');;
 }
 
 .rounded-corners {

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -269,6 +269,11 @@
   padding: 0;
 }
 
+.bg-transparent-black {
+  background: rgba(color('black'), 0.61);
+  // Opacity value explanation; We use this class to provide a background to white text which overlays a variety of images (therefore unknown colour contrast).  This opacity is the lightest we can go, while still providing sufficient contrast to pass WCAG guidlines, when it is displayed above a white background, i.e. worst case scenario.
+}
+
 .rounded-corners {
   border-radius: $border-radius-unit;
 }

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -270,7 +270,16 @@
 }
 
 .bg-transparent-black {
-  background: color('transparent-black');;
+  background: color('transparent-black');
+}
+
+.bg-transparent-black--hover {
+  transition: background 0.7s ease;
+
+  &[href]:hover,
+  &[href]:focus {
+    background: color('black');
+  }
 }
 
 .rounded-corners {

--- a/config/colors.js
+++ b/config/colors.js
@@ -26,6 +26,8 @@ const colors = {
   'java': ['#1fbea9', 'secondary'],
   'cotton-seed': ['#bcbab5', 'secondary'],
   'transparent': ['transparent', 'tertiary'],
+  'transparent-black': ['rgba(29, 29, 29, 0.61)', 'tertiary'],
+  // Opacity value explanation; We use transparent to provide a background to white text which overlays a variety of images (therefore unknown colour contrast).  This opacity is the lightest we can go, while still providing sufficient contrast to pass WCAG guidlines, when it is displayed above a white background, i.e. worst case scenario.
   'inherit': ['inherit', 'tertiary'],
   'currentColor': ['currentColor', 'tertiary']
 };

--- a/server/views/components/back-to-top/back-to-top.njk
+++ b/server/views/components/back-to-top/back-to-top.njk
@@ -1,5 +1,5 @@
 <a href="#top"
-   class="back-to-top icon-rounder bg-black border-color-silver js-back-to-top flex flex--v-center flex--h-center"
+   class="back-to-top icon-rounder bg-transparent-black border-color-silver js-back-to-top flex flex--v-center flex--h-center"
    data-track-event='{"category": "component", "action": "back-to-top:click", "label": "url:{{ data.trackId }}"}'>
   <span class="back-to-top__text">back to top</span>
   {% icon 'actions/chevron', null, ['icon--180', 'icon--white'] %}

--- a/server/views/components/button-button/button-button.njk
+++ b/server/views/components/button-button/button-button.njk
@@ -1,6 +1,6 @@
 <button class="btn {{ {s:'HNM5'} | fontClasses }} {{ modifierClasses }}" {{ attributes }}>
   {% if icon %}
-    {% icon icon, null, iconExtraClasses %}
+    {% icon icon, null, extraIconClasses %}
   {% endif %}
   {{text}}
 </button>

--- a/server/views/components/button-link/button-link.config.js
+++ b/server/views/components/button-link/button-link.config.js
@@ -20,6 +20,12 @@ export const variants = [{
     text: 'this is a link'
   }
 }, {
+  name: 'transparent-button',
+  context: {
+    modifierClasses: 'btn--transparent-black',
+    text: 'this is a link'
+  }
+}, {
   name: 'dark-button-with-icon',
   display: {
     background: '#000'

--- a/server/views/components/button-link/button-link.njk
+++ b/server/views/components/button-link/button-link.njk
@@ -1,7 +1,7 @@
 {# button-link component data: modifierClasses, href, text, icon #}
-<a class="btn {{ {s:'HNM5'} | fontClasses }} {{ modifierClasses }}" href="{{ href }}">
+<a class="btn {{ {s:'HNM5'} | fontClasses }} {{ modifierClasses }}" href="{{ href }}" {% if eventTracking %} data-event-tracking="{{ eventTracking }}" {% endif %}>
   {% if icon %}
-    {% icon icon, null, iconExtraClasses %}
+    {% icon icon, null, extraIconClasses %}
   {% endif %}
   {{ text }}
 </a>

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -36,7 +36,7 @@
         </div>
         {% if modifiers.full %}
           <button class="plain-button js-show-hide-trigger">
-            <span class="captioned-image__icon flex flex--v-center flex--h-center">
+            <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
               {% icon 'actions/information', 'information', ['icon--white'] %}
             </span>
           </button>

--- a/server/views/components/scroll-to-info/scroll-to-info.njk
+++ b/server/views/components/scroll-to-info/scroll-to-info.njk
@@ -1,6 +1,6 @@
 <a
   href="#{{ model.elementId }}"
-  class="scroll-to-info js-scroll-to-info plain-link flex--v-center flex--h-center flex bg-transparent-black {% for class in data.extraClasses %}{{ class }} {% endfor %}"
+  class="scroll-to-info js-scroll-to-info plain-link flex--v-center flex--h-center flex bg-transparent-black bg-transparent-black--hover {% for class in data.extraClasses %}{{ class }} {% endfor %}"
   data-track-event='{"category": "component", "action": "scroll-to-info:click", "label": "scrolled-to-id:{{ model.elementId }}"}'>
   {% icon 'actions/chevron', 'scroll to more information', data.extraIconClasses %}
 </a>

--- a/server/views/components/scroll-to-info/scroll-to-info.njk
+++ b/server/views/components/scroll-to-info/scroll-to-info.njk
@@ -1,6 +1,6 @@
 <a
   href="#{{ model.elementId }}"
-  class="scroll-to-info js-scroll-to-info plain-link flex--v-center flex--h-center flex {% for class in data.extraClasses %}{{ class }} {% endfor %}"
+  class="scroll-to-info js-scroll-to-info plain-link flex--v-center flex--h-center flex bg-transparent-black {% for class in data.extraClasses %}{{ class }} {% endfor %}"
   data-track-event='{"category": "component", "action": "scroll-to-info:click", "label": "scrolled-to-id:{{ model.elementId }}"}'>
   {% icon 'actions/chevron', 'scroll to more information', data.extraIconClasses %}
 </a>

--- a/server/views/components/work-media/work-media.njk
+++ b/server/views/components/work-media/work-media.njk
@@ -1,12 +1,11 @@
-<div class="row bg-black work-media js-work-media">
+<div class="row b-black work-media js-work-media">
   <div class="work-media__controls js-work-media-controls pointer-events-none">
     {% if model.queryString %}
       <div class="flush-container-left {{ {s:2} | spacingClasses({padding: ['top']}) }}">
-        <a href="/works{{ model.queryString }}#{{model.id}}"
-          data-track-event='{"category": "component", "action": "return-to-results:click", "label": "id:{{ model.id }}, query:{{ model.queryString }}, title:{{ model.trackTitle }}"}'
-          class="flex flex--v-center {{ {s:2} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }} {{ {s:'HNM6', m:'HNM5'} | fontClasses }} font-white plain-link pointer-events-all bg-transparent-black js-work-media-control">
-          {% icon 'actions/arrow', null, ['icon--match-text', 'icon--white', 'icon--180', 'margin-right-s1', 'margin-right-m1', 'margin-right-l1', 'margin-right-xl1'] %}Return to results
-        </a>
+      {% set btnHref = '/works' + model.queryString + '#' + model.id %}
+      {% set btnTracking = '{"category": "component", "action": "return-to-results:click", "label": "id:' + model.id + ', query:' + model.queryString + ', title:' + model.trackTitle +'"}' %}
+
+      {% component 'button-link', {href: btnHref, text: 'Return to results', icon: 'actions/arrow', modifierClasses: 'btn--transparent-black pointer-events-all', eventTracking: btnTracking, extraIconClasses: ['icon--180'] } %}
       </div>
     {% endif %}
 

--- a/server/views/components/work-media/work-media.njk
+++ b/server/views/components/work-media/work-media.njk
@@ -1,4 +1,4 @@
-<div class="row b-black work-media js-work-media">
+<div class="row bg-black work-media js-work-media">
   <div class="work-media__controls js-work-media-controls pointer-events-none">
     {% if model.queryString %}
       <div class="flush-container-left {{ {s:2} | spacingClasses({padding: ['top']}) }}">

--- a/server/views/components/work-media/work-media.njk
+++ b/server/views/components/work-media/work-media.njk
@@ -4,7 +4,7 @@
       <div class="flush-container-left {{ {s:2} | spacingClasses({padding: ['top']}) }}">
         <a href="/works{{ model.queryString }}#{{model.id}}"
           data-track-event='{"category": "component", "action": "return-to-results:click", "label": "id:{{ model.id }}, query:{{ model.queryString }}, title:{{ model.trackTitle }}"}'
-          class="flex flex--v-center {{ {s:'HNM6', m:'HNM5'} | fontClasses }} font-white plain-link pointer-events-all js-work-media-control">
+          class="flex flex--v-center {{ {s:2} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }} {{ {s:'HNM6', m:'HNM5'} | fontClasses }} font-white plain-link pointer-events-all bg-transparent-black js-work-media-control">
           {% icon 'actions/arrow', null, ['icon--match-text', 'icon--white', 'icon--180', 'margin-right-s1', 'margin-right-m1', 'margin-right-l1', 'margin-right-xl1'] %}Return to results
         </a>
       </div>


### PR DESCRIPTION
Closes #1491

## Type
✨ Feature  

## Value
Usability testing demonstrated that the black horizontal transparency on a /works/ viewing area gets in the way of reading any of the text at the top and bottom of the image. We now only add a background to controls themselves.

## Screenshot
before:
![screen shot 2017-10-05 at 14 20 36](https://user-images.githubusercontent.com/6051896/31229861-01d2808e-a9da-11e7-9c00-e8a778848cea.png)

after: 
![screen shot 2017-10-05 at 18 30 23](https://user-images.githubusercontent.com/6051896/31241311-72345e12-a9fb-11e7-99c5-19b141ca031f.png)



## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [-] Structured data tested: https://search.google.com/structured-data/testing-tool 
- [x] Browser tested: `npm run test:browsers <URL>`
- [-] Works without JS in the client
- [-] Relevant tracking/monitoring has been considered
