### PR TITLE
add componentList to ga event tracking label

### DIFF
--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -76,11 +76,9 @@ export default {
       const el = event.target.closest('[data-track-event]');
       const trackData = JSON.parse(el.getAttribute('data-track-event'));
       const componentList = getComponentList(el);
-      const componentListString = JSON.stringify(componentList)
-      if (componentList.length > 0) {
-        localStorage.setItem('wc_referring_component_list', componentListString);
-      }
+      const componentListString = JSON.stringify(componentList);
       const label = `${(trackData.label || '')},componentList:${componentListString}`;
+      console.info('track-event', componentListString)
       trackGaEvent(Object.assign({}, trackData, {label}));
     });
 
@@ -90,6 +88,18 @@ export default {
       const url = anchor.href;
       if (isExternal(url)) {
         trackOutboundLink(url);
+      } else {
+        // We set the component list data in localStorage,
+        // which we then retrieve on the next pageview,
+        // and pass along to GA there
+        const el = event.target.closest('[data-component]');
+        if (el) {
+          const componentList = getComponentList(el);
+          const componentListString = JSON.stringify(componentList);
+          if (componentList.length > 0) {
+            localStorage.setItem('wc_referring_component_list', componentListString);
+          }
+        }
       }
     });
   }

--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -78,7 +78,6 @@ export default {
       const componentList = getComponentList(el);
       const componentListString = JSON.stringify(componentList);
       const label = `${(trackData.label || '')},componentList:${componentListString}`;
-      console.info('track-event', componentListString)
       trackGaEvent(Object.assign({}, trackData, {label}));
     });
 

--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -25,7 +25,7 @@ const maybeTrackOutboundLinks = (hasAnalytics) => {
       // This means that we won't be *consistently* tracking external links
       // in IE11 and iOS Safari: https://caniuse.com/#feat=beacon
       // On balance, this is probably better than preventDefault-ing the link event,
-      // doing any tracking, then following the link programatically.
+      // doing any tracking, then following the link programmatically.
       ga('send', 'event', 'outbound', 'click', url, {'transport': 'beacon'});
     };
     return actuallyTrackLinks;
@@ -47,12 +47,41 @@ export const trackGaEvent = maybeTrackEvent(window.ga);
 
 export const trackOutboundLink = maybeTrackOutboundLinks(window.ga);
 
+// e.g:
+// [
+//  { ExhibitionPromo: {} },
+//  { WhatsOn: {active: 'tomorrow'} }
+// ]
+function getComponentList(el, componentList = []) {
+  const componentEl = el.closest('[data-component]');
+
+  if (componentEl) {
+    const componentName = componentEl.getAttribute('data-component');
+    const componentStateString = componentEl.getAttribute('data-component-state');
+    const componentState = componentStateString ? JSON.parse(componentStateString) : {};
+    const updatedComponentList = componentList.concat([{[componentName]: componentState}]);
+    if (componentEl.parentNode) {
+      return getComponentList(componentEl.parentNode, updatedComponentList)
+    }
+    return updatedComponentList;
+  } else {
+    return componentList;
+  }
+}
+
 export default {
   init: () => {
     // GA events
-    on('body', 'click', '[data-track-event]', ({ target }) => {
-      const el = target.closest('[data-track-event]');
-      trackGaEvent(JSON.parse(el.getAttribute('data-track-event')));
+    on('body', 'click', '[data-track-event]', (event) => {
+      const el = event.target.closest('[data-track-event]');
+      const trackData = JSON.parse(el.getAttribute('data-track-event'));
+      const componentList = getComponentList(el);
+      const componentListString = JSON.stringify(componentList)
+      if (componentList.length > 0) {
+        localStorage.setItem('wc_referring_component_list', componentListString);
+      }
+      const label = `${(trackData.label || '')},componentList:${componentListString}`;
+      trackGaEvent(Object.assign({}, trackData, {label}));
     });
 
     on('body', 'click', 'a', (event) => {
@@ -65,4 +94,5 @@ export default {
     });
   }
 };
+
 

--- a/server/views/components/exhibition-promo/exhibition-promo.njk
+++ b/server/views/components/exhibition-promo/exhibition-promo.njk
@@ -4,7 +4,9 @@
   {% set sizes = '100vw' %}
 {% endif %}
 
-<a id="{{model.id}}" href="{{ model.url }}" class="plain-link promo-link bg-cream rounded-top rounded-bottom overflow-hidden flex flex--column">
+<a data-component="ExhibitionPromo"
+   data-track-event="{{ {category: 'component', action: 'exhibition-promo:click' } | dump }}"
+   id="{{model.id}}" href="{{ model.url }}" class="plain-link promo-link bg-cream rounded-top rounded-bottom overflow-hidden flex flex--column">
 
   {% componentV2 'image', model.image, {}, {lazyload: true, sizesQueries: sizes, defaultSize: data.defaultSize} %}
 

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -21,8 +21,10 @@
         <script>
           window.isDigitalStory = true;
         </script>
-        {% set asyncContentEndpoint = '/series-nav/' + series.url + '?current=' + article.url %}
-        {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-nav' } %}
+        <div data-component="DigitalStoryNavTop">
+          {% set asyncContentEndpoint = '/series-nav/' + series.url + '?current=' + article.url %}
+          {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-nav' } %}
+        </div>
       {% endif %}
     {% endfor %}
   {% endblock %}
@@ -156,8 +158,10 @@
                 <div class="body-part body-part--full-width">
                   <div class="{{ {s:8} | spacingClasses({padding: ['bottom']}) }}">
                     <div class="wobbly-edge wobbly-edge--white wobbly-edge--small js-wobbly-edge" data-is-static="true"></div>
-                    {% set asyncContentEndpoint = '/series-transporter/' + series.url + '?current=' + article.url %}
-                    {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-article": true}' } %}
+                    <div data-component="DigitalStoryNavBottom">
+                      {% set asyncContentEndpoint = '/series-transporter/' + series.url + '?current=' + article.url %}
+                      {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-article": true}' } %}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -14,6 +14,8 @@ h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
 
   The v1 site was setup with a lot of configuration, which feels like it would be out of sync with
   the new questions we would like ask of our analytics, so this was for a clean slate.
+
+  dimension5 is a test dimension
 #}
 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 ga('create', 'UA-55614-24', 'auto', 'v2');
@@ -41,6 +43,13 @@ ga('set', 'dimension1', '2');
 {% if pageConfig.gaExp %}
   ga('set', 'exp', '{{ pageConfig.gaExp }}');
 {% endif %}
+
+{# see `tracking.js` where this storage item is set #}
+var referringComponentListString = localStorage.getItem('wc_referring_component_list');
+localStorage.removeItem('wc_referring_component_list');
+if (referringComponentListString) {
+  ga('set', 'dimension5', referringComponentListString);
+}
 
 ga('require', 'GTM-NXMJ6D9');
 ga('send', 'pageview');

--- a/whats_on/app/views/pages/whats-on.njk
+++ b/whats_on/app/views/pages/whats-on.njk
@@ -30,7 +30,9 @@
   {% set whatsOnData = {activeId: exhibitionAndEventPromos.active, id: 'whatsOnFilter' } %}
   {% componentV2 'whats-on-list-header', exhibitionAndEventPromos.listHeader, {}, whatsOnData %}
 
-  <div class="css-grid__container">
+  <div class="css-grid__container"
+       data-component="WhatsOn"
+       data-component-state="{{ {active:exhibitionAndEventPromos.active} | dump }}">
     <div class="css-grid {{ {s:2, m:4} | spacingClasses({margin: ['top', 'bottom']}) }}">
 
       {% if exhibitionAndEventPromos.active === 'everything' %}

--- a/whats_on/app/views/partials/mixed_exhibition_event_promos.njk
+++ b/whats_on/app/views/partials/mixed_exhibition_event_promos.njk
@@ -3,7 +3,7 @@
   <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top']}) }} {{ {s:1} | spacingClasses({margin: ['bottom']}) }} inline-block-medium-up">Exhibitions and Events</h2>
   <div class="flex-inline flex--v-center float-r-medium-up">
     {% icon 'ticket', null, [''] %}
-    <span class="{{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">FREE</span>
+    <span class="caps {{ {s:1} | spacingClasses({padding: ['left', 'right']}) }} {{ {s:'HNM5', m:'HNM4'} | fontClasses }}">Free</span>
   </div>
 </div>
 


### PR DESCRIPTION
Fixed #2050 

There is a new type of tracking on the block. This will allow us to say, "Give us pages that people visited by using the X component". X component is actually a hierarchical list e.g. WhatsOn,ExhibitionPromo. The state is also save with the component.

All of this is stored in JSON, which makes it a bit trickier to use in the console, but not any trickier than the comma separated lists. This is in the hope that we might be able to get machines to use it e.g. give me all pages that have a referring component... now analyse 🤖!

An example is:
```JS
[
  { ExhibitionPromo: {} },
  { WhatsOn: {active: 'tomorrow'} }
]
```

Stringified to `"[{"ExhibitionPromo":{}},{"WhatsOn":{"active":"tomorrow"}}]"`.

I have also added this to the component tracking label in case that is more useful.
In the famous words of @davidpmccormick, tracking it won't hurt.

On a more grass-roots level, this will answer the questions on What's On:
* How many people used the Promos to visit events / exhibitions?
* What was the state of the What's On page when it happened?

We can then design some tests, potentially around the order of the daterange picker and see if those numbers bubble up.

Bump @hthair @jennpb @Heesoomoon FYI