### PR TITLE
add generic booking info to events

### DIFF
--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -163,6 +163,15 @@
             </div>
           {% endif %}
 
+          {% if event.bookingInformation %}
+            <h3 class="{{ {s:'HNM4'} | fontClasses }}">
+              Booking information
+            </h3>
+            <div class="{{ {s:'HNL4'} | fontClasses }}">
+              {{ event.bookingInformation | safe }}
+            </div>
+          {% endif %}
+
           {% for interpretation in event.interpretations %}
             {% if interpretation.interpretationType.description %}
               <h3 class="flex {{ {s:'HNM4'} | fontClasses }}">

--- a/prismic-model/events.json
+++ b/prismic-model/events.json
@@ -117,6 +117,13 @@
         "options" : [ "yes" ],
         "label" : "Drop in"
       }
+    },
+    "bookingInformation" : {
+      "type" : "StructuredText",
+      "config" : {
+        "multi" : "paragraph, strong, em, hyperlink, list-item",
+        "label" : "Booking information"
+      }
     }
   },
   "Series" : {

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -94,6 +94,7 @@ export type Event = {|
   promo: ?ImagePromo,
   interpretations: Array<Interpretation>,
   audiences: Array<Audience>,
+  bookingInformation: ?HTMLString,
   // TODO:
   // this is programmatic and doesn't come from Prismic and can't be edited directly
   // it's more convenient that having to work it out.
@@ -245,5 +246,6 @@ export const eventExample = ({
       height: 100
     }
   },
+  bookingInformation: '<p>Group size of 15-30 students, accompanied by staff at a ratio of 1:10. Each date is available for booking by one school group. Bookings must be made by a lead teacher.</p>',
   bookingType: 'Drop in'
 }: Event);

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -95,6 +95,7 @@ export function parseEventDoc(doc: PrismicDoc): Event {
     promo: promo,
     series: [],
     location: location,
+    bookingInformation: asHtml(doc.data.bookingInformation),
     bookingType: bookingType
   }: Event);
 


### PR DESCRIPTION
Some events need a place to put in specific booking information e.g. School events that follows no pattern, but is very important.

This allows them to do that.

![screen shot 2018-01-22 at 11 52 28](https://user-images.githubusercontent.com/31692/35219608-476d3e0e-ff6b-11e7-9efb-91d29522021e.png)
