### PR TITLE
Update seasonal info banner to not show on works

### DIFF
--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -64,21 +64,23 @@
         title: 'What we do'
       }
     ] %}
+    {% block seasonalInfoBanner %}
+    <div class="row bg-yellow {{ {s:3} | spacingClasses({padding: ['top', 'bottom']}) }} {{ {s:'HNL5'} | fontClasses }}">
+      <div class="container">
+        <div class="grid">
+          <div class="{{ {s:12, m:10, l:10, xl:8} | gridClasses }} flex flex--v-center">
+            {% icon 'snowflake', null, ['margin-right-s2'] %}
+            <p class="no-margin">
+              We will be closed from 24-26 December, with modified opening hours from Saturday 23 December until Tuesday 2 January. Please check our <a href="https://wellcomecollection.org/visit-us/festive-opening-hours">full festive opening hours</a> before you travel.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endblock %}
+
     {% component 'header', { navLinks: navLinks } %}
 
     <div id="main" class="main" role="main">
-      <div class="row bg-yellow {{ {s:3} | spacingClasses({padding: ['top', 'bottom']}) }} {{ {s:'HNL5'} | fontClasses }}">
-        <div class="container">
-          <div class="flex flex--v-center {{ {s: 2} | spacingClasses({margin: ['bottom']}) }}">
-            <span class="{{ {s: 1} | spacingClasses({margin: ['right']}) }}">{% icon 'snowflake' %}</span>
-            <h2 class="{{ {s:'HNM5'} | fontClasses }} no-margin">Festive opening hours</h2>
-          </div>
-          <p class="no-margin">
-            We will be closed from 24-26 December, with modified opening hours from Saturday 23 December until Tuesday 2 January.
-          </p>
-          <p class="{{ {s:0} | spacingClasses({margin: ['bottom']}) }} {{ {s:2} | spacingClasses({margin: ['top']}) }}">Please check our <a href="https://wellcomecollection.org/visit-us/festive-opening-hours">full festive opening hours</a> before you travel.</p>
-        </div>
-      </div>
       {% block body %}
       {% endblock %}
     </div>

--- a/server/views/pages/search.njk
+++ b/server/views/pages/search.njk
@@ -1,5 +1,5 @@
 {% extends 'layout/default.njk' %}
-
+{% block seasonalInfoBanner %}{% endblock %}
 {% set metaTitle = 'Wellcome Collection search' %}
 {% if query %}
   {% set metaTitle = 'Wellcome Collection search: ' + query %}

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -1,6 +1,6 @@
 {% extends 'layout/default.njk' %}
 {# TODO: Maybe set this on the actual work? #}
-
+{% block seasonalInfoBanner %}{% endblock %}
 {% block pageMeta %}
   {% set metaContent = {
     type: 'website',


### PR DESCRIPTION
![screen shot 2017-12-19 at 10 52 09](https://user-images.githubusercontent.com/1394592/34153654-b634b69a-e4aa-11e7-8db7-a72258ffd143.png)

Smaller banner; moved above heading; not shown on works pages.