### PR TITLE
update rules for nginx so /flags goes to V2

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -52,7 +52,7 @@ http {
     add_header       x-wc-router true;
 
     # v2
-    location ~ ^/assets|^/async|^/explore|^/works|^/series|^/preview|^/download|^/articles/W|^/exhibitions/W|^/events/W {
+    location ~ ^/assets|^/async|^/explore|^/flags|^/works|^/series|^/preview|^/download|^/articles/W|^/exhibitions/W|^/events/W {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
stops /flags from 404ing
