### PR TITLE
Added missing sizes attribute

### DIFF
--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -61,6 +61,7 @@ const imageMarkup = (width, height, clipPathClass, lazyload = false, defaultSize
       data-srcset={sizes.map(size => {
         return `${convertImageUri(contentUrl, size, false)} ${size}w`;
       })}
+      sizes={sizesQueries}
       data-copyright={copyright}
       onClick={clickHandler}
       alt={alt} />


### PR DESCRIPTION
## Type
🐛 Bugfix  

## Value
Noticed sizes attribute was missing from images, meaning that larger images than necessary are loading

## Screenshot
Currently:
![screen shot 2018-03-12 at 15 14 43](https://user-images.githubusercontent.com/6051896/37292580-0a117c0e-2609-11e8-965e-657f200b07c7.png)


With sizes attribute back in:
![screen shot 2018-03-12 at 15 19 37](https://user-images.githubusercontent.com/6051896/37292587-0c449a6a-2609-11e8-901c-fe996517896a.png)


