### PR TITLE
Fix wobbly line on articles

### DIFF
--- a/client/js/components/wobbly-edge.js
+++ b/client/js/components/wobbly-edge.js
@@ -29,7 +29,7 @@ const wobblyEdge = (el) => {
 
   const polygonPoints = (totalPoints, intensity) => {
     // Determine whether wobbly edge should be a mountain or a valley
-    const first = settings.isValley ? '0% 100%, 0% 0%,' : '0% 100%';
+    const first = settings.isValley ? '0% 100%, 0% 0%,' : '0% 100%,';
     const last = settings.isValley ? ',100% 0%, 100% 100%' : ',100% 100%';
     const innerPoints = [];
 


### PR DESCRIPTION
While updating the wobbly line to allow for 'valleys' and 'mountains', I missed a comma off the start of the mountain string, which breaks the wobbly line. Everything's cool with this re-added comma.