### PR TITLE
add prismic preview toolbar as test to articles

### DIFF
--- a/common/styles/components/_prismic_toolbar.scss
+++ b/common/styles/components/_prismic_toolbar.scss
@@ -1,0 +1,18 @@
+.wio-link {
+  position: fixed;
+  border-radius: 50%;
+  width: 46px;
+  height: 46px;
+  z-index: 100;
+  top: $spacing-unit * 5;
+  right: $spacing-unit * 5;
+  background-color: #ffce3c;
+  display: flex;
+
+  img {
+    width: 18px !important;
+    height: 18px !important;
+    margin: 0 auto;
+    align-self: center;
+  }
+}

--- a/common/styles/non-critical.scss
+++ b/common/styles/non-critical.scss
@@ -16,6 +16,7 @@
 @import 'components/is_preview';
 @import 'components/opening_hours';
 @import 'components/pre';
+@import 'components/prismic_toolbar';
 @import 'components/quote';
 @import 'components/slider';
 @import 'components/slider__gallery';

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -226,6 +226,7 @@ export function parseArticleDoc(doc: PrismicDoc): Article {
 
   const article: Article = {
     contentType: 'article',
+    id: doc.id,
     headline: headline,
     url: url,
     datePublished: publishDate,

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -11,6 +11,15 @@
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
   <meta name="description" content="{{ article.description | safe | striptags }}" />
+
+  {% if isPreview %}
+    <script>
+      window.prismic = {
+        endpoint: 'https://wellcomecollection.prismic.io/api/v2'
+      };
+    </script>
+    <script type="text/javascript" src="//static.cdn.prismic.io/prismic.min.js"></script>
+  {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -38,7 +47,7 @@
   <script type="application/ld+json">
     {{ article | jsonLd('contentLd') | safe }}
   </script>
-  <article>
+  <article data-wio-id="{{ article.id }}">
     {% componentV2 'page-description', {
       intro: seriesTitle,
       title: article.headline,


### PR DESCRIPTION
# As a content editor I want better integration with editing in Prismic and Prismic previews

There is a pre-build prismic toolbar. It has:
* edit button from the article
* Preview sharing

~The button could do with a little styling.~

![bongs](https://user-images.githubusercontent.com/31692/37702712-5214e052-2ceb-11e8-8194-5227a99e0695.png)

## Better button styling:
<img width="579" alt="screen shot 2018-03-21 at 09 52 14" src="https://user-images.githubusercontent.com/31692/37703467-adde5344-2ced-11e8-94ea-166c99376ff2.png">

