### PR TITLE
Remove faulty selector

### DIFF
--- a/client/scss/components/_body_content.scss
+++ b/client/scss/components/_body_content.scss
@@ -123,10 +123,6 @@ $center-width-xlarge: (6/6) * 100%;
       clear: right;
       width: $narrow-width;
       margin-right: -$narrow-width;
-
-      .author + .article &:first-child {
-        margin-top: -$article-top-space;
-      }
     }
   }
 

--- a/client/scss/components/_gif_video.scss
+++ b/client/scss/components/_gif_video.scss
@@ -2,6 +2,10 @@
   width: 100%;
 }
 
+.gif-video__caption p:last-child {
+  margin-bottom: 0;
+}
+
 .gif-video__play-pause {
   background: transparent;
   border: 0;


### PR DESCRIPTION
Closes #2017

It's not clear to me what the `.author + .article &:first-child` selector should be doing, but whatever it is, I don't think it's doing it correctly. All items in the right-hand-rail are currently being negatively margined up by 30px, causing potential overlap when there's a lot of stuff in the rail.

I think the safest approach is to remove the selector for now.