### PR TITLE
Bugfixes for Licence information text

### DIFF
--- a/server/filters/get-license-info.js
+++ b/server/filters/get-license-info.js
@@ -28,13 +28,14 @@ const licenseMap = {
     text: 'CC BY-NC',
     icons: ['cc', 'cc_by', 'cc_nc'],
     description: 'Free to use with attribution for non-commercial purposes',
-    humanReadableText: `<p>You can use this work for any purpose, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.</p>Creative Commons Attribution Non-Commercial (CC BY-NC 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc/4.0">https://creativecommons.org/licenses/by-nc/4.0</a><p>`
+    humanReadableText: `<p>You can use this work for any purpose, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.</p><p>Creative Commons Attribution Non-Commercial (CC BY-NC 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc/4.0">https://creativecommons.org/licenses/by-nc/4.0</a><p>`
   },
   'CC-BY-NC-ND': {
     url: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
     text: 'CC BY-NC-ND',
     icons: ['cc', 'cc_by', 'cc_nc', 'cc_nd'],
-    description: 'Free to use with attribution for non-commercial purposes. No modifications permitted.'
+    description: 'Free to use with attribution for non-commercial purposes. No modifications permitted.',
+    humanReadableText: `<p>You can copy and distribute this work, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.</p><p>If you make any modifications to or derivatives of the work, it may not be distributed.</p><p>Creative Commons Attribution Non-Commercial No-Derivatives (CC BY-NC-ND 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">https://creativecommons.org/licenses/by-nc-nd/4.0/</a></p>`
   }
 };
 

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -53,7 +53,7 @@
 
           {% set licenseInfo = work.thumbnail.license.licenseType | getLicenseInfo %}
           {% set usingThisImageData = [
-            {title: 'License infomation', content: licenseInfo.humanReadableText},
+            {title: 'Licence information', content: licenseInfo.humanReadableText},
             {title: 'Credit', content: work.attribution}
           ] %}
 


### PR DESCRIPTION
Addresses 2/3rds of #1981. Specifically:

* CC BY-NC-ND licensed images now have human-readable text;
* "Licence information" is correctly spelt, with the British variant of "licen[cs]e".

I wasn’t sure exactly what to do about the extra space/full stop, so I decided to leave that for now.

![screen shot 2018-01-05 at 15 38 22](https://user-images.githubusercontent.com/301220/34615951-7c63c19a-f22e-11e7-993b-50ec31d4bc41.png)

  