### PR TITLE
allow multiline events titles

### DIFF
--- a/client/scss/utilities/_root-scope-classes.scss
+++ b/client/scss/utilities/_root-scope-classes.scss
@@ -406,6 +406,12 @@
   font-weight: bold;
 }
 
+// For when we get HTML out of systems like Prismic
+.first-para-no-margin p:first-of-type {
+  margin: 0;
+}
+
+
 // This removes the element from the flow, as well as it's visibility
 .visually-hidden {
   @include visually-hidden;

--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -56,12 +56,12 @@ export async function renderEventSeries(ctx, next) {
       path: ctx.request.url,
       title: series.title,
       description: asText(series.description),
-      htmlDescription: asHtml(series.description),
       inSection: 'whatson',
       category: 'public-programme',
       contentType: 'event-series',
       canonicalUri: `/events-series/${id}`
     }),
+    htmlDescription: asHtml(series.description),
     paginatedEvents
   });
 
@@ -77,13 +77,13 @@ export async function renderEventsList(ctx, next) {
     pageConfig: createPageConfig({
       path: ctx.request.url,
       title: 'Events',
-      htmlDescription: `<p>${description}</p>`,
       description: description,
       inSection: 'whatson',
       category: 'public-programme',
       contentType: 'event', // TODO: add pageType (list)
       canonicalUri: '/events'
     }),
+    htmlDescription: `<p>${description}</p>`,
     paginatedEvents
   });
 

--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -1,6 +1,6 @@
 import {model, prismic} from 'common';
 const {createPageConfig} = model;
-const {getPaginatedEventPromos, getEventSeries} = prismic;
+const {getPaginatedEventPromos, getEventSeries, asText, asHtml} = prismic;
 
 export async function renderEvent(ctx, next) {
   const id = `${ctx.params.id}`;
@@ -55,7 +55,8 @@ export async function renderEventSeries(ctx, next) {
     pageConfig: createPageConfig({
       path: ctx.request.url,
       title: series.title,
-      description: series.description || '',
+      description: asText(series.description),
+      htmlDescription: asHtml(series.description),
       inSection: 'whatson',
       category: 'public-programme',
       contentType: 'event-series',
@@ -70,12 +71,14 @@ export async function renderEventSeries(ctx, next) {
 export async function renderEventsList(ctx, next) {
   const page = ctx.request.query.page ? Number(ctx.request.query.page) : 1;
   const paginatedEvents = await getPaginatedEventPromos(page);
+  const description = 'Choose from an inspiring range of free talks, tours, discussions and more, all designed to challenge how we think and feel about health.';
 
   ctx.render('pages/events', {
     pageConfig: createPageConfig({
       path: ctx.request.url,
       title: 'Events',
-      description: 'Choose from an inspiring range of free talks, tours, discussions and more, all designed to challenge how we think and feel about health.',
+      htmlDescription: `<p>${description}</p>`,
+      description: description,
       inSection: 'whatson',
       category: 'public-programme',
       contentType: 'event', // TODO: add pageType (list)

--- a/events/app/views/pages/events.njk
+++ b/events/app/views/pages/events.njk
@@ -22,7 +22,7 @@
   </script>
   {% set listHeader = {
     name: pageConfig.title,
-    htmlDescription: pageConfig.htmlDescription,
+    htmlDescription: htmlDescription,
     total: paginatedEvents.results.length
   } %}
   {% componentV2 'list-header', listHeader %}

--- a/events/app/views/pages/events.njk
+++ b/events/app/views/pages/events.njk
@@ -22,7 +22,7 @@
   </script>
   {% set listHeader = {
     name: pageConfig.title,
-    description: pageConfig.description,
+    htmlDescription: pageConfig.htmlDescription,
     total: paginatedEvents.results.length
   } %}
   {% componentV2 'list-header', listHeader %}

--- a/prismic-model/event-series.json
+++ b/prismic-model/event-series.json
@@ -10,7 +10,7 @@
     "description" : {
       "type" : "StructuredText",
       "config" : {
-        "single" : "paragraph",
+        "multi" : "paragraph, hyperlink, strong, em",
         "label" : "Description"
       }
     }

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,7 @@ import {
   parsePromoListItem,
   parseExhibitionsDoc,
   prismicImage,
-  asText
+  asText, asHtml
 } from './services/prismic-parsers';
 
 export {setupApp};
@@ -34,6 +34,7 @@ export const prismic = {
   parseExhibitionsDoc,
   prismicImage,
   asText,
+  asHtml,
   getPaginatedEventPromos,
   getPaginatedExhibitionPromos,
   getExhibitionAndEventPromos

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -235,7 +235,7 @@ function createEventPromos(allResults): Array<EventPromo> {
     const series = event.data.series.map(series => !isEmptyDocLink(series.series) ? ({
       id: series.series.id,
       title: asText(series.series.data.title),
-      description: asText(series.series.data.description)
+      description: series.series.data.description
     }) : null).filter(_ => _);
 
     // A single Primsic 'event' can have multiple datetimes, but we

--- a/server/views/components/list-header/list-header.njk
+++ b/server/views/components/list-header/list-header.njk
@@ -9,6 +9,16 @@
             <p class="no-margin">{{ model.description }}</p>
           </div>
         {% endif %}
+        {#
+          This is a crap hack to allow putting HTML into the description
+          without having to refactor out all the places this is used.
+          We should probably only take Prismic HTML.
+        #}
+        {% if model.htmlDescription %}
+          <div class="first-para-no-margin {{ {s:2} | spacingClasses({margin: ['top']}) }}">
+            {{ model.htmlDescription | safe }}
+          </div>
+        {% endif %}
 
 	      {% block slot %}{% endblock %}
       </div>


### PR DESCRIPTION
Raises the question - where do we deserialise?
In my head it feels like it should always be at the template level?

Or we start creating things like `textDescription`, `htmlDescription` and `description` and just use `description` as the whatyoumightexpect type. 