### PR TITLE
use featured image for events twitter card

### DIFF
--- a/server/views/pages/event.njk
+++ b/server/views/pages/event.njk
@@ -4,7 +4,7 @@
   {% set metaContent = {
     type: 'website',
     title: event.title,
-    image: event.promo.media.contentUrl,
+    image: event.featuredImage and event.featuredImage.contentUrl,
     url: pageConfig.canonicalUri
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}


### PR DESCRIPTION
While playing around with WeCo Bot realised the image wasn't coming through.
We should have a chat about whether to use the promo or the main image.