### PR TITLE
remove type check from server app

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
     "app:build": "webpack",
     "app:dev": "../node_modules/.bin/nodemon --config ./nodemon.json --exec babel-node --inspect=4000 app.js",
     "optimise:svg": "node ./optimise-svgs.js",
-    "test": "ava && flow",
+    "test": "ava",
     "test:accessibility": "pa11y",
     "test:browsers": "node ./browserstack/browserstack.js",
     "test:typecheck-watch": "flow-bro watch",


### PR DESCRIPTION
This goes in with the caveat that everything in `common` gets type checked.