### PR TITLE
added another redirect rule

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -127,9 +127,13 @@ http {
   }
 
   # Wellcome Images deprecation
-  map $arg_MIRO $redirect_uri {
+  map $arg_MIRO $miro_uri {
     ""      https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
     default https://iiif.wellcomecollection.org/image/$arg_MIRO.jpg/full/125,/0/default.jpg;
+  }
+  map $arg_MIROPAC $miropac_uri {
+    ""      https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
+    default https://wellcomecollection.org/works?query=$arg_MIROPAC&wellcomeImagesUrl=$request_uri;
   }
 
   server {
@@ -144,16 +148,19 @@ http {
       rewrite ^/indexplus/image/(.*)\.html$ https://wellcomecollection.org/works?query=$1&wellcomeImagesUrl=$request permanent;
       rewrite '^/indexplus/gallery/AIDS posters\.html.*$' https://wellcomecollection.org/works?query=aids+poster&wellcomeImagesUrl=$request permanent;
       rewrite ^/indexplus/gallery/Witchcraft\.html.*$ https://wellcomecollection.org/works?query=witchcraft&wellcomeImagesUrl=$request permanent;
-      rewrite ^/indexplus/gallery/DNA.html\.*$ https://wellcomecollection.org/works?query=dna&wellcomeImagesUrl=$request permanent;
-      rewrite '^/indexplus/gallery/Florence Nightingale\.html.*$' https://wellcomecollection.org/works?query=florence+nightingale&wellcomeImagesUrl=$request;
-      rewrite ^/indexplus/gallery/Portraits\.html.*$ https://wellcomecollection.org/works?query=portrait&wellcomeImagesUrl=$request permanent;
-      rewrite '^/indexplus/gallery/Poster design\.html.*$' https://wellcomecollection.org/works?query=Poster&wellcomeImagesUrl=$request permanent;
+      rewrite ^/indexplus/gallery/DNA.html\.*$ https://wellcomecollection.org/works?query=dna&wellcomeImagesUrl=$request_uri permanent;
+      rewrite '^/indexplus/gallery/Florence Nightingale\.html.*$' https://wellcomecollection.org/works?query=florence+nightingale&wellcomeImagesUrl=$request_uri;
+      rewrite ^/indexplus/gallery/Portraits\.html.*$ https://wellcomecollection.org/works?query=portrait&wellcomeImagesUrl=$request_uri permanent;
+      rewrite '^/indexplus/gallery/Poster design\.html.*$' https://wellcomecollection.org/works?query=Poster&wellcomeImagesUrl=$request_uri permanent;
 
       return 301 https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
     }
 
     location = '/ixbin/imageserv' {
-      return 301 $redirect_uri;
+      return 301 $miro_uri;
+    }
+    location = '/ixbin/hixclient.exe' {
+      return 301 $miropac_uri;
     }
   }
 }


### PR DESCRIPTION
## Type 
🚑 Health

- [ ] Demoed to @davidpmccormick 

## Value
Seeing redirected urls of the form '/ixbin/hixclient.exe?MIROPAC=M0003688' showing up in analytics.

At present these will just go to /works. This addition will redirect such urls to a search for the miro number instead, which is probably more relevant