### PR TITLE
Allow TASL information to appear at top right

### DIFF
--- a/common/views/components/Picture/Picture.js
+++ b/common/views/components/Picture/Picture.js
@@ -6,10 +6,11 @@ import {convertImageUri} from '../../../utils/convert-image-uri';
 
 type Props = {|
   images: PictureProps[],
-  extraClasses?: string
+  extraClasses?: string,
+  isFull: boolean
 |};
 
-const Picture = ({ images, extraClasses }: Props) => {
+const Picture = ({ images, extraClasses, isFull = false }: Props) => {
   const lastImage = images[images.length - 1];
   return (
     <figure className='relative no-margin'>
@@ -45,7 +46,7 @@ const Picture = ({ images, extraClasses }: Props) => {
         license={lastImage.license}
         copyrightHolder={lastImage.copyright && lastImage.copyright.holder}
         copyrightLink={lastImage.copyright && lastImage.copyright.link}
-        isFull={false}
+        isFull={isFull}
       />}
     </figure>
   );

--- a/exhibitions/app/views/pages/exhibition.njk
+++ b/exhibitions/app/views/pages/exhibition.njk
@@ -29,7 +29,8 @@
       <div class="exhibition-hero">
         {% componentJsx 'Picture', {
           images: exhibition.featuredImages.toJS(),
-          extraClasses: 'exhibition-hero__picture'
+          extraClasses: 'exhibition-hero__picture',
+          isFull: true
         }%}
 
         <div class="exhibition-hero__copy {{ {l:10} | spacingClasses({margin: ['bottom']}) }}">

--- a/whats_on/app/views/pages/installation.njk
+++ b/whats_on/app/views/pages/installation.njk
@@ -25,7 +25,8 @@
     <div class="exhibition-hero">
       {% componentJsx 'Picture', {
         images: featredImageList,
-        extraClasses: 'exhibition-hero__picture'
+        extraClasses: 'exhibition-hero__picture',
+        isFull: true
       }%}
 
       <div class="exhibition-hero__copy {{ {l:10} | spacingClasses({margin: ['bottom']}) }}">


### PR DESCRIPTION
Hero images TASL should appear top-right (so's to avoid being covered by the wobbly-edge). This fixes a regression that prevented that from happening.

![screen shot 2018-03-28 at 10 09 42](https://user-images.githubusercontent.com/1394592/38019758-6111f48e-3270-11e8-8f7c-2a784ab295d6.png)
