### PR TITLE
Get some order into the way we fetch lists etc

### DIFF
--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -1,12 +1,11 @@
 import {model, prismic} from 'common';
 const {createPageConfig} = model;
-const {getPaginatedEventPromos, getEventSeries} = prismic;
+const {getPaginatedEventPromos, getEventSeries, getEvent} = prismic;
 
 export async function renderEvent(ctx, next) {
   const id = `${ctx.params.id}`;
   const format = ctx.request.query.format;
-  const isPreview = Boolean(ctx.params.preview);
-  const event = await prismic.getEvent(id, isPreview ? ctx.request : null);
+  const event = await getEvent(ctx.request, id);
   const path = ctx.request.url;
 
   if (event) {

--- a/exhibitions/app/controllers.js
+++ b/exhibitions/app/controllers.js
@@ -8,7 +8,7 @@ const {
 export async function renderExhibition(ctx, next) {
   const id = `${ctx.params.id}`;
   const isPreview = Boolean(ctx.params.preview);
-  const exhibitionContent = await getExhibitionAndRelatedContent(id, isPreview ? ctx.request : null);
+  const exhibitionContent = await getExhibitionAndRelatedContent(ctx.request, id);
   const format = ctx.request.query.format;
   const path = ctx.request.url;
   const tags = [{

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -8,7 +8,7 @@ import {collectorsPromo} from '../data/series';
 import {prismicAsText} from '../filters/prismic';
 import {
   getArticle, getSeriesAndArticles, getArticleList, getCuratedList,
-  defaultPageSize
+  defaultPageSize, getPaginatedArticlePromos
 } from '../services/prismic';
 import {PromoListFactory} from '../model/promo-list';
 import {PaginationFactory} from '../model/pagination';
@@ -19,7 +19,7 @@ export const renderArticle = async(ctx, next) => {
   // We rehydrate the `W` here as we take it off when we have the route.
   const id = `W${ctx.params.id}`;
   const isPreview = Boolean(ctx.params.preview);
-  const article = await getArticle(id, isPreview ? ctx.request : null);
+  const article = await getArticle(ctx.request, id);
 
   if (article) {
     if (format === 'json') {
@@ -201,8 +201,10 @@ export async function renderSeries(ctx, next) {
 
 export async function renderArticlesList(ctx, next) {
   // TODO: Remove WP content
-  const page = Number(ctx.request.query.page);
-  const articlesList = await getArticleList(page, {pageSize: 96});
+  const page = ctx.request.query.page ? Number(ctx.request.query.page) : 1;
+  const articlesList = await getPaginatedArticlePromos(ctx.request, page);
+  // console.info(articlesList)
+
   const contentPromos = List(articlesList.results);
 
   const series: Series = {

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,6 @@ import {Picture} from './model/picture';
 import {PaginationFactory} from './model/pagination';
 import {default as filtersMap} from './filters';
 import {
-  getPrismicApi,
   getEvent,
   getEventSeries,
   getExhibitionAndRelatedContent,
@@ -26,7 +25,6 @@ export const filters = filtersMap.toJS();
 export const model = {createPageConfig, Picture, UiComponent, PaginationFactory};
 export {List};
 export const prismic = {
-  getPrismicApi,
   getEvent,
   getEventSeries,
   getExhibitionAndRelatedContent,

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",
+    "cookies": "^0.7.1",
     "copy-webpack-plugin": "^4.2.3",
     "entities": "^1.1.1",
     "flow-bin": "^0.57.3",

--- a/server/services/prismic-api.js
+++ b/server/services/prismic-api.js
@@ -1,4 +1,5 @@
 import Prismic from 'prismic-javascript';
+import Cookies from 'cookies';
 
 const oneMinute = 1000 * 60;
 const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
@@ -18,6 +19,23 @@ export async function prismicApi() {
 
   return memoizedPrismic;
 }
+
+export function isPreview(req) {
+  return Boolean(new Cookies(req).get(Prismic.previewCookie));
+}
+
+export async function getPrismicApi(req) {
+  if (isPreview(req)) {
+    const api = await Prismic.getApi(apiUri, {req});
+    return api;
+  } else {
+    if (!memoizedPrismic) {
+      memoizedPrismic = await Prismic.getApi(apiUri);
+    }
+    return memoizedPrismic;
+  }
+}
+
 periodicallyUpdatePrismic();
 
 export async function prismicPreviewApi(req) {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1580,7 +1580,7 @@ cookiejar@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.1.tgz#41ad57b1b555951ec171412a81942b1e8200d34a"
 
-cookies@~0.7.0:
+cookies@^0.7.1, cookies@~0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.1.tgz#7c8a615f5481c61ab9f16c833731bcb8f663b99b"
   dependencies:


### PR DESCRIPTION
I've been left baffled a few times as to what some code does - this might hopefully add some clarity.
This is in regards to Prismic.

It came about from trying to change the way preview is decided (if you have a preview cookie, use preview API) and it started getting baffling.

The reason I was re-looking at the preview API is because we seem to have some issues with it on occasion, and I want to start looking at previewing lists (which I think is going to be tricky, so having tricky code won't help).

