### PR TITLE
run test on cookie notification position

### DIFF
--- a/common/styles/components/_cookie_notification.scss
+++ b/common/styles/components/_cookie_notification.scss
@@ -4,7 +4,6 @@
   background: color('teal');
   color: color('white');
   padding: $vertical-space-unit 0;
-  position: fixed;
   bottom: 0;
   left: 0;
   right: 0;
@@ -19,6 +18,10 @@
   .icon__shape {
     fill: color('white');
   }
+}
+
+.cookie-notification--is-fixed {
+  position: fixed;
 }
 
 .cookie-notification__inner {

--- a/server/views/components/cookie-notification/cookie-notification.njk
+++ b/server/views/components/cookie-notification/cookie-notification.njk
@@ -1,4 +1,5 @@
-<div class="cookie-notification is-hidden {{ {s:'HNM6', m:'HNM4'} | fontClasses }} js-info-banner"
+{{data | dump}}
+<div class="cookie-notification is-hidden {{ {s:'HNM6', m:'HNM4'} | fontClasses }} js-info-banner {{ 'cookie-notification--is-fixed' if isFixed }}"
   data-cookie-name="WC_cookiesAccepted">
   <div class="container">
     <div class="grid">

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -39,6 +39,10 @@
   <body {% if isPreview %}class="is-preview"{% endif %} data-page-state='{{ (pageConfig.pageState or {}) | dump | safe }}'>
     {% component 'skip-link' %}
 
+    {% if featuresCohort === 'testB' %}
+      {% component 'cookie-notification', { isFixed: false } %}
+    {% endif %}
+
     {% set navLinks = [
       {
         href: 'https://wellcomecollection.org/visit',
@@ -73,7 +77,10 @@
 
     {% componentJsx 'Footer', {openingHoursId: 'footer'} %}
 
-    {% component 'cookie-notification' %}
+
+    {% if featuresCohort !== 'testB' %}
+      {% component 'cookie-notification', { isFixed: true } %}
+    {% endif %}
 
     <noscript>
       <link rel="stylesheet" href="{{ '/assets/css/' | getHashedFile('non-critical.css') }}">


### PR DESCRIPTION
During in-person testing it seemed as though the cookie notification causes a natural barrier to what people might consider the end of the page [see screenshots].

Put it in as a test, but might need to think about what data to use for success measures.

We can use scroll depth, but we don't append whether the bar is visible or not to the pageview, so it would be hard to measure only scroll depth of pages with the cookie notification.

We could however measure that we aren't breaking anything by moving it up, and then rely on the qualitative research to make the decision on moving it.

## Top notification
![screen shot 2018-03-26 at 17 42 29](https://user-images.githubusercontent.com/31692/37920341-85f1586a-311e-11e8-872f-4d4cc7a89d30.png)

## End of the page?
![screen shot 2018-03-26 at 17 43 38](https://user-images.githubusercontent.com/31692/37920184-19c4d0e0-311e-11e8-8342-103da62512f2.png)
![screen shot 2018-03-26 at 17 43 45](https://user-images.githubusercontent.com/31692/37920185-19dbf7a2-311e-11e8-9a21-eb667a3486f9.png)
