### PR TITLE
do the series properly for webcomics

### DIFF
--- a/content-model/webcomics.json
+++ b/content-model/webcomics.json
@@ -81,29 +81,23 @@
   },
   "Series" : {
     "series" : {
-      "type" : "Slices",
+      "type" : "Group",
+      "fieldset" : "Series",
       "config" : {
-        "label" : "Series",
-        "choices" : {
+        "fields" : {
           "series" : {
-            "type" : "Slice",
+            "type" : "Link",
             "fieldset" : "Series",
-            "non-repeat" : {
-              "series" : {
-                "type" : "Link",
-                "config" : {
-                  "label" : "Series",
-                  "select" : "document",
-                  "customtypes" : [ "series" ],
-                  "placeholder" : "Select an series…"
-                }
-              },
-              "positionInSeries" : {
-                "type" : "Number",
-                "config" : {
-                  "label" : "Position in series"
-                }
-              }
+            "config" : {
+              "select" : "document",
+              "customtypes" : [ "series" ],
+              "label" : "Series"
+            }
+          },
+          "positionInSeries" : {
+            "type" : "Number",
+            "config" : {
+              "label" : "Position in series"
             }
           }
         }


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Use the series structure that articles use.

[Annoyingly, because of the lack of an `OR` predicate, we can't have webcomics on our series page anyway](
https://github.com/wellcometrust/wellcomecollection.org/blob/master/server/services/prismic.js#L131).

Definitely not a smart move to making webcomics a separate type.
Now, if only the import / export tool worked properly... (Prismic 🤦‍♂️).
