### PR TITLE
Remove work image padding

### DIFF
--- a/client/scss/components/_work_media.scss
+++ b/client/scss/components/_work_media.scss
@@ -40,5 +40,4 @@
   height: 100%;
   max-width: 800px;
   margin: 0 auto;
-  padding: 10 * $spacing-unit;
 }


### PR DESCRIPTION
## Type
🐛 Bugfix  

- [x] Demoed to @Heesoomoon 

## Value
Removes excess padding around image, increasing the chances of it being flush with the charcoal background (the image has a max-width of 800px).

## Screenshot
![screen shot 2017-11-20 at 16 26 45](https://user-images.githubusercontent.com/1394592/33029115-aa0b0060-ce0f-11e7-94a6-42f387018719.png)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged