### PR TITLE
label subtitle correctly

### DIFF
--- a/content-model/exhibitions.json
+++ b/content-model/exhibitions.json
@@ -11,7 +11,7 @@
       "type" : "StructuredText",
       "config" : {
         "single" : "heading2",
-        "label" : "Summary"
+        "label" : "Subtitle"
       }
     },
     "start" : {


### PR DESCRIPTION
## Type
🐛 Bugfix  


## Value
Stops people putting the summary in the subtitle box.