### PR TITLE
use a more accurate calc to see if text has been ellipsisised

### DIFF
--- a/client/js/components/truncate-text.js
+++ b/client/js/components/truncate-text.js
@@ -19,7 +19,7 @@ const toggleTruncate = function(isTruncated, control, className) {
 
 const hasBeenEllipsified = (e) => {
   return fastdom.measure(() => {
-    return (e.scrollWidth > e.offsetWidth);
+    return (e.scrollWidth >= e.offsetWidth);
   });
 };
 

--- a/client/js/components/truncate-text.js
+++ b/client/js/components/truncate-text.js
@@ -23,18 +23,22 @@ const hasBeenEllipsified = (e) => {
   });
 };
 
-const createControl = () => {
+const createControl = (slideNumber) => {
   const control = document.createElement('button');
   control.className = 'captioned-image__truncate-control';
   control.innerHTML = moreText;
   control.setAttribute('tabindex', -1);
+  control.setAttribute('data-track-event', JSON.stringify({
+    category: 'component',
+    action: 'truncated-text-control:click',
+    label: `slide:${slideNumber}`
+  }));
   return control;
 };
 
 const truncateText = (caption) => {
   if (caption) {
-    const truncateControl = createControl();
-
+    const truncateControl = createControl(caption.getAttribute('data-slide-number'));
     caption.classList.add(truncateClass);
 
     hasBeenEllipsified(caption).then((value) => {

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -48,7 +48,7 @@
     {% if model.caption %}
       <figcaption class="captioned-image__caption {{ {s:'LR3', m:'LR2'} | fontClasses }}">
         {% icon 'image', {}, ['float-l', 'margin-right-s1'] %}
-        <div class="captioned-image__caption-text{{ ' js-truncate-text' if data.truncateCaption }}" tabindex="0">
+        <div class="captioned-image__caption-text{{ ' js-truncate-text' if data.truncateCaption }}" tabindex="0"{% if data.slideNumbers %} data-slide-number="{{ data.slideNumbers.current }}"{% endif %}>
           {% if data.slideNumbers %}
             <span class="captioned-image__number {{ {s:'HNM5'} | fontClasses }} {{ {s:2} | spacingClasses({padding: ['right']}) }}"
               aria-label="slide {{ data.slideNumbers.current }} of {{ data.slideNumbers.total }}">


### PR DESCRIPTION
Turns out you could be 3-5 characters out because of the ellipsis itself.

But, it's not an exact science either, I have found 1 edge case where if you are 1 `i` extra, the text won't be ellipsised, but will show the control. Better this though, whereas before you weren't getting the control, and you couldn't see the text.

I'd really like to start looking at why we hide all this content, if editorial has put the effort in to explain something, why do we hide it? For this I have added tracking to the control.
