### PR TITLE
Reduce padding above author block on article page

### DIFF
--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -99,7 +99,7 @@
       </div>
     </div>
 
-    <div class="row bg-cream {{ {s:8} | spacingClasses({padding: ['top', 'bottom']}) }} ">
+    <div class="row bg-cream {{ {s:3} | spacingClasses({padding: ['top']}) }} {{ {s:8} | spacingClasses({padding: ['bottom']}) }} ">
       <div class="container">
         <div class="grid grid--no-gutters">
           <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 6, shiftXl: 1} | gridClasses }}">


### PR DESCRIPTION
Fixes #1771

## Type
🐛 Bugfix  

## Value
Removes excess padding above author byline.

## Screenshot
![screen shot 2017-10-30 at 15 25 09](https://user-images.githubusercontent.com/1394592/32179254-d876007e-bd86-11e7-9829-7bf1f349956c.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
