### PR TITLE
Use en-dashes without surrounding space for date ranges

### DIFF
--- a/exhibitions/app/views/components/exhibition-promo/exhibition-promo.njk
+++ b/exhibitions/app/views/components/exhibition-promo/exhibition-promo.njk
@@ -20,7 +20,7 @@
       <span class="{{ {s:1} | spacingClasses({padding: ['left']}) }}">FREE</span>
     </div>
     {% if model.start and model.end %}
-      <p class="{{ {s:'HNL4'} | fontClasses }}"><time datetime="{{model.start}}">{{ model.start | formatDate }}</time> &mdash; <time datetime="{{model.end}}">{{ model.end | formatDate }}</time></p>
+      <p class="{{ {s:'HNL4'} | fontClasses }}"><time datetime="{{model.start}}">{{ model.start | formatDate }}</time>&ndash;<time datetime="{{model.end}}">{{ model.end | formatDate }}</time></p>
     {% else %}
       <p class="{{ {s:'HNL5'} | fontClasses }}">{{ model.description | striptags | safe }}</p>
     {% endif %}

--- a/exhibitions/app/views/pages/exhibition.njk
+++ b/exhibitions/app/views/pages/exhibition.njk
@@ -54,7 +54,7 @@
                   <h1 class="{{ {s:'WB5', m:'WB4', xl:'WB3'} | fontClasses }}">{{ exhibition.title }}</h1>
                   <span class="{{ {s:'HNL4', m:'HNL3', l:'HNL3', xl:'HNL2'} | fontClasses }}">
                   {% if exhibition.end %}
-                    <time datetime="{{ exhibition.start }}">{{ exhibition.start | formatDate }}</time> – <time datetime="{{ exhibition.end }}">{{ exhibition.end | formatDate }}</time>
+                    <time datetime="{{ exhibition.start }}">{{ exhibition.start | formatDate }}</time>&ndash;<time datetime="{{ exhibition.end }}">{{ exhibition.end | formatDate }}</time>
                   {% endif %}
                 </span>
                 </div>


### PR DESCRIPTION
Uses en-dashes between dates on exhibition pages and promos.

![screen shot 2017-12-18 at 15 24 14](https://user-images.githubusercontent.com/1394592/34113409-8d74f3f8-e407-11e7-80e5-6cdafa5ffd50.png)
