### PR TITLE
make preview cache a day

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -41,7 +41,7 @@ export const renderArticle = async(ctx, next) => {
 export async function setPreviewSession(ctx, next) {
   const {token} = ctx.request.query;
   ctx.cookies.set(Prismic.previewCookie, token, {
-    maxAge: 60 * 30 * 1000,
+    maxAge: 24 * 60 * 60 * 1000,
     path: '/',
     httpOnly: false
   });


### PR DESCRIPTION
We're running off of `preview.wellcomecollection.org` - so having the longer time won't conflict with anything being viewed on wellcomecollection.org.

I was going to work on how we chose the preview API - but from Sadek @ Prismic:
"sharing previews is something we’ll most probably be working on next".

Fixes #1974 
Fixes #1973 
  