### PR TITLE
small download tracking fix

### DIFF
--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -103,7 +103,7 @@
             href="/download?uri={{ work.imgLink | convertImageUri(760, false) | urlencode }}"
             download="{{ work.id }}.jpg"
             rel="noopener noreferrer"
-            data-track-event='{"category": "component", "action": "download-button:click", "label": "id:{{ work.id }}, size:760"}, title:{{ work.title | truncate(50) }}'>
+            data-track-event='{"category": "component", "action": "download-button:click", "label": "id:{{ work.id }}", "size":760, "title":"{{ work.title | truncate(50) }}"}'>
             {% icon 'actions/download', null, ['icon--elf-green'] %}
             <div class="{{{s: 1} | spacingClasses({ margin: ['left'] })}}">
               Download small (760px)


### PR DESCRIPTION
Was broken now fixed.
@hthair note that we can't rely on the numbers for this* until we merge.

* This being the number of clicks on the small download button.