### PR TITLE
Add image gallery heading if available

### DIFF
--- a/client/scss/components/_image_gallery.scss
+++ b/client/scss/components/_image_gallery.scss
@@ -14,6 +14,16 @@ $image-gallery-control-margin: 18px;
   }
 }
 
+.image-gallery__heading {
+  position: relative;
+  z-index: 3;
+  top: $spacing-unit * 8;
+
+  @include respond-to('xlarge') {
+    position: absolute;
+  }
+}
+
 .image-gallery__item {
   flex-shrink: 0;
   margin-right: map_get($gutter-width, 'small');

--- a/server/views/components/image-gallery/image-gallery.njk
+++ b/server/views/components/image-gallery/image-gallery.njk
@@ -1,3 +1,9 @@
+{% if imageGallery.title %}
+  <div class="slider--in-article">
+    <h2 class="image-gallery__heading slides-container">{{ imageGallery.title }}</h2>
+  </div>
+{% endif %}
+
 <div class="wobbly-edge wobbly-edge--white wobbly-edge--small js-wobbly-edge" data-is-static="true"></div>
 <div class="image-gallery touch-scroll js-image-gallery" data-id="{{ id }}" id="{{ id }}">
   {% for item in imageGallery.items %}


### PR DESCRIPTION
Fixes #2084

![screen shot 2018-01-24 at 17 35 31](https://user-images.githubusercontent.com/1394592/35347440-07a9128e-012d-11e8-966a-f3aed83a3ef2.png)

- [ ] (Re)move pseudo image gallery headings from Prismic text content