### PR TITLE
don't cache HTML

### DIFF
--- a/server/config/index.js
+++ b/server/config/index.js
@@ -52,10 +52,6 @@ const defaultConfig = {
   },
   {
     contentType: 'application/font-woff2'
-  },
-  {
-    contentType: 'text/html',
-    maxAge: 1800
   }]
 };
 

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -50,6 +50,9 @@ export async function setPreviewSession(ctx, next) {
   });
 
   const redirectUrl = await getPreviewSession(token);
+
+  ctx.response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+  ctx.set('Pragma', 'no-cache');
   ctx.response.redirect(redirectUrl);
 }
 

--- a/server/middleware/set-cache-control.js
+++ b/server/middleware/set-cache-control.js
@@ -4,18 +4,11 @@ export default (options = {}) => {
 
   return function setCacheControl(ctx, next) {
     return next().then(() => {
-      const isPreview = /^\/preview\//.test(ctx.request.path);
-      const isHtml = ctx.response.type === 'text/html';
-      if(isPreview && isHtml) {
-        ctx.response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
-        ctx.set('Pragma', 'no-cache');
-      } else {
-        cacheControl.forEach((config) => {
-          if (config.contentType === ctx.response.type) {
-            ctx.response.set('Cache-Control', `max-age=${config.maxAge || year}`);
-          }
-        });
-      }
+      cacheControl.forEach((config) => {
+        if (config.contentType === ctx.response.type) {
+          ctx.response.set('Cache-Control', `max-age=${config.maxAge || year}`);
+        }
+      });
     });
   };
 }


### PR DESCRIPTION
We should think about moving cache control config to CloudFront.
An analysis of our cache would be good, as it's where we will probably get the best performance gains.