### PR TITLE
Use circleci node containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+            docker login --username $DOCKER_USER --password $DOCKER_PASS
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/exhibitions_webapp.yml build
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/exhibitions_webapp.yml push
   build_events_webapp:
@@ -130,7 +130,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+            docker login --username $DOCKER_USER --password $DOCKER_PASS
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/events_webapp.yml build
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/events_webapp.yml push
   build_eventbrite_webapp:
@@ -174,7 +174,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+            docker login --username $DOCKER_USER --password $DOCKER_PASS
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/eventbrite_webapp.yml build
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/eventbrite_webapp.yml push
   build_common_webapp:
@@ -235,7 +235,7 @@ jobs:
       - run:
           name: Deploy
           command: |
-            docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+            docker login --username $DOCKER_USER --password $DOCKER_PASS
             python ./.circleci/deploy_and_build_docker.py './' 'wellcome/wellcomecollection' $CIRCLE_SHA1
             python ./.circleci/deploy_and_build_docker.py './nginx-proxy' 'wellcome/wellcomecollection-nginx-proxy' $CIRCLE_SHA1
             python ./.circleci/deploy_and_build_docker.py './router' 'wellcome/wellcomecollection-router' $CIRCLE_SHA1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -307,7 +307,6 @@ workflows:
             branches:
               only:
                 - master
-                - use_circleci_node_containers
       - build_events_webapp:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Install server modules
           command: yarn install --production
       - save_cache:
-          key: server_modules_node_8_{{ checksum "yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "yarn.lock" }}
           paths:
             -  node_modules
   build_client:
@@ -38,7 +38,7 @@ jobs:
           name: Build client assets
           command: yarn run compile
       - save_cache:
-          key: client_modules_node_8_{{ checksum "yarn.lock" }}
+          key: client_modules_circleci_node_8_{{ checksum "yarn.lock" }}
           paths:
             -  node_modules
       - save_cache:
@@ -53,7 +53,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_node_8_{{ checksum "../../server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "../../server/yarn.lock" }}
       - restore_cache:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -97,7 +97,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_node_8_{{ checksum "../../server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "../../server/yarn.lock" }}
       - restore_cache:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -141,7 +141,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_node_8_{{ checksum "../../server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "../../server/yarn.lock" }}
       - restore_cache:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -185,7 +185,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_node_8_{{ checksum "server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "server/yarn.lock" }}
       - restore_cache:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
       - run:
@@ -213,7 +213,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_node_8_{{ checksum "server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "server/yarn.lock" }}
       - restore_cache:
           key: built_server_{{ .Environment.CIRCLE_SHA1 }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   checkout_code:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - checkout
@@ -12,7 +12,7 @@ jobs:
             -  ~/wellcomecollection.org
   install_server_modules:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org/server
     steps:
       - restore_cache:
@@ -26,7 +26,7 @@ jobs:
             -  node_modules
   build_client:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org/client
     steps:
       - restore_cache:
@@ -47,7 +47,7 @@ jobs:
             -  ~/wellcomecollection.org/dist
   build_exhibitions_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org/exhibitions/app
     steps:
       - restore_cache:
@@ -74,7 +74,7 @@ jobs:
             - .dist
   deploy_exhibitions_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -84,20 +84,6 @@ jobs:
       - add_ssh_keys
       - setup_remote_docker
       - run:
-          name: Install Docker Compose
-          command: |
-            set -x
-            curl -L https://github.com/docker/compose/releases/download/1.17.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
           name: Deploy
           command: |
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
@@ -105,7 +91,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/exhibitions_webapp.yml push
   build_events_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org/events/app
     steps:
       - restore_cache:
@@ -132,7 +118,7 @@ jobs:
             - .dist
   deploy_events_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -142,20 +128,6 @@ jobs:
       - add_ssh_keys
       - setup_remote_docker
       - run:
-          name: Install Docker Compose
-          command: |
-            set -x
-            curl -L https://github.com/docker/compose/releases/download/1.17.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
           name: Deploy
           command: |
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
@@ -163,7 +135,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/events_webapp.yml push
   build_eventbrite_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org/eventbrite/app
     steps:
       - restore_cache:
@@ -190,7 +162,7 @@ jobs:
             - .dist
   deploy_eventbrite_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -200,20 +172,6 @@ jobs:
       - add_ssh_keys
       - setup_remote_docker
       - run:
-          name: Install Docker Compose
-          command: |
-            set -x
-            curl -L https://github.com/docker/compose/releases/download/1.17.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose
-            chmod +x /usr/local/bin/docker-compose
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
           name: Deploy
           command: |
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
@@ -221,7 +179,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose --file ./build/eventbrite_webapp.yml push
   build_common_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -249,7 +207,7 @@ jobs:
             -  ~/wellcomecollection.org/dist
   test_common_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -263,7 +221,7 @@ jobs:
           command: pushd server && yarn run test && popd
   deploy_common_webapp:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -275,14 +233,6 @@ jobs:
       - add_ssh_keys
       - setup_remote_docker
       - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
           name: Deploy
           command: |
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
@@ -292,7 +242,7 @@ jobs:
             ./build-speedtracker.sh
   deploy_assets:
       docker:
-        - image: node:8.9.1
+        - image: circleci/node:8.9.3
       working_directory: ~/wellcomecollection.org/dist
       steps:
         - restore_cache:
@@ -312,7 +262,7 @@ jobs:
               aws s3 sync --only-show-errors . s3://i.wellcomecollection.org
   deploy_cardigan:
     docker:
-      - image: node:8.9.1
+      - image: circleci/node:8.9.3
     working_directory: ~/wellcomecollection.org
     steps:
       - restore_cache:
@@ -357,6 +307,7 @@ workflows:
             branches:
               only:
                 - master
+                - use_circleci_node_containers
       - build_events_webapp:
           requires:
             - checkout_code

--- a/build/Dockerfile_webapp
+++ b/build/Dockerfile_webapp
@@ -1,4 +1,4 @@
-FROM node:8.9.1-alpine
+FROM node:8.9.3-alpine
 
 ARG WEBAPP_NAME
 ARG WEBAPP_PORT

--- a/node-docker/Dockerfile
+++ b/node-docker/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:8.9.1
-
-RUN set -x \
-    chmod +x /usr/local/bin/docker \
-    curl -L https://github.com/docker/compose/releases/download/1.17.1/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose; \
-    chmod +x /usr/local/bin/docker-compose; \
-    docker-compose --version;

--- a/node-docker/docker-compose.yml
+++ b/node-docker/docker-compose.yml
@@ -1,7 +1,0 @@
-version: '3.3'
-services:
-  node_docker:
-    image: wellcome/node-docker:8.9.1
-    build:
-      context: ./
-      dockerfile: ./Dockerfile


### PR DESCRIPTION
Tidy up the circle build a wee bit by using their [preconfigured node image](https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/node/images/8.9.3/Dockerfile), which basically just installs Docker and a few other bits.

This will make it clearer and simpler to add a new service.