### PR TITLE
add promo to relevant content types

### DIFF
--- a/prismic-model/articles.json
+++ b/prismic-model/articles.json
@@ -411,13 +411,22 @@
                 "type" : "StructuredText",
                 "config" : {
                   "label" : "Promo text",
-                  "single" : "paragraph"
+                  "single" : "hyperlink, strong, em"
                 }
               },
               "image" : {
                 "type" : "Image",
                 "config" : {
-                  "label" : "Promo image"
+                  "label" : "Promo image",
+                  "thumbnails" : [ {
+                    "name" : "16:9",
+                    "width" : 3200,
+                    "height" : 1800
+                  }, {
+                    "name" : "square",
+                    "width" : 3200,
+                    "height" : 3200
+                  } ]
                 }
               }
             }

--- a/prismic-model/audiences.json
+++ b/prismic-model/audiences.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Audience" : {
     "title" : {
       "type" : "StructuredText",
       "config" : {

--- a/prismic-model/curated-lists.json
+++ b/prismic-model/curated-lists.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Curated list" : {
     "uid" : {
       "type" : "UID",
       "config" : {
@@ -33,6 +33,47 @@
               "select" : "document",
               "label" : "Series",
               "customtypes" : [ "series" ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "Promo" : {
+    "promo" : {
+      "type" : "Slices",
+      "config" : {
+        "label" : "Promo",
+        "choices" : {
+          "editorialImage" : {
+            "type" : "Slice",
+            "fieldset" : "Editorial image",
+            "config" : {
+              "label" : "Editorial image"
+            },
+            "non-repeat" : {
+              "caption" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "label" : "Promo text",
+                  "single" : "hyperlink, strong, em"
+                }
+              },
+              "image" : {
+                "type" : "Image",
+                "config" : {
+                  "label" : "Promo image",
+                  "thumbnails" : [ {
+                    "name" : "16:9",
+                    "width" : 3200,
+                    "height" : 1800
+                  }, {
+                    "name" : "square",
+                    "width" : 3200,
+                    "height" : 3200
+                  } ]
+                }
+              }
             }
           }
         }

--- a/prismic-model/editorial-contributor-roles.json
+++ b/prismic-model/editorial-contributor-roles.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Contributor" : {
     "title" : {
       "type" : "StructuredText",
       "config" : {

--- a/prismic-model/event-formats.json
+++ b/prismic-model/event-formats.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Event format" : {
     "title" : {
       "type" : "StructuredText",
       "config" : {

--- a/prismic-model/event-series.json
+++ b/prismic-model/event-series.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Event series" : {
     "title" : {
       "type" : "StructuredText",
       "config" : {
@@ -12,6 +12,47 @@
       "config" : {
         "single" : "paragraph",
         "label" : "Description"
+      }
+    }
+  },
+  "Promo" : {
+    "promo" : {
+      "type" : "Slices",
+      "config" : {
+        "label" : "Promo",
+        "choices" : {
+          "editorialImage" : {
+            "type" : "Slice",
+            "fieldset" : "Editorial image",
+            "config" : {
+              "label" : "Editorial image"
+            },
+            "non-repeat" : {
+              "caption" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "label" : "Promo text",
+                  "single" : "hyperlink, strong, em"
+                }
+              },
+              "image" : {
+                "type" : "Image",
+                "config" : {
+                  "label" : "Promo image",
+                  "thumbnails" : [ {
+                    "name" : "16:9",
+                    "width" : 3200,
+                    "height" : 1800
+                  }, {
+                    "name" : "square",
+                    "width" : 3200,
+                    "height" : 3200
+                  } ]
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/prismic-model/featureflag.json
+++ b/prismic-model/featureflag.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Feature flag" : {
     "flagName" : {
       "config" : {
         "label" : "Flag name"

--- a/prismic-model/featurescohort.json
+++ b/prismic-model/featurescohort.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Feature cohort" : {
     "cohortName" : {
       "type" : "Text",
       "config" : {

--- a/prismic-model/interpretation-types.json
+++ b/prismic-model/interpretation-types.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Interpretation" : {
     "title" : {
       "type" : "StructuredText",
       "config" : {

--- a/prismic-model/people.json
+++ b/prismic-model/people.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Person" : {
     "name" : {
       "config" : {
         "label" : "Full name",

--- a/prismic-model/series.json
+++ b/prismic-model/series.json
@@ -51,6 +51,47 @@
       }
     }
   },
+  "Promo" : {
+    "promo" : {
+      "type" : "Slices",
+      "config" : {
+        "label" : "Promo",
+        "choices" : {
+          "editorialImage" : {
+            "type" : "Slice",
+            "fieldset" : "Editorial image",
+            "config" : {
+              "label" : "Editorial image"
+            },
+            "non-repeat" : {
+              "caption" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "label" : "Promo text",
+                  "single" : "hyperlink, strong, em"
+                }
+              },
+              "image" : {
+                "type" : "Image",
+                "config" : {
+                  "label" : "Promo image",
+                  "thumbnails" : [ {
+                    "name" : "16:9",
+                    "width" : 3200,
+                    "height" : 1800
+                  }, {
+                    "name" : "square",
+                    "width" : 3200,
+                    "height" : 3200
+                  } ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "Deprecated": {
     "wordpressSlug" : {
       "type" : "Text",

--- a/prismic-model/webcomic-series.json
+++ b/prismic-model/webcomic-series.json
@@ -14,5 +14,46 @@
         "label" : "Description"
       }
     }
+  },
+  "Promo" : {
+    "promo" : {
+      "type" : "Slices",
+      "config" : {
+        "label" : "Promo",
+        "choices" : {
+          "editorialImage" : {
+            "type" : "Slice",
+            "fieldset" : "Editorial image",
+            "config" : {
+              "label" : "Editorial image"
+            },
+            "non-repeat" : {
+              "caption" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "label" : "Promo text",
+                  "single" : "hyperlink, strong, em"
+                }
+              },
+              "image" : {
+                "type" : "Image",
+                "config" : {
+                  "label" : "Promo image",
+                  "thumbnails" : [ {
+                    "name" : "16:9",
+                    "width" : 3200,
+                    "height" : 1800
+                  }, {
+                    "name" : "square",
+                    "width" : 3200,
+                    "height" : 3200
+                  } ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/prismic-model/webcomic-series.json
+++ b/prismic-model/webcomic-series.json
@@ -1,5 +1,5 @@
 {
-  "Main" : {
+  "Webcomic series" : {
     "title" : {
       "type" : "StructuredText",
       "config" : {

--- a/prismic-model/webcomics.json
+++ b/prismic-model/webcomics.json
@@ -15,38 +15,6 @@
       }
     }
   },
-  "Promo" : {
-    "promo" : {
-      "type" : "Slices",
-      "config" : {
-        "label" : "Promo",
-        "choices" : {
-          "editorialImage" : {
-            "type" : "Slice",
-            "fieldset" : "Editorial image",
-            "config" : {
-              "label" : "Editorial image"
-            },
-            "non-repeat" : {
-              "caption" : {
-                "type" : "StructuredText",
-                "config" : {
-                  "label" : "Promo text",
-                  "single" : "hyperlink, strong, em"
-                }
-              },
-              "image" : {
-                "type" : "Image",
-                "config" : {
-                  "label" : "Promo image"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
   "Contributors" : {
     "contributors" : {
       "type" : "Slices",
@@ -92,6 +60,47 @@
               "select" : "document",
               "customtypes" : [ "webcomic-series" ],
               "label" : "Series"
+            }
+          }
+        }
+      }
+    }
+  },
+  "Promo" : {
+    "promo" : {
+      "type" : "Slices",
+      "config" : {
+        "label" : "Promo",
+        "choices" : {
+          "editorialImage" : {
+            "type" : "Slice",
+            "fieldset" : "Editorial image",
+            "config" : {
+              "label" : "Editorial image"
+            },
+            "non-repeat" : {
+              "caption" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "label" : "Promo text",
+                  "single" : "hyperlink, strong, em"
+                }
+              },
+              "image" : {
+                "type" : "Image",
+                "config" : {
+                  "label" : "Promo image",
+                  "thumbnails" : [ {
+                    "name" : "16:9",
+                    "width" : 3200,
+                    "height" : 1800
+                  }, {
+                    "name" : "square",
+                    "width" : 3200,
+                    "height" : 3200
+                  } ]
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
* After the discussion around promo, I realise we had some inconsistencies re: Image crops that needed addressing.
* Added it to a the series content types.
* Updated the titles to human readable niceness.

Do we think it would be better to have this?
```JS
const Promo = {
  type: 'Slices',
  config: {
    label: 'Promo',
    choices: {
      editorialImage: {
        type: 'Slice',
        fieldset: 'Editorial image',
        config: {
          label: 'Editorial image'
        },
        'non-repeat': {
          caption: {
            type: 'StructuredText',
            config: {
              label: 'Promo text',
              single: 'hyperlink, strong, em'
            }
          },
          image: {
            type: 'Image',
            config: {
              label: 'Promo image',
              thumbnails: [
                {
                  name: '16:9',
                  width: 3200,
                  height: 1800
                },
                {
                  name: 'square',
                  width: 3200,
                  height: 3200
                }
              ]
            }
          }
        }
      }
    }
  }
}

const WebcomicSeries = {
  'Webcomic series': {
    title: {
      type: 'StructuredText',
        config: {
        single: 'heading1',
          label: 'Title'
      }
    },
    description: {
      type: 'StructuredText',
        config: {
        single: 'paragraph',
          label: 'Description'
      }
    }
  },
  Promo: {
    promo: Promo
  }
}
```