### PR TITLE
add itemprop to og:image for what's app

### DIFF
--- a/server/views/components/open-graph/open-graph.njk
+++ b/server/views/components/open-graph/open-graph.njk
@@ -1,6 +1,7 @@
 <meta property="og:type" content="{{ metaContent.type }}" />
 <meta property="og:title" content="{{ metaContent.title }}" />
-<meta property="og:image" content="{{ metaContent.image | convertImageUri(1200, false) }}" />
+{# we add itemprop="image" as it's required for WhatsApp #}
+<meta property="og:image" content="{{ metaContent.image | convertImageUri(1200, false) }}" itemprop="image" />
 <meta property="og:image:width" content="1200" />
 <meta property="og:url" content="{{ pageConfig.organization.url }}{{ metaContent.url }}" />
 <meta property="og:site_name" content="{{ pageConfig.organization.name }}" />


### PR DESCRIPTION
https://stackoverflow.com/questions/25100917/showing-thumbnail-for-link-in-whatsapp-ogimage-meta-tag-doesnt-work

No idea why. Tested it by sending all my friends ngrok links.
They were satisfied.