### PR TITLE
404 on v1 first, then fall back to v2

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -91,15 +91,15 @@ http {
       proxy_pass              http://v2;
     }
     location ~ ^/articles/.* {
+      proxy_set_header        HTTP_X_FORWARDED_PROTO https;
       proxy_set_header        Host $host;
-      proxy_pass              http://v2;
+      proxy_pass              http://v1;
       proxy_intercept_errors  on;
-      error_page 404 = @v1;
+      error_page 404 = @v2;
     }
-    location @v1 {
-      proxy_pass                 http://v1;
-      proxy_set_header           Host wellcomecollection.org;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
+    location @v2 {
+      proxy_set_header           Host $host;
+      proxy_pass                 http://v2;
     }
 
     # v1


### PR DESCRIPTION
We're creating quite a lot of noise and unnecessary strain on the server for articles that exist on v1.

We should go through and find these, but for now, I'd like to look for them on v1 first, then fallback to v2.

As `/articles/W(REST_OF_ID)` get's picked up earlier, this only affects Wordpress articles.