### PR TITLE
check for article before retrieving displayType

### DIFF
--- a/prismic-model/articles.json
+++ b/prismic-model/articles.json
@@ -519,7 +519,7 @@
     "displayType" : {
       "type" : "Select",
       "config" : {
-        "options" : [ "basic-page", "article" ],
+        "options" : [ "basic-page" ],
         "label" : "Display Type"
       }
     }

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -20,13 +20,14 @@ export const renderArticle = async(ctx, next) => {
   const id = `W${ctx.params.id}`;
   const isPreview = Boolean(ctx.params.preview);
   const article = await getArticle(id, isPreview ? ctx.request : null);
-  const displayType = article.displayType;
+
   if (article) {
     if (format === 'json') {
       ctx.body = article;
     } else {
+      const displayType = article.displayType;
       const trackingInfo = getEditorialAnalyticsInfo(article);
-      ctx.render(`pages/${displayType}`, {
+      ctx.render(`pages/${displayType || 'article'}`, {
         pageConfig: Object.assign({}, createPageConfig({
           path: path,
           title: article.headline,


### PR DESCRIPTION
Make sure we have an article to get a `displayType` from.
Also null as default, and basic as override.