### PR TITLE
Move event-series to its own template; highlight past events

### DIFF
--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -50,13 +50,14 @@ export async function renderEventSeries(ctx, next) {
   const paginatedResults = convertPrismicResultsToPaginatedResults(promos);
   const paginatedEvents = paginatedResults(promos);
   const series = paginatedEvents.results[0].series.find(series => series.id === id);
-  const withFilteredPromos = Object.assign({}, paginatedEvents, {results: promos.filter(e => london(e.end).isAfter(london()))});
+  const upcomingEvents = Object.assign({}, paginatedEvents, {results: promos.filter(e => london(e.end).isAfter(london()))});
+  const pastEvents = {results: promos.filter(e => london(e.end).isBefore(london())).slice(0, 2).reverse()};
   // TODO pagination will be out of sync with Prismic, since we're removing items after the request.
   // If we use dateAfter to query prismic, this would fix it, but we may end up with no results and hence no way of getting the series data to display.
   // The other alternative is to make two API calls, but since this will only be an issue if there are more
   // than 40 events, which is unlikely, I've left as is.
 
-  ctx.render('pages/events', {
+  ctx.render('pages/event-series', {
     pageConfig: createPageConfig({
       path: ctx.request.url,
       title: series.title,
@@ -64,11 +65,11 @@ export async function renderEventSeries(ctx, next) {
       inSection: 'whatson',
       category: 'public-programme',
       contentType: 'event-series',
-      canonicalUri: `/events-series/${id}`
+      canonicalUri: `/event-series/${id}`
     }),
     htmlDescription: asHtml(series.description),
-    hideArchivedEventsLink: true,
-    paginatedEvents: withFilteredPromos
+    paginatedEvents: upcomingEvents,
+    pastEvents: pastEvents
   });
 
   return next();

--- a/events/app/views/pages/event-series.njk
+++ b/events/app/views/pages/event-series.njk
@@ -40,18 +40,33 @@
   </div>
   {% endif %}
 
-  <div class="css-grid__container {{ {s:4} | spacingClasses({padding: ['top']}) }} ">
-    <div class="css-grid">
-      <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }}">
-        <div class="flex-inline flex--v-center">
-          <span class="{{ {s:'HNM5', m:'HNM4'} | fontClasses }}">Free admission</span>
-        </div>
+  <div class="row {{ {s: 6} | spacingClasses({margin: ['top']}) }} {{ {s: 10} | spacingClasses({margin: ['bottom']}) }}">
+    <div class="container">
+      <h2 class="{{ {s: 'WB5'} | fontClasses }} no-margin">Upcoming events</h2>
+    </div>
+    <div class="css-grid__container {{ {s: 4} | spacingClasses({padding: ['top']}) }} ">
+      <div class="css-grid">
+        {% for event in paginatedEvents.results %}
+          <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
+            {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+          </div>
+        {% endfor %}
       </div>
-      {% for event in paginatedEvents.results %}
-        <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
-          {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
-        </div>
-      {% endfor %}
+    </div>
+  </div>
+
+  <div class="row {{ {s: 10} | spacingClasses({margin: ['bottom']}) }}">
+    <div class="container">
+      <h2 class="{{ {s: 'WB5'} | fontClasses }} no-margin">Past events</h2>
+    </div>
+    <div class="css-grid__container {{ {s: 4} | spacingClasses({padding: ['top']}) }} ">
+      <div class="css-grid">
+        {% for event in pastEvents.results %}
+          <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
+            {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+          </div>
+        {% endfor %}
+      </div>
     </div>
   </div>
 
@@ -61,11 +76,6 @@
       {% if paginatedEvents.pagination.pageCount > 1  %}
         <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }} text-align-right">
           {% componentJsx 'Pagination', paginatedEvents.pagination %}
-        </div>
-      {% endif %}
-      {% if (paginatedEvents.currentPage === paginatedEvents.totalPages) %}
-        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }} {{ {s:4} | spacingClasses({margin: ['top']}) }} text-align-right">
-          {% componentJsx 'MoreInfoLink', { name: 'Past events', url: 'https://wellcomecollection.org/events/past' } %}
         </div>
       {% endif %}
 

--- a/server/filters/format-date.js
+++ b/server/filters/format-date.js
@@ -81,3 +81,10 @@ export function formatAndDedupeOnTime(d1: Date, d2: Date): List<string> {
 export function joinDateStrings(dateStrings: List<string>): string {
   return dateStrings.join('–');
 }
+
+export function isDatePast(date: Date): boolean {
+  const momentNow = london();
+  const momentEnd = london(date);
+
+  return momentEnd.isBefore(momentNow);
+}

--- a/server/filters/index.js
+++ b/server/filters/index.js
@@ -36,7 +36,8 @@ import {
   formatAndDedupeOnDate,
   formatAndDedupeOnTime,
   joinDateStrings,
-  formatDayDate
+  formatDayDate,
+  isDatePast
 } from './format-date';
 import {googleCal, yahooCal, iCal, outlookCal} from './add-to-calendar';
 import getLicenseInfo from './get-license-info';
@@ -93,5 +94,6 @@ export default Map({
   googleCal,
   yahooCal,
   iCal,
-  outlookCal
+  outlookCal,
+  isDatePast
 });

--- a/server/views/components/event-promo/event-promo.njk
+++ b/server/views/components/event-promo/event-promo.njk
@@ -49,8 +49,10 @@
       {% endfor %}
       <div class="{{ {s: 2} | spacingClasses({ margin: ['bottom'] }) }}"></div>
 
-      {# TODO: add 'fully booked' status when available #}
-      {% if model.start %}
+      {% set isPast = model.end | isDatePast %}
+      {% if isPast %}
+        <p class="{{ {s: 'HNM6'} | fontClasses }} font-red rounded-corners">Past event</p>
+      {% elif model.start %}
         <p class="{{ {s:'HNL4'} | fontClasses }} no-padding no-margin">
           <time datetime="{{ model.start }}">{{ model.start | formatDayDate }}</time>
         </p>
@@ -70,7 +72,7 @@
         </p>
       {% endif %}
 
-      {% if model.isFullyBooked %}
+      {% if model.isFullyBooked and not isPast %}
         <div class="{{- [
           {s:'HNM5'} | fontClasses
         ].join(' ') }} flex flex--v-center margin-top-auto">


### PR DESCRIPTION
Closes #2354

- [x] Only the last 3 past events should be displayed, most recent first
- [x] The past events should be listed separately from upcoming events
- [x] The past event promos should highlight the fact that they are past events

Worth noting the 'past event' label will be added to all event promos that have ended in the past (not just those on the event-series pages – this consistency seems like desirable 

Obviously needs more design (@Heesoomoon and Gareth) (but perhaps good enough to ship?)

![screen shot 2018-03-20 at 16 58 13](https://user-images.githubusercontent.com/1394592/37670404-1b7b2fd6-2c61-11e8-8fa9-d2e80ae34c84.png)