### PR TITLE
Make Safari transition clip-path

### DIFF
--- a/common/styles/components/_wobbly_edge.scss
+++ b/common/styles/components/_wobbly_edge.scss
@@ -4,7 +4,7 @@
   position: relative;
   top: 2px;
   z-index: 2;
-  transition: clip-path 2000ms ease-in-out;
+  transition: -webkit-clip-path 2000ms ease-in-out, clip-path 2000ms ease-in-out;
   display: none;
 
   @include respond-to('large') {


### PR DESCRIPTION
Safari doesn't need the `-webkit` prefix for `clip-path`, but it fails to transition the property without it.

Autoprefixer presumably doesn't add it because Safari doesn't report needing it.