### PR TITLE
add to calendar test

### DIFF
--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -150,16 +150,16 @@
                   description: event.description,
                   location: 'Wellcome Collection, 183 Euston Rd, Kings Cross, London NW1 2BE'
                 } %}
-                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'google'} | dump }}"
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'calendar:google'} | dump }}"
                    target="_blank" href="{{ eventCalendarProps | googleCal }}"
                    class="{{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Google</a>
-                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'outlook'} | dump }}"
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'calendar:outlook'} | dump }}"
                    target="_blank" href="{{ eventCalendarProps | outlookCal }}"
                    class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Outlook</a>
-                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'iCal'} | dump }}"
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'calendar:ical'} | dump }}"
                    target="_blank" href="{{ eventCalendarProps | iCal }}"
                    class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">iCal</a>
-                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'yahoo'} | dump }}"
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'calendar:yahoo'} | dump }}"
                    target="_blank" href="{{ eventCalendarProps | yahooCal }}"
                    class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Yahoo</a>
               </div>

--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -147,10 +147,18 @@
                   description: event.description,
                   location: 'Wellcome Collection, 183 Euston Rd, Kings Cross, London NW1 2BE'
                 } %}
-                <a target="_blank" href="{{ eventCalendarProps | googleCal }}" class="{{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Google</a>
-                <a target="_blank" href="{{ eventCalendarProps | outlookCal }}" class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Outlook</a>
-                <a target="_blank" href="{{ eventCalendarProps | iCal }}" class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">iCal</a>
-                <a target="_blank" href="{{ eventCalendarProps | yahooCal }}" class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Yahoo</a>
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'google'} | dump }}"
+                   target="_blank" href="{{ eventCalendarProps | googleCal }}"
+                   class="{{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Google</a>
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'outlook'} | dump }}"
+                   target="_blank" href="{{ eventCalendarProps | outlookCal }}"
+                   class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Outlook</a>
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'iCal'} | dump }}"
+                   target="_blank" href="{{ eventCalendarProps | iCal }}"
+                   class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">iCal</a>
+                <a data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'yahoo'} | dump }}"
+                   target="_blank" href="{{ eventCalendarProps | yahooCal }}"
+                   class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Yahoo</a>
               </div>
             </div>
           {% endif %}

--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -131,7 +131,10 @@
 
           {% if not (eventInfo.eventbriteId or event.bookingEnquiryTeam) and event.times.length === 1 %}
             <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
-              <button type="button" class="{{- [
+              <button
+                data-track-event="{{ {category: 'component', action: 'add-to-calendar:click', label: 'empty-button'} | dump }}"
+                type="button"
+                class="{{- [
                 {s:'HNM4'} | fontClasses,
                 {s: 4} | spacingClasses({padding: ['left', 'right']})
               ].join(' ') }} flex-inline flex--h-center btn btn--full-width-s">

--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -127,6 +127,33 @@
                   href="mailto:{{ event.bookingEnquiryTeam.email }}">{{ event.bookingEnquiryTeam.email }}</a>
             </div>
           {% endif %}
+
+
+          {% if not (eventInfo.eventbriteId or event.bookingEnquiryTeam) and event.times.length === 1 %}
+            <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
+              <button type="button" class="{{- [
+                {s:'HNM4'} | fontClasses,
+                {s: 4} | spacingClasses({padding: ['left', 'right']})
+              ].join(' ') }} flex-inline flex--h-center btn btn--full-width-s">
+                <span>{% icon 'calendar', null, ['icon--white'] %}</span>
+                Add to calendar
+              </button>
+              <div class="flex {{ {s: 1} | spacingClasses({padding: ['top']}) }}">
+                {% set eventCalendarProps = {
+                  url: 'https://wellcomecollection.org/events/' + event.id,
+                  startTime: event.times[0].startDateTime,
+                  endTime: event.times[0].endDateTime,
+                  title: event.title,
+                  description: event.description,
+                  location: 'Wellcome Collection, 183 Euston Rd, Kings Cross, London NW1 2BE'
+                } %}
+                <a target="_blank" href="{{ eventCalendarProps | googleCal }}" class="{{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Google</a>
+                <a target="_blank" href="{{ eventCalendarProps | outlookCal }}" class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Outlook</a>
+                <a target="_blank" href="{{ eventCalendarProps | iCal }}" class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">iCal</a>
+                <a target="_blank" href="{{ eventCalendarProps | yahooCal }}" class="border-left-width-1 border-color-pumice {{ {s: 1} | spacingClasses({padding: ['right', 'left']}) }}">Yahoo</a>
+              </div>
+            </div>
+          {% endif %}
         </div>
 
         <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">

--- a/server/filters/add-to-calendar.js
+++ b/server/filters/add-to-calendar.js
@@ -1,0 +1,70 @@
+// @flow
+import {deP} from "../services/prismic-parsers";
+
+type EventProps = {|
+  url: string;
+  startTime: Date;
+  endTime: Date;
+  title: string;
+  description: string;
+  location: string;
+|}
+
+// TODO: parse description as text, not HTML
+function formatDate(date: Date): string {
+  return date.toISOString().replace(/-|:|\.000/g, '');
+}
+
+export function googleCal(eventProps: EventProps): string {
+  return [
+    `https://calendar.google.com/calendar/render`,
+    `?action=TEMPLATE`,
+    `&text=${encodeURIComponent(eventProps.title)}`,
+    `&dates=${formatDate(eventProps.startTime)}`,
+    `/${formatDate(eventProps.endTime)}`,
+    `&details=${encodeURIComponent(eventProps.description)}`,
+    `&location=${encodeURIComponent(eventProps.location)}`
+  ].join('');
+}
+
+export function yahooCal(eventProps: EventProps): string {
+  const dur = (eventProps.endTime.getTime() - eventProps.startTime.getTime()) / (60 * 1000);
+  return [
+    `https://calendar.yahoo.com/?v=60&view=d&type=20`,
+    `&title=${encodeURIComponent(eventProps.title)}`,
+    `&st=${formatDate(eventProps.startTime)}`,
+    `&dur=${dur}`,
+    `&desc=${encodeURIComponent(eventProps.description)}`,
+    `&in_loc=${encodeURIComponent(eventProps.location)}`
+  ].join('');
+}
+
+export function outlookCal(eventProps: EventProps) {
+  return [
+    `https://outlook.live.com/owa/?rru=addevent`,
+    `&subject=${encodeURIComponent(eventProps.title)}`,
+    `&startdt=${formatDate(eventProps.startTime)}`,
+    `&enddt=${formatDate(eventProps.endTime)}`,
+    `&body=${encodeURIComponent(deP(eventProps.description))}`,
+    `&location=${encodeURIComponent(eventProps.location)}`,
+    `&uid=${(new Date()).getTime().toString()}`,
+    '&allday=false',
+    '&path=/calendar/view/Month'
+  ].join('');
+}
+
+export function iCal(eventProps: EventProps): string {
+  return `data:text/calendar;charset=utf8,${encodeURIComponent([
+    `BEGIN:VCALENDAR`,
+    `VERSION:2.0`,
+    `BEGIN:VEVENT`,
+    `URL: ${eventProps.url}`,
+    `DTSTART:${formatDate(eventProps.startTime)}`,
+    `DTEND:${formatDate(eventProps.endTime)}`,
+    `SUMMARY:${eventProps.title}`,
+    `DESCRIPTION:${deP(eventProps.description)}`,
+    `LOCATION:${eventProps.location}`,
+    `END:VEVENT`,
+    `END:VCALENDAR`
+  ].join('\n'))}`;
+}

--- a/server/filters/add-to-calendar.js
+++ b/server/filters/add-to-calendar.js
@@ -45,7 +45,7 @@ export function outlookCal(eventProps: EventProps) {
     `&subject=${encodeURIComponent(eventProps.title)}`,
     `&startdt=${formatDate(eventProps.startTime)}`,
     `&enddt=${formatDate(eventProps.endTime)}`,
-    `&body=${encodeURIComponent(deP(eventProps.description))}`,
+    `&body=${encodeURIComponent(deP(eventProps.description) || '')}`,
     `&location=${encodeURIComponent(eventProps.location)}`,
     `&uid=${(new Date()).getTime().toString()}`,
     '&allday=false',
@@ -62,7 +62,7 @@ export function iCal(eventProps: EventProps): string {
     `DTSTART:${formatDate(eventProps.startTime)}`,
     `DTEND:${formatDate(eventProps.endTime)}`,
     `SUMMARY:${eventProps.title}`,
-    `DESCRIPTION:${deP(eventProps.description)}`,
+    `DESCRIPTION:${deP(eventProps.description) || ''}`,
     `LOCATION:${eventProps.location}`,
     `END:VEVENT`,
     `END:VCALENDAR`

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -38,6 +38,7 @@ import {
   joinDateStrings,
   formatDayDate
 } from './format-date';
+import {googleCal, yahooCal, iCal, outlookCal} from './add-to-calendar';
 import getLicenseInfo from './get-license-info';
 import getTaslMarkup from './get-tasl-markup';
 import getBreakpoint from './get-breakpoint';
@@ -88,5 +89,9 @@ export default Map({
   getBreakpoint,
   joinDateStrings,
   getHashedFile,
-  aOrAn
+  aOrAn,
+  googleCal,
+  yahooCal,
+  iCal,
+  outlookCal
 });

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -423,6 +423,6 @@ export function isEmptyDocLink(fragment: Object) {
 // This is used for when we have a "single" `StructuredText` and want to maintain the inline HTML
 // (`a`, `em` etc) but would rather Prismic not wrap it in a `p` for us.
 // The empty `class` attribute 🤷‍
-function deP(text: ?string) {
+export function deP(text: ?string) {
   return text && text.replace(/<\/?p( class="")?>/g, '');
 }


### PR DESCRIPTION
![screen shot 2018-01-23 at 09 52 50](https://user-images.githubusercontent.com/31692/35269169-31ba3fcc-0023-11e8-9346-2d772e7ad464.png)

Only for events that have no other form of booking, and only if there is 1 date.
If this seems to prove popular (via tracking) we could look at implementing it across all dates - but something to explore, not have as part of a 404(ish) test

__TODO__
- [x] create all links
- [x] confirm links works
- [x] add tracking