### PR TITLE
Added heading to cookie notification

### DIFF
--- a/server/views/components/cookie-notification/cookie-notification.njk
+++ b/server/views/components/cookie-notification/cookie-notification.njk
@@ -5,9 +5,9 @@
     <div class="grid">
       <div class="grid__cell">
         <div class="cookie-notification__inner">
-          <span class="cookie-notification__content">
+          <h2 class="cookie-notification__content">
             {% icon 'cookies' %}<p class="cookie-notification__text">Wellcome uses cookies. <a href="https://wellcome.ac.uk/about-us/terms-use#cookies">Read our policy</a>.</p>
-          </span>
+          </h2>
           <button class="cookie-notification__close js-info-banner-close">
             {% icon 'cross', 'Close cookie notification' %}
           </button>

--- a/server/views/components/cookie-notification/cookie-notification.njk
+++ b/server/views/components/cookie-notification/cookie-notification.njk
@@ -1,13 +1,16 @@
-{{data | dump}}
-<div class="cookie-notification is-hidden {{ {s:'HNM6', m:'HNM4'} | fontClasses }} js-info-banner {{ 'cookie-notification--is-fixed' if isFixed }}"
+<div class="cookie-notification is-hidden {{ {s:'HNM6', m:'HNM4'} | fontClasses }} js-info-banner"
   data-cookie-name="WC_cookiesAccepted">
   <div class="container">
     <div class="grid">
       <div class="grid__cell">
         <div class="cookie-notification__inner">
-          <h2 class="cookie-notification__content">
-            {% icon 'cookies' %}<p class="cookie-notification__text">Wellcome uses cookies. <a href="https://wellcome.ac.uk/about-us/terms-use#cookies">Read our policy</a>.</p>
-          </h2>
+          <div class="cookie-notification__content">
+            {% icon 'cookies' %}
+            <div class="cookie-notification__text">
+            <h2 class="no-margin inline">Wellcome uses cookies.</h2>
+            <a href="https://wellcome.ac.uk/about-us/terms-use#cookies">Read our policy</a>.
+            </div>
+          </div>
           <button class="cookie-notification__close js-info-banner-close">
             {% icon 'cross', 'Close cookie notification' %}
           </button>


### PR DESCRIPTION
## Type
🚑 Health

## Value
Makes the cookie notice more discoverable by users of AT, such as screen readers
