### PR TITLE
catch all exhibitions in path_pattern of exhibition service

### DIFF
--- a/exhibitions/terraform/services.tf
+++ b/exhibitions/terraform/services.tf
@@ -29,5 +29,5 @@ module "exhibitions" {
   primary_container_port   = "80"
   secondary_container_port = "3001"
 
-  path_pattern = "/exhibitions/*"
+  path_pattern = "/exhibitions*"
 }


### PR DESCRIPTION
Allows the catching of `/exhibitions`