### PR TITLE
Move position of free text on what’s on, exhibitions and events

### DIFF
--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -238,8 +238,20 @@
   display: inline-block;
 }
 
+.inline-block-medium-up {
+  @include respond-to('medium') {
+    display: inline-block;
+  }
+}
+
 .float-r {
   float: right;
+}
+
+.float-r-medium-up {
+  @include respond-to('medium') {
+    float: right;
+  }
 }
 
 .float-l {

--- a/events/app/views/pages/events.njk
+++ b/events/app/views/pages/events.njk
@@ -22,7 +22,7 @@
     {% endfor %}]
   </script>
 
-  {% componentV2 'list-header', {name: 'Events', total: paginatedEvents.results.length}, {}, {showFree: true} %}
+  {% componentV2 'list-header', {name: 'Events', total: paginatedEvents.results.length} %}
 
   {% if paginatedEvents.pagination.pageCount > 1  %}
   <div class="css-grid__container">
@@ -39,6 +39,12 @@
 
   <div class="css-grid__container {{ {s:4} | spacingClasses({padding: ['top']}) }} ">
     <div class="css-grid">
+      <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }}">
+        <div class="flex-inline flex--v-center">
+          {% icon 'ticket', null, [''] %}
+          <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
+        </div>
+      </div>
       {% for event in paginatedEvents.results %}
         <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
           {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}

--- a/exhibitions/app/views/pages/exhibitions.njk
+++ b/exhibitions/app/views/pages/exhibitions.njk
@@ -23,7 +23,7 @@
     {% endfor %}]
   </script>
 
-  {% componentV2 'list-header', {name: 'Exhibitions', description: metaContent.description, total: paginatedExhibitions.results.length}, {}, {showFree: true} %}
+  {% componentV2 'list-header', {name: 'Exhibitions', description: metaContent.description, total: paginatedExhibitions.results.length} %}
 
   {% if paginatedExhibitions.pagination.pageCount > 1  %}
     <div class="css-grid__container">
@@ -40,6 +40,12 @@
 
   <div class="css-grid__container {{ {s:4} | spacingClasses({padding: ['top']}) }} ">
     <div class="css-grid">
+        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }}">
+          <div class="flex-inline flex--v-center">
+            {% icon 'ticket', null, [''] %}
+            <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
+          </div>
+        </div>
         {% for exhibition in paginatedExhibitions.results %}
           <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
             {% componentV2 'exhibition-promo', exhibition, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}

--- a/server/views/components/list-header/list-header.njk
+++ b/server/views/components/list-header/list-header.njk
@@ -2,15 +2,7 @@
   <div class="container">
     <div class="grid">
       <div class="{{ {s: 12, m: 12, l: 8, xl: 8} | gridClasses }}">
-        {% if data.showFree %}
-          <h1 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:4} | spacingClasses({padding: ['right']}) }} no-margin inline">{{ model.name }}</h1>
-          <div class="flex-inline flex--v-center">
-            {% icon 'ticket', null, [''] %}
-            <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
-          </div>
-        {% else %}
-          <h1 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} no-margin">{{ model.name }}</h1>
-        {% endif %}
+        <h1 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} no-margin">{{ model.name }}</h1>
 
         {% if model.description %}
           <div class="{{ {s:2} | spacingClasses({margin: ['top']}) }}">

--- a/whats_on/app/views/components/whats-on-list-header/whats-on-list-header.njk
+++ b/whats_on/app/views/components/whats-on-list-header/whats-on-list-header.njk
@@ -8,10 +8,6 @@
               {s:'WB6', m:'WB5', l:'WB4'}| fontClasses,
               {s:4} | spacingClasses({padding: ['right']})
             ].join(' ') }} no-margin inline">{{ model.name }}</h1>
-            <div class="flex-inline flex--v-center">
-              {% icon 'ticket', null, [''] %}
-              <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
-            </div>
           </div>
           <div class="flex flex--v-center flex--wrap">
             <div class="flex flex--v-center">

--- a/whats_on/app/views/partials/mixed_exhibition_event_promos.njk
+++ b/whats_on/app/views/partials/mixed_exhibition_event_promos.njk
@@ -1,7 +1,12 @@
 <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">
   {% include './date_range.njk' %}
-  <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">Exhibitions and Events</h2>
+  <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }} {{ {s:1} | spacingClasses({margin: ['bottom']}) }} inline-block-medium-up">Exhibitions and Events</h2>
+  <div class="flex-inline flex--v-center float-r-medium-up">
+    {% icon 'ticket', null, [''] %}
+    <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
+  </div>
 </div>
+
 
 {% for exhibition in exhibitionAndEventPromos.temporaryExhibitionPromos %}
   <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">

--- a/whats_on/app/views/partials/separate_exhibition_event_promos.njk
+++ b/whats_on/app/views/partials/separate_exhibition_event_promos.njk
@@ -1,6 +1,10 @@
 <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">
   {% include './date_range.njk' %}
-  <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">Exhibitions</h2>
+  <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }} {{ {s:1} | spacingClasses({margin: ['bottom']}) }} inline-block-medium-up">Exhibitions</h2>
+  <div class="flex-inline flex--v-center float-r-medium-up">
+    {% icon 'ticket', null, [''] %}
+    <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
+  </div>
 </div>
 
 {% for exhibition in exhibitionAndEventPromos.temporaryExhibitionPromos %}
@@ -23,7 +27,11 @@
   {% componentV2 'divider', null, {'dashed': true} %}
 </div>
 <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }}">
-  <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">Events</h2>
+  <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }} {{ {s:1} | spacingClasses({margin: ['bottom']}) }} inline-block-medium-up">Events</h2>
+  <div class="flex-inline flex--v-center float-r-medium-up">
+    {% icon 'ticket', null, [''] %}
+    <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
+  </div>
 </div>
 
 <div class="js-events-filter tabs {{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }}">


### PR DESCRIPTION
## Screenshot
![localhost_3003_whats-on_startdate 2018-01-24 enddate 2018-04-24](https://user-images.githubusercontent.com/6051896/35332015-76b356e8-0101-11e8-9f16-653ab4acdeaf.png)

![localhost_3003_whats-on_startdate 2018-01-24 enddate 2018-04-24 1](https://user-images.githubusercontent.com/6051896/35332025-7eec4018-0101-11e8-9b7b-01ad292b8787.png)
