### PR TITLE
remove truncate text from image gallery

### DIFF
--- a/server/views/components/image-gallery/image-gallery.njk
+++ b/server/views/components/image-gallery/image-gallery.njk
@@ -14,8 +14,7 @@
       {% set imageModel = item | objectAssign({
         lazyload: true,
         sizesQueries: queries,
-        slideNumbers: slideNumbers,
-        truncateCaption: true
+        slideNumbers: slideNumbers
       }) %}
       {% set tasl = {name: 'Tasl', model: imageModel}
         if (imageModel.title or imageModel.source.name or imageModel.copyright.name or imageModel.license)


### PR DESCRIPTION
Based on this data:
Timeframe: 1 Jan - Today
Total more clicks: 4,770
Total views for the top pages with more clicks: 7,971 + 3,400 (11371)

The two articles:
https://wellcomecollection.org/articles/WjK0mSsAAJCEh4A1
https://wellcomecollection.org/articles/Wi_yzSQAAFqPOrDY

Meaning that under half of people aren't seeing the interesting editorial content that gives the image gallery a narrative and context (which is the point of not using image descriptions as captions).

Thoughts are it would be good to show the content.

![screen shot 2018-03-12 at 13 14 44](https://user-images.githubusercontent.com/31692/37285925-6e45c74a-25f8-11e8-9aba-de56d4ee4521.png)

![screen shot 2018-03-12 at 13 15 08](https://user-images.githubusercontent.com/31692/37285952-7a729336-25f8-11e8-8d76-12c972191fb6.png)



