### PR TITLE
Router cloudfront

### DIFF
--- a/router/terraform/alb.tf
+++ b/router/terraform/alb.tf
@@ -1,5 +1,5 @@
 module "router_alb" {
-  source  = "git::https://github.com/wellcometrust/terraform.git//ecs_alb?ref=v1.0.0"
+  source  = "git::https://github.com/wellcometrust/terraform.git//ecs_alb?ref=v1.0.1"
   name    = "router"
   subnets = ["${local.vpc_subnets}"]
 

--- a/router/terraform/asg.tf
+++ b/router/terraform/asg.tf
@@ -16,5 +16,5 @@ module "router_cluster_asg" {
   sns_topic_arn         = "${module.ec2_terminating_topic.arn}"
   publish_to_sns_policy = "${module.ec2_terminating_topic.publish_policy}"
 
-  alarm_topic_arn       = "${module.ec2_instance_terminating_for_too_long_alarm.arn}"
+  alarm_topic_arn = "${module.ec2_instance_terminating_for_too_long_alarm.arn}"
 }

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -19,7 +19,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   enabled         = true
   is_ipv6_enabled = true
 
-  aliases = ["dev.wellcomecollection.org"]
+  aliases = ["nut.wellcomecollection.org"]
 
   default_cache_behavior {
     allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -1,0 +1,342 @@
+data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
+  provider = "aws.us-east-1"
+  domain   = "wellcomecollection.org"
+  statuses = ["ISSUED"]
+}
+
+
+resource "aws_cloudfront_distribution" "cardigan" {
+  origin {
+    domain_name = "cardigan.wellcomecollection.org.s3.amazonaws.com"
+    origin_id   = "S3-cardigan.wellcomecollection.org"
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+  is_ipv6_enabled     = true
+
+  aliases = ["cardigan.wellcomecollection.org"]
+
+  default_cache_behavior {
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id       = "S3-cardigan.wellcomecollection.org"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  retain_on_delete = true
+}
+
+resource "aws_cloudfront_distribution" "static" {
+  origin {
+    domain_name = "static.wellcomecollection.org.s3.amazonaws.com"
+    origin_id   = "S3-static.wellcomecollection.org"
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+  is_ipv6_enabled     = true
+
+  aliases = ["static.wellcomecollection.org"]
+
+  default_cache_behavior {
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id       = "S3-static.wellcomecollection.org"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.id}"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  retain_on_delete = true
+}
+
+resource "aws_cloudfront_distribution" "next" {
+  origin {
+    domain_name = "${module.router_alb.dns_name}"
+    origin_id   = "${module.router_alb.id}"
+
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      http_port              = "80"
+      https_port             = "443"
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+
+  aliases = ["wellcomecollection.org", "*.wellcomecollection.org"]
+
+  default_cache_behavior {
+    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id       = "${module.router_alb.id}"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      headers                 = ["Host"]
+      query_string            = true
+      query_string_cache_keys = ["page", "current", "q", "format", "query", "cohort", "uri"]
+
+      cookies {
+        forward           = "whitelist"
+        whitelisted_names = [
+          "WC_wpAuthToken",
+          "WC_featuresCohort",
+          "*SESS*",
+          # A/B tests
+          "WC_graphicdesign"
+        ]
+      }
+    }
+  }
+
+  # TODO: Deprecate
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/articles/preview/*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/preview/*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/preview"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/flags"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/management/*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+
+
+  # This is all for Drupal...
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/system/ajax"
+    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/admin/*"
+    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/user"
+    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  cache_behavior {
+    target_origin_id       = "${module.router_alb.id}"
+    path_pattern           = "/node/*"
+    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = true
+      headers      = ["*"]
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  # End Drupal...
+
+  viewer_certificate {
+    acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.id}"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  retain_on_delete = true
+}

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -1,101 +1,9 @@
 data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
   provider = "aws.us-east-1"
   domain   = "wellcomecollection.org"
-  statuses = ["ISSUED"]
 }
 
-
-resource "aws_cloudfront_distribution" "cardigan" {
-  origin {
-    domain_name = "cardigan.wellcomecollection.org.s3.amazonaws.com"
-    origin_id   = "S3-cardigan.wellcomecollection.org"
-  }
-
-  enabled             = true
-  default_root_object = "index.html"
-  is_ipv6_enabled     = true
-
-  aliases = ["cardigan.wellcomecollection.org"]
-
-  default_cache_behavior {
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
-    viewer_protocol_policy = "redirect-to-https"
-    target_origin_id       = "S3-cardigan.wellcomecollection.org"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
-    }
-  }
-
-  viewer_certificate {
-    acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
-    ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-
-  retain_on_delete = true
-}
-
-resource "aws_cloudfront_distribution" "static" {
-  origin {
-    domain_name = "static.wellcomecollection.org.s3.amazonaws.com"
-    origin_id   = "S3-static.wellcomecollection.org"
-  }
-
-  enabled             = true
-  default_root_object = "index.html"
-  is_ipv6_enabled     = true
-
-  aliases = ["static.wellcomecollection.org"]
-
-  default_cache_behavior {
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
-    viewer_protocol_policy = "redirect-to-https"
-    target_origin_id       = "S3-static.wellcomecollection.org"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = false
-
-      cookies {
-        forward = "none"
-      }
-    }
-  }
-
-  viewer_certificate {
-    acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.id}"
-    ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
-  }
-
-  restrictions {
-    geo_restriction {
-      restriction_type = "none"
-    }
-  }
-
-  retain_on_delete = true
-}
-
-resource "aws_cloudfront_distribution" "next" {
+resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   origin {
     domain_name = "${module.router_alb.dns_name}"
     origin_id   = "${module.router_alb.id}"
@@ -128,13 +36,15 @@ resource "aws_cloudfront_distribution" "next" {
       query_string_cache_keys = ["page", "current", "q", "format", "query", "cohort", "uri"]
 
       cookies {
-        forward           = "whitelist"
+        forward = "whitelist"
+
         whitelisted_names = [
           "WC_wpAuthToken",
           "WC_featuresCohort",
           "*SESS*",
+
           # A/B tests
-          "WC_graphicdesign"
+          "WC_graphicdesign",
         ]
       }
     }
@@ -241,8 +151,6 @@ resource "aws_cloudfront_distribution" "next" {
     }
   }
 
-
-
   # This is all for Drupal...
   cache_behavior {
     target_origin_id       = "${module.router_alb.id}"
@@ -327,16 +235,14 @@ resource "aws_cloudfront_distribution" "next" {
   # End Drupal...
 
   viewer_certificate {
-    acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.id}"
+    acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1"
   }
-
   restrictions {
     geo_restriction {
       restriction_type = "none"
     }
   }
-
   retain_on_delete = true
 }

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -19,7 +19,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   enabled         = true
   is_ipv6_enabled = true
 
-  aliases = ["wellcomecollection.org", "*.wellcomecollection.org"]
+  aliases = ["dev.wellcomecollection.org"]
 
   default_cache_behavior {
     allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]

--- a/router/terraform/locals.tf
+++ b/router/terraform/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  vpc_id = "${data.terraform_remote_state.wellcomecollection.vpc_id}"
+  vpc_id      = "${data.terraform_remote_state.wellcomecollection.vpc_id}"
   vpc_subnets = "${data.terraform_remote_state.wellcomecollection.vpc_subnets}"
 }

--- a/router/terraform/s3.tf
+++ b/router/terraform/s3.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "alb-logs" {
   policy = "${data.aws_iam_policy_document.alb_logs.json}"
 
   lifecycle {
-//    prevent_destroy = true
+    //    prevent_destroy = true
   }
 
   lifecycle_rule {

--- a/router/terraform/services.tf
+++ b/router/terraform/services.tf
@@ -16,11 +16,11 @@ module "router" {
   deployment_minimum_healthy_percent = "50"
   deployment_maximum_percent         = "200"
 
-  loadbalancer_cloudwatch_id   = "${module.router_alb.cloudwatch_id}"
+  loadbalancer_cloudwatch_id = "${module.router_alb.cloudwatch_id}"
 
   server_error_alarm_topic_arn = "${module.alb_server_error_alarm.arn}"
   client_error_alarm_topic_arn = "${module.alb_client_error_alarm.arn}"
 
-  memory = "490"
+  memory                 = "490"
   primary_container_port = "80"
 }

--- a/router/terraform/terraform.tf
+++ b/router/terraform/terraform.tf
@@ -20,6 +20,12 @@ data "terraform_remote_state" "wellcomecollection" {
 }
 
 provider "aws" {
-  region     = "eu-west-1"
   version = "~> 0.1"
+  region     = "eu-west-1"
+}
+
+provider "aws" {
+  version = "~> 0.1"
+  region = "us-east-1"
+  alias = "us-east-1"
 }

--- a/router/terraform/terraform.tf
+++ b/router/terraform/terraform.tf
@@ -21,11 +21,11 @@ data "terraform_remote_state" "wellcomecollection" {
 
 provider "aws" {
   version = "~> 0.1"
-  region     = "eu-west-1"
+  region  = "eu-west-1"
 }
 
 provider "aws" {
   version = "~> 0.1"
-  region = "us-east-1"
-  alias = "us-east-1"
+  region  = "us-east-1"
+  alias   = "us-east-1"
 }

--- a/router/terraform/userdata.tf
+++ b/router/terraform/userdata.tf
@@ -1,4 +1,4 @@
 module "router_userdata" {
-  source            = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
-  cluster_name      = "${aws_ecs_cluster.router.name}"
+  source       = "git::https://github.com/wellcometrust/terraform.git//userdata?ref=v1.0.0"
+  cluster_name = "${aws_ecs_cluster.router.name}"
 }


### PR DESCRIPTION
References #1616 

## Type
✨ Feature  

Puts a CloudFront dist in front of the new router service.

It's a copy / paste job and we can refine it as we move some parts (namely the no-cache routes) into their relevant places.