### PR TITLE
update rules for nginx to make sure we only catch URLs starting in...

### DIFF
--- a/router/README.md
+++ b/router/README.md
@@ -4,6 +4,23 @@ An nginx proxy to route traffic for wellcomecollection.org
 
 This application is split into a seperate stack.
 
+
+## To run a dev version
+
+You can run a dev version by installing Nginx, and starting it with
+the router's conf file:
+
+```sh
+nginx -c /path/to/project/wellcomecollection.org/router/nginx.conf
+```
+
+If you need to test changes on the app too,
+you can then set the v2 upstream to `localhost:3000`. 
+
+
+_TODO:_ Improve dev experience.
+
+
 ## Deploying
 
 Run:

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -52,7 +52,7 @@ http {
     add_header       x-wc-router true;
 
     # v2
-    location ~ ^/assets|/async|/explore|/works|/series|/preview|/download|/articles/W|/exhibitions/W|/events/W {
+    location ~ ^/assets|^/async|^/explore|^/works|^/series|^/preview|^/download|^/articles/W|^/exhibitions/W|^/events/W {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }


### PR DESCRIPTION
## Type
🐛 Bugfix  

We are catching `/things/explore` and sending to v2, whereas it should only be URLs starting in.
`/download` being the main issue.