### PR TITLE
add eventbrite to event model

### DIFF
--- a/content-model/events.json
+++ b/content-model/events.json
@@ -66,7 +66,7 @@
       "fieldset" : "Location",
       "config" : {
         "fields" : {
-          "buildingLocation" : {
+          "location" : {
             "type" : "Link",
             "fieldset" : "Access option",
             "config" : {
@@ -87,10 +87,16 @@
         "select" : "document",
         "customtypes" : [ "event-booking-enquiry-teams" ]
       }
+    },
+    "eventbriteEvent" : {
+      "type" : "Embed",
+      "config" : {
+        "label" : "Eventbrite Event"
+      }
     }
   },
   "Series" : {
-    "series": {
+    "series" : {
       "type" : "Group",
       "fieldset" : "Event series",
       "config" : {

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -86,6 +86,10 @@ export type EventPromo = {|
 
 export const eventExample = ({
   id: 'WXmdTioAAJWWjZdH',
+  identifiers: [{
+    identifierScheme: 'eventbrite-id',
+    value: '40144900478'
+  }],
   title: 'Haitian Vodou Ritual',
   format: {
     id: 'QYCcAACcAoiJS',

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -52,8 +52,16 @@ type BuildingLocation = {|
   level: number;
 |}
 
+type IdentifierScheme = 'eventbrite-id';
+
+type Identifier = {|
+  identifierScheme: IdentifierScheme;
+  value: string;
+|}
+
 export type Event = {|
   id: string;
+  identifiers: Array<Identifier>;
   title: ?string;
   format: ?EventFormat;
   times: Array<DateTimeRange>;

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -27,6 +27,14 @@ export function parseEventDoc(doc: PrismicDoc): Event {
       endDateTime: new Date(date.endDateTime)
     }: DateTimeRange);
   });
+
+  // matching https://www.eventbrite.co.uk/e/40144900478?aff=efbneb
+  const eventbriteIdMatch = doc.data.eventbriteEvent && /\/e\/([0-9]+)/.exec(doc.data.eventbriteEvent.url);
+  const identifiers = eventbriteIdMatch ? [{
+    identifierScheme: 'eventbrite-id',
+    value: eventbriteIdMatch[1]
+  }] : [];
+
   const bookingEnquiryTeam = doc.data.bookingEnquiryTeam.data && ({
     id: doc.data.bookingEnquiryTeam.id,
     title: asText(doc.data.bookingEnquiryTeam.data.title),
@@ -37,6 +45,7 @@ export function parseEventDoc(doc: PrismicDoc): Event {
 
   const e = ({
     id: doc.id,
+    identifiers: identifiers,
     title: asText(doc.data.title),
     format: doc.data.format.data && ({
       id: doc.data.format.id,


### PR DESCRIPTION
Allow us to access the Eventbrite ID to make some async calls to get ticket info.
Following the platform schema of identifiers as it makes sense.