### PR TITLE
Don't throw 404s to sentry

### DIFF
--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -10,8 +10,9 @@ export function serverError(beaconError) {
       const url = ctx.request.href;
       ctx.status = err.status || 500;
 
-      console.error(err, url);
-      if (beaconError) {
+      console.error(err, url, ctx.status);
+      if (beaconError && (ctx.status < 400 || ctx.status >= 500)) {
+        console.info('boom')
         Raven.captureException(err, {extra: {url: ctx.request.href}});
       }
 


### PR DESCRIPTION
🚑 Health

They make a noise.
We can track these in webmaster tools and GA.