### PR TITLE
wrap prefixed / parametered vals when linking to the catalogue search…

### DIFF
--- a/server/filters/get-link-objects.js
+++ b/server/filters/get-link-objects.js
@@ -4,7 +4,7 @@ import type {Link} from '../model/link';
 export function createLinkObject(val: string, prepend?: string): Link {
   return {
     text: val,
-    url: prepend ? `/works?query=${encodeURIComponent(prepend + val)}` : `/works?query=${encodeURI(val)}`
+    url: prepend ? `/works?query=${encodeURIComponent(prepend + `"${val}"`)}` : `/works?query=${encodeURI(`"${val}"`)}`
   };
 };
 

--- a/server/filters/get-link-objects.js
+++ b/server/filters/get-link-objects.js
@@ -4,7 +4,7 @@ import type {Link} from '../model/link';
 export function createLinkObject(val: string, prepend?: string): Link {
   return {
     text: val,
-    url: prepend ? `/works?query=${encodeURIComponent(prepend + `"${val}"`)}` : `/works?query=${encodeURI(`"${val}"`)}`
+    url: prepend ? `/works?query=${encodeURIComponent(`${prepend}"${val}"`)}` : `/works?query=${encodeURI(`"${val}"`)}`
   };
 };
 


### PR DESCRIPTION
Fixes #1932 

Makes sure that if we're labelling the field we're searching for we wrap it in quotes.

https://wellcomecollection.org/works?query=creators%3A%22Odra+Noel%22
vs
https://wellcomecollection.org/works?query=creators%3AOdra+Noel