### PR TITLE
Image info overlay

### DIFF
--- a/client/scss/components/_captioned_image.scss
+++ b/client/scss/components/_captioned_image.scss
@@ -116,14 +116,3 @@
     display: none;
   }
 }
-
-.captioned-image__icon {
-  display: none;
-
-  .enhanced & {
-    display: block;
-    width: $icon-dimension;
-    height: $icon-dimension;
-    border-radius: 50%;
-  }
-}

--- a/client/scss/components/_tasl.scss
+++ b/client/scss/components/_tasl.scss
@@ -1,6 +1,11 @@
 .tasl {
   text-align: right;
 
+  a:link { // overriding .body-content a:link
+    text-decoration: underline;
+    box-shadow: none;
+  }
+
   .enhanced & {
     position: absolute;
     width: 100%;
@@ -13,8 +18,45 @@
   }
 }
 
+.tasl__button {
+  right: 0;
+
+  .tasl--top & {
+    top: 2px;
+  }
+
+  .tasl--bottom & {
+    bottom: 2px;
+  }
+}
+
 .tasl--top {
   .enhanced & {
     top: 0;
+  }
+}
+
+.tasl__icon {
+  display: none;
+  width: $icon-dimension;
+  height: $icon-dimension;
+  border-radius: 50%;
+}
+
+.tasl__icon--close {
+  display: none;
+
+  .tasl.is-active & {
+    display: flex;
+  }
+}
+
+.tasl__icon--open {
+  .enhanced & {
+    display: flex;
+  }
+
+  .tasl.is-active & {
+    display: none;
   }
 }

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -9,7 +9,7 @@ import {
   parseExhibitionsDoc,
   getPositionInPrismicSeries,
   parseAudience, parsePromoListItem, parseEventFormat, parseEventBookingType,
-  parseImagePromo, asHtml, isEmptyDocLink
+  parseImagePromo, isEmptyDocLink
 } from './prismic-parsers';
 import {List} from 'immutable';
 import moment from 'moment';

--- a/server/views/components/tasl/tasl.njk
+++ b/server/views/components/tasl/tasl.njk
@@ -1,6 +1,6 @@
 <div class="{{- [
     'tasl--top' if modifiers.full else 'tasl--bottom',
-    {s:'HNM6', m:'HNM6', l:'HNM6'} | fontClasses
+    {s:'LR3', m:'LR2'} | fontClasses
   ].join(' ') }} tasl drawer js-show-hide"
     data-track-action="toggle-image-credit"
     data-track-label="image:{{ model.contentUrl }}">

--- a/server/views/components/tasl/tasl.njk
+++ b/server/views/components/tasl/tasl.njk
@@ -5,19 +5,25 @@
     data-track-action="toggle-image-credit"
     data-track-label="image:{{ model.contentUrl }}">
   {% if not modifiers.full %}
-    <button class="plain-button js-show-hide-trigger">
-      <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
+    <button class="tasl__button plain-button js-show-hide-trigger absolute">
+      <span class="tasl__icon tasl__icon--open flex--v-center flex--h-center bg-transparent-black">
         {% icon 'information', 'information', ['icon--white'] %}
+      </span>
+      <span class="tasl__icon tasl__icon--close flex--v-center flex--h-center bg-transparent-black">
+        {% icon 'cross', 'close', ['icon--white'] %}
       </span>
     </button>
   {% endif %}
-  <div class="drawer__body js-show-hide-drawer bg-white {{ {s:1} | spacingClasses({padding: ['top', 'right', 'bottom', 'left']}) }}">
+  <div class="drawer__body js-show-hide-drawer bg-black font-white {{ {s:1} | spacingClasses({padding: ['top', 'bottom', 'left']}) }} {{ {s:6} | spacingClasses({padding: ['right']}) }}">
     {{ model | getTaslMarkup | safe }}
   </div>
   {% if modifiers.full %}
-    <button class="plain-button js-show-hide-trigger">
-      <span class="captioned-image__icon flex flex--v-center flex--h-center bg-transparent-black">
+    <button class="tasl__button absolute plain-button js-show-hide-trigger">
+      <span class="tasl__icon tasl__icon--open flex--v-center flex--h-center bg-transparent-black">
         {% icon 'information', 'information', ['icon--white'] %}
+      </span>
+      <span class="tasl__icon tasl__icon--close flex--v-center flex--h-center bg-transparent-black">
+        {% icon 'cross', 'close', ['icon--white'] %}
       </span>
     </button>
   {% endif %}


### PR DESCRIPTION
Updates the TASL info overlay to what @Heesoomoon and @Norvard have been asking for for a while.

![jan-23-2018 16-48-02](https://user-images.githubusercontent.com/1394592/35289089-4700f12e-005e-11e8-96f8-e2acb30f0c10.gif)
