### PR TITLE
use the filepath when useing hashedAsset helper

### DIFF
--- a/server/filters/get-hashed-file.js
+++ b/server/filters/get-hashed-file.js
@@ -3,6 +3,6 @@ import config from '../config/index';
 import {getFlag} from '../util/flags';
 
 export function getHashedFile(path: string, filename: string): string {
-  const root = getFlag('useS3Assets').enabled ? `${config.fileRoot}${path}` : '';
+  const root = getFlag('useS3Assets').enabled ? `${config.fileRoot}${path}` : path;
   return `${root}${(config.hashedFiles[filename] || filename)}`;
 }


### PR DESCRIPTION
Blast it - don't know how this slipped through - not really a test I can write for it either.