### PR TITLE
start interval cache

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,7 @@
     "entities": "^1.1.1",
     "flow-bin": "^0.57.3",
     "immutable": "^4.0.0-rc.9",
-    "interval-cache": "1.0.0",
+    "interval-cache": "^1.0.0",
     "koa": "^2.4.1",
     "koa-router": "^7.1.0",
     "koa-static": "^3.0.0",

--- a/server/services/interval-cache.js
+++ b/server/services/interval-cache.js
@@ -9,4 +9,5 @@ function getTweets() {
 const fiveMinutes = 1000 * 60 * 5;
 export const cache = new IntervalCache()
   .every('flags', fiveMinutes, getFlags, [])
-  .every('tweets', fiveMinutes, getTweets, {});
+  .every('tweets', fiveMinutes, getTweets, {})
+  .start();

--- a/server/view/render.js
+++ b/server/view/render.js
@@ -8,9 +8,10 @@ export default function render(root, extraGlobals) {
     const [flags, cohorts] = ctx.intervalCache.get('flags');
     const globals = Map(Object.assign({}, extraGlobals, {
       featuresCohort: ctx.featuresCohort,
-      featureFlags: flags,
-      cohorts: cohorts
+      featureFlags: flags || {},
+      cohorts: cohorts || {}
     }));
+    console.info(globals);
     const env = getEnvWithGlobalsExtensionsAndFilters(root, globals);
     ctx.render = (relPath, templateData) => ctx.body = env.render(`${relPath}.njk`, templateData);
     markdown.register(env, marked);

--- a/server/view/render.js
+++ b/server/view/render.js
@@ -11,7 +11,6 @@ export default function render(root, extraGlobals) {
       featureFlags: flags || {},
       cohorts: cohorts || {}
     }));
-    console.info(globals);
     const env = getEnvWithGlobalsExtensionsAndFilters(root, globals);
     ctx.render = (relPath, templateData) => ctx.body = env.render(`${relPath}.njk`, templateData);
     markdown.register(env, marked);

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -2586,7 +2586,7 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-interval-cache@1.0.0:
+interval-cache@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/interval-cache/-/interval-cache-1.0.0.tgz#3dcd594422c0b9b4e4c044a0f00260ce6f50b7b0"
   dependencies:


### PR DESCRIPTION
My bad - new version of interval cache needs `.start()`.
We should also remove having GA in a flag if we can.