### PR TITLE
add i.wc.org for static assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,8 +115,6 @@ jobs:
       working_directory: ~/wellcomecollection.org/dist
       steps:
         - restore_cache:
-            key: repo_{{ .Environment.CIRCLE_SHA1 }}
-        - restore_cache:
             key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
         - add_ssh_keys
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,19 +104,33 @@ jobs:
       - run:
           name: Deploy
           command: |
-            # Install AWS CLI. Taken from:
-            # http://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html
-            apt-get -y -qq update
-            apt-get -y -qq install python3.4-dev
-            curl -O https://bootstrap.pypa.io/get-pip.py
-            python3.4 get-pip.py --user
-            export PATH=~/.local/bin:$PATH
-            pip install awscli --upgrade --user
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
             python ./.circleci/deploy_and_build_docker.py './' 'wellcome/wellcomecollection' $CIRCLE_SHA1
             python ./.circleci/deploy_and_build_docker.py './nginx-proxy' 'wellcome/wellcomecollection-nginx-proxy' $CIRCLE_SHA1
             python ./.circleci/deploy_and_build_docker.py './router' 'wellcome/wellcomecollection-router' $CIRCLE_SHA1
             ./build-speedtracker.sh
+  deploy_assets:
+      docker:
+        - image: node:6.10
+      working_directory: ~/wellcomecollection.org/dist
+      steps:
+        - restore_cache:
+            key: repo_{{ .Environment.CIRCLE_SHA1 }}
+        - restore_cache:
+            key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
+        - add_ssh_keys
+        - run:
+            name: Install AWS CLI
+            command: |
+              # Taken from
+              # http://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html
+              apt-get -y -qq update
+              apt-get -y -qq install python3.4-dev
+              curl -O https://bootstrap.pypa.io/get-pip.py
+              python3.4 get-pip.py --user
+              export PATH=~/.local/bin:$PATH
+              pip install awscli --upgrade --user
+              aws s3 sync . s3://i.wellcomecollection.org
   deploy_cardigan:
     docker:
       - image: node:6.10
@@ -168,6 +182,14 @@ workflows:
             branches:
               only:
                 - master
+      - deploy_assets:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+                - i-hosted-assets
       - deploy_cardigan:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
               python3.4 get-pip.py --user
               export PATH=~/.local/bin:$PATH
               pip install awscli --upgrade --user
-              aws s3 sync . s3://i.wellcomecollection.org
+              aws s3 sync --only-show-errors . s3://i.wellcomecollection.org
   deploy_cardigan:
     docker:
       - image: node:6.10
@@ -175,6 +175,9 @@ workflows:
           requires:
             - checkout_code
             - build
+      - deploy_assets:
+          requires:
+            - test
       - deploy_app:
           requires:
             - test
@@ -182,14 +185,6 @@ workflows:
             branches:
               only:
                 - master
-      - deploy_assets:
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - master
-                - i-hosted-assets
       - deploy_cardigan:
           requires:
             - test

--- a/build-cardigan.sh
+++ b/build-cardigan.sh
@@ -7,6 +7,6 @@ pushd cardigan
   npm run app:build
 
   pushd .dist
-    aws s3 sync . s3://cardigan.wellcomecollection.org
+    aws s3 sync --only-show-errors . s3://cardigan.wellcomecollection.org
   popd
 popd

--- a/client/terraform/terraform.tf
+++ b/client/terraform/terraform.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    key            = "build-state/client.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+    bucket         = "wellcomecollection-infra"
+  }
+}
+
+provider "aws" {
+  version = "~> 1.0"
+  region  = "eu-west-1"
+}
+
+provider "aws" {
+  version = "~> 1.0"
+  region  = "us-east-1"
+  alias   = "us-east-1"
+}
+
+data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
+  provider = "aws.us-east-1"
+  domain   = "wellcomecollection.org"
+}
+
+module "static" {
+  source = "../../shared-infra/terraform/https-s3-website"
+  website_uri = "i.wellcomecollection.org"
+  acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
+}

--- a/shared-infra/terraform/https-s3-website/cloudfront.tf
+++ b/shared-infra/terraform/https-s3-website/cloudfront.tf
@@ -18,6 +18,7 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
+    compress               = true
 
     forwarded_values {
       query_string = false


### PR DESCRIPTION
Creating a bucket / CF dist that we can send assets from.
This should stop us having to serve static assets through Koa.

- [x] Good idea?
- ~Bad idea?~