### PR TITLE
ordering of events reverse startDate

### DIFF
--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -43,7 +43,7 @@ export async function renderEvent(ctx, next) {
 }
 
 export async function renderEventsList(ctx, next) {
-  const page = Number(ctx.request.query.page);
+  const page = ctx.request.query.page ? Number(ctx.request.query.page) : 1;
   const paginatedEvents = await getPaginatedEventPromos(page);
 
   ctx.render('pages/events', {

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -284,7 +284,7 @@ function convertPrismicResultsToPaginatedResults(prismicResults: Object): (resul
 export async function getPaginatedEventPromos(page: number): Promise<Array<EventPromo>> {
   const events = await getAllOfType(['events'], {
     page,
-    orderings: '[my.events.times.startDateTime]',
+    orderings: '[my.events.times.startDateTime desc]',
     fetchLinks: eventFields
   });
   const promos = createEventPromos(events.results);

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -255,7 +255,7 @@ function createEventPromos(allResults): Array<EventPromo> {
     return curr.concat(acc);
   }, []).sort((a, b) => {
     return convertStringToNumber(b.start || '') - convertStringToNumber(a.start || '');
-  }).sort((a, b) => a.start.localeCompare(b.start));
+  });
 }
 
 function convertStringToNumber(string: string): number {


### PR DESCRIPTION
To prevent events that have ended popping up at the top.
Waiting on some feedback from Prismic as I think there is a problem their side.