### PR TITLE
Additional text on more info links, specifically for screen readers

### DIFF
--- a/common/views/components/EventScheduleItem/EventScheduleItem.js
+++ b/common/views/components/EventScheduleItem/EventScheduleItem.js
@@ -50,7 +50,7 @@ const EventScheduleItem = ({event}: Props) => (
           <p className={`${spacing({s: 2}, {margin: ['bottom']})} ${font({s: 'HNL5', m: 'HNL4'})}`} dangerouslySetInnerHTML={{__html: event.description}} />
 
           {event.hasOwnPage &&
-            <MoreInfoLink url={`/events/${event.id}`} name='More information' />
+            <MoreInfoLink url={`/events/${event.id}`} name='More information' screenReaderText={`about ${event.title}`} />
           }
 
           {(event.eventInfo && event.eventInfo.eventbriteId || event.bookingEnquiryTeam) &&

--- a/common/views/components/MoreInfoLink/MoreInfoLink.js
+++ b/common/views/components/MoreInfoLink/MoreInfoLink.js
@@ -5,10 +5,11 @@ import Icon from '../Icon/Icon';
 
 type Props = {|
   url: string,
-  name: string
+  name: string,
+  screenReaderText?: string
 |}
 
-const MoreInfoLink = ({url, name}: Props) => (
+const MoreInfoLink = ({url, name, screenReaderText}: Props) => (
   <a className={[
     'flex-inline',
     'flex-v-center',
@@ -19,7 +20,10 @@ const MoreInfoLink = ({url, name}: Props) => (
     <span className='width-1-em'>
       <Icon name='arrow' extraClasses='icon--green' />
     </span>
-    <span className={spacing({s: 1}, {margin: ['left']})}>{name}</span>
+    <span className={spacing({s: 1}, {margin: ['left']})}>
+      {name}
+      { screenReaderText && <span className='visually-hidden'> {screenReaderText}</span>}
+    </span>
   </a>
 );
 

--- a/common/views/components/MoreInfoLink/MoreInfoLink.js
+++ b/common/views/components/MoreInfoLink/MoreInfoLink.js
@@ -22,7 +22,7 @@ const MoreInfoLink = ({url, name, screenReaderText}: Props) => (
     </span>
     <span className={spacing({s: 1}, {margin: ['left']})}>
       {name}
-      { screenReaderText && <span className='visually-hidden'> {screenReaderText}</span>}
+      {screenReaderText && <span className='visually-hidden'> {screenReaderText}</span>}
     </span>
   </a>
 );


### PR DESCRIPTION
## Type
🚑 Health

## Value
Allows us to add additional text to MoreInfoLinks for screen readers. This is important if the link text, in isolation, doesn't provide enough details to describe the link destination.

Not sure if this is the correct approach, or we should just never have links that just say 'more information'.

## Screenshot
![more-info](https://user-images.githubusercontent.com/6051896/37596033-bebbe1e4-2b72-11e8-8e7d-c8804240a436.gif)

