### PR TITLE
correctly parse nullable dates in exhibitions

### DIFF
--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -132,8 +132,8 @@ export function parseExhibitionsDoc(doc: PrismicDoc): Exhibition {
   ]).filter(_ => _);
 
   // Exhibitions are always open and shut on days, rather than hours
-  const startDate = london(doc.data.start).startOf('day').toDate();
-  const endDate = london(doc.data.end).endOf('day').toDate();
+  const startDate = doc.data.start && london(doc.data.start).startOf('day').toDate();
+  const endDate = doc.data.end && london(doc.data.end).endOf('day').toDate();
 
   const exhibition = ({
     id: doc.id,


### PR DESCRIPTION
Stops us showing "Invalid date"
https://wellcomecollection.org/exhibitions/Weoe4SQAAKJwjcDC
