### PR TITLE
Get the correct series position

### DIFF
--- a/server/data/series.js
+++ b/server/data/series.js
@@ -13,7 +13,7 @@ export function getPositionInSeries(tags: {}): ?number {
 export function getPositionInPrismicSeries(headline, seriesUrl) {
   const currentSeries = series.find(s => s.url === seriesUrl);
   const item = currentSeries && currentSeries.items.find(i => i.headline === headline);
-  const itemIndex = currentSeries.items.indexOf(item);
+  const itemIndex = item && currentSeries.items.indexOf(item);
 
   return itemIndex && itemIndex + 1;
 }

--- a/server/data/series.js
+++ b/server/data/series.js
@@ -10,6 +10,14 @@ export function getPositionInSeries(tags: {}): ?number {
   return chapterTag ? parseInt(chapterTag.slice(chapterString.length), 10) : null;
 }
 
+export function getPositionInPrismicSeries(headline, seriesUrl) {
+  const currentSeries = series.find(s => s.url === seriesUrl);
+  const item = currentSeries && currentSeries.items.find(i => i.headline === headline);
+  const itemIndex = currentSeries.items.indexOf(item);
+
+  return itemIndex && itemIndex + 1;
+}
+
 export function getSeriesColor(seriesUrl: string): ?string {
   const lookup = {
     'electric-sublime': 'turquoise',

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -10,6 +10,7 @@ import type {Article} from '../model/article';
 import type {Promo} from '../model/promo';
 import type {Picture} from '../model/picture';
 import {isEmptyObj} from '../util/is-empty-obj';
+import {getPositionInPrismicSeries} from '../data/series';
 
 // This is just JSON
 type PrismicDoc = Object<any>;
@@ -111,14 +112,14 @@ export function parseArticleDoc(doc: PrismicDoc): Article {
   const series = parseSeries(doc.data.series);
 
   const bodyParts = parseBody(doc.data.body);
-
+  const headline = asText(doc.data.title);
   // TODO: The whole scheduled content has some work to be getting on with
   const seriesWithCommissionedLength = series.find(series => series.commissionedLength);
-  const positionInSeries = seriesWithCommissionedLength && (seriesWithCommissionedLength.positionInSeries || 1);
+  const positionInSeries = seriesWithCommissionedLength && getPositionInPrismicSeries(headline, seriesWithCommissionedLength.url) || 1;
 
   const article: Article = {
     contentType: 'article',
-    headline: asText(doc.data.title),
+    headline: headline,
     url: url,
     datePublished: publishDate,
     thumbnail: thumbnail,


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Displays the correct series part on digital stories from Prismic.

## Screenshot
![screen shot 2017-10-12 at 19 13 29](https://user-images.githubusercontent.com/1394592/31512026-7657c26e-af81-11e7-8fb6-f26e8c5cc05c.png)


## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged