### PR TITLE
Hide past parts of multi-part events on event pages

### DIFF
--- a/events/app/views/partials/event_without_schedule.njk
+++ b/events/app/views/partials/event_without_schedule.njk
@@ -78,31 +78,33 @@
 
         <div class="{{ {s:'HNL4'} | fontClasses }}">
           {% for eventTime in event.times %}
-            <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
-              {% set formattedDateRange = eventTime.range.startDateTime | formatAndDedupeOnDate(eventTime.range.endDateTime) %}
-              <time class="block">
-                <b class="{{ {s:'HNM4'} | fontClasses }}">{{ formattedDateRange | joinDateStrings }}</b>
-              </time>
-              {% if (formattedDateRange.size === 1) %}
-                <div class="flex">
-                  <time class="block">
-                    {{ eventTime.range.startDateTime | formatAndDedupeOnTime(eventTime.range.endDateTime) | joinDateStrings }}
-                  </time>
-                  {% if eventTime.isFullyBooked and not event.isCompletelySoldOut %}
-                    <div class="{{- [
-                      {s:'HNM5'} | fontClasses,
-                      {s:2} | spacingClasses({margin: ['left']
-                      })
-                    ].join(' ') }} flex flex--v-center">
-                      <span class="{{ {s:1} | spacingClasses({margin: ['right']}) }} flex flex--v-center">
-                        {% icon 'status_indicator', null, ['icon--red', 'icon--match-text'] %}
-                      </span>
-                      Fully booked
-                    </div>
-                  {% endif %}
-                </div>
-              {% endif %}
-            </div>
+            {% if not eventTime.range.endDateTime | isDatePast %}
+              <div class="border-top-width-1 border-color-pumice {{ {s: 2} | spacingClasses({padding: ['top', 'bottom']}) }}">
+                {% set formattedDateRange = eventTime.range.startDateTime | formatAndDedupeOnDate(eventTime.range.endDateTime) %}
+                <time class="block">
+                  <b class="{{ {s:'HNM4'} | fontClasses }}">{{ formattedDateRange | joinDateStrings }}</b>
+                </time>
+                {% if (formattedDateRange.size === 1) %}
+                  <div class="flex">
+                    <time class="block">
+                      {{ eventTime.range.startDateTime | formatAndDedupeOnTime(eventTime.range.endDateTime) | joinDateStrings }}
+                    </time>
+                    {% if eventTime.isFullyBooked and not event.isCompletelySoldOut %}
+                      <div class="{{- [
+                        {s:'HNM5'} | fontClasses,
+                        {s:2} | spacingClasses({margin: ['left']
+                        })
+                      ].join(' ') }} flex flex--v-center">
+                        <span class="{{ {s:1} | spacingClasses({margin: ['right']}) }} flex flex--v-center">
+                          {% icon 'status_indicator', null, ['icon--red', 'icon--match-text'] %}
+                        </span>
+                        Fully booked
+                      </div>
+                    {% endif %}
+                  </div>
+                {% endif %}
+              </div>
+            {% endif %}
           {% endfor %}
 
           {% if event.eventbriteId %}


### PR DESCRIPTION
The events page currently displays all parts of multi-part events, past and future.

This work hides the past ones.

An alternative would be to add 'Past event' in the status style, as we've recently implemented on the `/events` page (https://wellcomecollection.org/events).

@jennpb do you have a preference?

Another consideration is the 'Free admission | Enquire to book' messaging – perhaps that needs to be switched out with 'Past event' once all events are in the past?

Keeping as WIP while we decide which implementation we prefer.