### PR TITLE
Wedge for what-on content to redirect to root

### DIFF
--- a/whats_on/app/routes.js
+++ b/whats_on/app/routes.js
@@ -4,5 +4,8 @@ import {renderWhatsOn} from './controllers';
 const r = new Router({ sensitive: true });
 
 r.get('/whats-on', renderWhatsOn);
+r.get('/whats-on/:blah+', (ctx) => {
+  ctx.redirect('/whats-on');
+});
 
 export const router = r.middleware();

--- a/whats_on/app/routes.js
+++ b/whats_on/app/routes.js
@@ -4,6 +4,7 @@ import {renderWhatsOn} from './controllers';
 const r = new Router({ sensitive: true });
 
 r.get('/whats-on', renderWhatsOn);
+// Used to deal with the gumpf Drupal creates e.g. /whats-on/events/all-events
 r.get('/whats-on/:blah+', (ctx) => {
   ctx.redirect('/whats-on');
 });


### PR DESCRIPTION
To deal with the URLs Drupal creates e.g. `/whats-on/events/all-events`.