### PR TITLE
remove s3 assets flag

### DIFF
--- a/server/filters/get-hashed-file.js
+++ b/server/filters/get-hashed-file.js
@@ -1,8 +1,7 @@
 // @flow
 import config from '../config/index';
-import {getFlag} from '../util/flags';
 
 export function getHashedFile(path: string, filename: string): string {
-  const root = getFlag('useS3Assets').enabled ? `${config.fileRoot}${path}` : path;
+  const root = `${config.fileRoot}${path}`;
   return `${root}${(config.hashedFiles[filename] || filename)}`;
 }


### PR DESCRIPTION
[Looking at speedtracker](http://ghp.wellcomecollection.org/speedtracker/works/?period=week) there is no noticeable difference in the load speeds. This is because of the cache I suppose, as you can do manual testing to see significant increases.

There is also a complexity thing, where the client and server apps are slightly more decoupled, helping us move to the multiple services architecture.