### PR TITLE
Check for non-empty html from Prismic

### DIFF
--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -191,7 +191,7 @@ export function parsePicture(captionedImage: Object, minWidth: ?string = null): 
     contentUrl: image && image.url,
     width: image && image.dimensions.width,
     height: image && image.dimensions.height,
-    caption: captionedImage.caption && captionedImage.caption.length !== 0 ? asHtml(captionedImage.caption) : null,
+    caption: captionedImage.caption && asHtml(captionedImage.caption),
     alt: image && image.alt,
     title: tasl && tasl.title,
     author: tasl && tasl.author,
@@ -317,7 +317,11 @@ export function asText(maybeContent: any) {
 }
 
 export function asHtml(maybeContent: any) {
-  return maybeContent && RichText.asHtml(maybeContent).trim();
+  // Prismic can send us empty html elements which can lead to unwanted UI in templates.
+  // Check that there's at least one non-empty item.
+  const isNonEmpty = maybeContent && maybeContent.some(el => el.text && el.text.trim() !== '');
+
+  return isNonEmpty ? RichText.asHtml(maybeContent).trim() : null;
 }
 
 function isEmptyDocLink(fragment) {

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -318,8 +318,8 @@ export function asText(maybeContent: any) {
 
 export function asHtml(maybeContent: any) {
   // Prismic can send us empty html elements which can lead to unwanted UI in templates.
-  // Check that there's at least one non-empty item.
-  const isNonEmpty = maybeContent && maybeContent.some(el => el.text && el.text.trim() !== '');
+  // Check that `asText` wouldn't return an empty string.
+  const isNonEmpty = maybeContent && asText(maybeContent).trim() !== '';
 
   return isNonEmpty ? RichText.asHtml(maybeContent).trim() : null;
 }

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -319,9 +319,9 @@ export function asText(maybeContent: any) {
 export function asHtml(maybeContent: any) {
   // Prismic can send us empty html elements which can lead to unwanted UI in templates.
   // Check that `asText` wouldn't return an empty string.
-  const isNonEmpty = maybeContent && asText(maybeContent).trim() !== '';
+  const isEmpty = maybeContent && asText(maybeContent).trim() === '';
 
-  return isNonEmpty ? RichText.asHtml(maybeContent).trim() : null;
+  return isEmpty ? null : RichText.asHtml(maybeContent).trim();
 }
 
 function isEmptyDocLink(fragment) {


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Prismic can send us empty html elements, and we conditionally show/hide UI based on whether certain bits of content exist. An empty element can cause e.g. the caption photo icon to appear below a picture even if the caption is empty. This prevents this from happening by checking that at least one piece of `text` from the content to be passed to `asHtml` is non-empty.
