### PR TITLE
remove featured image from exhibitions model

### DIFF
--- a/prismic-model/exhibitions.json
+++ b/prismic-model/exhibitions.json
@@ -26,27 +26,6 @@
         "label" : "End date"
       }
     },
-    "featuredImage" : {
-      "type" : "Image",
-      "config" : {
-        "label" : "Featured image",
-        "thumbnails" : [ {
-          "name" : "32:15",
-          "width" : 3200,
-          "height" : 1500
-        }, {
-          "name" : "square",
-          "width" : 3200,
-          "height" : 3200
-        } ]
-      }
-    },
-    "featuredImageMobileCrop" : {
-      "type" : "Image",
-      "config" : {
-        "label" : "Featured image, mobile crop"
-      }
-    },
     "intro" : {
       "type" : "StructuredText",
       "config" : {


### PR DESCRIPTION
We don't use it in the template anymore - this came up in the content meeting too.