### PR TITLE
Exhibitions meta description

### DIFF
--- a/events/app/views/pages/events.njk
+++ b/events/app/views/pages/events.njk
@@ -1,5 +1,5 @@
 {% extends 'layout/default.njk' %}
-{# TODO: add description for meta and list-header #}
+{# TODO: add description list-header #}
 {% block pageMeta %}
   {% set metaContent = {
     type: 'website',

--- a/events/app/views/pages/events.njk
+++ b/events/app/views/pages/events.njk
@@ -6,7 +6,7 @@
     title: 'Events',
     image: paginatedEvents.results[0].image.contentUrl,
     url: pageConfig.canonicalUri,
-    description: ''
+    description: 'Take part in a range of free talks, tours, performances and workshops. Join artists, scientists, and educators to unravel big ideas around health and wellbeing.'
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}

--- a/exhibitions/app/views/pages/exhibitions.njk
+++ b/exhibitions/app/views/pages/exhibitions.njk
@@ -1,16 +1,16 @@
 {% extends 'layout/default.njk' %}
-{# TODO: add description for meta and list-header #}
+
+{% set metaContent = {
+  type: 'website',
+  title: 'Exhibitions',
+  image: temporaryExhibitions[0].image.contentUrl,
+  url: pageConfig.canonicalUri,
+  description: 'Explore the connections between science, medicine, life and art through our permanent and temporary exhibitions. Admission is always free.'
+} %}
+
 {% block pageMeta %}
-  {% set metaContent = {
-    type: 'website',
-    title: 'Exhibitions',
-    image: temporaryExhibitions[0].image.contentUrl,
-    url: pageConfig.canonicalUri,
-    description: ''
-  } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
-
   <meta name="description" content="{{ metaContent.description }}" />
 {% endblock %}
 
@@ -23,7 +23,7 @@
     {% endfor %}]
   </script>
 
-  {% componentV2 'list-header', {name: 'Exhibitions', total: paginatedExhibitions.results.length} %}
+  {% componentV2 'list-header', {name: 'Exhibitions', description: metaContent.description, total: paginatedExhibitions.results.length} %}
 
   {% if paginatedExhibitions.pagination.pageCount > 1  %}
   <div class="row">

--- a/server/views/components/list-header/list-header.njk
+++ b/server/views/components/list-header/list-header.njk
@@ -8,7 +8,7 @@
 
     {% if model.description %}
       <div class="grid">
-        <div class="{{ {s: 12, m: 12, l: 8} | gridClasses }}">
+        <div class="{{ {s: 12, m: 12, l: 8, xl: 8} | gridClasses }}">
           <p class="{{ {s:2, m:2, l:2} | spacingClasses({margin: ['top']}) }} {{ {s:0, m:0, l:0} | spacingClasses({margin: ['bottom']}) }}">{{ model.description }}</p>
         </div>
       </div>


### PR DESCRIPTION
References #1897. Closes #1893

Adds the copy in #1893 to the events/exhibitions listing pages' meta-descriptions. Also adds the copy for the exhibition to the `list-header` component on the `/exhibitions` page (as specified in #1897).
