### PR TITLE
Add space in footer address

### DIFF
--- a/common/views/components/FindUs/FindUs.js
+++ b/common/views/components/FindUs/FindUs.js
@@ -18,7 +18,7 @@ const FindUs = () => (
         <Icon name='location' extraClasses={`float-l ${spacing({s: 2, m: 2, l: 2, xl: 2}, {margin: ['right']})}`} />
         <p>
           <span className='find-us__street'>{wellcomeCollectionAddress.streetAddress}</span>
-          <span className='find-us__locality'>{wellcomeCollectionAddress.addressLocality}</span>
+          <span className='find-us__locality'>{wellcomeCollectionAddress.addressLocality}</span>{' '}
           <span className='find-us__postal-code'>{wellcomeCollectionAddress.postalCode}</span>
           <span className='find-us__country'>{wellcomeCollectionAddress.addressCountry}</span>
         </p>


### PR DESCRIPTION
Inline elements in HTML add a space for a newline. [This isn't true for JSX](https://github.com/facebook/react/issues/1643#issuecomment-45148887):

> This is an intentional deviation from HTML because usually you don't want extra whitespace between tags. See here for a summary of the current rules:

http://facebook.github.io/react/blog/2014/02/20/react-v0.9.html#jsx-whitespace

One fix is to add `{' '}` after inline elements that want space when written on a new line.