### PR TITLE
add favicon

### DIFF
--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -14,6 +14,8 @@
     </style>
     <link rel="preload" href="/assets/css/{{ 'non-critical.css' | getCacheBustFile }}" as="style" onload="this.rel='stylesheet'">
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png"/>
+
+    <link rel="shortcut icon" href="/assets/icons/favicon.ico" type="image/ico">
     <link rel="icon" type="image/png" href="/assets/icons/favicon-32x32.png" sizes="32x32"/>
     <link rel="icon" type="image/png" href="/assets/icons/favicon-16x16.png" sizes="16x16"/>
     <link rel="manifest" href="/assets/icons/manifest.json"/>


### PR DESCRIPTION
## Type
🐛 Bugfix  

Noticed it didn't show in Firefox.
Now it does.

Still doesn't make it much easier to know it's Wellcome Collection unless I know the icon.