### PR TITLE
render exhibition pages without featured images

### DIFF
--- a/server/util/json-ld.js
+++ b/server/util/json-ld.js
@@ -26,7 +26,7 @@ export function exhibitionLd(content) {
   return objToJsonLd({
     name: content.title,
     description: content.safeDescription.val,
-    image: content.featuredImage.contentUrl,
+    image: content.featuredImage && content.featuredImage.contentUrl,
     location: {
       '@type': 'Place',
       name: 'Wellcome Collection',

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -4,7 +4,7 @@
   {% set metaContent = {
     type: 'website',
     title: exhibition.title,
-    image: exhibition.featuredImage.contentUrl,
+    image: exhibition.featuredImage and exhibition.featuredImage.contentUrl,
     url: pageConfig.canonicalUri
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}


### PR DESCRIPTION
## Type
🐛 Bugfix  

Allows editors to preview exhibitions without `featuredImages`