### PR TITLE
move exhibitions preview to exhibitions service

### DIFF
--- a/exhibitions/app/setup-app.js
+++ b/exhibitions/app/setup-app.js
@@ -5,7 +5,7 @@ import {renderExhibition} from './controllers';
 
 const r = new Router({ sensitive: true });
 
-r.get('/:preview(preview)?/exhibitions/:id', renderExhibition);
+r.get('/exhibitions/:id/:preview(preview)?', renderExhibition);
 
 const router = r.middleware();
 const staticPath = path.join(__dirname, '../../dist');

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -58,7 +58,7 @@ async function getPreviewSession(token) {
       switch (doc.type) {
         case 'articles'    : return `/preview/articles/${doc.id}`;
         case 'webcomics'   : return `/preview/articles/${doc.id}`;
-        case 'exhibitions' : return `/preview/exhibitions/${doc.id}`;
+        case 'exhibitions' : return `/exhibitions/${doc.id}/preview`;
         case 'events' : return `/preview/events/${doc.id}`;
         // We don't use a `/preview` prefix here.
         // It's just a way for editors to get to the content via Prismic


### PR DESCRIPTION
Once we get to the events we can come up with a nicer way to do this, but seems sensible for now.