### PR TITLE
use target blank on exhibition downloads

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -38,8 +38,6 @@ r.get('/download', async (ctx, next) => {
   } else {
     ctx.throw('Invalid image host', 422);
   }
-
-  return next();
 });
 r.get('/management/healthcheck', healthcheck);
 r.get('/management/manifest', async (ctx, next) => {

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -112,8 +112,9 @@
 
             <div class="{{ {s:5} | spacingClasses({margin: ['top']}) }}">
               {% if exhibitionContent.textAndCaptionsDocument %}
-                <a href="/download?uri={{ exhibitionContent.textAndCaptionsDocument.url }}"
-                  download="{{ exhibitionContent.textAndCaptionsDocument.name }}"
+                <a href="{{ exhibitionContent.textAndCaptionsDocument.url }}"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   data-track-event='{"category": "component", "action": "download-pdf:click", "label": "name:{{ exhibitionContent.textAndCaptionsDocument.name }}, url:{{ exhibitionContent.textAndCaptionsDocument.url }}"}'
                   class="plain-link font-elf-green font-hover-mint flex {{ {s:1} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM4'} | fontClasses}}">
                   <div class="{{ {s:1} | spacingClasses({margin:['right']}) }} flex flex--v-center">{% icon 'formats/pdf', null, ['icon--elf-green'] %}</div>


### PR DESCRIPTION
Annoyingly following a terrible pattern as the `/download` path is hanging.