### PR TITLE
Prevent horizontal scroll (measure width correctly)

### DIFF
--- a/client/scss/components/_slider__in-article.scss
+++ b/client/scss/components/_slider__in-article.scss
@@ -3,18 +3,19 @@ $slider-one-column-width: (100 / 12) * 1%;
 .slider--in-article {
   .slides-container {
     @include respond-to('medium') {
-      width: calc(100vw - #{map-get($container-padding, 'medium')} - $slider-one-column-width);
+      width: calc(100vw - #{map-get($container-padding, 'medium')} - #{$slider-one-column-width});
       margin-left: $slider-one-column-width;
     }
 
     @include respond-to('large') {
+      width: calc(100vw - #{map-get($container-padding, 'large')});
       margin-left: 0;
     }
 
     @include respond-to('xlarge') {
       position: relative;
 
-      width: calc(100vw - ((100vw - #{$container-width-max}) / 2));
+      width: calc(100vw - ((100vw - #{$container-width-max}) / 2) - #{2 * map-get($gutter-width, 'xlarge')});
       left: calc(((100vw - #{$container-width-max}) / 2));
     }
   }


### PR DESCRIPTION
There's a horizontal scrollbar that appears when the page is larger than the xl breakpoint because we've not measured the size of the slider correctly.

### Before
![screen shot 2018-02-01 at 16 52 04](https://user-images.githubusercontent.com/1394592/35691600-cdedda6c-0770-11e8-93df-3d25b2ba9360.png)

### After
![screen shot 2018-02-01 at 16 52 25](https://user-images.githubusercontent.com/1394592/35691617-d6d60cee-0770-11e8-895c-c36233c2a40c.png)

Just realised these screenshots are pretty much meaningless on a white background, but you can see the bug by going to [this page](https://wellcomecollection.org/articles/WnBAsSoAACsA5tuj), making your browser wider than 1338px and scrolling to the right.

One day soon, this will all be simplified by css grid.