### PR TITLE
Event schedule contributors

### DIFF
--- a/events/app/views/partials/event_with_schedule.njk
+++ b/events/app/views/partials/event_with_schedule.njk
@@ -98,7 +98,8 @@
             {% component 'author', {
               name: contributor.name,
               image: contributor.image.contentUrl,
-              description: contributor.description
+              description: contributor.description,
+              twitterHandle: contributor.twitterHandle
             } %}
           {% endif %}
         {% endfor %}

--- a/events/app/views/partials/event_with_schedule.njk
+++ b/events/app/views/partials/event_with_schedule.njk
@@ -91,6 +91,18 @@
             %}
           {% endfor %}
         </ul>
+
+        <h2 class="{{ {s: 'WB6', l: 'WB5'} | fontClasses }} {{ {s: 4} | spacingClasses({padding: ['bottom']}) }}">Contributors</h2>
+        {% for contributor in event.contributors %}
+          {% if contributor.contributorType === 'people' %}
+            {% component 'author', {
+              name: contributor.name,
+              image: contributor.image.contentUrl,
+              description: contributor.description
+            } %}
+          {% endif %}
+        {% endfor %}
+
       </div>
     </div>
   </div>

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -98,11 +98,23 @@ export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): Event
       switch (contributor.contributor.type) {
         case 'organisations':
           return {
+            contributorType: 'organisations',
+            id: contributor.contributor.id,
             name: asText(contributor.contributor.data.name),
             image: contributor.contributor.data.image && parsePicture({
               image: contributor.contributor.data.image
             }),
             url: contributor.contributor.data.url
+          };
+        case 'people':
+          return {
+            contributorType: 'people',
+            id: contributor.contributor.id,
+            name: contributor.contributor.data.name,
+            image: contributor.contributor.data.image && parsePicture({
+              image: contributor.contributor.data.image
+            }),
+            description: contributor.contributor.data.description && asHtml(contributor.contributor.data.description)
           };
       }
     })();

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -111,6 +111,7 @@ export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): Event
             contributorType: 'people',
             id: contributor.contributor.id,
             name: contributor.contributor.data.name,
+            twitterHandle: contributor.contributor.data.twitterHandle,
             image: contributor.contributor.data.image && parsePicture({
               image: contributor.contributor.data.image
             }),


### PR DESCRIPTION
See tin for details.
First pass, we'll look at contributors as a whole later when we're not being so responsive.

![screen shot 2018-03-20 at 15 49 45](https://user-images.githubusercontent.com/31692/37666156-c44ad928-2c56-11e8-98e1-a62c068542fb.png)
![screen shot 2018-03-20 at 15 52 02](https://user-images.githubusercontent.com/31692/37666157-c46edf26-2c56-11e8-9a11-5e78d8c5dcd0.png)
