### PR TITLE
Add ticket status to event promos

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -34,6 +34,7 @@ import iframeContainer from './components/iframe-container';
 import {eventbriteTicketButton} from './components/eventbrite-ticket-button';
 import segmentedControl from './components/segmented-control';
 import tabs from './components/tabs';
+import {eventbriteTicketStatus} from './components/eventbrite-ticket-status';
 
 const init = () => {
   polyfills.init();
@@ -134,6 +135,7 @@ const init = () => {
   nodeList(truncateTextNodes).forEach(truncateText);
 
   nodeList(document.querySelectorAll('.js-eventbrite-ticket-button')).forEach(eventbriteTicketButton);
+  nodeList(document.querySelectorAll('.js-eventbrite-ticket-status')).forEach(eventbriteTicketStatus);
 };
 
 function initWithRaven() {

--- a/client/js/components/eventbrite-ticket-status.js
+++ b/client/js/components/eventbrite-ticket-status.js
@@ -1,0 +1,14 @@
+/* global fetch */
+import fastdom from 'fastdom';
+
+export function eventbriteTicketStatus(el) {
+  fastdom.measure(() => {
+    const eventbriteId = el.getAttribute('data-eventbrite-ticket-id');
+
+    fetch(`/eventbrite/button/events/${eventbriteId}/ticket_status`).then(resp => resp.json()).then(ticketButton => {
+      fastdom.mutate(() => {
+        el.innerHTML = ticketButton.html;
+      });
+    });
+  });
+}

--- a/eventbrite/app/controllers.js
+++ b/eventbrite/app/controllers.js
@@ -33,6 +33,23 @@ async function getEventbriteEventTickets(id: string) {
   return tickets;
 }
 
+export async function renderEventbriteTicketStatus(ctx, next) {
+  const id = ctx.params.id;
+  const tickets = await getEventbriteEventTickets(id);
+
+  const standardTicket = tickets.find(ticket => ticket.ticketType === 'standard');
+  if (standardTicket) {
+    ctx.render('components/eventbrite-button/eventbrite-ticket-status', {
+      ticket: standardTicket
+    });
+
+    ctx.body = {
+      html: ctx.body
+    };
+  }
+  return next();
+}
+
 export async function renderEventbriteButton(ctx, next) {
   const id = ctx.params.id;
   const tickets = await getEventbriteEventTickets(id);

--- a/eventbrite/app/routes.js
+++ b/eventbrite/app/routes.js
@@ -1,7 +1,11 @@
 import Router from 'koa-router';
-import {renderEventbriteButton} from './controllers';
+import {
+  renderEventbriteButton,
+  renderEventbriteTicketStatus
+} from './controllers';
 
 const r = new Router({ sensitive: true });
 r.get('/eventbrite/button/events/:id/ticket_classes', renderEventbriteButton);
+r.get('/eventbrite/button/events/:id/ticket_status', renderEventbriteTicketStatus);
 
 export const router = r.middleware();

--- a/eventbrite/app/views/components/eventbrite-button/eventbrite-button.njk
+++ b/eventbrite/app/views/components/eventbrite-button/eventbrite-button.njk
@@ -28,9 +28,9 @@
       {% if ticket.onSaleStatus === 'available' %}
         Book free tickets
       {% elif ticket.onSaleStatus === 'sold_out' %}
-        Sold out
+        Fully booked
       {% elif ticket.onSaleStatus === 'not_yet_on_sale' %}
-        Not yet on sale
+        Not yet on available
       {% endif %}
     </span>
   </a>

--- a/eventbrite/app/views/components/eventbrite-button/eventbrite-ticket-status.njk
+++ b/eventbrite/app/views/components/eventbrite-button/eventbrite-ticket-status.njk
@@ -1,0 +1,11 @@
+{% if ticket.onSaleStatus === 'sold_out' %}
+  <div class="{{- [
+    {s:'HNM5'} | fontClasses
+  ].join(' ') }} flex flex--v-center">
+
+    <span class="{{ {s:1} | spacingClasses({margin: ['right']}) }} flex flex--v-center">
+      {% icon 'status_indicator', null, ['icon--red-graphics', 'icon--match-text'] %}
+    </span>
+    Fully booked
+  </div>
+{% endif %}

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -113,7 +113,7 @@ export type EventPromo = {|
   bookingType: ?string,
   image: ?Picture,
   interpretations: Array<Interpretation>,
-  eventbriteId: ?string,
+  eventbriteId?: ?string,
   // These are used for when we have a human written string for the dates.
   // Shouldn't really happen, but we have manually added promos at the moment.
   // Hence the nullable key - easier than implementing schedules for 1 event.

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -113,6 +113,7 @@ export type EventPromo = {|
   bookingType: ?string,
   image: ?Picture,
   interpretations: Array<Interpretation>,
+  eventbriteId: ?string,
   // These are used for when we have a human written string for the dates.
   // Shouldn't really happen, but we have manually added promos at the moment.
   // Hence the nullable key - easier than implementing schedules for 1 event.

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -19,6 +19,7 @@ import type {ExhibitionAndRelatedContent} from '../model/exhibition-and-related-
 import {PaginationFactory} from '../model/pagination';
 import type {EventPromo} from '../content-model/events';
 import {galleryOpeningHours} from '../model/opening-hours';
+import {isEmptyObj} from '../utils/is-empty-obj';
 
 type DocumentType = 'articles' | 'webcomics' | 'events' | 'exhibitions';
 
@@ -224,6 +225,9 @@ function createEventPromos(allResults): Array<EventPromo> {
       isPrimary: Boolean(interpretation.isPrimary)
     }) : null).filter(_ => _);
 
+    const eventbriteIdMatch = isEmptyObj(event.data.eventbriteEvent) ? null : /\/e\/([0-9]+)/.exec(event.data.eventbriteEvent.url);
+    const eventbriteId = eventbriteIdMatch ? eventbriteIdMatch[1] : null;
+
     // A single Primsic 'event' can have multiple datetimes, but we
     // want to display each datetime as an individual promo, so we
     // map and flatten.
@@ -239,7 +243,8 @@ function createEventPromos(allResults): Array<EventPromo> {
         image: promo && promo.image,
         description: promo && promo.caption,
         bookingType: bookingType,
-        interpretations: interpretations
+        interpretations: interpretations,
+        eventbriteId: eventbriteId
       };
     });
   }).reduce((acc, curr) => {

--- a/server/views/components/event-promo/event-promo.njk
+++ b/server/views/components/event-promo/event-promo.njk
@@ -52,10 +52,8 @@
         </p>
       {% endif %}
 
-      {% if model.bookingType %}
-        <p class="{{ {s:'HNL4'} | fontClasses }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }} no-padding">
-          {{ model.bookingType }}
-        </p>
-      {% endif %}
+      <div
+        {% if model.eventbriteId %} data-eventbrite-ticket-id="{{ model.eventbriteId }}"{% endif %}
+        class="flex flex--h-space-between flex--wrap margin-top-auto{{ ' js-eventbrite-ticket-status' if model.eventbriteId }}"></div>
     </div>
 </a>


### PR DESCRIPTION
Fixes #2008 

Basic implementation of the ticket status.

We can take a look at it once it's out to see how it fits with the other elements of the design (the traffic light system specifically used on exhibitions).

This does __not__ cater for multi-events, which we haven't addressed yet here nor on the actual event pages.

![screen shot 2018-02-01 at 14 00 46](https://user-images.githubusercontent.com/31692/35682360-5bf43658-0758-11e8-8d5c-a8782661137d.png)
