### PR TITLE
better regexp in nginx for /articles

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -60,7 +60,7 @@ http {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
-    location /articles {
+    location ~ ^/articles$ {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }


### PR DESCRIPTION
## Type
🐛 Bugfix  

Turns out I need to work on my Nginx Regex.
This helps: http://nginx.viraptor.info/

Will stop these 404ing:
https://wellcomecollection.org/articles/tetanus-cut-finger