### PR TITLE
Whats on image credits

### DIFF
--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div class="is-hidden-l is-hidden-xl css-grid__cell--full">
-      {% componentV2 'image', event.promo.image, {} , { lazyload: true } %}
+      {% componentV2 'captioned-image', event.promo.image, {}, {showCopyright: true} %}
     </div>
   {% endif %}
 
@@ -243,7 +243,7 @@
     <div class="css-grid__cell--primary">
       {% if event.promo.image %}
         <div class="is-hidden-s is-hidden-m rounded-corners overflow-hidden">
-          {% componentV2 'image', event.promo.image, {} , { lazyload: true } %}
+          {% componentV2 'captioned-image', event.promo.image, {}, {showCopyright: true} %}
         </div>
       {% endif %}
 

--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -31,7 +31,7 @@
       </div>
     </div>
     <div class="is-hidden-l is-hidden-xl css-grid__cell--full">
-      {% componentV2 'captioned-image', event.promo.image, {}, {showCopyright: true} %}
+      {% componentV2 'captioned-image', event.promo.image, {full: true}, {showCopyright: true} %}
     </div>
   {% endif %}
 

--- a/exhibitions/app/views/pages/exhibition.njk
+++ b/exhibitions/app/views/pages/exhibition.njk
@@ -26,7 +26,7 @@
       </div>
 
       <div class="exhibition-hero">
-        {% componentV2 'picture', {images: exhibition.featuredImages.toJS()}, {}, {'lazyload': true, extraClasses: ['exhibition-hero__picture']} %}
+        {% componentV2 'picture', {images: exhibition.featuredImages.toJS()}, {}, {'lazyload': true, extraClasses: ['exhibition-hero__picture'], showCopyright: true} %}
 
         <div class="exhibition-hero__copy {{ {l:10} | spacingClasses({margin: ['bottom']}) }}">
           <div class="is-hidden-l is-hidden-xl">

--- a/server/views/components/picture/picture.njk
+++ b/server/views/components/picture/picture.njk
@@ -31,3 +31,16 @@
     {% endif %}
   {% endfor %}
 </picture>
+{% set singleImage = model.images[0] %}
+{% if ((singleImage.title or singleImage.source.name or singleImage.copyright.name or singleImage.license) and data.showCopyright) %}
+  {% set tasl = {
+    title: singleImage.title,
+    author: singleImage.author,
+    sourceName: singleImage.source.name,
+    sourceLink: singleImage.source.link,
+    license: singleImage.license,
+    copyrightHolder: singleImage.copyright.holder,
+    copyrightLink: singleImage.copyright.link
+  } %}
+  {% componentV2 'tasl', tasl, {'full': true} %}
+{% endif %}

--- a/server/views/components/picture/picture.njk
+++ b/server/views/components/picture/picture.njk
@@ -1,46 +1,47 @@
 {% set useIiifOrigin = featuresCohort | isFlagEnabled('imagesFromOrigin', featureFlags) %}
 {% set comma = joiner() %}
-
-<picture class="{% for class in data.extraClasses %}{{ class }} {% endfor %}">
-  {% for image in model.images %}
-    {% set sizes = image | getImageSizesFor %}
-    <source media="(min-width: {{ image.minWidth }})"
-      {% if data.lazyload %}
-        data-srcset="
-        {%- for size in sizes -%}
-          {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiifOrigin) }} {{ size }}w
-        {%- endfor %}"
-      {% else %}
-        srcset="
-        {%- for size in sizes -%}
-          {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiifOrigin) }} {{ size }}w
-        {%- endfor %}"
-      {% endif %}>
-
-    {% if loop.last %}
-      <img
-        height="{{ image.height }}"
-        width="{{ image.width }}"
-        class="image {{ 'lazy-image lazyload' if data.lazyload }}"
+<figure class="relative">
+  <picture class="{% for class in data.extraClasses %}{{ class }} {% endfor %}">
+    {% for image in model.images %}
+      {% set sizes = image | getImageSizesFor %}
+      <source media="(min-width: {{ image.minWidth }})"
         {% if data.lazyload %}
-          data-src="{{ image.contentUrl | convertImageUri(image.width, useIiifOrigin) }}"
+          data-srcset="
+          {%- for size in sizes -%}
+            {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiifOrigin) }} {{ size }}w
+          {%- endfor %}"
         {% else %}
-          src="{{ image.contentUrl | convertImageUri(image.width, useIiifOrigin) }}"
-        {% endif %}
-        alt="{{ image.alt }}" />
-    {% endif %}
-  {% endfor %}
-</picture>
-{% set singleImage = model.images[0] %}
-{% if ((singleImage.title or singleImage.source.name or singleImage.copyright.name or singleImage.license) and data.showCopyright) %}
-  {% set tasl = {
-    title: singleImage.title,
-    author: singleImage.author,
-    sourceName: singleImage.source.name,
-    sourceLink: singleImage.source.link,
-    license: singleImage.license,
-    copyrightHolder: singleImage.copyright.holder,
-    copyrightLink: singleImage.copyright.link
-  } %}
-  {% componentV2 'tasl', tasl, {'full': true} %}
-{% endif %}
+          srcset="
+          {%- for size in sizes -%}
+            {{ comma() }}{{ image.contentUrl | convertImageUri(size, useIiifOrigin) }} {{ size }}w
+          {%- endfor %}"
+        {% endif %}>
+
+      {% if loop.last %}
+        <img
+          height="{{ image.height }}"
+          width="{{ image.width }}"
+          class="image {{ 'lazy-image lazyload' if data.lazyload }}"
+          {% if data.lazyload %}
+            data-src="{{ image.contentUrl | convertImageUri(image.width, useIiifOrigin) }}"
+          {% else %}
+            src="{{ image.contentUrl | convertImageUri(image.width, useIiifOrigin) }}"
+          {% endif %}
+          alt="{{ image.alt }}" />
+      {% endif %}
+    {% endfor %}
+  </picture>
+  {% set singleImage = model.images[0] %}
+  {% if ((singleImage.title or singleImage.source.name or singleImage.copyright.name or singleImage.license) and data.showCopyright) %}
+    {% set tasl = {
+      title: singleImage.title,
+      author: singleImage.author,
+      sourceName: singleImage.source.name,
+      sourceLink: singleImage.source.link,
+      license: singleImage.license,
+      copyrightHolder: singleImage.copyright.holder,
+      copyrightLink: singleImage.copyright.link
+    } %}
+    {% componentV2 'tasl', tasl, {'full': true} %}
+  {% endif %}
+</figure>


### PR DESCRIPTION
Fixes #2140

## Type
✨ Feature  

## Value
Adds image credit info. to main images on event page and exhibition page
N.B. not many event images have credit info. populated

## Screenshot

### Exhibition page
![screen shot 2018-02-06 at 12 21 13](https://user-images.githubusercontent.com/6051896/35863405-79ee9080-0b46-11e8-89b2-45a66b182a29.png)

### Event page
<img width="788" alt="screen shot 2018-02-06 at 13 56 18" src="https://user-images.githubusercontent.com/6051896/35863442-93d76530-0b46-11e8-8ae2-e20ce6030e63.png">
<img width="519" alt="screen shot 2018-02-06 at 14 00 27" src="https://user-images.githubusercontent.com/6051896/35863451-97ecea28-0b46-11e8-8f16-ec5a3f16ec93.png">



## Checklist
### All
- [ ] PR labelled and assigned
- [ ] Any introduced code complexity has been flagged

<!-- delete below if not UI -->
### UI component only
- [ ] A11y tested: `npm run test:accessibility <URL>`
- [ ] Structured data tested: https://search.google.com/structured-data/testing-tool 
- [ ] Browser tested: `npm run test:browsers <URL>`
- [ ] Works without JS in the client
- [ ] Relevant tracking/monitoring has been considered
