### PR TITLE
allow the use of sold out on eventbrite shows too

### DIFF
--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -127,26 +127,36 @@
 
           {% if eventInfo.eventbriteId %}
             <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
-              <div class="js-eventbrite-ticket-button" data-eventbrite-ticket-id="{{ eventInfo.eventbriteId }}">
-                <a class="{{- [
-                  'flex-inline',
-                  'flex--v-center',
-                  'flex--h-center',
-                  'btn btn--full-width-s',
+              {% if eventInfo.isCompletelySoldOut %}
+                <button class="{{- [
                   {s:'HNM4'} | fontClasses,
                   {s: 4} | spacingClasses({padding: ['left', 'right']})
-                ].join(' ') }}"
-                    href="https://www.eventbrite.com/e/{{ eventInfo.eventbriteId }}/">
-                  <span>{% icon 'ticket' %}</span>
-                  <span class="js-eventbrite-ticket-button-text">Book free tickets</span>
-                </a>
-                <p class="{{- [
-                  'font-charcoal',
-                  {s:'HNL5'} | fontClasses,
-                  {s:1} | spacingClasses({margin: ['top']}),
-                  {s:0} | spacingClasses({margin: ['bottom']})
-                ].join(' ') -}}">with Eventbrite</p>
-              </div>
+                ].join(' ') }} flex-inline flex--h-center btn btn--full-width-s"
+                        disabled="disabled" aria-disabled="true">
+                  Fully booked
+                </button>
+              {% else %}
+                <div class="js-eventbrite-ticket-button" data-eventbrite-ticket-id="{{ eventInfo.eventbriteId }}">
+                  <a class="{{- [
+                    'flex-inline',
+                    'flex--v-center',
+                    'flex--h-center',
+                    'btn btn--full-width-s',
+                    {s:'HNM4'} | fontClasses,
+                    {s: 4} | spacingClasses({padding: ['left', 'right']})
+                  ].join(' ') }}"
+                      href="https://www.eventbrite.com/e/{{ eventInfo.eventbriteId }}/">
+                    <span>{% icon 'ticket' %}</span>
+                    <span class="js-eventbrite-ticket-button-text">Book free tickets</span>
+                  </a>
+                  <p class="{{- [
+                    'font-charcoal',
+                    {s:'HNL5'} | fontClasses,
+                    {s:1} | spacingClasses({margin: ['top']}),
+                    {s:0} | spacingClasses({margin: ['bottom']})
+                  ].join(' ') -}}">with Eventbrite</p>
+                </div>
+            {% endif %}
             </div>
           {% endif %}
 
@@ -234,22 +244,24 @@
               </p>
             </div>
           {% elif eventInfo.eventbriteId %}
-            <h3 class="{{ {s:'HNM4'} | fontClasses }} no-margin">First come, first seated</h3>
-            <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
-              <p>
-                Please note, booking a ticket for a free event does not
-                guarantee a place on the day. Doors usually open 15 minutes
-                before an event starts, and you can take your seats in order of
-                arrival. We advise arriving 10 minutes before the event is
-                scheduled to start.
-              </p>
-              <p>
-                We hold some spaces for people with access requirements.
-                Please email
-                <a href="mailto:access@wellcomecollection.org?subject={{event.title}}">access@wellcomecollection.org</a>
-                if you would like to request one of these spaces.
-              </p>
-            </div>
+            {% if not eventInfo.isCompletelySoldOut %}
+              <h3 class="{{ {s:'HNM4'} | fontClasses }} no-margin">First come, first seated</h3>
+              <div class="{{ {s:'HNL4'} | fontClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
+                <p>
+                  Please note, booking a ticket for a free event does not
+                  guarantee a place on the day. Doors usually open 15 minutes
+                  before an event starts, and you can take your seats in order of
+                  arrival. We advise arriving 10 minutes before the event is
+                  scheduled to start.
+                </p>
+                <p>
+                  We hold some spaces for people with access requirements.
+                  Please email
+                  <a href="mailto:access@wellcomecollection.org?subject={{event.title}}">access@wellcomecollection.org</a>
+                  if you would like to request one of these spaces.
+                </p>
+              </div>
+            {% endif %}
           {% elif event.bookingEnquiryTeam %}
             {# Don't show anything as the booking team deal with this #}
           {% else %}


### PR DESCRIPTION
Allows the usage of the `isSoldOut` flag to change the status on eventbrite events too.
<img width="509" alt="screen shot 2018-03-02 at 13 23 02" src="https://user-images.githubusercontent.com/31692/36900969-3b63704e-1e1d-11e8-9846-47a3b930f0cc.png">
