### PR TITLE
Use black instead of white for tag border to be less zingy

### DIFF
--- a/server/views/components/tags/tags.njk
+++ b/server/views/components/tags/tags.njk
@@ -6,7 +6,7 @@
         data-track-event='{"category": "component", "action": "tag:click", "label": "text:{{ tag.prefix + ' ' if tag.prefix }}{{ tag.text }}, url:{{ tag.url }}"}'>
         <{{'a' if isLink else 'div'}}
           {% if isLink %}href="{{ tag.url }}"{% endif %}
-          class="plain-link flex font-white bg-charcoal border-color-white border-width-1 {% if isLink %}bg-hover-elf-green transition-bg{% endif %} {{ {s:1} | spacingClasses({padding: ['left', 'right', 'top', 'bottom']}) }} {{ {l:2} | spacingClasses({padding: ['left', 'right']}) }} rounded-diagonal">
+          class="plain-link flex font-white bg-charcoal border-color-black border-width-1 {% if isLink %}bg-hover-elf-green transition-bg{% endif %} {{ {s:1} | spacingClasses({padding: ['left', 'right', 'top', 'bottom']}) }} {{ {l:2} | spacingClasses({padding: ['left', 'right']}) }} rounded-diagonal">
           {{ tag.text }}
         </{{'a' if isLink else 'div'}}>
       </li>


### PR DESCRIPTION
## Type
🐛 Bugfix
  
## Value
Makes tags less zingy when they're on a dark background.

## Screenshot
![screen shot 2017-10-31 at 12 38 27](https://user-images.githubusercontent.com/1394592/32224346-fb243aca-be38-11e7-92e8-c45d812f2f1c.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged
