### PR TITLE
Add wellcome images domains to router cloudfront

### DIFF
--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -22,7 +22,9 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   aliases = [
     "wellcomecollection.org",
     "next.wellcomecollection.org",
-    "blog.wellcomecollection.org"
+    "blog.wellcomecollection.org",
+    "wellcomeimages.org",
+    "router.wellcomeimages.org"
   ]
 
   default_cache_behavior {


### PR DESCRIPTION
## Type
🚑 Health

## Value
Allows us to redirect  wellcome images traffic to the router on cloudfront
