### PR TITLE
move place to the top of access in prismic

### DIFF
--- a/prismic-model/events.json
+++ b/prismic-model/events.json
@@ -15,6 +15,15 @@
         "customtypes" : [ "event-formats" ]
       }
     },
+    "place" : {
+      "type" : "Link",
+      "fieldset" : "Place",
+      "config" : {
+        "select" : "document",
+        "customtypes" : [ "places" ],
+        "label" : "Where is the event held?"
+      }
+    },
     "series" : {
       "type" : "Group",
       "fieldset" : "Event series",
@@ -100,15 +109,6 @@
             }
           }
         }
-      }
-    },
-    "place" : {
-      "type" : "Link",
-      "fieldset" : "Place",
-      "config" : {
-        "select" : "document",
-        "customtypes" : [ "places" ],
-        "label" : "Where is the event held?"
       }
     }
   },


### PR DESCRIPTION
As it's important and it's used everytime, let's move it up (it was lost otherwise).