### PR TITLE
use routing that deal with all 3 of our types of articles

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -64,7 +64,17 @@ http {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
-
+    location ~ ^/articles/.* {
+      proxy_set_header        Host $host;
+      proxy_pass              http://v2;
+      proxy_intercept_errors  on;
+      error_page 404 = @v1;
+    }
+    location @v1 {
+      proxy_pass                 http://v1;
+      proxy_set_header           Host wellcomecollection.org;
+      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
+    }
 
     # v1
     location ~ ^/admin/.* {


### PR DESCRIPTION

## Type
🐛 Bugfix  

Caters for and tested on Drupal, Wordpress and Prismic article paths:
https://wellcomecollection.org/articles/tetanus-cut-finger
https://wellcomecollection.org/articles/museuminstaswap
https://wellcomecollection.org/articles/WcppcigAAJwPEevo

(Currently WP articles don't work)