### PR TITLE
Pass tags as an object

### DIFF
--- a/common/views/components/Index/index.js
+++ b/common/views/components/Index/index.js
@@ -8,6 +8,7 @@ import License from '../License/License';
 import MetaUnit from '../MetaUnit/MetaUnit';
 import MoreInfoLink from '../MoreInfoLink/MoreInfoLink';
 import SearchBox from '../SearchBox/SearchBox';
+import Tags from '../Tags/Tags';
 import Tasl from '../Tasl/Tasl';
 import WorkDrawer from '../WorkDrawer/WorkDrawer';
 import WorkMedia from '../WorkMedia/WorkMedia';
@@ -25,6 +26,7 @@ export {
   MetaUnit,
   MoreInfoLink,
   SearchBox,
+  Tags,
   Tasl,
   WorkDrawer,
   WorkMedia,

--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -37,7 +37,7 @@ export async function renderEvent(ctx, next) {
         }),
         event: event,
         eventInfo: eventInfo,
-        tags: tags
+        tags: {tags}
       });
     }
   }


### PR DESCRIPTION
Fixes a bad merge – Tags JSX hadn't been added to the index and tags themselves were being passed in as an array instead of an object containing an array.