### PR TITLE
show source name and link on TASL info

### DIFF
--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -16,7 +16,7 @@
             {% elif bodyPart.type === 'picture' %}
               {# On old content, the first paragraph is sometimes a picture #}
               {% set imageModel = bodyPart.value | objectAssign({lazyload: true, sizesQueries: '(min-width: 960px) 710px, 100vw', showCopyright: true}) %}
-              {% set tasl = {name: 'Tasl', model: imageModel}
+              {% set tasl = {name: 'Tasl', model: imageModel | objectAssign({sourceName: imageModel.source.name, sourceLink: imageModel.source.link})}
                 if (imageModel.title or imageModel.source.name or imageModel.copyright.name or imageModel.license)
                 else null
               %}
@@ -43,7 +43,7 @@
             {% endif %}
             <div class="{{wrapperClasses}}">
               {% set imageModel = bodyPart.value | objectAssign({lazyload: true, sizesQueries: sizes}) %}
-              {% set tasl = {name: 'Tasl', model: imageModel}
+              {% set tasl = {name: 'Tasl', model: imageModel | objectAssign({sourceName: imageModel.source.name, sourceLink: imageModel.source.link})}
                 if (imageModel.title or imageModel.source.name or imageModel.copyright.name or imageModel.license)
                 else null
               %}
@@ -92,7 +92,7 @@
 
                     {% set imageModel = item.image | objectAssign({lazyload: true}) %}
 
-                    {% set tasl = {name: 'Tasl', model: imageModel}
+                    {% set tasl = {name: 'Tasl', model: imageModel | objectAssign({sourceName: imageModel.source.name, sourceLink: imageModel.source.link})}
                       if (imageModel.title or imageModel.source.name or imageModel.copyright.name or imageModel.license)
                       else null
                     %}


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Source name and link was missing from tasl info., this puts it back

## Screenshot
Before:
![image](https://user-images.githubusercontent.com/6051896/36853077-609ada54-1d65-11e8-840d-fbf7e72d6235.png)

After:
![screen shot 2018-03-01 at 15 30 32](https://user-images.githubusercontent.com/6051896/36853135-8a34c6c2-1d65-11e8-8345-d450a2be5bb4.png)
