### PR TITLE
restart PM2 on cron

### DIFF
--- a/server/pm2.yml
+++ b/server/pm2.yml
@@ -4,6 +4,6 @@ apps:
     exec_mode: 'cluster'
     instances: 'max'
     # Every 6 hours
-    cron_restart: '0 0 0/6 1/1 * ? *'
+    cron_restart: '0 */6 * * *'
     env:
       NODE_ENV: "production"

--- a/server/pm2.yml
+++ b/server/pm2.yml
@@ -3,5 +3,7 @@ apps:
     name     : 'wellcomecollection.org'
     exec_mode: 'cluster'
     instances: 'max'
+    # Every 6 hours
+    cron_restart: '0 0 0/6 1/1 * ? *'
     env:
       NODE_ENV: "production"


### PR DESCRIPTION
Restarts PM2 every 6 hours.
I would have loved to have had this on CPU usage, but there is no such option.

Hopefully this will wedge it until we get to the bottom of the solution and will stop us having to be on support.