### PR TITLE
Make all tags black; link tags hover to elf-green

### DIFF
--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -33,6 +33,11 @@
 }
 
 @for $i from 1 through 5 {
+  .border-width-#{$i} {
+    border-width: #{$i}px;
+    border-style: solid;
+  }
+
   @each $direction in $spacing-directions {
     .border-#{$direction}-width-#{$i} {
       border-#{$direction}-width: #{$i}px;
@@ -56,6 +61,13 @@
     background: nth($color-value, 1);
   }
 
+  .bg-hover-#{$color-key} {
+    &:hover,
+    &:focus {
+      background: nth($color-value, 1);
+    }
+  }
+
   .border-color-#{$color-key} {
     border-color: nth($color-value, 1);
   }
@@ -65,6 +77,11 @@
     border-color: nth($color-value, 1);
   }
 }
+
+.transition-bg {
+  transition: background $transition-properties;
+}
+
 // stylelint-enable sh-waqar/declaration-use-variable
 
 .caps {

--- a/client/scss/utilities/_variables.scss
+++ b/client/scss/utilities/_variables.scss
@@ -210,6 +210,7 @@ $container-padding-xl: map-get($container-padding, 'xlarge');
 
 $icon-dimension: 26px;
 $icon-container-dimension: 46px;
+$transition-properties: 600ms ease;
 
 $breakpoints: (
   'small': 0,

--- a/server/views/components/tags/tags.config.js
+++ b/server/views/components/tags/tags.config.js
@@ -7,7 +7,6 @@ export const context = {
       text: 'Walking tour'
     }, {
       text: 'A Museum of Modern Nature',
-      url: '/components/preview/exhibition-template.html',
-      bgColor: 'teal'
+      url: '/components/preview/exhibition-template.html'
     }]
 };

--- a/server/views/components/tags/tags.njk
+++ b/server/views/components/tags/tags.njk
@@ -6,7 +6,7 @@
         data-track-event='{"category": "component", "action": "tag:click", "label": "text:{{ tag.prefix + ' ' if tag.prefix }}{{ tag.text }}, url:{{ tag.url }}"}'>
         <{{'a' if isLink else 'div'}}
           {% if isLink %}href="{{ tag.url }}"{% endif %}
-          class="plain-link flex font-white bg-{{ tag.bgColor or 'black' }} {{ {s:1} | spacingClasses({padding: ['left', 'right', 'top', 'bottom']}) }} {{ {l:2} | spacingClasses({padding: ['left', 'right']}) }} rounded-diagonal">
+          class="plain-link flex font-white bg-black border-color-white border-width-1 {% if isLink %}bg-hover-elf-green transition-bg{% endif %} {{ {s:1} | spacingClasses({padding: ['left', 'right', 'top', 'bottom']}) }} {{ {l:2} | spacingClasses({padding: ['left', 'right']}) }} rounded-diagonal">
           {{ tag.text }}
         </{{'a' if isLink else 'div'}}>
       </li>

--- a/server/views/components/tags/tags.njk
+++ b/server/views/components/tags/tags.njk
@@ -6,7 +6,7 @@
         data-track-event='{"category": "component", "action": "tag:click", "label": "text:{{ tag.prefix + ' ' if tag.prefix }}{{ tag.text }}, url:{{ tag.url }}"}'>
         <{{'a' if isLink else 'div'}}
           {% if isLink %}href="{{ tag.url }}"{% endif %}
-          class="plain-link flex font-white bg-black border-color-white border-width-1 {% if isLink %}bg-hover-elf-green transition-bg{% endif %} {{ {s:1} | spacingClasses({padding: ['left', 'right', 'top', 'bottom']}) }} {{ {l:2} | spacingClasses({padding: ['left', 'right']}) }} rounded-diagonal">
+          class="plain-link flex font-white bg-charcoal border-color-white border-width-1 {% if isLink %}bg-hover-elf-green transition-bg{% endif %} {{ {s:1} | spacingClasses({padding: ['left', 'right', 'top', 'bottom']}) }} {{ {l:2} | spacingClasses({padding: ['left', 'right']}) }} rounded-diagonal">
           {{ tag.text }}
         </{{'a' if isLink else 'div'}}>
       </li>

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -62,14 +62,14 @@
             <p class="{{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNL3', m:'HNL2'} | fontClasses }}">Discover our collections through these topics.</p>
             <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
               {% componentV2 'tags', [
-                {text: 'Quacks', url: '/works?query=quack+OR+quacks', bgColor: 'turquoise-text'},
-                {text: 'James Gillray', url: '/works?query=james+gillray', bgColor: 'turquoise-text'},
-                {text: 'Botany', url: '/works?query=botany', bgColor: 'turquoise-text'},
-                {text: 'Optics', url: '/works?query=optics', bgColor: 'turquoise-text'},
-                {text: 'Sun', url: '/works?query=sun', bgColor: 'turquoise-text'},
-                {text: 'Health', url: '/works?query=health', bgColor: 'turquoise-text'},
-                {text: 'Paintings', url: '/works?query=paintings', bgColor: 'turquoise-text'},
-                {text: 'Science', url: '/works?query=science', bgColor: 'turquoise-text'}
+                {text: 'Quacks', url: '/works?query=quack+OR+quacks'},
+                {text: 'James Gillray', url: '/works?query=james+gillray'},
+                {text: 'Botany', url: '/works?query=botany'},
+                {text: 'Optics', url: '/works?query=optics'},
+                {text: 'Sun', url: '/works?query=sun'},
+                {text: 'Health', url: '/works?query=health'},
+                {text: 'Paintings', url: '/works?query=paintings'},
+                {text: 'Science', url: '/works?query=science'}
               ] %}
             </div>
 

--- a/server/views/templates/exhibition.config.js
+++ b/server/views/templates/exhibition.config.js
@@ -16,8 +16,7 @@ export const context = {
     {
       prefix: 'Part of:',
       text: 'A Museum of Modern Nature',
-      url: '/components/preview/exhibition-template.html',
-      bgColor: 'teal'
+      url: '/components/preview/exhibition-template.html'
     }]
   },
   video: {


### PR DESCRIPTION
## Type  
🐛 Bugfix  

## Value
Makes the tags more accessible by giving a visual change on hover/focus. Tag colour is not configurable (for now). They're black and elf-green on hover.

## Screenshot
![hover](https://user-images.githubusercontent.com/1394592/32103314-c13a458a-bb17-11e7-8d93-5777af06c8f8.gif)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [ ] A11y tested: `npm run test:accessibility <URL>`
- [ ] Structured data tested: https://search.google.com/structured-data/testing-tool 
- [ ] Browser tested: `npm run test:browsers <URL>`
- [ ] Works without JS in the client
- [ ] Relevant tracking/monitoring has been considered
