### PR TITLE
fix the works image ratio in IE

### DIFF
--- a/client/scss/components/_work_media.scss
+++ b/client/scss/components/_work_media.scss
@@ -2,22 +2,18 @@
   position: relative;
   min-height: 200px;
   height: calc(100vh - 160px);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 
   @include respond-to(large) {
     height: calc(100vh - 200px);
   }
 
   .image {
-    min-height: 200px;
     max-height: 100%;
-    max-width: 800px;
-    width: auto;
+    max-width: 100%;
     height: auto;
+    width: auto;
+    align-self: center;
     margin: 0 auto;
-    padding: 10 * $spacing-unit;
 
     .enhanced & {
       padding: 0;
@@ -34,4 +30,13 @@
   .image--noscript {
     display: block;
   }
+}
+
+.work-media__image-container {
+  display: flex;
+  -ms-flex: 1 0 auto;
+  height: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 10 * $spacing-unit;
 }

--- a/server/views/components/work-media/work-media.njk
+++ b/server/views/components/work-media/work-media.njk
@@ -19,7 +19,9 @@
     {% componentV2 'scroll-to-info', {elementId: 'work-info'}, {'work': true}, {extraClasses: ['flush-container-right','js-work-media-control', 'pointer-events-all'], extraIconClasses: ['icon--white']} %}
   </div>
 
-  {% componentV2 'image', model.iiifModel, {}, model.iiifData %}
+  <div class="work-media__image-container">
+    {% componentV2 'image', model.iiifModel, {}, model.iiifData %}
+  </div>
 
   {% if featuresCohort | isFlagEnabled('zoomImages', featureFlags) %}
     {% componentV2 'image-viewer', {imageUrl: model.iiifModel.contentUrl}, null, {id: model.id, trackTitle: model.trackTitle} %}


### PR DESCRIPTION
Seems, after trolling through the internet explorer bugs and features, this is the Goldilocks combination to get `max-width` / `width: auto` / and `flex-center` working.

Tested in IE / Firefox / Safari / Chrome.

Related: #1304 