### PR TITLE
Correct title in series json

### DIFF
--- a/server/data/series.js
+++ b/server/data/series.js
@@ -73,7 +73,7 @@ export const series = List([
       }: ArticleStub),
       ({
         contentType: 'article',
-        headline: 'Theriac: an ancient pharmaceutical brand?',
+        headline: 'Theriac: an ancient brand?',
         url: '',
         description: '',
         datePublished: new Date('2017-10-19')


### PR DESCRIPTION
## Type
🐛 Bugfix

## Value
Quick fix so that 'Theriac: an ancient brand?' articles shows the correct position in series.

Will look into long term fix next
