### PR TITLE
move split_clients into http block in nginx

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -2,19 +2,19 @@ worker_processes 1;
 
 events { worker_connections 1024; }
 
-### A/B test
-split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
-  33%     "testA";
-  33%     "testB";
-  34%     "";
-}
-map $cookie_WC_featuresCohort $cohort {
-  ""      $cohort_split_test;
-  default $cookie_WC_featuresCohort;
-}
-###
-
 http {
+  ### A/B test
+  split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
+    33%     "testA";
+    33%     "testB";
+    34%     "";
+  }
+  map $cookie_WC_featuresCohort $cohort {
+    ""      $cohort_split_test;
+    default $cookie_WC_featuresCohort;
+  }
+  ###
+
   server {
     listen 80;
     listen 443;


### PR DESCRIPTION
`split_clients` has to be in the `http` block.