### PR TITLE
Display 'no upcoming events' where necessary

### DIFF
--- a/events/app/views/pages/event-series.njk
+++ b/events/app/views/pages/event-series.njk
@@ -41,33 +41,41 @@
   {% endif %}
 
   <div class="row {{ {s: 6} | spacingClasses({margin: ['top']}) }} {{ {s: 10} | spacingClasses({margin: ['bottom']}) }}">
-    <div class="container">
-      <h2 class="{{ {s: 'WB5'} | fontClasses }} no-margin">Upcoming events</h2>
-    </div>
-    <div class="css-grid__container {{ {s: 4} | spacingClasses({padding: ['top']}) }} ">
-      <div class="css-grid">
-        {% for event in paginatedEvents.results %}
-          <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
-            {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
-          </div>
-        {% endfor %}
+    {% if paginatedEvents.results.length > 0 %}
+      <div class="container">
+        <h2 class="{{ {s: 'WB5'} | fontClasses }} no-margin">Upcoming events</h2>
       </div>
+      <div class="css-grid__container {{ {s: 4} | spacingClasses({padding: ['top']}) }} ">
+        <div class="css-grid">
+          {% for event in paginatedEvents.results %}
+            <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
+              {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="container">
+          <h2 class="{{ {s: 'WB5'} | fontClasses }} no-margin">No upcoming events</h2>
+        </div>
+      {% endif %}
     </div>
   </div>
 
   <div class="row {{ {s: 10} | spacingClasses({margin: ['bottom']}) }}">
-    <div class="container">
-      <h2 class="{{ {s: 'WB5'} | fontClasses }} no-margin">Past events</h2>
-    </div>
-    <div class="css-grid__container {{ {s: 4} | spacingClasses({padding: ['top']}) }} ">
-      <div class="css-grid">
-        {% for event in pastEvents.results %}
-          <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
-            {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
-          </div>
-        {% endfor %}
+    {% if pastEvents.results.length > 0 %}
+      <div class="container">
+        <h2 class="{{ {s: 'WB5'} | fontClasses }} no-margin">Past events</h2>
       </div>
-    </div>
+      <div class="css-grid__container {{ {s: 4} | spacingClasses({padding: ['top']}) }} ">
+        <div class="css-grid">
+          {% for event in pastEvents.results %}
+            <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
+              {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
   </div>
 
   <div class="css-grid__container {{ {s:2, m:2, l:2} | spacingClasses({padding: ['top']}) }} {{ {s:3, m:3, l:3} | spacingClasses({padding: ['bottom']}) }} ">

--- a/server/views/components/event-promo/event-promo.njk
+++ b/server/views/components/event-promo/event-promo.njk
@@ -51,7 +51,7 @@
 
       {% set isPast = model.end | isDatePast %}
       {% if isPast %}
-        <p class="{{ {s: 'HNM6'} | fontClasses }} font-red rounded-corners">Past event</p>
+        <p class="{{ {s: 'HNM6'} | fontClasses }} font-red">Past event</p>
       {% elif model.start %}
         <p class="{{ {s:'HNL4'} | fontClasses }} no-padding no-margin">
           <time datetime="{{ model.start }}">{{ model.start | formatDayDate }}</time>

--- a/server/views/components/event-promo/event-promo.njk
+++ b/server/views/components/event-promo/event-promo.njk
@@ -50,9 +50,7 @@
       <div class="{{ {s: 2} | spacingClasses({ margin: ['bottom'] }) }}"></div>
 
       {% set isPast = model.end | isDatePast %}
-      {% if isPast %}
-        <p class="{{ {s: 'HNM6'} | fontClasses }} font-red">Past event</p>
-      {% elif model.start %}
+      {% if model.start and not isPast %}
         <p class="{{ {s:'HNL4'} | fontClasses }} no-padding no-margin">
           <time datetime="{{ model.start }}">{{ model.start | formatDayDate }}</time>
         </p>
@@ -80,6 +78,15 @@
             {% icon 'status_indicator', null, ['icon--red', 'icon--match-text'] %}
           </span>
           Fully booked{{ ', more dates available' if model.hasNotFullyBookedTimes }}
+        </div>
+      {% elif isPast %}
+        <div class="{{- [
+          {s:'HNM5'} | fontClasses
+        ].join(' ') }} flex flex--v-center margin-top-auto">
+          <span class="{{ {s:1} | spacingClasses({margin: ['right']}) }} flex flex--v-center">
+            {% icon 'status_indicator', null, ['icon--red', 'icon--match-text'] %}
+          </span>
+          Past event
         </div>
       {% elif model.eventbriteId %}
         <div


### PR DESCRIPTION
References #2355 
![screen shot 2018-03-21 at 11 01 28](https://user-images.githubusercontent.com/1394592/37706386-415bcd96-2cf7-11e8-8bf8-bf3752f5dec2.png)

- [ ] Needs message text?

(Also moves 'past event' messaging to same style/location as status (e.g. 'fully booked') messaging).
