### PR TITLE
mark exhibitions as to whether they are permanent or current

### DIFF
--- a/server/filters/format-date.js
+++ b/server/filters/format-date.js
@@ -55,16 +55,14 @@ function getRelativeTime({start, end}: {start: Date, end: Date}): {} {
 export function formatDateRangeWithMessage({start, end}: {start: Date, end: Date}): {text: string, color: string} {
   const relativeTime = getRelativeTime({start, end});
 
-  if (end === null) {
-    return {text: 'Ongoing', color: 'green'};
-  } else if (relativeTime.isFuture) {
+  if (relativeTime.isFuture) {
     return {text: 'Coming soon', color: 'marble'};
   } else if (relativeTime.isPast) {
     return {text: 'Past', color: 'marble'};
   } else if (relativeTime.isLastWeek) {
-    return {text: 'Last week', color: 'orange'};
+    return {text: 'Final week', color: 'orange'};
   } else {
-    return {text: 'Current', color: 'green'};
+    return {text: 'Now on', color: 'green'};
   }
 }
 

--- a/server/views/components/exhibition-promo/exhibition-promo.njk
+++ b/server/views/components/exhibition-promo/exhibition-promo.njk
@@ -18,7 +18,13 @@
       {s:4} | spacingClasses({padding: ['bottom']})
     ].join(' ') }} flex flex--column flex-1">
 
-    <p class="no-padding {{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">Exhibition</p>
+    <p class="no-padding {{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">
+      {% if not model.end %}
+        Permanent exhibition
+      {% else %}
+        Exhibition
+      {% endif %}
+    </p>
 
     <h2 class="promo-link__title {{ {s:'WB5'} | fontClasses }}  {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{ model.title }}</h2>
 


### PR DESCRIPTION
We now flag if an exhibition is permanent or current (temporary).
The times we surface are:
* Coming soon
* Past
* Last week
* Now on

I wonder if the "Last week" should be "Ending soon" or "Final week" as last week, in my head means, well... last week.

Do we also want to flag perm / current on the exhibitions pages?

![screen shot 2018-02-12 at 16 56 13](https://user-images.githubusercontent.com/31692/36108977-fad9268c-1015-11e8-9fd6-8dbcb678c9db.png)
![screen shot 2018-02-12 at 16 56 27](https://user-images.githubusercontent.com/31692/36108978-fb0ca548-1015-11e8-9b6a-04b640375a95.png)
