### PR TITLE
fix exhibition routes to be consistent with others

### DIFF
--- a/exhibitions/app/controllers.js
+++ b/exhibitions/app/controllers.js
@@ -8,8 +8,7 @@ const {
 
 export async function renderExhibition(ctx, next) {
   const id = `${ctx.params.id}`;
-  const isPreview = Boolean(ctx.params.preview);
-  const exhibitionContent = await getExhibitionAndRelatedContent(id, isPreview ? ctx.request : null);
+  const exhibitionContent = await getExhibitionAndRelatedContent(id);
   const format = ctx.request.query.format;
   const path = ctx.request.url;
   const tags = [{
@@ -31,7 +30,6 @@ export async function renderExhibition(ctx, next) {
           canonicalUri: `${ctx.globals.rootDomain}/exhibitions/${exhibitionContent.exhibition.id}`
         }),
         exhibitionContent: exhibitionContent,
-        isPreview: isPreview,
         tags
       });
     }

--- a/exhibitions/app/controllers.js
+++ b/exhibitions/app/controllers.js
@@ -8,7 +8,8 @@ const {
 
 export async function renderExhibition(ctx, next) {
   const id = `${ctx.params.id}`;
-  const exhibitionContent = await getExhibitionAndRelatedContent(id);
+  const isPreview = Boolean(ctx.params.preview);
+  const exhibitionContent = await getExhibitionAndRelatedContent(id, isPreview ? ctx.request : null);
   const format = ctx.request.query.format;
   const path = ctx.request.url;
   const tags = [{
@@ -30,6 +31,7 @@ export async function renderExhibition(ctx, next) {
           canonicalUri: `${ctx.globals.rootDomain}/exhibitions/${exhibitionContent.exhibition.id}`
         }),
         exhibitionContent: exhibitionContent,
+        isPreview: isPreview,
         tags
       });
     }

--- a/exhibitions/app/routes.js
+++ b/exhibitions/app/routes.js
@@ -3,6 +3,6 @@ import {renderExhibition, renderExhibitionsList} from './controllers';
 
 const r = new Router({ sensitive: true });
 r.get('/exhibitions/:id/:preview(preview)?', renderExhibition);
-r.get('/exhibitions/:preview(preview)?', renderExhibitionsList);
+r.get('/exhibitions', renderExhibitionsList);
 
 export const router = r.middleware();


### PR DESCRIPTION
`/exhibitions` isn't working, and we don't support preview on lists yet - so getting rid of it.