### PR TITLE
Add basic background implementation

### DIFF
--- a/common/styles/components/_event_schedule.scss
+++ b/common/styles/components/_event_schedule.scss
@@ -21,6 +21,12 @@
   z-index: -1;
   height: 60vh;
   width: 100%;
+  background-repeat: repeat;
+  background-size: 7vw;
+
+  @include respond-to('xlarge') {
+    background-size: 80px;
+  }
 }
 
 .event-schedule__partnership {

--- a/common/styles/components/_event_schedule.scss
+++ b/common/styles/components/_event_schedule.scss
@@ -19,13 +19,19 @@
   top: 0;
   position: fixed;
   z-index: -1;
-  height: 60vh;
+  height: 40vw;
+  max-height: 66vh;
   width: 100%;
-  background-repeat: repeat;
-  background-size: 7vw;
+  background-size: 150%;
+  background-position: top;
+
+  @include respond-to('medium') {
+    background-size: 120%;
+  }
 
   @include respond-to('xlarge') {
-    background-size: 80px;
+    background-size: 100%;
+    height: 33vw;
   }
 }
 

--- a/events/app/views/partials/event_with_schedule.njk
+++ b/events/app/views/partials/event_with_schedule.njk
@@ -1,5 +1,6 @@
 <div class="event-schedule row relative">
-  <div class="event-schedule__header-image bg-turquoise">
+  <div class="event-schedule__header-image overflow-hidden {{ 'bg-turquoise' if not event.backgroundTexture }}"
+  {% if event.backgroundTexture %}style="background-image: url({{ event.backgroundTexture }});"{% endif %}>
     <div class="event-schedule__wobbly-edge absolute">
       <div class="wobbly-edge wobbly-edge--white js-wobbly-edge"
         data-is-valley="true"

--- a/prismic-model/json/background-textures.json
+++ b/prismic-model/json/background-textures.json
@@ -1,0 +1,13 @@
+{
+  "BackgroundTexture" : {
+    "backgroundTexture" : {
+      "type" : "Image"
+    },
+    "backgroundName" : {
+      "type" : "Text",
+      "config" : {
+        "label" : "Background name"
+      }
+    }
+  }
+}

--- a/prismic-model/json/background-textures.json
+++ b/prismic-model/json/background-textures.json
@@ -1,12 +1,12 @@
 {
   "BackgroundTexture" : {
-    "backgroundTexture" : {
+    "image" : {
       "type" : "Image"
     },
-    "backgroundName" : {
+    "name" : {
       "type" : "Text",
       "config" : {
-        "label" : "Background name"
+        "label" : "name"
       }
     }
   }

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -243,9 +243,11 @@
       }
     },
     "backgroundTexture" : {
-      "type" : "Image",
+      "type" : "Link",
       "config" : {
-        "label" : "Background texture"
+        "label" : "Background texture",
+        "select" : "document",
+        "customtypes" : [ "background-textures" ]
       }
     }
   }

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -241,6 +241,12 @@
           }
         }
       }
+    },
+    "backgroundTexture" : {
+      "type" : "Image",
+      "config" : {
+        "label" : "Background texture"
+      }
     }
   }
 }

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -108,7 +108,11 @@ export type Event = {|
   bookingType: ?string,
   schedule?: Array<Event>,
   eventbriteId?: string,
-  isCompletelySoldOut?: boolean,
+  isCompletelySoldOut?: boolean
+|}
+
+export type DisplayEvent = {|
+  ...Event,
   backgroundTexture?: string
 |}
 

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -108,7 +108,8 @@ export type Event = {|
   bookingType: ?string,
   schedule?: Array<Event>,
   eventbriteId?: string,
-  isCompletelySoldOut?: boolean
+  isCompletelySoldOut?: boolean,
+  backgroundTexture?: string
 |}
 
 export type EventPromo = {|

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -3,7 +3,7 @@ import {List} from 'immutable';
 import {RichText, Date as PrismicDate} from 'prismic-dom';
 import type {Exhibition} from '../content-model/exhibition';
 import type {
-  EventTime, Event, Contributor, Team,
+  EventTime, DisplayEvent, Contributor, Team,
   Place, EventFormat, Audience
 } from '../content-model/events';
 import getBreakpoint from '../filters/get-breakpoint';
@@ -24,7 +24,7 @@ type PrismicDoc = Object;
 // This is because it could be any part of a JSON doc
 type PrismicDocFragment = Object | Array<any>;
 
-export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): Event {
+export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): DisplayEvent {
   const eventSchedule = scheduleDocs && scheduleDocs.results.map(doc => parseEventDoc(doc));
   const promo = parseImagePromo(doc.data.promo);
 
@@ -133,10 +133,10 @@ export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): Event
     bookingType: bookingType,
     cost: cost,
     schedule: eventSchedule,
-    backgroundTexture: doc.data.backgroundTexture && doc.data.backgroundTexture.url,
+    backgroundTexture: doc.data.backgroundTexture.data && doc.data.backgroundTexture.data.backgroundTexture.url,
     eventbriteId,
     isCompletelySoldOut
-  }: Event);
+  }: DisplayEvent);
 
   return e;
 }

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -133,6 +133,7 @@ export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): Event
     bookingType: bookingType,
     cost: cost,
     schedule: eventSchedule,
+    backgroundTexture: doc.data.backgroundTexture && doc.data.backgroundTexture.url,
     eventbriteId,
     isCompletelySoldOut
   }: Event);

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -133,7 +133,7 @@ export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): Displ
     bookingType: bookingType,
     cost: cost,
     schedule: eventSchedule,
-    backgroundTexture: doc.data.backgroundTexture.data && doc.data.backgroundTexture.data.backgroundTexture.url,
+    backgroundTexture: doc.data.backgroundTexture.data && doc.data.backgroundTexture.data.image.url,
     eventbriteId,
     isCompletelySoldOut
   }: DisplayEvent);

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -46,7 +46,7 @@ const eventFields = [
   'interpretation-types.description', 'interpretation-types.primaryDescription',
   'audiences.title',
   'event-series.title', 'event-series.description',
-  'organisations.name', 'organisations.image', 'organisations.url', 'background-textures.backgroundTexture'
+  'organisations.name', 'organisations.image', 'organisations.url', 'background-textures.image'
 ];
 
 export const defaultPageSize = 40;

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -46,7 +46,7 @@ const eventFields = [
   'interpretation-types.description', 'interpretation-types.primaryDescription',
   'audiences.title',
   'event-series.title', 'event-series.description',
-  'organisations.name', 'organisations.image', 'organisations.url'
+  'organisations.name', 'organisations.image', 'organisations.url', 'background-textures.backgroundTexture'
 ];
 
 export const defaultPageSize = 40;


### PR DESCRIPTION
Adding a `backgroundTexture` property to the `Event` model so that we can display a background image at the top of the events with schedules.

I'm not really happy with the implementation though – doesn't really seem like this deserves to be part of the event model. I'm still not clear on how much freedom we want to give to anyone adding this content as regards which image should appear behind. Ideas?

One idea is that an event could be given a 'mood' (or something similar) property, and we select an appropriate background from a pre-determined library based on this mood. Which would be _less_ of an abuse of the event model.

![screen shot 2018-03-21 at 14 54 56](https://user-images.githubusercontent.com/1394592/37717542-aa9d28b0-2d18-11e8-8f90-3a1abb6e530e.png)
