### PR TITLE
add 'otjar poll when someone downloads the exhibition texts

### DIFF
--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -115,7 +115,8 @@
                 <a href="/download?uri={{ exhibitionContent.textAndCaptionsDocument.url }}"
                    download="{{ exhibitionContent.textAndCaptionsDocument.name }}"
                    data-track-event='{"category": "component", "action": "download-pdf:click", "label": "name:{{ exhibitionContent.textAndCaptionsDocument.name }}, url:{{ exhibitionContent.textAndCaptionsDocument.url }}"}'
-                   class="plain-link font-elf-green font-hover-mint flex {{ {s:1} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM4'} | fontClasses}}">
+                   class="plain-link font-elf-green font-hover-mint flex {{ {s:1} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM4'} | fontClasses}}"
+                   onclick="hj('trigger', 'exhibitions_texts_download');">
                   <div class="{{ {s:1} | spacingClasses({margin:['right']}) }} flex flex--v-center">{% icon 'formats/pdf', null, ['icon--elf-green'] %}</div>
                   <span>Download exhibition texts (PDF {{ exhibitionContent.textAndCaptionsDocument.sizeInKb }}KB)</span>
                 </a>
@@ -256,4 +257,3 @@
 
 </article>
 {% endblock %}
-


### PR DESCRIPTION
Perhaps shining some light on what they're used for.
As a tip off, I heard two people asking if the items would be on the website while in the exhibition.

If @jennpb's happy for this to go in, it's inactive in 'otjar, so we can merge and refine the copy, then activate it.