### PR TITLE
Add gif video from Prismic

### DIFF
--- a/client/js/components/gif-video.js
+++ b/client/js/components/gif-video.js
@@ -13,21 +13,22 @@ function inViewport(el) {
   );
 }
 
-function autoPlayGif(video, playPause) {
+function autoPlayGif(video, textEl) {
   if (inViewport(video)) {
     if (video.paused && shouldAutoPlay) {
       video.play();
-      playPause.classList.add('is-playing');
+      textEl.classList.add('gif-video__text--is-playing');
     }
   } else {
     video.pause();
-    playPause.classList.remove('is-playing');
+    textEl.classList.remove('gif-video__text--is-playing');
   }
 };
 
 export default function(el) {
   const video = el.querySelector('.js-gif-video__video');
   const playPause = el.querySelector('.js-gif-video__play-pause');
+  const textEl = playPause.querySelector('.js-gif-video__text');
 
   video.muted = true;
   video.loop = true;
@@ -37,27 +38,27 @@ export default function(el) {
   playPause.addEventListener('click', () => {
     if (video.paused) {
       video.play();
-      playPause.classList.add('is-playing');
+      textEl.classList.add('gif-video__text--is-playing');
       shouldAutoPlay = true;
     } else {
       video.pause();
-      playPause.classList.remove('is-playing');
+      textEl.classList.remove('gif-video__text--is-playing');
       shouldAutoPlay = false;
     }
   });
 
   onWindowScrollThrottle$.subscribe({
     next() {
-      autoPlayGif(video, playPause);
+      autoPlayGif(video, textEl);
     }
   });
 
   onWindowResizeDebounce$.subscribe({
     next() {
-      autoPlayGif(video, playPause);
+      autoPlayGif(video, textEl);
     }
   });
 
-  autoPlayGif(video, playPause);
+  autoPlayGif(video, textEl);
 }
 

--- a/client/js/components/gif-video.js
+++ b/client/js/components/gif-video.js
@@ -13,13 +13,15 @@ function inViewport(el) {
   );
 }
 
-function autoPlayGif(video) {
+function autoPlayGif(video, playPause) {
   if (inViewport(video)) {
     if (video.paused && shouldAutoPlay) {
       video.play();
+      playPause.classList.add('is-playing');
     }
   } else {
     video.pause();
+    playPause.classList.remove('is-playing');
   }
 };
 
@@ -35,25 +37,27 @@ export default function(el) {
   playPause.addEventListener('click', () => {
     if (video.paused) {
       video.play();
+      playPause.classList.add('is-playing');
       shouldAutoPlay = true;
     } else {
       video.pause();
+      playPause.classList.remove('is-playing');
       shouldAutoPlay = false;
     }
   });
 
   onWindowScrollThrottle$.subscribe({
     next() {
-      autoPlayGif(video);
+      autoPlayGif(video, playPause);
     }
   });
 
   onWindowResizeDebounce$.subscribe({
     next() {
-      autoPlayGif(video);
+      autoPlayGif(video, playPause);
     }
   });
 
-  autoPlayGif(video);
+  autoPlayGif(video, playPause);
 }
 

--- a/client/js/components/gif-video.js
+++ b/client/js/components/gif-video.js
@@ -1,4 +1,5 @@
 import { onWindowScrollThrottle$, onWindowResizeDebounce$ } from '../utils/dom-events';
+import { trackGaEvent } from '../tracking';
 
 let shouldAutoPlay = true;
 
@@ -29,6 +30,7 @@ export default function(el) {
   const video = el.querySelector('.js-gif-video__video');
   const playPause = el.querySelector('.js-gif-video__play-pause');
   const textEl = playPause.querySelector('.js-gif-video__text');
+  const trackingLabel = playPause.getAttribute('data-track-label');
 
   video.muted = true;
   video.loop = true;
@@ -36,6 +38,12 @@ export default function(el) {
   // If the user stops the video, don't autoplay
   // unless they restart the video manually
   playPause.addEventListener('click', () => {
+    trackGaEvent({
+      category: 'component',
+      action: 'toggle-gif-video-play:click',
+      label: `gif-video:${trackingLabel}, click-action:${video.paused ? 'did-play' : 'did-pause'}`
+    });
+
     if (video.paused) {
       video.play();
       textEl.classList.add('gif-video__text--is-playing');

--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -117,27 +117,6 @@
   }
 }
 
-.captioned-image__copyright-holder {
-  text-align: right;
-
-  .enhanced & {
-    position: absolute;
-    width: 100%;
-  }
-}
-
-.captioned-image__copyright-holder--bottom {
-  .enhanced & {
-    bottom: 0;
-  }
-}
-
-.captioned-image__copyright-holder--top {
-  .enhanced & {
-    top: 0;
-  }
-}
-
 .captioned-image__icon {
   display: none;
 

--- a/client/scss/components/_gif_video.scss
+++ b/client/scss/components/_gif_video.scss
@@ -25,20 +25,16 @@
   }
 }
 
-.gif-video__play {
-  .gif-video__play-pause.is-playing & {
-    display: none;
+.gif-video__text {
+  &:before {
+    content: 'play';
+    color: color('white');
+    background: rgba(color('black'), 0.6);
+    padding: $spacing-unit;
+    border-radius: $border-radius-unit;
   }
 }
 
-.gif-video__pause {
-  display: none;
-  border: 2px solid color('black');
-  width: 20px;
-  height: 20px;
-  border-radius: $border-radius-unit;
-
-  .gif-video__play-pause.is-playing & {
-    display: inline-block;
-  }
+.gif-video__text--is-playing:before {
+  content: 'pause';
 }

--- a/client/scss/components/_gif_video.scss
+++ b/client/scss/components/_gif_video.scss
@@ -1,15 +1,4 @@
-.gif-video {
-  margin-top: 0;
-  margin-left: 0;
-  margin-right: 0;
-}
-
-.gif-video__inner {
-  position: relative;
-}
-
 .gif-video__video {
-  display: block;
   width: 100%;
 }
 
@@ -17,8 +6,7 @@
   background: transparent;
   border: 0;
   appearance: none;
-  position: absolute;
-  bottom: 10px;
+  top: 10px;
   left: 10px;
   opacity: 0;
   display: none;
@@ -52,18 +40,5 @@
 
   .gif-video__play-pause.is-playing & {
     display: inline-block;
-  }
-}
-
-.gif-video__button-text {
-  @include visually-hidden();
-}
-
-.gif-video__caption {
-  border-bottom: 1px solid color('pumice');
-
-  .icon {
-    vertical-align: top;
-    float: left;
   }
 }

--- a/client/scss/components/_gif_video.scss
+++ b/client/scss/components/_gif_video.scss
@@ -37,6 +37,24 @@
   }
 }
 
+.gif-video__play {
+  .gif-video__play-pause.is-playing & {
+    display: none;
+  }
+}
+
+.gif-video__pause {
+  display: none;
+  border: 2px solid color('black');
+  width: 20px;
+  height: 20px;
+  border-radius: $border-radius-unit;
+
+  .gif-video__play-pause.is-playing & {
+    display: inline-block;
+  }
+}
+
 .gif-video__button-text {
   @include visually-hidden();
 }

--- a/client/scss/components/_tasl.scss
+++ b/client/scss/components/_tasl.scss
@@ -1,0 +1,20 @@
+.tasl {
+  text-align: right;
+
+  .enhanced & {
+    position: absolute;
+    width: 100%;
+  }
+}
+
+.tasl--bottom {
+  .enhanced & {
+    bottom: 0;
+  }
+}
+
+.tasl--top {
+  .enhanced & {
+    top: 0;
+  }
+}

--- a/client/scss/critical.scss
+++ b/client/scss/critical.scss
@@ -50,5 +50,6 @@
 @import 'components/skip_link';
 @import 'components/standfirst';
 @import 'components/tags';
+@import 'components/tasl';
 @import 'components/wobbly_edge';
 @import 'components/work_media';

--- a/prismic-model/articles.json
+++ b/prismic-model/articles.json
@@ -23,6 +23,10 @@
             "name" : "standalone",
             "display" : "Standalone"
           } ],
+          "gifVideo" : [ {
+            "name" : "supporting",
+            "display" : "Supporting"
+          } ],
           "iframe" : [ {
             "name" : "supporting",
             "display" : "Supporting"
@@ -65,6 +69,33 @@
                 "config" : {
                   "label" : "Text",
                   "multi" : "heading2,paragraph,strong,em,hyperlink,strike,list-item,embed"
+                }
+              }
+            }
+          },
+          "gifVideo" : {
+            "type" : "Slice",
+            "fieldset" : "Gif video",
+            "non-repeat" : {
+              "caption" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "hyperlink, bold, em",
+                  "label" : "Caption"
+                }
+              },
+              "posterFrame" : {
+                "type" : "Image",
+                "config" : {
+                  "label" : "Poster frame"
+                }
+              },
+              "movieFile" : {
+                "type" : "Link",
+                "config" : {
+                  "select" : "media",
+                  "label" : "Movie file",
+                  "placeholder" : "Movie file"
                 }
               }
             }

--- a/prismic-model/articles.json
+++ b/prismic-model/articles.json
@@ -90,12 +90,12 @@
                   "label" : "Poster frame"
                 }
               },
-              "movieFile" : {
+              "video" : {
                 "type" : "Link",
                 "config" : {
                   "select" : "media",
-                  "label" : "Movie file",
-                  "placeholder" : "Movie file"
+                  "label" : "Video",
+                  "placeholder" : "Video"
                 }
               }
             }

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -128,6 +128,17 @@ function parseBodyPart(slice) {
         }
       };
 
+    case 'gifVideo':
+      return {
+        type: 'gifVideo',
+        weight: slice.slice_label,
+        value: {
+          posterFrameUrl: slice.primary.posterFrame.url,
+          caption: slice.primary.caption && asHtml(slice.primary.caption),
+          movieFileUrl: slice.primary.movieFile.url
+        }
+      };
+
     default:
       break;
   }

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -135,7 +135,7 @@ function parseBodyPart(slice) {
         value: {
           posterFrame: slice.primary.posterFrame && parsePicture({image: slice.primary.posterFrame}),
           caption: slice.primary.caption && asHtml(slice.primary.caption),
-          movieFileUrl: slice.primary.movieFile.url
+          videoUrl: slice.primary.video && slice.primary.video.url
         }
       };
 

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -133,7 +133,7 @@ function parseBodyPart(slice) {
         type: 'gifVideo',
         weight: slice.slice_label,
         value: {
-          posterFrameUrl: slice.primary.posterFrame.url,
+          posterFrame: slice.primary.posterFrame && parsePicture({image: slice.primary.posterFrame}),
           caption: slice.primary.caption && asHtml(slice.primary.caption),
           movieFileUrl: slice.primary.movieFile.url
         }

--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -95,6 +95,10 @@
             <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
               {% componentV2 'iframe', bodyPart.value %}
             </div>
+          {% elif bodyPart.type === 'gifVideo' %}
+            <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
+              {% componentV2 'gif-video', bodyPart.value %}
+            </div>
           {% else %}
             {{ bodyPart.value | safe }}
           {% endif %}

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -11,37 +11,7 @@
       {% componentV2 'image', model, {}, {lazyload: true, sizesQueries: data.sizesQueries} %}
     {% endif %}
     {% if ((model.title or model.source.name or model.copyright.name or model.license) and data.showCopyright) %}
-      <div class="captioned-image__copyright-holder {% if modifiers.full %}captioned-image__copyright-holder--top{% else %}captioned-image__copyright-holder--bottom{% endif %} {{ {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses }} drawer js-show-hide"
-        data-track-action="toggle-image-credit"
-        data-track-label="image:{{ model.contentUrl }}">
-        {% if not modifiers.full %}
-          <button class="plain-button js-show-hide-trigger">
-            <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
-              {% icon 'information', 'information', ['icon--white'] %}
-            </span>
-          </button>
-        {% endif %}
-        <div class="drawer__body js-show-hide-drawer bg-white {{ {s:1} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}">
-          {% set tasl = {
-            title: model.title,
-            author: model.author,
-            sourceName: model.source.name,
-            sourceLink: model.source.link,
-            license: model.license,
-            copyrightHolder: model.copyright.holder,
-            copyrightLink: model.copyright.link
-          } %}
-
-          {{ tasl | getTaslMarkup | safe }}
-        </div>
-        {% if modifiers.full %}
-          <button class="plain-button js-show-hide-trigger">
-            <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
-              {% icon 'information', 'information', ['icon--white'] %}
-            </span>
-          </button>
-        {% endif %}
-      </div>
+      {% componentV2 'tasl', model, modifiers %}
     {% endif %}
   </div>
   {% block figcaption %}

--- a/server/views/components/captioned-image/captioned-image.njk
+++ b/server/views/components/captioned-image/captioned-image.njk
@@ -12,7 +12,7 @@
     {% endif %}
     {% if ((model.title or model.source.name or model.copyright.name or model.license) and data.showCopyright) %}
       <div class="captioned-image__copyright-holder {% if modifiers.full %}captioned-image__copyright-holder--top{% else %}captioned-image__copyright-holder--bottom{% endif %} {{ {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses }} drawer js-show-hide"
-        data-track-action="toggle-image-credit",
+        data-track-action="toggle-image-credit"
         data-track-label="image:{{ model.contentUrl }}">
         {% if not modifiers.full %}
           <button class="plain-button js-show-hide-trigger">

--- a/server/views/components/gif-video/gif-video.njk
+++ b/server/views/components/gif-video/gif-video.njk
@@ -9,7 +9,10 @@
       {# Fallback to poster frame #}
       {% componentV2 'image', model.posterFrame %}
     </video>
-    <button class="gif-video__play-pause absolute js-gif-video__play-pause" type="button" tabindex="0">
+    <button class="gif-video__play-pause absolute js-gif-video__play-pause"
+      type="button"
+      tabindex="0"
+      data-track-label="{{ model.videoUrl }}">
       <span class="{{ {s:'LR3'} | fontClasses }} js-gif-video__text gif-video__text"></span>
     </button>
     {% componentV2 'tasl', model.posterFrame %}

--- a/server/views/components/gif-video/gif-video.njk
+++ b/server/views/components/gif-video/gif-video.njk
@@ -1,18 +1,20 @@
 <figure class="js-gif-video gif-video {{ {s:3} | spacingClasses({margin: ['bottom']}) }}">
   <div class="gif-video__inner">
     <video class="gif-video__video js-gif-video__video"
-      poster="{{ model.posterImage.contentUrl }}" >
-      {% for source in model.sources %}
-        <source src="{{ source.url }}" type='{{ source.fileFormat }}'>
-      {% endfor %}
-      <p class="gif-video__unsupported">Your browser can't handle our GIFs.</p>
+      poster="{{ model.posterFrameUrl }}" >
+      <source src="{{ model.movieFileUrl }}" type="video/mp4">
+      {# Fallback to poster frame #}
+      <img src="{{ model.posterFrameUrl }}" alt="{{ model.caption | safe | striptags }}" />
     </video>
     <button class="gif-video__play-pause js-gif-video__play-pause" type="button" tabindex="0">
-      {% icon 'play' %}
+      <span class="gif-video__play">{% icon 'play' %}</span>
+      <span class="gif-video__pause"></span>
       <span class="gif-video__button-text">play/pause</span>
     </button>
   </div>
-  <figcaption class="gif-video__caption {{ {s:'LR3', m:'LR2'} | fontClasses }} {{ {s:3} | spacingClasses({padding: ['top', 'bottom']}) }} ">
-    {% icon 'image',  null, ['margin-right-s1'] %}{{ model.caption }}
-  </figcaption>
+  {% if model.caption %}
+    <figcaption class="gif-video__caption {{ {s:'LR3', m:'LR2'} | fontClasses }} {{ {s:3} | spacingClasses({padding: ['top', 'bottom']}) }} ">
+      {% icon 'image',  null, ['margin-right-s1'] %}{{ model.caption | safe }}
+    </figcaption>
+  {% endif %}
 </figure>

--- a/server/views/components/gif-video/gif-video.njk
+++ b/server/views/components/gif-video/gif-video.njk
@@ -1,20 +1,24 @@
-<figure class="js-gif-video gif-video {{ {s:3} | spacingClasses({margin: ['bottom']}) }}">
-  <div class="gif-video__inner">
-    <video class="gif-video__video js-gif-video__video"
+<figure class="{{- [
+  {s:0} | spacingClasses({margin: ['top', 'left', 'right' ]}),
+  {s:3} | spacingClasses({margin: ['bottom']})
+  ].join(' ') }} js-gif-video gif-video">
+  <div class="gif-video__inner relative">
+    <video class="gif-video__video block js-gif-video__video"
       poster="{{ model.posterFrameUrl }}" >
       <source src="{{ model.movieFileUrl }}" type="video/mp4">
       {# Fallback to poster frame #}
-      <img src="{{ model.posterFrameUrl }}" alt="{{ model.caption | safe | striptags }}" />
+      {% componentV2 'image', model.posterFrame %}
     </video>
-    <button class="gif-video__play-pause js-gif-video__play-pause" type="button" tabindex="0">
+    <button class="gif-video__play-pause absolute js-gif-video__play-pause" type="button" tabindex="0">
       <span class="gif-video__play">{% icon 'play' %}</span>
       <span class="gif-video__pause"></span>
-      <span class="gif-video__button-text">play/pause</span>
+      <span class="gif-video__button-text visually-hidden">play/pause</span>
     </button>
+    {% componentV2 'tasl', model.posterFrame %}
   </div>
   {% if model.caption %}
-    <figcaption class="gif-video__caption {{ {s:'LR3', m:'LR2'} | fontClasses }} {{ {s:3} | spacingClasses({padding: ['top', 'bottom']}) }} ">
-      {% icon 'image',  null, ['margin-right-s1'] %}{{ model.caption | safe }}
+    <figcaption class="gif-video__caption border-bottom-width-1 border-color-pumice {{ {s:'LR3', m:'LR2'} | fontClasses }} {{ {s:3} | spacingClasses({padding: ['top', 'bottom']}) }} ">
+      {% icon 'image',  null, ['margin-right-s1', 'float-l'] %}{{ model.caption | safe }}
     </figcaption>
   {% endif %}
 </figure>

--- a/server/views/components/gif-video/gif-video.njk
+++ b/server/views/components/gif-video/gif-video.njk
@@ -10,8 +10,7 @@
       {% componentV2 'image', model.posterFrame %}
     </video>
     <button class="gif-video__play-pause absolute js-gif-video__play-pause"
-      type="button"
-      tabindex="0"
+      aria-label="play/pause button"
       data-track-label="{{ model.videoUrl }}">
       <span class="{{ {s:'LR3'} | fontClasses }} js-gif-video__text gif-video__text"></span>
     </button>

--- a/server/views/components/gif-video/gif-video.njk
+++ b/server/views/components/gif-video/gif-video.njk
@@ -5,14 +5,12 @@
   <div class="gif-video__inner relative">
     <video class="gif-video__video block js-gif-video__video"
       poster="{{ model.posterFrameUrl }}" >
-      <source src="{{ model.movieFileUrl }}" type="video/mp4">
+      <source src="{{ model.videoUrl }}" type="video/mp4">
       {# Fallback to poster frame #}
       {% componentV2 'image', model.posterFrame %}
     </video>
     <button class="gif-video__play-pause absolute js-gif-video__play-pause" type="button" tabindex="0">
-      <span class="gif-video__play">{% icon 'play' %}</span>
-      <span class="gif-video__pause"></span>
-      <span class="gif-video__button-text visually-hidden">play/pause</span>
+      <span class="{{ {s:'LR3'} | fontClasses }} js-gif-video__text gif-video__text"></span>
     </button>
     {% componentV2 'tasl', model.posterFrame %}
   </div>

--- a/server/views/components/tasl/tasl.config.js
+++ b/server/views/components/tasl/tasl.config.js
@@ -1,0 +1,1 @@
+export const hidden = true;

--- a/server/views/components/tasl/tasl.njk
+++ b/server/views/components/tasl/tasl.njk
@@ -1,6 +1,9 @@
-<div class="captioned-image__copyright-holder {% if modifiers.full %}captioned-image__copyright-holder--top{% else %}captioned-image__copyright-holder--bottom{% endif %} {{ {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses }} drawer js-show-hide"
-        data-track-action="toggle-image-credit",
-        data-track-label="image:{{ model.contentUrl }}">
+<div class="{{- [
+    'tasl--top' if modifiers.full else 'tasl--bottom',
+    {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses
+  ].join(' ') }} tasl drawer js-show-hide"
+    data-track-action="toggle-image-credit"
+    data-track-label="image:{{ model.contentUrl }}">
   {% if not modifiers.full %}
     <button class="plain-button js-show-hide-trigger">
       <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">

--- a/server/views/components/tasl/tasl.njk
+++ b/server/views/components/tasl/tasl.njk
@@ -1,0 +1,31 @@
+<div class="captioned-image__copyright-holder {% if modifiers.full %}captioned-image__copyright-holder--top{% else %}captioned-image__copyright-holder--bottom{% endif %} {{ {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses }} drawer js-show-hide"
+        data-track-action="toggle-image-credit",
+        data-track-label="image:{{ model.contentUrl }}">
+  {% if not modifiers.full %}
+    <button class="plain-button js-show-hide-trigger">
+      <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
+        {% icon 'information', 'information', ['icon--white'] %}
+      </span>
+    </button>
+  {% endif %}
+  <div class="drawer__body js-show-hide-drawer bg-white {{ {s:1} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}">
+    {% set tasl = {
+      title: model.title,
+      author: model.author,
+      sourceName: model.source.name,
+      sourceLink: model.source.link,
+      license: model.license,
+      copyrightHolder: model.copyright.holder,
+      copyrightLink: model.copyright.link
+    } %}
+
+    {{ tasl | getTaslMarkup | safe }}
+  </div>
+  {% if modifiers.full %}
+    <button class="plain-button js-show-hide-trigger">
+      <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
+        {% icon 'information', 'information', ['icon--white'] %}
+      </span>
+    </button>
+  {% endif %}
+</div>


### PR DESCRIPTION
Closes #1991 

## Value
Allows content editors to add movies-that-behave-like-gifs to articles.

## Screenshot
![gun_show](https://user-images.githubusercontent.com/1394592/34682563-20d8cf4e-f497-11e7-9685-baaa31f07fc9.gif)

## Checklist
### All
- [x] PR labelled and assigned
- [x] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [x] A11y tested: `npm run test:accessibility <URL>`
- [x] Browser tested: `npm run test:browsers <URL>`
- [x] Works without JS in the client
- [x] Relevant tracking/monitoring has been considered
