### PR TITLE
revert to node 6 for build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   checkout_code:
     docker:
-      - image: node:8.4.0
+      - image: node:6.10
     working_directory: ~/wellcomecollection.org
     steps:
       - checkout
@@ -12,7 +12,7 @@ jobs:
             -  ~/wellcomecollection.org
   install_server_modules:
     docker:
-      - image: node:8.4.0
+      - image: node:6.10
     working_directory: ~/wellcomecollection.org/server
     steps:
       - restore_cache:
@@ -26,7 +26,7 @@ jobs:
             -  ~/wellcomecollection.org/server/node_modules
   install_client_modules:
     docker:
-      - image: node:8.4.0
+      - image: node:6.10
     working_directory: ~/wellcomecollection.org/client
     steps:
       - restore_cache:
@@ -40,7 +40,7 @@ jobs:
             -  ~/wellcomecollection.org/client/node_modules
   build:
     docker:
-      - image: node:8.4.0
+      - image: node:6.10
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -67,7 +67,7 @@ jobs:
             -  ~/wellcomecollection.org/dist
   test:
     docker:
-      - image: node:8.4.0
+      - image: node:6.10
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -82,7 +82,7 @@ jobs:
           command: pushd server && npm run test && popd
   deploy_app:
     docker:
-      - image: node:8.4.0
+      - image: node:6.10
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -120,7 +120,7 @@ jobs:
             ./build-speedtracker.sh
   deploy_cardigan:
     docker:
-      - image: node:8.4.0
+      - image: node:6.10
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install server modules
           command: npm install --production
       - save_cache:
-          key: server_modules_{{ checksum "server/package.json" }}
+          key: server_modules_node_6_{{ checksum "server/package.json" }}
           paths:
             -  ~/wellcomecollection.org/server/node_modules
   install_client_modules:
@@ -35,7 +35,7 @@ jobs:
           name: Install client modules
           command: npm install
       - save_cache:
-          key: client_modules_{{ checksum "client/package.json" }}
+          key: client_modules_node_6_{{ checksum "client/package.json" }}
           paths:
             -  ~/wellcomecollection.org/client/node_modules
   build:
@@ -46,11 +46,11 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_{{ checksum "server/package.json" }}
-          key: server_modules_
+          key: server_modules_node_6_{{ checksum "server/package.json" }}
+          key: server_modules_node_6_
       - restore_cache:
-          key: client_modules_{{ checksum "client/package.json" }}
-          key: client_modules_
+          key: client_modules_node_6_{{ checksum "client/package.json" }}
+          key: client_modules_node_6_
       - run:
           name: Build client
           command: ./build-client.sh
@@ -73,8 +73,8 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_{{ checksum "server/package.json" }}
-          key: server_modules_
+          key: server_modules_node_6_{{ checksum "server/package.json" }}
+          key: server_modules_node_6_
       - restore_cache:
           key: built_server_{{ .Environment.CIRCLE_SHA1 }}
       - run:


### PR DESCRIPTION
Turns out node8's `install file:` creates a symlink, and doesn't actually copy the files over.
This is an interim solution, we can either look at moving backwards and using something like [`install-local`](https://github.com/nicojs/node-install-local) or start thinking about how to manage inter-project dependencies.

We have the problem with the coupling of the client / server with the `js/css-assets` which I hope to solve by making `client` it's own app.

This also points out that we should probably running the tests in our docker containers.