### PR TITLE
make exhibition date range span from beginning - end of respective dates

### DIFF
--- a/server/content-model/exhibition.js
+++ b/server/content-model/exhibition.js
@@ -7,8 +7,8 @@ import type {BodyPart} from '../model/body-part';
 export type Exhibition = {|
   id: string;
   title: ?string;
-  start: ?DateRange;
-  end: ?DateRange;
+  start: Date;
+  end: ?Date;
   subtitle: ?string;
   intro: ?string;
   featuredImages: List<any>;

--- a/server/filters/format-date.js
+++ b/server/filters/format-date.js
@@ -3,7 +3,7 @@ import 'moment-timezone';
 import moment from 'moment';
 import {List} from 'immutable';
 
-function london(d) {
+export function london(d: ?Date | ?string) {
   return moment.tz(d, 'Europe/London');
 }
 

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -16,6 +16,7 @@ import {isEmptyObj} from '../utils/is-empty-obj';
 import type {Series} from '../model/series';
 import type {LicenseType} from '../model/license';
 import {licenseTypeArray} from '../model/license';
+import {london} from "../filters/format-date";
 
 // This is just JSON
 type PrismicDoc = Object;
@@ -130,12 +131,16 @@ export function parseExhibitionsDoc(doc: PrismicDoc): Exhibition {
     featuredImageSquare
   ]).filter(_ => _);
 
+  // Exhibitions are always open and shut on days, rather than hours
+  const startDate = london(doc.data.start).startOf('day').toDate();
+  const endDate = london(doc.data.end).endOf('day').toDate();
+
   const exhibition = ({
     id: doc.id,
     title: asText(doc.data.title),
     subtitle: asText(doc.data.subtitle),
-    start: doc.data.start,
-    end: doc.data.end,
+    start: startDate,
+    end: endDate,
     featuredImages: featuredImages,
     featuredImage: featuredImages.first(),
     intro: asText(doc.data.intro),


### PR DESCRIPTION
We could make the type of the fields `Date`s - but it feels like we might lock ourselves into something, and I have very rarely seen a place where a Date is better than a DateTime.

A test is hard to write as this logic is on the template side, where we don't have tests.

Fixes #2019 