### PR TITLE
add management and download URIs to pass to v2

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -52,6 +52,10 @@ http {
       proxy_set_header        Host $host;
       proxy_pass              http://wellcomecollection:3000;
     }
+    location ~ ^/management/.* {
+      proxy_set_header        Host $host;
+      proxy_pass              http://wellcomecollection:3000;
+    }
     location /articles {
       proxy_set_header        Host $host;
       proxy_pass              http://wellcomecollection:3000;

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -44,7 +44,11 @@ http {
     add_header       x-wc-router true;
 
     # These are the locations we know exist solely on v2
-    location ~ ^/assets|/async|/explore|/works|/series|/preview|/articles/W|/exhibitions/W|/events/W {
+    location ~ ^/assets|/async|/explore|/works|/series|/preview|/download/articles/W|/exhibitions/W|/events/W {
+      proxy_set_header        Host $host;
+      proxy_pass              http://v2;
+    }
+    location ~ ^/management/.* {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -44,7 +44,7 @@ http {
     add_header       x-wc-router true;
 
     # These are the locations we know exist solely on v2
-    location ~ ^/assets|/async|/explore|/works|/series|/preview|/download/articles/W|/exhibitions/W|/events/W {
+    location ~ ^/assets|/async|/explore|/works|/series|/preview|/download|/articles/W|/exhibitions/W|/events/W {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }


### PR DESCRIPTION
## Type
🚑 Health

Allows URIs to go to V2.
Next is to remove all routing from the `nginx-router` attached to that should be the router's job.