### PR TITLE
add docker client to /usr/local/bin

### DIFF
--- a/node-docker/Dockerfile
+++ b/node-docker/Dockerfile
@@ -5,10 +5,9 @@ RUN set -x \
     VER="17.03.0-ce" \
     curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz \
     tar -xz -C /tmp -f /tmp/docker-$VER.tgz \
-    mv /tmp/docker/* /usr/bin
+    mv /tmp/docker/* /usr/local/bin
 
 # Docker compose
 RUN set -x \
     curl -L https://github.com/docker/compose/releases/download/1.17.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose \
     chmod +x /usr/local/bin/docker-compose
-


### PR DESCRIPTION
I thing this might fix the build, as the containers can't find the docker client.