### PR TITLE
organise event by booking info / event description

### DIFF
--- a/eventbrite/app/controllers.js
+++ b/eventbrite/app/controllers.js
@@ -1,6 +1,6 @@
 import {eventbritePersonalOauthToken} from './config';
 import superagent from 'superagent';
-import {formatDate} from 'common/filters/format-date';
+import {formatDateTime} from 'common/filters/format-date';
 
 const eventbriteApiRoot = 'https://www.eventbriteapi.com/v3';
 
@@ -25,7 +25,7 @@ async function getEventbriteEventTickets(id: string) {
     const ticketType: TicketType =
       ticketClassName.startsWith('waiting list') ? 'waitinglist'
         : ticketClassName.startsWith('comp ') ? 'comp' : 'standard';
-    const saleStarts = formatDate(new Date(ticketClass.sales_start));
+    const saleStarts = formatDateTime(new Date(ticketClass.sales_start));
 
     return ({onSaleStatus, ticketType, saleStarts, eventbriteId: ticketClass.event_id}: Ticket);
   }).filter(ticket => ticket.ticketType === 'standard'); // we only want to show standard tickets for now...

--- a/eventbrite/app/views/components/eventbrite-button/eventbrite-button.njk
+++ b/eventbrite/app/views/components/eventbrite-button/eventbrite-button.njk
@@ -46,6 +46,25 @@
     'font-charcoal',
     {s:'HNL5'} | fontClasses,
     {s:1} | spacingClasses({margin: ['top']}),
-    {s:0} | spacingClasses({margin: ['bottom']})
+    {s:1} | spacingClasses({margin: ['bottom']})
   ].join(' ') -}}">with Eventbrite</p>
+
+  {% if ticket.onSaleStatus === 'sold_out' %}
+    <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top']}) }} {{ {s: 2} | spacingClasses({margin: ['top']}) }}">
+      <h3 class="{{ {s:'HNM4'} | fontClasses }} no-margin">Waiting list</h3>
+      <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }}">
+        <p>
+          A waiting list will operate for most free ticketed events.
+          This opens in Wellcome Collection 60 minutes before the event starts
+          and must be registered for in person. If you register for the waiting
+          list, you'll be given a numbered ticket to take away, so you can enjoy
+          the café, galleries and bookshop if they are open before the event.
+          Moments before it starts, pre-booked places that fail to show are
+          allocated to waiting list ticket holders according to the numbers on
+          their tickets.
+        </p>
+        <p class="no-margin">If you come to register for the waiting list in person, you can take away a maximum of two tickets.</p>
+      </div>
+    </div>
+  {% endif %}
 </div>

--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -166,82 +166,30 @@
         </div>
 
         <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
-          {% if event.bookingType == 'Ticketed' %}
-            <h3 class="{{ {s:'HNM4'} | fontClasses }}">Booking information</h3>
-            <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
-              <p class="no-margin">
-                Please be aware that booking a ticket for a free event does not guarantee you place.
-                Admission is on a first come, first serve basis for ticket holders.
-              </p>
-              <div class="{{ {s:1} | spacingClasses({margin: ['top']}) }}">
-                {% componentJsx 'MoreInfoLink', { name: 'View our ticketing policy', url: 'https://wellcomecollection.org/visit-us/events-tickets' } %}
-              </div>
-            </div>
-          {% elif event.bookingType === 'First come, first served' %}
-            <h3 class="{{ {s:'HNM4'} | fontClasses }}">Booking information</h3>
-            <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
-              <p class="no-margin">
-                First come, first served from the Information Point on level 0.
-                Please be aware that tickets can run out if we are busy.
-                Doors open 15 minutes prior to the event starting.
-              </p>
-              <div class="{{ {s:1} | spacingClasses({margin: ['top']}) }}">
-                {% componentJsx 'MoreInfoLink', { name: 'View our ticketing policy', url: 'https://wellcomecollection.org/visit-us/events-tickets' } %}
-              </div>
-            </div>
-          {% elif event.bookingType === 'Drop in' %}
-            <h3 class="{{ {s:'HNM4'} | fontClasses }}">Booking information</h3>
-            <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
-              <p class="no-margin">
-                This is a drop in event.
-                For these events you just have to turn up, and there is usually room for everyone.
-              </p>
-              <div class="{{ {s:1} | spacingClasses({margin: ['top']}) }}">
-                {% componentJsx 'MoreInfoLink', { name: 'View our ticketing policy', url: 'https://wellcomecollection.org/visit-us/events-tickets' } %}
-              </div>
-            </div>
-          {% endif %}
-
-          {% for interpretation in event.interpretations %}
-            {% if interpretation.interpretationType.description %}
-              <h3 class="flex {{ {s:'HNM4'} | fontClasses }}">
-                <span class="{{ {s: 1} | spacingClasses({margin: ['right']}) }}">{% icon interpretation.interpretationType.title | replace(' ', '_') | replace('-', '_') | lower %}</span>
-                <span>{{ interpretation.interpretationType.title }}</span>
-              </h3>
-              <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
-                <p class="no-margin">
-                  {% if interpretation.isPrimary %}
-                    {{ interpretation.interpretationType.primaryDescription | safe }}.
-                  {% else %}
-                    {{ interpretation.interpretationType.description | safe }}.
-                  {% endif %}
-                </p>
-                <div class="{{ {s:1} | spacingClasses({margin: ['top']}) }}">
-                  {% componentJsx 'MoreInfoLink', { name: 'View our accessibility statement', url: 'https://wellcomecollection.org/visit-us/accessibility' } %}
-                </div>
-              </div>
-            {% endif %}
-          {% endfor %}
-
-          {% if event.format.isDropIn %}
-            <h3 class="{{ {s:'HNM4'} | fontClasses }}">
-              <span>Drop-in</span>
-            </h3>
-            <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
+          {% if event.isDropIn %}
+            <h3 class="{{ {s:'HNM4'} | fontClasses }} no-margin">Drop-in</h3>
+            <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }}">
               <p>
                 We try to programme some drop-in events every month.
                 There are where activities happen all over the building.
-                For these events you just have to turn up, and there is usually room for everyone.
+                For these events you just have to turn up, and there is usually
+                room for everyone. Doors open 15 minutes prior to the event starting.
               </p>
+              <div class="{{ {s:1} | spacingClasses({margin: ['top']}) }}">
+                {% componentJsx 'MoreInfoLink', { name: 'View our ticketing policy', url: 'https://wellcomecollection.org/visit-us/events-tickets' } %}
+              </div>
             </div>
-          {% endif %}
-
-          {% if event.format.description %}
-            <h3 class="{{ {s:'HNM4'} | fontClasses }}">
-              <span>{{ event.format.title }}</span>
-            </h3>
+          {% else %}
+            <h3 class="{{ {s:'HNM4'} | fontClasses }} no-margin">First come, first seated</h3>
             <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
-              {{ event.format.description | safe }}
+              <p>
+                Please be aware that booking a ticket for a free event does not
+                guarantee your place. Admission is on a first come, first served
+                basis for ticket-holders.
+              </p>
+              <div class="{{ {s:1} | spacingClasses({margin: ['top']}) }}">
+                {% componentJsx 'MoreInfoLink', { name: 'View our ticketing policy', url: 'https://wellcomecollection.org/visit-us/events-tickets' } %}
+              </div>
             </div>
           {% endif %}
 
@@ -267,6 +215,82 @@
       <div class="{{ {s: 3, m: 4, l: 5, xl: 5} | spacingClasses({margin: ['bottom']}) }}">
         {{ event.description | safe }}
       </div>
+
+      {% if event.format.description %}
+        {% componentJsx 'Divider', {
+          extraClasses: 'divider--pumice divider--keyline ' + ({s: 1} | spacingClasses({margin: ['top', 'bottom']}))
+        } %}
+        <h2 class="{{[
+          {s:'HNM5', m:'HNM4'} | fontClasses,
+          {s: 0} | spacingClasses({margin: ['top']}),
+          {s: 1} | spacingClasses({margin: ['bottom']})
+        ].join(' ')}}">{{ event.format.title }}</h2>
+        <div class="{{[
+          {s:'HNL4'} | fontClasses,
+          {s:4} | spacingClasses({margin: ['bottom']})
+        ].join(' ') }}">{{ event.format.description | safe }}</div>
+      {% endif %}
+
+      {% for audience in event.audiences %}
+        {% if audience.description %}
+          {% componentJsx 'Divider', {
+            extraClasses: 'divider--pumice divider--keyline ' + ({s: 1} | spacingClasses({margin: ['top', 'bottom']}))
+          } %}
+          <h2 class="{{[
+            {s:'HNM5', m:'HNM4'} | fontClasses,
+            {s: 0} | spacingClasses({margin: ['top']}),
+            {s: 1} | spacingClasses({margin: ['bottom']})
+          ].join(' ')}}">Part of: {{ audience.title }}</h2>
+          <div class="{{[
+            {s:'HNL4'} | fontClasses,
+            {s:4} | spacingClasses({margin: ['bottom']})
+          ].join(' ') }}">{{ audience.description | safe }}</div>
+        {% endif %}
+      {% endfor %}
+
+      {% for interpretation in event.interpretations %}
+        {% if interpretation.interpretationType.description %}
+          {% componentJsx 'Divider', {
+            extraClasses: 'divider--pumice divider--keyline ' + ({s: 1} | spacingClasses({margin: ['top', 'bottom']}))
+          } %}
+          <h2 class="{{[
+            'flex',
+            {s:'HNM5', m:'HNM4'} | fontClasses,
+            {s: 0} | spacingClasses({margin: ['top']}),
+            {s: 1} | spacingClasses({margin: ['bottom']})
+          ].join(' ')}}">
+            <span class="{{ {s: 1} | spacingClasses({margin: ['right']}) }}">
+              {% icon interpretation.interpretationType.title | replace(' ', '_') | replace('-', '_') | lower %}
+            </span>
+            <span>{{ interpretation.interpretationType.title }}</span>
+          </h2>
+          <div class="{{[
+            {s:'HNL4'} | fontClasses,
+            {s:4} | spacingClasses({margin: ['bottom']})
+          ].join(' ') }}">
+            {% if interpretation.isPrimary %}
+              {{ interpretation.interpretationType.primaryDescription | safe }}
+            {% else %}
+              {{ interpretation.interpretationType.description | safe }}
+            {% endif %}
+          </div>
+        {% endif %}
+      {% endfor %}
+
+      {% for series in event.series %}
+        {% componentJsx 'Divider', {
+          extraClasses: 'divider--pumice divider--keyline ' + ({s: 1} | spacingClasses({margin: ['top', 'bottom']}))
+        } %}
+        <h2 class="{{[
+          {s:'HNM5', m:'HNM4'} | fontClasses,
+          {s: 0} | spacingClasses({margin: ['top']}),
+          {s: 1} | spacingClasses({margin: ['bottom']})
+        ].join(' ')}}">Part of: {{ series.title }}</h2>
+        <div class="{{[
+          {s:'HNL4'} | fontClasses,
+          {s:4} | spacingClasses({margin: ['bottom']})
+        ].join(' ') }}">{{ series.description | safe }}</div>
+      {% endfor %}
     </div>
   </div>
 

--- a/prismic-model/interpretation-types.json
+++ b/prismic-model/interpretation-types.json
@@ -17,14 +17,14 @@
     "description" : {
       "type" : "StructuredText",
       "config" : {
-        "single" : "paragraph, hyperlink",
+        "multi" : "paragraph, hyperlink",
         "label" : "Message"
       }
     },
     "primaryDescription" : {
       "type" : "StructuredText",
       "config" : {
-        "single" : "paragraph, hyperlink",
+        "multi" : "paragraph, hyperlink",
         "label" : "Message if primary interpretation"
       }
     }

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -29,8 +29,7 @@ export type EventFormat = {|
 export type EventSeries = {|
   id: string,
   title: string,
-  description: ?HTMLString,
-  contributors: Array<Contributor>
+  description: ?HTMLString
 |}
 
 // E.g. 'British sign language interpreted' | 'Audio described' | 'Speech-to-Text';
@@ -184,8 +183,7 @@ export const eventExample = ({
         'we actually trust our senses? A scientific, ' +
         'philosophical and creative approach to this ' +
         'question will invite you on a journey into your ' +
-        'inner and outer experiences of the world.',
-      contributors: []
+        'inner and outer experiences of the world.'
     },
     {
       id: 'WcPx8ygAAH4Q9WgN',
@@ -197,8 +195,7 @@ export const eventExample = ({
         'the bar and restaurant open all night, it’s a great ' +
         'place for meeting with friends, looking at your favourite ' +
         'ideas in spectrum of different ways, or just learning ' +
-        'something new on a Friday night.',
-      contributors: []
+        'something new on a Friday night.'
     }
   ],
   place: {

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -68,8 +68,8 @@ export function parseEventDoc(doc: PrismicDoc): Event {
     interpretationType: {
       title: asText(interpretation.interpretationType.data.title),
       abbreviation: asText(interpretation.interpretationType.data.abbreviation),
-      description: deP(asHtml(interpretation.interpretationType.data.description)),
-      primaryDescription: deP(asHtml(interpretation.interpretationType.data.primaryDescription))
+      description: asHtml(interpretation.interpretationType.data.description),
+      primaryDescription: asHtml(interpretation.interpretationType.data.primaryDescription)
     },
     isPrimary: Boolean(interpretation.isPrimary)
   }) : null).filter(_ => _);
@@ -79,9 +79,13 @@ export function parseEventDoc(doc: PrismicDoc): Event {
     description: asText(audience.audience.data.description)
   }) : null).filter(_ => _);
 
-  const bookingType = parseEventBookingType(doc);
+  const series = doc.data.series.map(series => !isEmptyDocLink(series.series) ? ({
+    id: series.id,
+    title: asText(series.series.data.title),
+    description: asText(series.series.data.description)
+  }) : null).filter(_ => _);
 
-  console.info(bookingType);
+  const bookingType = parseEventBookingType(doc);
 
   const e = ({
     id: doc.id,
@@ -96,7 +100,7 @@ export function parseEventDoc(doc: PrismicDoc): Event {
     bookingEnquiryTeam: bookingEnquiryTeam,
     contributors: contributors,
     promo: promo,
-    series: [],
+    series: series,
     place: place,
     bookingInformation: asHtml(doc.data.bookingInformation),
     bookingType: bookingType
@@ -125,7 +129,7 @@ export function parseAudience(frag: Object): ?Audience {
 export function parseEventBookingType(eventDoc: Object): ?string {
   return !isEmptyObj(eventDoc.data.eventbriteEvent) ? 'Ticketed'
     : !isEmptyDocLink(eventDoc.data.bookingEnquiryTeam) ? 'Enquire to book'
-      : !isEmptyDocLink(eventDoc.data.location) && eventDoc.data.location.data.capacity  ? 'First come, first served'
+      : !isEmptyDocLink(eventDoc.data.place) && eventDoc.data.place.data.capacity  ? 'First come, first served'
         : null;
 }
 

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -43,7 +43,8 @@ const eventFields = [
   'places.title', 'places.geolocation', 'places.level', 'places.capacity',
   'interpretation-types.title', 'interpretation-types.abbreviation',
   'interpretation-types.description', 'interpretation-types.primaryDescription',
-  'audiences.title'
+  'audiences.title',
+  'event-series.title', 'event-series.description'
 ];
 
 export const defaultPageSize = 40;


### PR DESCRIPTION
__Adds waiting list text when an event is fully booked. Currently:__
"A waiting list will operate for most free ticketed events. This opens in Wellcome Collection 60 minutes before the event starts and must be registered for in person. If you register for the waiting list, you'll be given a numbered ticket to take away, so you can enjoy the café, galleries and bookshop if they are open before the event. Moments before it starts, pre-booked places that fail to show are allocated to waiting list ticket holders according to the numbers on their tickets.

If you come to register for the waiting list in person, you can take away a maximum of two tickets."
@jennpb @Heesoomoon ^ this might need some work.

__fixes showing time on when tickets become available, previously was just the date (not so useful)__

__Simplify logic around drop in - FCFS from this diagram__
![image 1](https://user-images.githubusercontent.com/31692/36097388-b59ac30a-0ff2-11e8-9302-a8110a4d6b6c.png)

__Event description is now__
* Description
* Format description (if available)
* Interpretations info 
* Series info

__Upcoming__
* Orgs / partners
* Paid for events
