### PR TITLE
New prismic API function that self-selects if it is in preview mode

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -46,11 +46,11 @@ export async function setPreviewSession(ctx, next) {
     httpOnly: false
   });
 
-  const redirectUrl = await getPreviewSession(token);
+  const redirectUrl = await getPreviewSession(ctx, token);
   ctx.response.redirect(redirectUrl);
 }
 
-async function getPreviewSession(token) {
+async function getPreviewSession(ctx, token) {
   const prismic = await prismicApi();
 
   return new Promise((resolve, reject) => {
@@ -84,7 +84,7 @@ export const renderEventbriteEmbed = async(ctx, next) => {
 
 export async function renderExplore(ctx, next) {
   // TODO: Remove WP content
-  const contentListPromise = getArticleList();
+  const contentListPromise = getArticleList(ctx.cookies);
 
   const listRequests = [getCuratedList('explore'), contentListPromise];
   const [curatedList, contentList] = await Promise.all(listRequests);
@@ -123,7 +123,7 @@ export async function renderExplore(ctx, next) {
 export async function renderSeries(ctx, next) {
   const page = Number(ctx.request.query.page);
   const {id} = ctx.params;
-  const seriesArticles = await getSeriesAndArticles(`W${id}`);
+  const seriesArticles = await getSeriesAndArticles(ctx.cookies, {id: `W${id}`});
 
   if (seriesArticles) {
     const {series, paginatedResults} = seriesArticles;
@@ -157,7 +157,7 @@ export async function renderSeries(ctx, next) {
 export async function renderArticlesList(ctx, next) {
   // TODO: Remove WP content
   const page = Number(ctx.request.query.page);
-  const articlesList = await getArticleList(page, {pageSize: 96});
+  const articlesList = await getArticleList(ctx.cookies, {page, pageSize: 96});
   const contentPromos = List(articlesList.results);
 
   const series: Series = {

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-env": "^1.6.1",
+    "cookies": "^0.7.1",
     "copy-webpack-plugin": "^4.2.3",
     "entities": "^1.1.1",
     "flow-bin": "^0.57.3",

--- a/server/services/prismic-api.js
+++ b/server/services/prismic-api.js
@@ -1,4 +1,5 @@
 import Prismic from 'prismic-javascript';
+import Cookies from 'cookies';
 
 const oneMinute = 1000 * 60;
 const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
@@ -9,6 +10,16 @@ function periodicallyUpdatePrismic() {
   setInterval(async() => {
     memoizedPrismic = await Prismic.getApi(apiUri);
   }, oneMinute);
+}
+
+export async function getPrismic(cookies) {
+  const previewCookie = cookies.get(Prismic.previewCookie);
+  
+  const api = previewCookie ? await Prismic.getApi(apiUri, {req: cookies.request})
+    : !memoizedPrismic ? await Prismic.getApi(apiUri)
+    : memoizedPrismic;
+
+  return api;
 }
 
 export async function prismicApi() {

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -157,7 +157,7 @@ export async function getArticleSeries(seriesId) {
 }
 
 export async function getSeriesAndArticles(cookies, {id, page = 1} = {}) {
-  const paginatedResults = await getArticleList(request, {
+  const paginatedResults = await getArticleList(cookies, {
     page,
     predicates: [Prismic.Predicates.at('my.articles.series.series', id)]
   });

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -1,5 +1,5 @@
 import Prismic from 'prismic-javascript';
-import {prismicApi, prismicPreviewApi} from './prismic-api';
+import {getPrismic, prismicApi, prismicPreviewApi} from './prismic-api';
 import {
   parseArticleDoc,
   parseEventDoc,
@@ -44,7 +44,6 @@ const defaultPageSize = 40;
 
 export async function getPrismicApi(req: ?Request) {
   const api = req ? await prismicPreviewApi(req) : await prismicApi();
-
   return api;
 }
 
@@ -88,14 +87,14 @@ export async function getEvent(id: string, previewReq: ?Request): Promise<?Event
   return parseEventDoc(event);
 }
 
-export async function getArticleList(page = 1, {pageSize = 10, predicates = []} = {}) {
+export async function getArticleList(cookies, {page = 1, pageSize = 10, predicates = []} = {}) {
   const fetchLinks = [
     'people.name', 'people.image', 'people.twitterHandle', 'people.description',
     'series.name', 'series.description', 'series.color', 'series.commissionedLength', 'series.schedule'
   ];
   // TODO: This order is not really doing what we expect it to do.
   const orderings = '[document.first_publication_date desc, my.articles.publishDate desc, my.webcomics.publishDate desc]';
-  const prismic = await prismicApi();
+  const prismic = await getPrismic(cookies);
   const articlesList = await prismic.query([
     Prismic.Predicates.any('document.type', ['articles', 'webcomics']),
     Prismic.Predicates.not('document.tags', ['delist'])
@@ -157,8 +156,9 @@ export async function getArticleSeries(seriesId) {
   }, {items: List(scheduleItems)}, {id: seriesId});
 }
 
-export async function getSeriesAndArticles(id: string, page: number = 1) {
-  const paginatedResults = await getArticleList(page, {
+export async function getSeriesAndArticles(cookies, {id, page = 1} = {}) {
+  const paginatedResults = await getArticleList(request, {
+    page,
     predicates: [Prismic.Predicates.at('my.articles.series.series', id)]
   });
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1560,7 +1560,7 @@ cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
-cookies@~0.7.0:
+cookies@^0.7.1, cookies@~0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.1.tgz#7c8a615f5481c61ab9f16c833731bcb8f663b99b"
   dependencies:


### PR DESCRIPTION
Starting working on trying to get preview in lists working, so editors can see what it'll look like.
Taking it as a good place to start trying to get preview into a better, if not only universal, state.

Basically the algorithm is: If there is a preview cookie, show the preview version.
  
References: #1988
