### PR TITLE
Show viewer in webpage if fullscreen not supported

### DIFF
--- a/client/js/components/image-viewer.js
+++ b/client/js/components/image-viewer.js
@@ -55,19 +55,18 @@ const createImageViewer = (viewer) => {
     });
 
     image.addEventListener('dblclick', (e) => {
-      setupViewer(imageInfoSrc, viewer, viewerId);
       const gaData = {
         category: 'component',
         action: 'work-enter-fullscreen-image:dblclick',
         label: `id:${window.location.pathname.match(/\/works\/(.+)/)[1]}, title:${document.title}`
       };
+      setupViewer(imageInfoSrc, viewer, viewerId);
       if (hasFullscreen()) {
         enterFullscreen(viewerContent);
-        trackGaEvent(gaData);
       } else {
         showViewerOnPage(viewerContent);
-        trackGaEvent(gaData);
       }
+      trackGaEvent(gaData);
     });
 
     enterFullscreenButton.addEventListener('click', (e) => {

--- a/client/js/components/image-viewer.js
+++ b/client/js/components/image-viewer.js
@@ -33,8 +33,16 @@ function setupViewer(imageInfoSrc, viewer, viewerId) {
   }).catch(err => { throw err; });
 }
 
+function showViewerOnPage(viewerContent) {
+  viewerContent.style.display = 'block';
+}
+
+function hideViewerOnPage(viewerContent) {
+  viewerContent.style.display = 'none';
+}
+
 const createImageViewer = (viewer) => {
-  if (window.fetch && hasFullscreen()) {
+  if (window.fetch) {
     const image = viewer.previousElementSibling;
     const viewerContent = viewer.querySelector('.image-viewer-fullscreen__content');
     const viewerId = viewerContent.getAttribute('id');
@@ -48,21 +56,35 @@ const createImageViewer = (viewer) => {
 
     image.addEventListener('dblclick', (e) => {
       setupViewer(imageInfoSrc, viewer, viewerId);
-      enterFullscreen(viewerContent);
-      trackGaEvent({
+      const gaData = {
         category: 'component',
         action: 'work-enter-fullscreen-image:dblclick',
         label: `id:${window.location.pathname.match(/\/works\/(.+)/)[1]}, title:${document.title}`
-      });
+      };
+      if (hasFullscreen()) {
+        enterFullscreen(viewerContent);
+        trackGaEvent(gaData);
+      } else {
+        showViewerOnPage(viewerContent);
+        trackGaEvent(gaData);
+      }
     });
 
     enterFullscreenButton.addEventListener('click', (e) => {
       setupViewer(imageInfoSrc, viewer, viewerId);
-      enterFullscreen(viewerContent);
+      if (hasFullscreen()) {
+        enterFullscreen(viewerContent);
+      } else {
+        showViewerOnPage(viewerContent);
+      }
     });
 
     exitFullscreenButton.addEventListener('click', (e) => {
-      exitFullscreen(viewer);
+      if (hasFullscreen()) {
+        exitFullscreen(viewer);
+      } else {
+        hideViewerOnPage(viewerContent);
+      }
     });
   }
 };

--- a/client/scss/components/_image_viewer.scss
+++ b/client/scss/components/_image_viewer.scss
@@ -7,8 +7,13 @@
   width: 100vw;
   height: 100vh;
   display: none;
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  left: 0;
 
   &:fullscreen {
+    position: static;
     display: block;
   }
 }


### PR DESCRIPTION
References #1125

## Type
✨ Feature  

- [ ] Demoed to @davidpmccormick 

## Value
Shows viewer within the browser if fullscreen is not supported,  e.g. iOS

