### PR TITLE
add the crude concept of installation

### DIFF
--- a/exhibitions/app/controllers.js
+++ b/exhibitions/app/controllers.js
@@ -15,7 +15,9 @@ export async function renderExhibition(ctx, next) {
   const tags = [{
     text: 'Exhibitions',
     url: '/exhibitions'
-  }];
+  }].concat(exhibitionContent.exhibition.format ? [{
+    text: exhibitionContent.exhibition.format.title
+  }] : []);
 
   if (exhibitionContent) {
     if (format === 'json') {

--- a/exhibitions/app/views/pages/exhibition.njk
+++ b/exhibitions/app/views/pages/exhibition.njk
@@ -97,17 +97,21 @@
               {% if exhibitionContent.galleryLevel !== null %}
                 <div class="flex {{ {s:1} | spacingClasses({margin: ['top', 'bottom']}) }} {{ {s:'HNL4'} | fontClasses}}">
                   <div class="{{ {s:1} | spacingClasses({margin:['right']}) }}">{% icon 'lifts' %}</div>
-                  <p class="no-margin">This exhibition is on level {{ exhibitionContent.galleryLevel }}</p>
+                  <p class="no-margin">This {{ exhibition.format.title if exhibition.format else 'exhibition' }} is on level {{ exhibitionContent.galleryLevel }}</p>
                 </div>
               {% endif %}
               <div class="flex {{ {s:1} | spacingClasses({margin: ['top', 'bottom']}) }} {{ {s:'HNL4'} | fontClasses}}">
                 <div class="{{ {s:1} | spacingClasses({margin:['right']}) }}">{% icon 'a11y' %}</div>
                 <p class="no-margin">Step-free access is available to all floors of the building</p>
               </div>
-              <div class="flex {{ {s:1} | spacingClasses({margin: ['top', 'bottom']}) }} {{ {s:'HNL4'} | fontClasses}}">
-                <div class="{{ {s:1} | spacingClasses({margin:['right']}) }}">{% icon 'a11y_visual' %}</div>
-                <p class="no-margin">Large print guides, transcripts and magnifiers are available in the gallery</p>
-              </div>
+
+              {# We only have large print guides for plain exhibitions #}
+              {% if not exhibition.format %}
+                <div class="flex {{ {s:1} | spacingClasses({margin: ['top', 'bottom']}) }} {{ {s:'HNL4'} | fontClasses}}">
+                  <div class="{{ {s:1} | spacingClasses({margin:['right']}) }}">{% icon 'a11y_visual' %}</div>
+                  <p class="no-margin">Large print guides, transcripts and magnifiers are available in the gallery</p>
+                </div>
+              {% endif %}
 
               <div class="{{ {s:5} | spacingClasses({margin: ['top']}) }}">
                 {% if exhibitionContent.textAndCaptionsDocument %}

--- a/prismic-model/exhibition-formats.json
+++ b/prismic-model/exhibition-formats.json
@@ -1,0 +1,18 @@
+{
+  "Main" : {
+    "title" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "heading1",
+        "label" : "Title"
+      }
+    },
+    "description" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "paragraph,hyperlink",
+        "label" : "Description"
+      }
+    }
+  }
+}

--- a/prismic-model/exhibitions.json
+++ b/prismic-model/exhibitions.json
@@ -26,6 +26,14 @@
         "label" : "End date"
       }
     },
+    "format" : {
+      "type" : "Link",
+      "config" : {
+        "label" : "Format",
+        "select" : "document",
+        "customtypes" : [ "exhibition-formats" ]
+      }
+    },
     "intro" : {
       "type" : "StructuredText",
       "config" : {

--- a/server/content-model/exhibition.js
+++ b/server/content-model/exhibition.js
@@ -4,16 +4,22 @@ import type {ImagePromo} from './content-blocks';
 import type {Picture} from '../model/picture';
 import type {BodyPart} from '../model/body-part';
 
+export type ExhibitionFormat = {|
+  id: string,
+  title: string
+|}
+
 export type Exhibition = {|
-  id: string;
-  title: ?string;
-  start: Date;
-  end: ?Date;
-  subtitle: ?string;
-  intro: ?string;
-  featuredImages: List<any>;
-  featuredImage: ?Picture;
-  description: ?string;
-  promo: ?ImagePromo;
-  body: Array<BodyPart>;
+  id: string,
+  title: ?string,
+  start: Date,
+  end: ?Date,
+  format: ?ExhibitionFormat,
+  subtitle: ?string,
+  intro: ?string,
+  featuredImages: List<any>,
+  featuredImage: ?Picture,
+  description: ?string,
+  promo: ?ImagePromo,
+  body: Array<BodyPart>
 |}

--- a/server/model/exhibition-promo.js
+++ b/server/model/exhibition-promo.js
@@ -1,12 +1,14 @@
 // @flow
 import type {Picture} from './picture';
+import type {ExhibitionFormat} from '../content-model/exhibition';
 
 export type ExhibitionPromo = {|
-  id: string;
-  url: string;
-  title: string;
-  image: Picture;
-  description: ?string;
-  start: string;
-  end: ?string;
+  id: string,
+  url: string,
+  title: string,
+  image: Picture,
+  description: ?string,
+  start: string,
+  end: ?string,
+  format: ?ExhibitionFormat
 |}

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -143,6 +143,10 @@ export function parseExhibitionsDoc(doc: PrismicDoc): Exhibition {
   // Exhibitions are always open and shut on days, rather than hours
   const startDate = doc.data.start && london(doc.data.start).startOf('day').toDate();
   const endDate = doc.data.end && london(doc.data.end).endOf('day').toDate();
+  const format = !isEmptyDocLink(doc.data.format) ? {
+    id: doc.id,
+    title: asText(doc.data.format.data.title)
+  } : null;
 
   const exhibition = ({
     id: doc.id,
@@ -150,6 +154,7 @@ export function parseExhibitionsDoc(doc: PrismicDoc): Exhibition {
     subtitle: asText(doc.data.subtitle),
     start: startDate,
     end: endDate,
+    format: format,
     featuredImages: featuredImages,
     featuredImage: featuredImages.first(),
     intro: asText(doc.data.intro),

--- a/server/views/components/exhibition-promo/exhibition-promo.njk
+++ b/server/views/components/exhibition-promo/exhibition-promo.njk
@@ -14,7 +14,7 @@
       {s:4} | spacingClasses({padding: ['bottom']})
     ].join(' ') }} flex flex--column flex-1">
 
-    <p class="no-padding {{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">Exhibition</p>
+    <p class="no-padding {{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">{{ model.format.title if model.format else 'Exhibition' }}</p>
 
     <h2 class="promo-link__title {{ {s:'WB5'} | fontClasses }}  {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{ model.title }}</h2>
 

--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -4,8 +4,7 @@ import {
   bookshopPromo,
   cafePromo,
   readingRoomPromo,
-  restaurantPromo,
-  spiritBoothPromo
+  restaurantPromo
 } from '../../server/data/facility-promos';
 const {createPageConfig} = model;
 const {
@@ -14,6 +13,14 @@ const {
 
 export async function renderWhatsOn(ctx, next) {
   const exhibitionAndEventPromos = await getExhibitionAndEventPromos(ctx.query);
+  // TODO: This isn't the tidiest implementation, but I've tried to keep it
+  // close to the edge as I'm not sold we know what to do with "Installations" yet.
+  const whileVisitPromos = [readingRoomPromo]
+    .concat(exhibitionAndEventPromos.installationPromos)
+    .map(promo => Object.assign({}, {
+      metaIcon: 'clock',
+      metaText: 'Open during gallery hours'
+    }, promo));
 
   ctx.render('pages/whats-on', {
     pageConfig: createPageConfig({
@@ -25,7 +32,7 @@ export async function renderWhatsOn(ctx, next) {
       canonicalUri: '/whats-on'
     }),
     exhibitionAndEventPromos,
-    whileVisitPromos: [readingRoomPromo, spiritBoothPromo],
+    whileVisitPromos,
     eatShopPromos: [cafePromo, restaurantPromo, bookshopPromo]
   });
 


### PR DESCRIPTION
Adding the rudimentary concept of an installation to get started with it.
The decision was taken to make it an exhibition format.

It seems to fit in pretty well - let's have a closer look tomorrow.
The content for these might need a bit of rehashing, but let's work with the content team on that.

![spiritbooth](https://user-images.githubusercontent.com/31692/35291602-c1ccac5c-0065-11e8-8159-d366b6b4cb1e.png)

![screen shot 2018-01-23 at 17 51 52](https://user-images.githubusercontent.com/31692/35291723-202fc518-0066-11e8-9d40-8e34f62307cb.png)

Fixes #2049 