### PR TITLE
remove npm script for running app in prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ EXPOSE 3000
 
 WORKDIR $HOME/server
 
-CMD ["npm", "run", "app:docker"]
+CMD ["npx", "pm2-docker", "--json", "pm2.yml"]

--- a/server/package.json
+++ b/server/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "app:build": "babel . -d .dist --ignore=node_modules --copy-files",
     "app:dev": "nodemon -e js,njk,json --exec babel-node --inspect run.js",
-    "app:docker": "pm2-docker --json pm2.yml",
-    "app:run": "pm2 start pm2.yml",
     "optimise:svg": "node ./optimise-svgs.js",
     "test": "ava && flow",
     "test:accessibility": "pa11y",


### PR DESCRIPTION
While looking through the processor use on the docker containers, I found this:
![screen shot 2017-11-01 at 11 48 01](https://user-images.githubusercontent.com/31692/32273559-c274c164-befa-11e7-89f1-9eb3707b900c.png)

That's near 100% - which we don't want.

This might help but not jumping through loads of hoops to get our app running.