### PR TITLE
allow MIRO args through cache for redirects

### DIFF
--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -49,6 +49,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
           "WC_featuresCohort",
           "*SESS*", # Drupal
           "WC_*_test", # A/B tests
+          "MIROPAC",
+          "MIRO"
         ]
       }
     }


### PR DESCRIPTION
Allows the MIRO args through the cache.