### PR TITLE
Allow supporting/standalone YouTube/Vimeo videos

### DIFF
--- a/content-model/articles.json
+++ b/content-model/articles.json
@@ -30,6 +30,20 @@
             "name" : "standalone",
             "display" : "Standalone"
           } ],
+          "vimeoVideoEmbed" : [ {
+            "name" : "supporting",
+            "display" : "Supporting"
+          }, {
+            "name" : "standalone",
+            "display" : "Standalone"
+          } ],
+          "youtubeVideoEmbed" : [ {
+            "name" : "supporting",
+            "display" : "Supporting"
+          }, {
+            "name" : "standalone",
+            "display" : "Standalone"
+          } ],
           "imageList" : [ {
             "name" : "featured",
             "display" : "Featured"

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -108,6 +108,7 @@ export function parseBody(content) {
         const embedUrl = slice.primary.embed.html.match(/src="([a-zA-Z0-9://.]+)?/)[1];
         return {
           type: 'video-embed',
+          weight: slice.slice_label,
           value: {
             embedUrl: embedUrl
           }

--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -36,7 +36,9 @@
               {% componentV2 'captioned-image', bodyPart.value, {'has-border-bottom': bodyPart.value.caption}, {sizesQueries: sizes, showCopyright: true} %}
             </div>
           {% elif bodyPart.type === 'video-embed' %}
-            {% componentV2 'iframed-video', bodyPart.value %}
+            <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
+              {% componentV2 'iframed-video', bodyPart.value %}
+            </div>
           {% elif bodyPart.type === 'list' %}
             {% component 'list', {list: bodyPart.value} %}
           {% elif bodyPart.type === 'interview' %}


### PR DESCRIPTION
## Type
✨ Feature  

## Value
Allows editorial team to add supporting (sticky) videos in the right hand rail, or 'standalone' videos that span the full grid width

## Screenshot
![screen shot 2017-10-17 at 12 23 20](https://user-images.githubusercontent.com/1394592/31662367-02b5bd1c-b336-11e7-8b7e-ef65d8df5ab3.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
