### PR TITLE
Changed image path to 800px version

### DIFF
--- a/server/views/components/twitter-card/twitter-card.njk
+++ b/server/views/components/twitter-card/twitter-card.njk
@@ -3,5 +3,5 @@
 <meta name="twitter:site" content="{{ pageConfig.organization.twitterHandle }}" />
 <meta name="twitter:title" content="{{ metaContent.title }}" />
 <meta name="twitter:description" content="{{ (metaContent.description | striptags | safe | truncate(200)) or metaContent.title }}" />
-<meta name="twitter:image" content="{{ metaContent.image | convertImageUri('full', false) }}" />
+<meta name="twitter:image" content="{{ metaContent.image | convertImageUri(800, false) }}" />
 {#<meta name="twitter:image:alt" content=" {{ article.thumbnailAlt }}" />#}{# TODO not available from wordpress #}


### PR DESCRIPTION
## Type
🐛 Bugfix 
🚑 Health

## Value
Reduces the size of the image being used for twitter cards to the recommended size (https://business.twitter.com/en/help/campaign-setup/advertiser-card-specifications.html)

