### PR TITLE
deal with empty access linked documents

### DIFF
--- a/client/js/components/image-viewer.js
+++ b/client/js/components/image-viewer.js
@@ -6,31 +6,31 @@ import OpenSeadragon from 'openseadragon';
 function setupViewer(imageInfoSrc, viewer, viewerId) {
   if (viewer.querySelector('.openseadragon-container')) return;
   window.fetch(imageInfoSrc)
-  .then(response => response.json())
-  .then((response) => {
-    OpenSeadragon({
-      id: `image-viewer-${viewerId}`,
-      visibilityRatio: 1,
-      showFullPageControl: false,
-      showHomeControl: false,
-      zoomInButton: `zoom-in-${viewerId}`,
-      zoomOutButton: `zoom-out-${viewerId}`,
-      showNavigator: true,
-      controlsFadeDelay: 0,
-      tileSources: [{
-        '@context': 'http://iiif.io/api/image/2/context.json',
-        '@id': response['@id'],
-        'height': response.height,
-        'width': response.width,
-        'profile': [ 'http://iiif.io/api/image/2/level2.json' ],
-        'protocol': 'http://iiif.io/api/image',
-        'tiles': [{
-          'scaleFactors': [ 1, 2, 4, 8, 16, 32 ],
-          'width': 400
+    .then(response => response.json())
+    .then((response) => {
+      OpenSeadragon({
+        id: `image-viewer-${viewerId}`,
+        visibilityRatio: 1,
+        showFullPageControl: false,
+        showHomeControl: false,
+        zoomInButton: `zoom-in-${viewerId}`,
+        zoomOutButton: `zoom-out-${viewerId}`,
+        showNavigator: true,
+        controlsFadeDelay: 0,
+        tileSources: [{
+          '@context': 'http://iiif.io/api/image/2/context.json',
+          '@id': response['@id'],
+          'height': response.height,
+          'width': response.width,
+          'profile': [ 'http://iiif.io/api/image/2/level2.json' ],
+          'protocol': 'http://iiif.io/api/image',
+          'tiles': [{
+            'scaleFactors': [ 1, 2, 4, 8, 16, 32 ],
+            'width': 400
+          }]
         }]
-      }]
-    });
-  }).catch(err => { throw err; });
+      });
+    }).catch(err => { throw err; });
 }
 
 function showViewerOnPage(viewerContent) {

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -55,9 +55,9 @@ export function parseEventDoc(doc: PrismicDoc): Event {
     description: asHtml(doc.data.description),
     featuredImage: featuredImage,
     featuredImages: featuredImages,
-    accessOptions: List(doc.data.accessOptions.map(ao => ({
+    accessOptions: List(doc.data.accessOptions.map(ao => !isEmptyDocLink(ao.accessOption) ? ({
       accessOption: { title: asText(ao.accessOption.data.title), acronym: ao.accessOption.data.acronym }
-    }))),
+    }) : null).filter(_ => _)),
     bookingEnquiryTeam: bookingEnquiryTeam,
     bookingInformation: asHtml(doc.data.bookingInformation),
     isDropIn: isDropIn,
@@ -295,4 +295,8 @@ export function asText(maybeContent) {
 
 export function asHtml(maybeContent) {
   return maybeContent && RichText.asHtml(maybeContent).trim();
+}
+
+function isEmptyDocLink(fragment) {
+  return fragment.link_type === 'Document' && !fragment.data;
 }


### PR DESCRIPTION
## Type
🐛 Bugfix  

Deals with the fact that people might partially add access option data.

It is a bit hard to fathom what is required / not required, but for preview, nothing should be required as you might want to check impartial data.

