### PR TITLE
add inspect to node JS command app:dev

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "app:build": "babel . -d .dist --ignore=node_modules --copy-files",
-    "app:dev": "nodemon -e js,njk,json --exec babel-node run.js",
+    "app:dev": "nodemon -e js,njk,json --exec babel-node --inspect run.js",
     "app:docker": "pm2-docker --json pm2.yml",
     "app:run": "pm2 start pm2.yml",
     "optimise:svg": "node ./optimise-svgs.js",


### PR DESCRIPTION
Allows us to use the Chrome inspector for nodejs.