### PR TITLE
build in the right order to get assetshashes in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,11 +52,11 @@ jobs:
           key: client_modules_node_6_{{ checksum "client/package.json" }}
           key: client_modules_node_6_
       - run:
-          name: Build prod config
-          command: ./build_prod_config.py
-      - run:
           name: Build client
           command: ./build-client.sh
+      - run:
+          name: Build prod config
+          command: ./build_prod_config.py
       - run:
           name: Build server
           command: ./build-server.sh $CIRCLE_SHA1


### PR DESCRIPTION
A new order:
* Build client, create asset hash
* Take those hashes, stick them into the server overrides
* Build server with the assetHashes and prod overrides