### PR TITLE
use promo image for exhibitions

### DIFF
--- a/prismic-model/exhibitions.json
+++ b/prismic-model/exhibitions.json
@@ -128,7 +128,7 @@
                 "type" : "StructuredText",
                 "config" : {
                   "label" : "Promo text",
-                  "single" : "hyperlink, strong, em"
+                  "single" : "paragraph"
                 }
               },
               "image" : {
@@ -194,7 +194,7 @@
           "description" : {
             "type" : "StructuredText",
             "config" : {
-              "single" : "strong, em, hyperlink",
+              "single" : "paragraph",
               "label" : "Description"
             }
           },

--- a/prismic-model/exhibitions.json
+++ b/prismic-model/exhibitions.json
@@ -128,13 +128,26 @@
                 "type" : "StructuredText",
                 "config" : {
                   "label" : "Promo text",
-                  "single" : "paragraph"
+                  "single" : "hyperlink, strong, em"
                 }
               },
               "image" : {
                 "type" : "Image",
                 "config" : {
-                  "label" : "Promo image"
+                  "label" : "Promo image",
+                  "thumbnails" : [ {
+                    "name" : "32:15",
+                    "width" : 3200,
+                    "height" : 1500
+                  }, {
+                    "name" : "16:9",
+                    "width" : 3200,
+                    "height" : 1800
+                  }, {
+                    "name" : "square",
+                    "width" : 3200,
+                    "height" : 3200
+                  } ]
                 }
               }
             }

--- a/prismic-model/exhibitions.json
+++ b/prismic-model/exhibitions.json
@@ -165,7 +165,16 @@
           "image" : {
             "type" : "Image",
             "config" : {
-              "label" : "Image"
+              "label" : "Image",
+              "thumbnails" : [ {
+                "name" : "16:9",
+                "width" : 3200,
+                "height" : 1800
+              }, {
+                "name" : "square",
+                "width" : 3200,
+                "height" : 3200
+              } ]
             }
           },
           "type" : {

--- a/server/content-model/exhibition.js
+++ b/server/content-model/exhibition.js
@@ -11,7 +11,7 @@ export type Exhibition = {|
   end: ?DateRange;
   subtitle: ?string;
   intro: ?string;
-  featuredImages: List<Picture>;
+  featuredImages: List<any>;
   featuredImage: ?Picture;
   description: ?string;
   promo: ?ImagePromo;

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -8,7 +8,7 @@ import {
   prismicImage,
   parseExhibitionsDoc,
   getPositionInPrismicSeries,
-  parsePromoListItem, parseEventFormat, parseEventBookingType
+  parsePromoListItem, parseEventFormat, parseEventBookingType, parseImagePromo
 } from './prismic-parsers';
 import {List} from 'immutable';
 import type {PaginatedResults, PaginatedResultsType} from '../model/paginated-results';
@@ -191,8 +191,8 @@ function createExhibitionPromos(allResults: Object): Array<ExhibitionPromo> {
       id: e.id,
       url: `/exhibitions/${e.id}`,
       title: asText(e.data.title),
-      image: prismicImage(e.data.promo[0].primary.image),
-      description: asText(e.data.promo[0].primary.caption),
+      image: e.data.promo && parseImagePromo(e.data.promo).image,
+      description: e.data.promo && parseImagePromo(e.data.promo).caption,
       start: e.data.start ? e.data.start : '2007-06-21T00:00:00+0000',
       end: e.data.end
     };


### PR DESCRIPTION
* Force 16:9 images for exhibition promos.
* Move over to using promo for featured content on exhibitions

