### PR TITLE
include node_modules in docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
 .git
-node_modules*
 terraform*
 */terraform
-*/node_modules*


### PR DESCRIPTION
We can see that the docker size went down massively here in commit: ad7b7baf06482b89dba43be9d2af15e934c60f0b

https://hub.docker.com/r/wellcome/wellcomecollection/tags/

Seems we need the node_modules.
I'll relook at the docker context size as a separate thing with it's own set of testing.
