### PR TITLE
return copyright if it's not set correctly

### DIFF
--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -288,7 +288,7 @@ function parseTaslFromCopyright(copyright) {
     const [title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink] = v;
     return {title, author, sourceName, sourceLink, license, copyrightHolder, copyrightLink};
   } catch (e) {
-    return copyright;
+    return {title: copyright};
   }
 }
 


### PR DESCRIPTION
## Type
🐛 Bugfix  

At the moment we're returning nothing, making content editors believe that it's broken.

My fear now is that they will not look behind the show / hide copyright button, leaving broken copyright info.

Thoughts? Show copyright all the time? Show it on;y if it's broken?