### PR TITLE
CSS grids

### DIFF
--- a/client/scss/critical.scss
+++ b/client/scss/critical.scss
@@ -22,6 +22,7 @@
 @import 'grids/grid_scroll';
 @import 'grids/grid_size';
 @import 'grids/grid_theme';
+@import 'grids/css_grid';
 
 // Components
 @import 'components/article';

--- a/client/scss/grids/_css_grid.scss
+++ b/client/scss/grids/_css_grid.scss
@@ -47,7 +47,6 @@
   position: relative;
   grid-column: main;
   grid-auto-rows: minmax(50px, auto);
-  grid-row-gap: 20px; // TODO properly
   background: color('seaweed');
   display: grid;
 
@@ -64,6 +63,7 @@
 
     @include respond-to(nth($respond, 1)) {
       grid-column-gap: $gutter;
+      grid-row-gap: $gutter;
       grid-template-columns: unquote($columns-string);
     }
   }

--- a/client/scss/grids/_css_grid.scss
+++ b/client/scss/grids/_css_grid.scss
@@ -1,7 +1,6 @@
 .css-grid__container {
   display: grid;
-  background: yellow;
-  grid-auto-rows: minmax(50px, auto);
+  grid-auto-rows: minmax(0, auto);
 
   @each $label, $map in $grid-config {
     $respond: map-get($map, 'respond');
@@ -46,8 +45,7 @@
 .css-grid {
   position: relative;
   grid-column: main;
-  grid-auto-rows: minmax(50px, auto);
-  background: color('seaweed');
+  grid-auto-rows: minmax(0, auto);
   display: grid;
 
   @each $label, $map in $grid-config {

--- a/client/scss/grids/_css_grid.scss
+++ b/client/scss/grids/_css_grid.scss
@@ -1,0 +1,114 @@
+.x-grid { // is equivalent of container
+  display: grid;
+  background: yellow;
+  grid-auto-rows: minmax(50px, auto);
+
+  @each $label, $map in $grid-config {
+    $respond: map-get($map, 'respond');
+    $min: map-get($map, 'padding');
+    $columns: '[full-start] minmax(#{$min}, 1fr) [main-start] minmax(0, #{$container-width-max}) [main-end] minmax(#{$min}, 1fr) [full-end]';
+
+    @include respond-to(nth($respond, 1)) {
+      grid-template-columns: unquote($columns);
+    }
+  }
+}
+
+// TODO how container queries work?
+
+@function grid-columns($primary-start: 1, $primary-end: 7, $secondary-start: 8, $secondary-end: 12, $columns: $totalColumns) {
+
+  $column-string: '';
+
+  @for $i from 1 through $columns {
+    @if $i == $primary-start and $primary-start == $secondary-start {
+      $column-string: $column-string + '[primary-start secondary-start]';
+    } @else if $i == $primary-start {
+      $column-string: $column-string + '[primary-start]';
+    } @else if $i == $secondary-start and $primary-end == $secondary-start - 1 {
+      $column-string: $column-string + '[primary-end secondary-start]';
+    } @else if $i == $secondary-start {
+      $column-string: $column-string + '[secondary-start]';
+    }
+
+    $column-string: $column-string + ' 1fr ';
+
+    @if $i == $primary-end and $primary-end == $secondary-end {
+      $column-string: $column-string + '[primary-end secondary-end]';
+    } @else if $i == $primary-end and $primary-end != $secondary-start - 1 {
+      $column-string: $column-string + '[primary-end]';
+    } @else if $i == $secondary-end {
+      $column-string: $column-string + '[secondary-end]';
+    }
+  }
+
+  @return $column-string;
+}
+
+.grid-12 { // is equivalent of grid
+  position: relative;
+  grid-column: main;
+  grid-auto-rows: minmax(50px, auto);
+  grid-row-gap: 20px; // TODO properly
+  background: color('seaweed');
+  display: grid;
+
+  @each $label, $map in $grid-config {
+    $respond: map-get($map, 'respond');
+    $gutter: map-get($map, 'gutter');
+    $primary-start: map-get($map, 'primaryStart');
+    $primary-end: map-get($map, 'primaryEnd');
+    $secondary-start: map-get($map, 'secondaryStart');
+    $secondary-end: map-get($map, 'secondaryEnd');
+    $columns: map-get($map, 'columns');
+
+    $columns-string: grid-columns($primary-start, $primary-end, $secondary-start, $secondary-end, $columns);
+
+    @include respond-to(nth($respond, 1)) {
+      grid-column-gap: $gutter;
+      grid-template-columns: unquote($columns-string);
+    }
+  }
+}
+
+.x-full { // is equivalent of breakout
+  grid-column: full;
+  background: color('elf-green');
+}
+
+.x-cell {
+  background: color('petrol');
+}
+
+@each $key, $list in $grid-config {
+  $columns: map-get($list, 'columns');
+  $respond: map-get($list, 'respond');
+
+  @if (length($respond) > 1) {
+    $lower: nth($respond, 1);
+    $higher: nth($respond, 2);
+
+    @include respond-between($lower, $higher) {
+      @include css-grid-cells($columns, $key);
+    }
+  } @else {
+    @include respond-to($respond) {
+      @include css-grid-cells($columns, $key);
+    }
+  }
+}
+
+// for each class
+// grid-column: span 3;
+
+.cell--primary {
+  background: color('mint');
+  grid-column: primary;
+}
+
+.cell--secondary {
+  background: color('smoke');
+  grid-column: secondary;
+  position: sticky;
+  // height: 0;
+}

--- a/client/scss/grids/_css_grid.scss
+++ b/client/scss/grids/_css_grid.scss
@@ -1,4 +1,4 @@
-.x-grid { // is equivalent of container
+.css-grid__container {
   display: grid;
   background: yellow;
   grid-auto-rows: minmax(50px, auto);
@@ -13,8 +13,6 @@
     }
   }
 }
-
-// TODO how container queries work?
 
 @function grid-columns($primary-start: 1, $primary-end: 7, $secondary-start: 8, $secondary-end: 12, $columns: $totalColumns) {
 
@@ -45,7 +43,7 @@
   @return $column-string;
 }
 
-.grid-12 { // is equivalent of grid
+.css-grid {
   position: relative;
   grid-column: main;
   grid-auto-rows: minmax(50px, auto);
@@ -71,13 +69,8 @@
   }
 }
 
-.x-full { // is equivalent of breakout
+.css-grid__cell--breakout {
   grid-column: full;
-  background: color('elf-green');
-}
-
-.x-cell {
-  background: color('petrol');
 }
 
 @each $key, $list in $grid-config {
@@ -98,17 +91,10 @@
   }
 }
 
-// for each class
-// grid-column: span 3;
-
-.cell--primary {
-  background: color('mint');
+.css-grid__cell--primary {
   grid-column: primary;
 }
 
-.cell--secondary {
-  background: color('smoke');
+.css-cell--secondary {
   grid-column: secondary;
-  position: sticky;
-  // height: 0;
 }

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -93,7 +93,7 @@
 
 @mixin css-grid-cells($columns, $key) {
   @for $i from 1 through $columns {
-    .x-cell--#{$key}#{$i} {
+    .css-grid__cell--#{$key}#{$i} {
       grid-column: span #{$i};
     }
   }

--- a/client/scss/utilities/_mixins.scss
+++ b/client/scss/utilities/_mixins.scss
@@ -91,6 +91,14 @@
   }
 }
 
+@mixin css-grid-cells($columns, $key) {
+  @for $i from 1 through $columns {
+    .x-cell--#{$key}#{$i} {
+      grid-column: span #{$i};
+    }
+  }
+}
+
 @mixin font($font-name) {
   $font: map-get($fonts, $font-name);
 

--- a/server/filters/css-grid-classes.js
+++ b/server/filters/css-grid-classes.js
@@ -1,0 +1,10 @@
+export default function cssGridClasses(sizes) {
+  const base = 'x-cell';
+  const modifierClasses = Object.keys(sizes).map(key => {
+    const size = sizes[key];
+    const modifier = key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+    return `${base}--${modifier}${size}`;
+  });
+
+  return [base].concat(modifierClasses).join(' ');
+}

--- a/server/filters/css-grid-classes.js
+++ b/server/filters/css-grid-classes.js
@@ -1,5 +1,5 @@
 export default function cssGridClasses(sizes) {
-  const base = 'x-cell';
+  const base = 'css-grid__cell';
   const modifierClasses = Object.keys(sizes).map(key => {
     const size = sizes[key];
     const modifier = key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -7,6 +7,7 @@ import getCommissionedSeries from './get-commissioned-series';
 import getSeriesTitle from './get-series-title';
 import getViewBox from './get-viewbox';
 import gridClasses from './grid-classes';
+import cssGridClasses from './css-grid-classes';
 import spacingClasses from './spacing-classes';
 import fontClasses from './font-classes';
 import componentClasses from './component-classes';
@@ -48,6 +49,7 @@ export default Map({
   getViewBox,
   getA11yIcon,
   gridClasses,
+  cssGridClasses,
   spacingClasses,
   fontClasses,
   concat,

--- a/server/ui-config/grid-config.js
+++ b/server/ui-config/grid-config.js
@@ -6,24 +6,40 @@ const gridConfig = {
     padding: containerPadding.small,
     gutter: gutterWidth.small,
     columns: 12,
+    primaryStart: 1,
+    primaryEnd: 12,
+    secondaryStart: 1,
+    secondaryEnd: 12,
     respond: ['small', 'medium']
   },
   m: {
     padding: containerPadding.medium,
     gutter: gutterWidth.medium,
     columns: 12,
+    primaryStart: 2,
+    primaryEnd: 11,
+    secondaryStart: 2,
+    secondaryEnd: 11,
     respond: ['medium', 'large']
   },
   l: {
     padding: containerPadding.large,
     gutter: gutterWidth.large,
     columns: 12,
+    primaryStart: 1,
+    primaryEnd: 7,
+    secondaryStart: 8,
+    secondaryEnd: 12,
     respond: ['large', 'xlarge']
   },
   xl: {
     padding: containerPadding.xlarge,
     gutter: gutterWidth.xlarge,
     columns: 12,
+    primaryStart: 2,
+    primaryEnd: 7,
+    secondaryStart: 8,
+    secondaryEnd: 11,
     respond: 'xlarge'
   }
 };

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -16,6 +16,16 @@
 {% endblock %}
 
 {% block body %}
+  <div class="row">
+    <div class="css-grid__container">
+      <div class="grid">
+      {# <div class="{{ {s: 12, m: 6, l: 6, xl:6} | cssGridClasses }}">library promo</div>
+      <div class="{{ {s: 12, m: 6, l: 6, xl:6} | cssGridClasses }}">reading room promo</div>
+      <div class="{{ {s: 12, m: 6, l: 6, xl:6} | cssGridClasses }}">cafe and kitchen</div>
+      <div class="{{ {s: 12, m: 6, l: 6, xl:6} | cssGridClasses }}">Shop</div> #}
+    </div>
+  </div>
+
   {% componentV2 'page-description', { title: 'Explore' }, {'hidden': true} %}
   <div class="row bg-cream row--has-wobbly-background {{ {s:10} | spacingClasses({padding: ['top']}) }}">
     <div class="container">


### PR DESCRIPTION
✨ Feature  

Adds CSS grids styles and nunjucks filter, so we can start making use of CSS grids for layout. 

## Value
Simplification of current layouts and greater potential for new layouts.  It looks like we will need grids for the what's on pages and events page (and using grids for articles will make it way less complicated and easy to maintain).

For now I've just added styles to replicate our current grid functionality and it can be used in a similar way **(N.B. `<div class="row">` is not required as the .css-grid__container runs the full width of the screen)**:

    <div class="css-grid__container">
      <div class="css-grid">
      <div class="{{ {s: 12, m: 12, l: 6, xl:6} | cssGridClasses }}">library promo</div>
    </div>

N.B. It adds about 12KB to the CSS, but in the long term as we move over to using grids instead of flexbox for the main layout we should be able to remove more than this.
