### PR TITLE
move non-vital parts over to new router

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -2,32 +2,6 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
-  # Wordpress Blog deprecation
-  server {
-    listen      80;
-    server_name blog.wellcomecollection.org;
-    add_header  x-wc-nginx-proxy true;
-
-    location ~* \/feed\/?$ {
-      # we send the traffic over to the Wordpress servers, and the host, they then resolve correctly,
-      # even though it's a proxy.
-      proxy_pass https://192.0.78.12;
-      proxy_set_header Host $host;
-    }
-
-    location ~* (?<!feed\/) {
-      # articles
-      rewrite ^/\d+\/\d+\/\d+\/(.*)/?$ https://wellcomecollection.org/articles/$1 permanent;
-
-      # pages
-      rewrite ^/about/?$ https://wellcomecollection.org/what-we-do/about-wellcome-collection permanent;
-      rewrite ^/about/terms-and-conditions/?$ https://wellcome.ac.uk/about-us/terms-use permanent;
-
-      # index
-      rewrite ^/?$ https://wellcomecollection.org/explore permanent;
-    }
-  }
-
   server {
     listen           80;
     listen           443 ssl;
@@ -40,12 +14,6 @@ http {
     # See: http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
     gzip_min_length 860;
     gzip_proxied any;
-
-    # Added for supporting the Drupal adminstration functions.
-    proxy_buffer_size         512k;
-    proxy_buffers             8 256k;
-    client_body_buffer_size   512k;
-    client_max_body_size      200M;
 
     # These are the locations we know exist solely on v2
     location ~ ^/assets|/async|/explore|/works|/series|/preview|/articles/W|/exhibitions/W|/events/W {
@@ -80,14 +48,6 @@ http {
       proxy_set_header        Host $host;
       proxy_pass              http://wellcomecollection:3000;
     }
-  }
-
-  # redirect next. traffic
-  server {
-    listen 80;
-    listen 443 ssl;
-    server_name next.wellcomecollection.org;
-    return 301 https://wellcomecollection.org$request_uri;
   }
 
   # for now we just allow you through to the site

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -28,6 +28,14 @@ http {
     }
   }
 
+  # redirect next. traffic
+  server {
+    listen 80;
+    listen 443 ssl;
+    server_name next.wellcomecollection.org;
+    return 301 https://wellcomecollection.org$request_uri;
+  }
+
   upstream v1 {
     server prev.wellcomecollection.org;
   }
@@ -43,7 +51,7 @@ http {
     server_name      _;
     add_header       x-wc-router true;
 
-    # These are the locations we know exist solely on v2
+    # v2
     location ~ ^/assets|/async|/explore|/works|/series|/preview|/download|/articles/W|/exhibitions/W|/events/W {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
@@ -57,12 +65,24 @@ http {
       proxy_pass              http://v2;
     }
 
+    # v1
+    location ~ /admin/.* {
+      proxy_buffer_size         512k;
+      proxy_buffers             8 256k;
+      client_body_buffer_size   512k;
+      client_max_body_size      200M;
+
+      proxy_pass                 http://v1;
+      proxy_set_header           Host prev.wellcomecollection.org;
+      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
+    }
     location / {
       proxy_pass                 http://v1;
       proxy_set_header           Host prev.wellcomecollection.org;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
 
+    # healthcheck
     location /management/healthcheck {
       add_header Content-Type text/plain;
       return 200 'OK';

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -19,7 +19,11 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   enabled         = true
   is_ipv6_enabled = true
 
-  aliases = ["wellcomecollection.org", "next.wellcomecollection.net"]
+  aliases = [
+    "wellcomecollection.org",
+    "next.wellcomecollection.net",
+    "blog.wellcomecollection.org"
+  ]
 
   default_cache_behavior {
     allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]


### PR DESCRIPTION
## Type
🚑 Health

Moving over non-vital (by this I mean non-user-facing) parts of the nginx-proxy to the router.
This will land up with the dealing simply with the node app.

