### PR TITLE
add infra for catalogue

### DIFF
--- a/catalogue/terraform/terraform.tf
+++ b/catalogue/terraform/terraform.tf
@@ -90,5 +90,6 @@ module "catalogue" {
   primary_container_port             = "80"
   secondary_container_port           = "3000"
   path_pattern                       = "/works*"
+  healthcheck_path                   = "/management/healthcheck"
   alb_priority                       = "110"
 }

--- a/catalogue/terraform/terraform.tf
+++ b/catalogue/terraform/terraform.tf
@@ -1,0 +1,94 @@
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    key            = "build-state/catalogue.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+    bucket         = "wellcomecollection-infra"
+  }
+}
+
+provider "aws" {
+  version = "~> 1.10"
+  region  = "eu-west-1"
+}
+
+provider "aws" {
+  version = "~> 1.10"
+  region  = "us-east-1"
+  alias   = "us-east-1"
+}
+
+provider "random" {
+  version = "~> 1.1"
+}
+
+provider "template" {
+  version = "~> 1.0"
+}
+
+data "terraform_remote_state" "infra" {
+  backend = "s3"
+
+  config {
+    bucket = "wellcomecollection-infra"
+    key    = "terraform.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+data "terraform_remote_state" "router" {
+  backend = "s3"
+
+  config {
+    bucket = "wellcomecollection-infra"
+    key    = "build-state/router.tfstate"
+    region = "eu-west-1"
+  }
+}
+
+locals {
+  vpc_id                 = "${data.terraform_remote_state.infra.vpc_id}"
+  vpc_subnets            = "${data.terraform_remote_state.infra.vpc_subnets}"
+  alb_cloudwatch_id      = "${data.terraform_remote_state.infra.alb_cloudwatch_id}"
+  alb_listener_https_arn = "${data.terraform_remote_state.router.alb_listener_https_arn}"
+  alb_listener_http_arn  = "${data.terraform_remote_state.router.alb_listener_http_arn}"
+  cluster_name           = "${data.terraform_remote_state.router.cluster_name}"
+}
+
+module "alb_server_error_alarm" {
+  source = "git::https://github.com/wellcometrust/terraform.git//sns?ref=v7.0.1"
+  name   = "alb_server_error_alarm"
+}
+
+module "alb_client_error_alarm" {
+  source = "git::https://github.com/wellcometrust/terraform.git//sns?ref=v7.0.1"
+  name   = "alb_client_error_alarm"
+}
+
+module "catalogue" {
+  source     = "git::https://github.com/wellcometrust/terraform.git//ecs/service?ref=v7.0.1"
+  name       = "catalogue"
+  cluster_id = "${local.cluster_name}"
+
+  vpc_id = "${local.vpc_id}"
+
+  nginx_uri                          = "wellcome/nginx_webapp:latest"
+  app_uri                            = "wellcome/catalogue_webapp:test"
+  listener_https_arn                 = "${local.alb_listener_https_arn}"
+  listener_http_arn                  = "${local.alb_listener_http_arn}"
+  server_error_alarm_topic_arn       = "${module.alb_server_error_alarm.arn}"
+  client_error_alarm_topic_arn       = "${module.alb_client_error_alarm.arn}"
+  loadbalancer_cloudwatch_id         = "${local.alb_cloudwatch_id}"
+  deployment_minimum_healthy_percent = "50"
+  deployment_maximum_percent         = "200"
+  env_vars_length                    = 0
+  desired_count                      = 2
+  cpu                                = "384"                                  # (1024/2) - 128
+  memory                             = "369"                                  # (995/2) - 128
+  primary_container_port             = "80"
+  secondary_container_port           = "3000"
+  path_pattern                       = "/works*"
+  alb_priority                       = "110"
+}

--- a/router/terraform/asg.tf
+++ b/router/terraform/asg.tf
@@ -7,8 +7,8 @@ module "router_cluster_asg" {
   user_data             = "${module.router_userdata.rendered}"
   vpc_id                = "${local.vpc_id}"
 
-  asg_desired = "2"
-  asg_max     = "2"
+  asg_desired = "4"
+  asg_max     = "4"
 
   image_id      = "${data.aws_ami.stable_coreos.image_id}"
   instance_type = "t2.micro"

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -5,8 +5,8 @@ data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
 
 resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   origin {
-    domain_name = "${module.router_alb.dns_name}"
-    origin_id   = "${module.router_alb.id}"
+    domain_name = "origin.wellcomecollection.org"
+    origin_id   = "origin"
 
     custom_origin_config {
       origin_protocol_policy = "https-only"
@@ -24,9 +24,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     "next.wellcomecollection.org",
     "blog.wellcomecollection.org",
     "wellcomeimages.org",
-    "*.wellcomeimages.org",
-    "nut.wellcomecollection.org",
-    "geb.wellcomecollection.org"
+    "*.wellcomeimages.org"
   ]
 
   default_cache_behavior {

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -25,8 +25,8 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     "blog.wellcomecollection.org",
     "wellcomeimages.org",
     "*.wellcomeimages.org",
-    "nut.wellcomeimages.org",
-    "geb.wellcomeimages.org"
+    "nut.wellcomecollection.org",
+    "geb.wellcomecollection.org"
   ]
 
   default_cache_behavior {

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -24,7 +24,9 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     "next.wellcomecollection.org",
     "blog.wellcomecollection.org",
     "wellcomeimages.org",
-    "*.wellcomeimages.org"
+    "*.wellcomeimages.org",
+    "nut.wellcomeimages.org",
+    "geb.wellcomeimages.org"
   ]
 
   default_cache_behavior {

--- a/router/terraform/services.tf
+++ b/router/terraform/services.tf
@@ -21,6 +21,7 @@ module "router" {
   server_error_alarm_topic_arn = "${module.alb_server_error_alarm.arn}"
   client_error_alarm_topic_arn = "${module.alb_client_error_alarm.arn}"
 
-  memory                 = "490"
+  cpu                      = "384" # (1024/2) - 128
+  memory                   = "369" # (995/2) - 128
   primary_container_port = "80"
 }

--- a/router/terraform/terraform.tf
+++ b/router/terraform/terraform.tf
@@ -29,3 +29,15 @@ provider "aws" {
   region  = "us-east-1"
   alias   = "us-east-1"
 }
+
+output "cluster_name" {
+  value = "${aws_ecs_cluster.router.name}"
+}
+
+output "alb_listener_https_arn" {
+  value = "${module.router_alb.listener_https_arn}"
+}
+
+output "alb_listener_http_arn" {
+  value = "${module.router_alb.listener_http_arn}"
+}


### PR DESCRIPTION
💻  As a webapp I need a place to live in the cloud to pass on my value to people.
To do this we are setting up the infrastructure needed to host the webapp.

__Notes__
* This app might not live in the `app_cluster`, but the `router` cluster as we want to have it accessible to the router ALB and potentially bypass the router service completely and just have it go straight from the request to the app.
* This should allow us to split traffic to the two different services to test for improved performance, which is one of the reasons we have done this.

![img_20180228_123347](https://user-images.githubusercontent.com/31692/36788041-4c85e7b6-1c84-11e8-837c-a41c5594681f.jpg)

in favour of #2277 