### PR TITLE
Limit wobbly line height

### DIFF
--- a/client/scss/components/_wobbly_edge.scss
+++ b/client/scss/components/_wobbly_edge.scss
@@ -36,4 +36,8 @@
 .wobbly-edge--small {
   height: 5vw;
   margin-top: -5vw;
+
+  @include respond-to('large') {
+    margin-top: -60px;
+  }
 }

--- a/client/scss/components/_wobbly_edge.scss
+++ b/client/scss/components/_wobbly_edge.scss
@@ -7,6 +7,11 @@
   transition: clip-path 2000ms ease-in-out;
   display: none;
 
+  @include respond-to('large') {
+    max-height: 60px;
+    margin-top: -60px;
+  }
+
   @supports ((clip-path: polygon(0 0)) or (-webkit-clip-path: polygon(0 0))) {
     .enhanced & {
       display: block;
@@ -30,4 +35,5 @@
 
 .wobbly-edge--small {
   height: 5vw;
+  margin-top: -5vw;
 }

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -149,7 +149,7 @@
   {% block transporters %}
     {% for series in article.series %}
       {% if series.commissionedLength %}
-        <div class="row {{ {s:10} | spacingClasses({padding: ['top']}) }}">
+        <div class="row">
           <div class="container digital-story-transporter">
             <div class="grid grid--no-gutters">
               <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">


### PR DESCRIPTION
Fixes#1733

## Type
🐛 Bugfix  

## Value
Prevents the wobbly line obscuring content by limiting its height at the large breakpoint

## Screenshot
![screen shot 2017-10-26 at 17 29 12](https://user-images.githubusercontent.com/1394592/32064981-55971b40-ba73-11e7-87ef-95f4389338da.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged