### PR TITLE
add linkResolvers to allow linking of prismic=>prismic content

### DIFF
--- a/server/filters/prismic.js
+++ b/server/filters/prismic.js
@@ -1,9 +1,10 @@
-import {RichText} from 'prismic-dom';
+import {asHtml, asText} from '../services/prismic-parsers';
+
 
 export function prismicAsHtml(content) {
-  return RichText.asHtml(content);
+  return asHtml(content);
 }
 
 export function prismicAsText(content) {
-  return RichText.asText(content).trim();
+  return asText(content);
 }

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -12,14 +12,14 @@ function parseBodyPart(slice) {
       return {
         type: 'standfirst',
         weight: 'default',
-        value: RichText.asHtml(slice.primary.text)
+        value: asHtml(slice.primary.text)
       };
 
     case 'text':
       return {
         type: 'text',
         weight: 'default',
-        value: RichText.asHtml(slice.primary.text)
+        value: asHtml(slice.primary.text)
       };
 
     case 'editorialImage':
@@ -65,9 +65,9 @@ function parseBodyPart(slice) {
         type: 'quote',
         weight: 'default',
         value: {
-          body: RichText.asHtml(slice.primary.quote),
+          body: asHtml(slice.primary.quote),
           footer: slice.primary.citation && slice.primary.source ? `${slice.primary.citation} - ${slice.primary.source}` : null,
-          quote: RichText.asHtml(slice.primary.quote),
+          quote: asHtml(slice.primary.quote),
           citation: `${slice.primary.citation} - ${slice.primary.source}`
         }
       };

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -368,8 +368,18 @@ function parseTaslFromCopyright(copyright): Tasl {
 }
 
 // This purposefully isn't named `parseText` | `parseHtml` to match the prismic API.
+const linkResolver = (doc) => {
+  switch (doc.type) {
+    case 'articles'    : return `/articles/${doc.id}`;
+    case 'webcomics'   : return `/articles/${doc.id}`;
+    case 'exhibitions' : return `/exhibitions/${doc.id}`;
+    case 'events'      : return `/events/${doc.id}`;
+    case 'series'      : return `/series/${doc.id}`;
+  }
+};
+
 export function asText(maybeContent: any) {
-  return maybeContent && RichText.asText(maybeContent).trim();
+  return maybeContent && RichText.asText(maybeContent, linkResolver).trim();
 }
 
 export function asHtml(maybeContent: any) {
@@ -377,7 +387,7 @@ export function asHtml(maybeContent: any) {
   // Check that `asText` wouldn't return an empty string.
   const isEmpty = !maybeContent || asText(maybeContent).trim() === '';
 
-  return isEmpty ? null : RichText.asHtml(maybeContent).trim();
+  return isEmpty ? null : RichText.asHtml(maybeContent, linkResolver).trim();
 }
 
 export function isEmptyDocLink(fragment: Object) {


### PR DESCRIPTION
Allows users to add internal links to Prismic content.

Way nicer and easier for the editor and stops us copy / pasting links and running into sharing preview link problems.