### PR TITLE
Target blank analytics

### DIFF
--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -21,14 +21,12 @@ const maybeTrackEvent = (hasAnalytics) => {
 
 const maybeTrackOutboundLinks = (hasAnalytics) => {
   if (hasAnalytics) {
-    const actuallyTrackLinks = (url, shouldOpenNewTab) => {
-      const options =  {
-        'transport': 'beacon',
-        'hitCallback': () => {
-          document.location = url;
-        }
-      };
-      ga('send', 'event', 'outbound', 'click', url, (shouldOpenNewTab ? {} : options));
+    const actuallyTrackLinks = (url) => {
+      // This means that we won't be *consistently* tracking external links
+      // in IE11 and iOS Safari: https://caniuse.com/#feat=beacon
+      // On balance, this is probably better than preventDefault-ing the link event,
+      // doing any tracking, then following the link programatically.
+      ga('send', 'event', 'outbound', 'click', url, {'transport': 'beacon'});
     };
     return actuallyTrackLinks;
   } else {
@@ -59,12 +57,10 @@ export default {
 
     on('body', 'click', 'a', (event) => {
       const anchor = event.target.closest('a');
-      const ctrlOrMetaKey = event.metaKey || event.ctrlKey;
-      const shouldOpenNewTab = anchor.target === '_blank' || ctrlOrMetaKey;
 
       const url = anchor.href;
       if (isExternal(url)) {
-        trackOutboundLink(url, shouldOpenNewTab);
+        trackOutboundLink(url);
       }
     });
   }

--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -21,13 +21,14 @@ const maybeTrackEvent = (hasAnalytics) => {
 
 const maybeTrackOutboundLinks = (hasAnalytics) => {
   if (hasAnalytics) {
-    const actuallyTrackLinks = (url) => {
-      ga('send', 'event', 'outbound', 'click', url, {
+    const actuallyTrackLinks = (url, shouldOpenNewTab) => {
+      const options =  {
         'transport': 'beacon',
         'hitCallback': () => {
           document.location = url;
         }
-      });
+      };
+      ga('send', 'event', 'outbound', 'click', url, (shouldOpenNewTab ? {} : options));
     };
     return actuallyTrackLinks;
   } else {
@@ -56,11 +57,14 @@ export default {
       trackGaEvent(JSON.parse(el.getAttribute('data-track-event')));
     });
 
-    on('body', 'click', 'a', ({ target }) => {
-      const anchor = target.closest('a');
+    on('body', 'click', 'a', (event) => {
+      const anchor = event.target.closest('a');
+      const ctrlOrMetaKey = event.metaKey || event.ctrlKey;
+      const shouldOpenNewTab = anchor.target === '_blank' || ctrlOrMetaKey;
+
       const url = anchor.href;
       if (isExternal(url)) {
-        trackOutboundLink(url);
+        trackOutboundLink(url, shouldOpenNewTab);
       }
     });
   }

--- a/server/model/page-config.js
+++ b/server/model/page-config.js
@@ -39,7 +39,7 @@ export function getEditorialAnalyticsInfo(article: Article) {
   const seriesTracking = article.series.map(series => {
     if (series.id) {
       return `${series.name}:${series.id}`;
-    } else if (series.url && seriesUrls.indexOf(series.url) !== -1){
+    } else if (series.url && seriesUrls.indexOf(series.url) !== -1) {
       return `${series.name}:${series.url}`;
     }
   }).filter(_ => _).join(',');


### PR DESCRIPTION
Fixes #1843 

## Type
🐛 Bugfix  

## Value
Prevents external links that _should_ open in a new tab or window from opening in both the current and the new windows (e.g. links with `target="_blank"` or `ctrl`/`⌘`-clicked links) as a result of our GA setup.

This prevents GA from running the `hitCallback` function if we decide you've opened a new tab.

It's a bit of a blunt instrument but I can't think of any real negatives.

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged