### PR TITLE
Add background to captioned image body icons

### DIFF
--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -16,7 +16,7 @@
         data-track-label="image:{{ model.contentUrl }}">
         {% if not modifiers.full %}
           <button class="plain-button js-show-hide-trigger">
-            <span class="captioned-image__icon flex flex--v-center flex--h-center">
+            <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
               {% icon 'actions/information', 'information', ['icon--white'] %}
             </span>
           </button>


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Puts the dark background back on in-page info icons (so they can be seen on light images).

## Screenshot
![screen shot 2017-10-06 at 14 37 04](https://user-images.githubusercontent.com/1394592/31280292-ca02e7be-aaa3-11e7-9067-1b9d75c5951f.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
