### PR TITLE
Part indicators back on transporter

### DIFF
--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -48,8 +48,6 @@ export const work = async(ctx, next) => {
   const imgLink = imageUrlFromMiroId(miroId);
   const encoreLink = sierraId && encoreLinkFromSierraId(sierraId);
 
-  console.info(imgWidth, imgLink, encoreLink);
-
   ctx.render('pages/work', {
     id,
     queryString,

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -61,7 +61,6 @@ r.get('/works/:id', work);
 r.get('/articles/:slug', article);
 r.get('/articles/preview/:id', preview);
 r.get('/series/:id', series);
-r.get('/articles', articles);
 r.get('/articles', async (ctx, next) => {
   const format = ctx.query.format;
   if (format === 'archive') {

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -97,8 +97,8 @@ export function parseExhibitionsDoc(doc: PrismicDoc): Exhibition {
   return exhibition;
 }
 
-function getPositionInPrismicSeries(series, doc) {
-  return doc.data.series.find((s) => s.series.id === series[0].id).positionInSeries;
+export function getPositionInPrismicSeries(seriesId, seriesList) {
+  return seriesList.find((s) => s.series.id === seriesId).positionInSeries;
 };
 
 export function parseArticleDoc(doc: PrismicDoc): Article {
@@ -119,7 +119,7 @@ export function parseArticleDoc(doc: PrismicDoc): Article {
   const headline = asText(doc.data.title);
   // TODO: The whole scheduled content has some work to be getting on with
   const seriesWithCommissionedLength = series.find(series => series.commissionedLength);
-  const positionInSeries = seriesWithCommissionedLength && getPositionInPrismicSeries(series, doc) || null;
+  const positionInSeries = seriesWithCommissionedLength && getPositionInPrismicSeries(series[0].id, doc.data.series) || null;
 
   const article: Article = {
     contentType: 'article',


### PR DESCRIPTION
## Type 
🐛 Bugfix


## Value
Puts missing indicator bars back on transporter

## Screenshot
![screen shot 2017-10-20 at 12 02 22](https://user-images.githubusercontent.com/6051896/31818138-a9b90fc4-b58e-11e7-9221-5a7afcb33d56.png)
