### PR TITLE
create new route for the archive artidles

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -210,7 +210,7 @@ export async function renderArticlesList(ctx, next) {
   const promoList = PromoListFactory.fromSeries(series);
   const pagination = PaginationFactory.fromList(promoList.items, articlesList.totalResults, page || 1, articlesList.pageSize);
   const path = ctx.request.url;
-  const moreLink = articlesList.totalPages === 1 || articlesList.currentPage === articlesList.totalPages ? '/articles?format=archive' : null;
+  const moreLink = articlesList.totalPages === 1 || articlesList.currentPage === articlesList.totalPages ? '/articles/archive' : null;
 
   ctx.render('pages/list', {
     pageConfig: createPageConfig({

--- a/server/controllers/index.js
+++ b/server/controllers/index.js
@@ -37,13 +37,13 @@ export const articles = async(ctx, next) => {
   const {page, q} = ctx.request.query;
   const articleStubsResponse = await getArticleStubs(maxItemsPerPage, {page}, q);
   const series: Series = {
-    url: '/articles',
+    url: '/articles/archive',
     name: 'Articles',
     items: articleStubsResponse.data,
     total: articleStubsResponse.total
   };
   const promoList = PromoListFactory.fromSeries(series);
-  const pagination = PaginationFactory.fromList(promoList.items, promoList.total, parseInt(page, 10) || 1, 32, { format: 'archive' });
+  const pagination = PaginationFactory.fromList(promoList.items, promoList.total, parseInt(page, 10) || 1, 32);
 
   ctx.render('pages/list', {
     pageConfig: createPageConfig({
@@ -55,8 +55,6 @@ export const articles = async(ctx, next) => {
     list: promoList,
     pagination
   });
-
-  return next();
 };
 
 export const series = async(ctx, next) => {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -56,17 +56,11 @@ r.get('/works', search);
 r.get('/works/:id', work);
 
 // Deprecated: Wordpress content
+r.get('/articles/archive', articles);
 r.get('/articles/:slug', article);
 r.get('/articles/preview/:id', preview);
 r.get('/series/:id', series);
-r.get('/articles', async (ctx, next) => {
-  const format = ctx.query.format;
-  if (format === 'archive') {
-    return articles(ctx, next);
-  } else {
-    return renderArticlesList(ctx, next);
-  }
-});
+r.get('/articles', renderArticlesList);
 
 // Async
 r.get('/async/series-nav/:id', seriesNav);

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -54,7 +54,7 @@
       {% if moreLink %}
         <div class="grid">
           <div class="grid__cell text-align-right">
-            <a href="{{moreLink}}">More articles from the archive</a>
+            {% componentJsx 'MoreInfoLink', { url: moreLink, name: 'More articles from the archive' } %}
           </div>
         </div>
       {% else %}


### PR DESCRIPTION
We removed the format query parameter as we don't use it.
Well we do, but incorrectly, this creates a separate route for the article archive.