### PR TITLE
pass prev. as host to drupal site

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -48,34 +48,28 @@ http {
     client_max_body_size      200M;
 
     # These are the locations we know exist solely on v2
-    location ~ ^/assets|/async|/explore|/works|/series|/preview {
+    location ~ ^/assets|/async|/explore|/works|/series|/preview|/articles/W|/exhibitions/W|/events/W {
       proxy_set_header        Host $host;
       proxy_pass              http://wellcomecollection:3000;
     }
-
-    # For exhibitions, we default to v2 and fallback to v1
-    # This is because drupal considers /exhibitions/anything/goes
-    # to be a valid request
-    location ~ ^/exhibitions/.* {
+    location /articles {
       proxy_set_header        Host $host;
       proxy_pass              http://wellcomecollection:3000;
-      proxy_intercept_errors  on;
-      error_page 404 = @v1;
     }
 
     # Everything else - if we 404 on v1, we fallback to v2
     location / {
-      proxy_pass              http://prev.wellcomecollection.org;
-      proxy_set_header        Host $host;
+      proxy_set_header        Host prev.wellcomecollection.org;
       proxy_set_header        HTTP_X_FORWARDED_PROTO https;
+      proxy_pass              http://prev.wellcomecollection.org;
       proxy_intercept_errors  on;
       error_page 404 = @v2;
     }
 
     location @v1 {
-      proxy_pass              http://prev.wellcomecollection.org;
-      proxy_set_header        Host $host;
+      proxy_set_header        Host prev.wellcomecollection.org;
       proxy_set_header        HTTP_X_FORWARDED_PROTO https;
+      proxy_pass              http://prev.wellcomecollection.org;
     }
 
     location @v2 {

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -55,7 +55,7 @@ http {
 
     location / {
       proxy_pass                 http://v1;
-      proxy_set_header           Host $host;
+      proxy_set_header           Host prev.wellcomecollection.org;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
 


### PR DESCRIPTION
References #1616

## Type
🚑 Health

## Value
It seems when we pass the wellcomecollection.org host to the Drupal NGXIN conf, we hit something that is not transparent, so we can't tell what it's doing.

This makes sure our test / prod envs are the same.

I ran the test on the nut / router first, so we should be good.