### PR TITLE
Remove 'by' from TASL

### DIFF
--- a/server/filters/get-tasl-markup.js
+++ b/server/filters/get-tasl-markup.js
@@ -3,7 +3,7 @@ import getLicenseInfo from './get-license-info';
 function getTitleHtml(title, author, sourceLink) {
   if (!title) return '';
 
-  const byAuthor = author ? `, by ${author}` : '';
+  const byAuthor = author ? `, ${author}` : '';
 
   if (sourceLink) {
     return `<a href="${sourceLink}" property="dc:title" rel="cc:attributionURL">${title}${byAuthor}</a>. `;


### PR DESCRIPTION
Bye-bye, 'by'.