### PR TITLE
Align divider under hero with content at medium bp

### DIFF
--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -93,8 +93,10 @@
 
     <div class="row bg-cream">
       <div class="container">
-        <div class="{{ {s:6} | spacingClasses({padding: ['top']}) }}">
-          {% componentV2 'divider', null, {'pumice': true, 'keyline': true} %}
+        <div class="grid {{ {s:6} | spacingClasses({padding: ['top']}) }}">
+          <div class="{{ {s: 12, m: 10, shiftM: 1, l: 12, xl: 12} | gridClasses }}">
+            {% componentV2 'divider', null, {'pumice': true, 'keyline': true} %}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The divider above the content/below the hero image is wider than the content at the medium breakpoint (which has one blank column either side). This fixes it.

![screen shot 2018-01-25 at 10 39 48](https://user-images.githubusercontent.com/1394592/35384201-7a6e1e88-01bc-11e8-9b8f-bd0eb273aa2b.png)
