### PR TITLE
remove the training slash from what-on

### DIFF
--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -22,7 +22,7 @@ export async function renderEvent(ctx, next, overrideId, gaExp) {
       // TODO: add the `Part of:` tag, we don't have a way of doing this in the model
       const tags = [{
         text: 'Events',
-        url: 'https://wellcomecollection.org/whats-on/events/all-events'
+        url: 'https://wellcomecollection.org/events'
       }].concat(event.programme ? [{
         text: event.programme.title
         // TODO: link through to others of this type?

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -345,7 +345,7 @@ function getListHeader(dates) {
   const todayDateString = `startDate=${dates.today}&endDate=${dates.today}`;
   const weekendDateString = `startDate=${dates.weekend[0]}&endDate=${dates.weekend[1]}`;
   const allDateString = `startDate=${dates.all[0]}&endDate=${dates.all[1]}`;
-  const urlBeginning = `${encodeURI('/whats-on/?')}`;
+  const urlBeginning = `${encodeURI('/whats-on?')}`;
 
   return {
     todayOpeningHours,


### PR DESCRIPTION
Let's keep it tidy from the get go.
No trailing slashes (although they will work).