### PR TITLE
Don't repeat the URL in og:url

### DIFF
--- a/server/views/components/open-graph/open-graph.njk
+++ b/server/views/components/open-graph/open-graph.njk
@@ -2,7 +2,7 @@
 <meta property="og:title" content="{{ metaContent.title }}" />
 <meta property="og:image" content="{{ metaContent.image | convertImageUri(1200, false) }}" />
 <meta property="og:image:width" content="1200" />
-<meta property="og:url" content="{{ pageConfig.organization.url }}{{ metaContent.url }}" />
+<meta property="og:url" content="{{ metaContent.url }}" />
 <meta property="og:site_name" content="{{ pageConfig.organization.name }}" />
 
 {% if metaContent.description %}


### PR DESCRIPTION
I can't see why it was there is the first place.
I tested across content types, and they all link correctly/