### PR TITLE
Fix exhibition hero title box padding regression

### DIFF
--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -36,14 +36,14 @@
       {% componentV2 'picture', {images: exhibition.featuredImages.toJS()}, {}, {'lazyload': true, extraClasses: ['exhibition-hero__picture']} %}
 
       <div class="exhibition-hero__copy {{ {l:10} | spacingClasses({margin: ['bottom']}) }}">
-        <div class="is-hidden-m is-hidden-l is-hidden-xl">
+        <div class="is-hidden-l is-hidden-xl">
           {% component 'wobbly-edge', {background: 'white'} %}
         </div>
 
-        <div class="{{ {s:12, m:10, shiftM:1, l:12, xl:12} | gridClasses }}">
+        <div class="container">
           <div class="grid">
-            <div class="{{ {s:12} | gridClasses }}">
-              <div class="bg-white inline-block exhibition-hero__box {{ {m:3, l:4} | spacingClasses({'padding': ['right', 'left']}) }} {{ {s:4} | spacingClasses({'padding': ['top', 'bottom']}) }} rounded-diagonal">
+            <div class="{{ {s:12, m:10, shiftM:1, l:12, xl:12} | gridClasses }}">
+              <div class="bg-white inline-block exhibition-hero__box {{ {l:4} | spacingClasses({'padding': ['right', 'left']}) }} {{ {s:4} | spacingClasses({'padding': ['top', 'bottom']}) }} rounded-diagonal">
                 <div class="flex flex--v-center flex--h-space-between {{ {s:'HNM4', m:'HNM5', l:'HNM4'} | fontClasses }}">
                   <span class="flex flex--v-center">
                     {% icon 'other/ticket' %}
@@ -73,7 +73,7 @@
     </div>
 
 
-    <div class="is-hidden-s">
+    <div class="is-hidden-s is-hidden-m">
       {% component 'wobbly-edge', {background: 'white', intensity: 30} %}
     </div>
   </div>


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Stops the title box from bleeding to the edge of the screen. Keeps the wobbly line at every breakpoint.

## Screenshot
![screen shot 2017-10-12 at 10 39 16](https://user-images.githubusercontent.com/1394592/31489786-c974a536-af39-11e7-9d78-9d1aab21ed5b.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged