### PR TITLE
align footer content

### DIFF
--- a/client/scss/components/_footer_nav.scss
+++ b/client/scss/components/_footer_nav.scss
@@ -8,9 +8,8 @@
 }
 
 .footer-nav__brand {
-  padding-bottom: 1rem;
-  border-bottom: 1px solid color('charcoal');
   display: block;
+  bottom: 0;
 }
 
 .footer-nav__nav {

--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -334,6 +334,11 @@
   font-weight: bold;
 }
 
+// This removes the element from the flow, as well as it's visibility
 .visually-hidden {
   @include visually-hidden;
+}
+
+.hidden {
+  visibility: hidden;
 }

--- a/server/views/components/footer-nav/footer-nav.njk
+++ b/server/views/components/footer-nav/footer-nav.njk
@@ -1,7 +1,4 @@
 <div class="footer-nav">
-  <a href="#" class="footer-nav__brand">
-    {% include "icons/other/wellcome-collection-white.svg.njk" %}
-  </a>
   <nav class="footer-nav__nav">
     <ul class="plain-list footer-nav__list {{ {s:0} | spacingClasses({margin: ['top', 'left', 'bottom', 'right'], padding: ['top', 'left', 'bottom', 'right']}) }}">
       {% for link in navLinks %}

--- a/server/views/components/footer/footer.njk
+++ b/server/views/components/footer/footer.njk
@@ -2,7 +2,15 @@
   <div class="container">
     <div class="grid">
       <div class="{{ {s:12, m:6, l:3} | gridClasses }}">
-        {% component 'footer-nav', {navLinks: navLinks} %}
+        <h3 class="footer__heading {{ {s:'HNL5'} | fontClasses }} relative">
+          <span class="hidden">Wellcome collection</span>
+          <a href="#" class="footer-nav__brand absolute">
+            {% include "icons/other/wellcome-collection-white.svg.njk" %}
+          </a>
+        </h3>
+        <div class="border-top-width-1 border-color-charcoal">
+          {% component 'footer-nav', {navLinks: navLinks} %}
+        </div>
       </div>
       <div class="{{ {s:12, m:6, l:3} | gridClasses }}">
         <h3 class="footer__heading {{ {s:'HNL5'} | fontClasses }}">Finding us:</h3>


### PR DESCRIPTION
FIxes #720

🐛 Bugfix

`visibility: hidden` is hidden from screenreaders, which is great, as the SVG has a title.
Although I do wonder what the heading adds to screenreader users in general?