### PR TITLE
Change 'Explore' to 'Stories'

### DIFF
--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -86,7 +86,7 @@ const navLinks = [{
   siteSection: 'whatson'
 }, {
   href: '/explore',
-  title: 'Explore',
+  title: 'Stories',
   siteSection: 'explore'
 }, {
   href: '/works',

--- a/common/views/components/FooterNav/FooterNav.js
+++ b/common/views/components/FooterNav/FooterNav.js
@@ -13,7 +13,7 @@ const navLinks = [
   },
   {
     url: '/explore',
-    text: 'Explore'
+    text: 'Stories'
   },
   {
     url: '/works',

--- a/server/views/components/footer-nav/footer-nav.config.js
+++ b/server/views/components/footer-nav/footer-nav.config.js
@@ -11,7 +11,7 @@ export const context = {
     title: `What's on`
   }, {
     href: '#',
-    title: 'Explore'
+    title: 'Stories'
   }, {
     href: '#',
     title: 'What we do'

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -51,7 +51,7 @@
       },
       {
         href: '/explore',
-        title: 'Explore',
+        title: 'Stories',
         isCurrent: pageConfig.inSection === 'explore'
       },
       {

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -33,7 +33,7 @@
     } %}
     {% componentV2 'list-header', listHeader %}
   {% else %}
-    {% componentV2 'page-description', { title: 'Explore' }, {'hidden': true} %}
+    {% componentV2 'page-description', { title: 'Stories' }, {'hidden': true} %}
   {% endif %}
   <div class="row bg-cream row--has-wobbly-background {{ {s:10} | spacingClasses({padding: ['top']}) }}">
     <div class="container">

--- a/server/views/templates/explore.njk
+++ b/server/views/templates/explore.njk
@@ -1,7 +1,7 @@
 {% extends "layout/default.njk" %}
 
 {% block body %}
-  {% componentV2 'page-description', { title: 'Explore' }, {'hidden': true} %}
+  {% componentV2 'page-description', { title: 'Stories' }, {'hidden': true} %}
 
   <div class="row bg-cream row--has-wobbly-background {{ {s:10} | spacingClasses({padding: ['top']}) }}">
     <div class="container">


### PR DESCRIPTION
Changing 'Explore' to 'Stories' because there wasn't a difference in A/B and we prefer 'Stories'.

This doesn't affect the url or the `inSection` (used to e.g. highlight active route in nav).