### PR TITLE
Fixes weird Safari bug

### DIFF
--- a/client/js/components/segmented-control.js
+++ b/client/js/components/segmented-control.js
@@ -5,8 +5,8 @@ import fastdom from '../utils/fastdom-promise';
 
 export default (el) => {
   const showHideEl = el.querySelector('.js-segmented-control-show-hide');
-  const controlDrawerLinks = el.querySelectorAll('.js-segmented-control__drawer-link');
-  const controlLinks = el.querySelectorAll('.js-segmented-control__link');
+  const controlDrawerLinks = el.querySelector('.js-segmented-control__drawer-list');
+  const controlLinks = el.querySelector('.js-segmented-control__list');
   const controlButtonText = el.querySelector('.js-segmented-control__button-text');
   const fullPage = showHide({el: showHideEl});
   const trap = focusTrap(el);
@@ -46,29 +46,27 @@ export default (el) => {
       toggleElementVisibility();
     });
 
-    controlDrawerLinks.forEach((link, index) => {
-      link.addEventListener('click', (event) => { // TODO move listener up the DOM
-        if (link.getAttribute('href').charAt(0) === '#') {
-          controlButtonText.innerText = link.innerText;
-          toggleElementVisibility();
-        }
+    controlDrawerLinks.addEventListener('click', (e) => {
+      const link = e.target;
+      if (link.getAttribute('href').charAt(0) === '#') {
+        controlButtonText.innerText = link.innerText;
+        toggleElementVisibility();
+      }
+    }, false);
+
+    controlLinks.addEventListener('click', (e) => {
+      const link = e.target;
+      if (link.classList.contains('is-active') || link.getAttribute('href').charAt(0) !== '#') return;
+
+      const currentActive = el.querySelector('.is-active');
+
+      fastdom.mutate(() => {
+        currentActive.classList.remove(...activeClasses);
+        currentActive.classList.add(...inactiveClasses);
+        link.classList.remove(...inactiveClasses);
+        link.classList.add(...activeClasses);
       });
-    });
-
-    controlLinks.forEach((link, index) => {
-      link.addEventListener('click', (event) => { // TODO move listener up the DOM
-        if (link.classList.contains('is-active')) return;
-
-        const currentActive = el.querySelector('.is-active');
-
-        fastdom.mutate(() => {
-          currentActive.classList.remove(...activeClasses);
-          currentActive.classList.add(...inactiveClasses);
-          link.classList.remove(...inactiveClasses);
-          link.classList.add(...activeClasses);
-        });
-      });
-    });
+    }, false);
 
     onWindowResizeDebounce$.subscribe({
       next() {

--- a/whats_on/app/views/components/segmented-control/segmented-control.njk
+++ b/whats_on/app/views/components/segmented-control/segmented-control.njk
@@ -31,7 +31,7 @@
 
       <span class="{{ {s:3} | spacingClasses({margin: ['bottom']}) }} segmented-control__label block">See:</span>
 
-      <ul class="segmented-control__drawer-list no-margin no-padding plain-list">
+      <ul class="segmented-control__drawer-list js-segmented-control__drawer-list no-margin no-padding plain-list">
         {% for item in model %}
           <li class="{{- [
             {s:'WB6'} | fontClasses,
@@ -49,7 +49,7 @@
       <span class="visually-hidden js-trap-end">reset focus</span>
     </div>
   </div>
-  <ul class="segmented-control__list no-margin no-padding plain-list border-width-1 border-color-black rounded-diagonal overflow-hidden {{'js-tablist segmented-control__list--inline' if data.isTabControl }}">
+  <ul class="js-segmented-control__list segmented-control__list no-margin no-padding plain-list border-width-1 border-color-black rounded-diagonal overflow-hidden {{'js-tablist segmented-control__list--inline' if data.isTabControl }}">
     {% for item in model %}
       <li class="{{- [
         {s:'WB7'} | fontClasses,


### PR DESCRIPTION
Also, moves event listeners up the DOM, so don’t have to attach one to every link.

## Safari: What's On page
When the segmented control is used to move from the 'Today' view to the 'Weekend' view, and then the browser back button is used to navigate back to the 'Today' view, the active state does not update correctly. It seems that Safari is running the click event handler for the segmented control link, which is odd. I couldn't prevent that, but have added a check in the function that gets fired to prevent the weird behaviour.

## Type
🐛 Bugfix  
