### PR TITLE
Treat Vimeo the same way as YouTube

### DIFF
--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -103,6 +103,7 @@ export function parseBody(content) {
         };
 
       case 'youtubeVideoEmbed':
+      case 'vimeoVideoEmbed':
         // TODO: Not this ;﹏;
         const embedUrl = slice.primary.embed.html.match(/src="([a-zA-Z0-9://.]+)?/)[1];
         return {

--- a/server/views/components/iframed-video/iframed-video.njk
+++ b/server/views/components/iframed-video/iframed-video.njk
@@ -1,4 +1,4 @@
-<div class="iframe-container">
-    <iframe allowfullscreen="allowfullscreen" mozallowfullscreen="mozallowfullscreen" msallowfullscreen="msallowfullscreen" oallowfullscreen="oallowfullscreen" webkitallowfullscreen="webkitallowfullscreen" src="{{ model.embedUrl }}" frameborder="0" class="iframe-container__iframe"></iframe>
+<div class="iframe-container relative">
+    <iframe allowfullscreen="allowfullscreen" mozallowfullscreen="mozallowfullscreen" msallowfullscreen="msallowfullscreen" oallowfullscreen="oallowfullscreen" webkitallowfullscreen="webkitallowfullscreen" src="{{ model.embedUrl }}" frameborder="0" class="iframe-container__iframe absolute"></iframe>
 </div>
 {{ model.description }}


### PR DESCRIPTION
## Type
✨ Feature  
🐛 Bugfix  


## Value
Allows Vimeo videos to show up on the front end. Also fixes a regression where YouTube videos wouldn't display because of missing classes on the iframe/container.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
