### PR TITLE
track series across WP and Prismic content

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -17,6 +17,7 @@ export const renderArticle = async(ctx, next) => {
   const id = `W${ctx.params.id}`;
   const isPreview = Boolean(ctx.params.preview);
   const article = await getArticle(id, isPreview ? ctx.request : null);
+  const trackingInfo = getEditorialAnalyticsInfo(article);
 
   if (article) {
     if (format === 'json') {
@@ -29,7 +30,7 @@ export const renderArticle = async(ctx, next) => {
           inSection: 'explore',
           category: 'editorial',
           canonicalUri: `${ctx.globals.rootDomain}/articles/${id}`
-        }), getEditorialAnalyticsInfo(article)),
+        }), trackingInfo),
         article: article,
         isPreview: isPreview
       });

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -32,12 +32,18 @@ const seriesUrls = [
   'electric-sublime',
   'body-squabbles',
   'electric-age',
-  'outsiders'
+  'the-outsiders'
 ];
 
 export function getEditorialAnalyticsInfo(article: Article) {
-  const series = article.series.find(a => seriesUrls.indexOf(a.url) > -1);
-  const seriesUrl = series ? series.url : null;
+  const seriesTracking = article.series.map(series => {
+    if (series.id) {
+      return `${series.name}:${series.id}`;
+    } else if (series.url && seriesUrls.indexOf(series.url) !== -1){
+      return `${series.name}:${series.url}`;
+    }
+  }).filter(_ => _).join(',');
+  const seriesUrl = seriesTracking !== '' ? seriesTracking : null;
   const positionInSeries = article.positionInSeries;
   const contentType = article.contentType;
 


### PR DESCRIPTION
References #1823 

This will return as a comma separated list of series attached to an article, with it's ID attached to ensure uniqueness (in the case of Wordpress articles the slug).

e.g.
`Memory objects:WdJB3CcAAIE-RlQp,The Outsiders:the-outsiders`.

@hthair would this be god for you to answer the question of how a series is performing via GA?