### PR TITLE
New webpack

### DIFF
--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -209,7 +209,7 @@ gulp.task('watch', () => {
   gulp.watch(sources.scss.jsConfig, ['scss:compileJsToScss']);
   gulp.watch(sources.scss.nonCritical.all, ['css:bust', 'scss:compileCritical']);
   gulp.watch(sources.scss.critical.manifests, ['scss:compileCritical']);
-  gulp.watch(sources.js.all, ['js:bust']);
+  gulp.watch(sources.js.all, ['js:compile']);
   gulp.watch(sources.fonts.srcPath, ['fonts:copy']);
   gulp.watch(sources.images.srcPath, ['images:copy']);
   gulp.watch(sources.icons.srcPath, ['icons:copy']);

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -127,13 +127,13 @@
       "dev": true
     },
     "anymatch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-      "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "aproba": {
@@ -1279,9 +1279,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
-      "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "block-stream": {
@@ -4457,7 +4457,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.9.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
@@ -5865,7 +5865,7 @@
         "stream-browserify": "2.0.1",
         "stream-http": "2.7.2",
         "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.2",
+        "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
@@ -8358,9 +8358,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
-      "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
@@ -8738,9 +8738,9 @@
           "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
           "dev": true,
           "requires": {
-            "anymatch": "1.3.0",
+            "anymatch": "1.3.2",
             "async-each": "1.0.1",
-            "fsevents": "1.1.2",
+            "fsevents": "1.1.3",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -8750,14 +8750,14 @@
           }
         },
         "fsevents": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-          "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+          "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
           "dev": true,
           "optional": true,
           "requires": {
             "nan": "2.6.2",
-            "node-pre-gyp": "0.6.36"
+            "node-pre-gyp": "0.6.39"
           },
           "dependencies": {
             "abbrev": {
@@ -8915,7 +8915,6 @@
               "version": "2.0.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "boom": "2.10.1"
               }
@@ -8959,6 +8958,12 @@
             },
             "delegates": {
               "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.2",
               "bundled": true,
               "dev": true,
               "optional": true
@@ -9104,7 +9109,6 @@
               "version": "3.1.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "boom": "2.10.1",
                 "cryptiles": "2.0.5",
@@ -9276,11 +9280,13 @@
               "optional": true
             },
             "node-pre-gyp": {
-              "version": "0.6.36",
+              "version": "0.6.39",
               "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
+                "detect-libc": "1.0.2",
+                "hawk": "3.1.3",
                 "mkdirp": "0.5.1",
                 "nopt": "4.0.1",
                 "npmlog": "4.1.0",
@@ -9488,7 +9494,6 @@
               "version": "1.0.9",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "hoek": "2.16.3"
               }

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,7 @@
     "stylelint-declaration-use-variable": "^1.6.0",
     "stylelint-scss": "^1.5.2",
     "stylelint-selector-bem-pattern": "^1.1.1",
-    "webpack-stream": "^3.2.0"
+    "webpack-stream": "^4.0.0"
   },
   "scripts": {
     "build": "gulp build",

--- a/server/views/pages/exhibition.njk
+++ b/server/views/pages/exhibition.njk
@@ -115,7 +115,8 @@
                 <a href="/download?uri={{ exhibitionContent.textAndCaptionsDocument.url }}"
                    download="{{ exhibitionContent.textAndCaptionsDocument.name }}"
                    data-track-event='{"category": "component", "action": "download-pdf:click", "label": "name:{{ exhibitionContent.textAndCaptionsDocument.name }}, url:{{ exhibitionContent.textAndCaptionsDocument.url }}"}'
-                   class="plain-link font-elf-green font-hover-mint flex {{ {s:1} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM4'} | fontClasses}}">
+                   class="plain-link font-elf-green font-hover-mint flex {{ {s:1} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM4'} | fontClasses}}"
+                   onclick="hj('trigger', 'exhibitions_texts_download');">
                   <div class="{{ {s:1} | spacingClasses({margin:['right']}) }} flex flex--v-center">{% icon 'formats/pdf', null, ['icon--elf-green'] %}</div>
                   <span>Download exhibition texts (PDF {{ exhibitionContent.textAndCaptionsDocument.sizeInKb }}KB)</span>
                 </a>
@@ -256,4 +257,3 @@
 
 </article>
 {% endblock %}
-


### PR DESCRIPTION
Old file: 324kb
New file: 323kb

Webpack 3 has some new features which might help us get this down (it's quite heavy).

Updated the watch JS to just compile, as we don't reference the hashed version on dev leading to a quick dev cycle.