### PR TITLE
add page headers as a component type

### DIFF
--- a/cardigan/docs/BodyBlock.jsx
+++ b/cardigan/docs/BodyBlock.jsx
@@ -1,5 +1,4 @@
 // @flow
-
 import {grid, spacing} from '../../common/utils/classnames';
 
 type Props = {|

--- a/common/icons/index.js
+++ b/common/icons/index.js
@@ -31,6 +31,7 @@ import tumblr from './tumblr';
 import youtube from './youtube';
 import tripadvisor from './tripadvisor';
 import wellcome from './wellcome';
+import statusIndicator from './status_indicator';
 export {
   arrow,
   audioDescribed,
@@ -69,5 +70,6 @@ export {
   tumblr,
   youtube,
   tripadvisor,
-  wellcome
+  wellcome,
+  statusIndicator
 };

--- a/common/icons/status_indicator.js
+++ b/common/icons/status_indicator.js
@@ -1,0 +1,5 @@
+const StatusIndicator = () => (
+  <svg viewBox="0 0 26 26"><circle className="icon__shape" cx="13" cy="13" r="10"/></svg>
+);
+
+export default StatusIndicator;

--- a/common/utils/classnames.js
+++ b/common/utils/classnames.js
@@ -1,7 +1,7 @@
 // @flow
+export type SizeMap = { [string]: number };
 type SpacingCssProps = 'margin' | 'padding';
 type SpacingCssPropValues = 'top' | 'bottom' | 'left' | 'right';
-type SizeMap = { [string]: number };
 type SpacingProps = { [SpacingCssProps]: SpacingCssPropValues[] }
 type FontMap = { [string]: string }
 

--- a/common/utils/format-date.js
+++ b/common/utils/format-date.js
@@ -26,3 +26,19 @@ export function isDatePast(date: Date): boolean {
 
   return momentEnd.isBefore(momentNow);
 }
+
+export function formatDateRangeWithMessage({start, end}: {start: Date, end: Date}): {text: string, color: string} {
+  const now = london();
+  const s = london(start);
+  const e = london(end);
+
+  if (s.isAfter(now)) {
+    return {text: 'Coming soon', color: 'marble'};
+  } else if (e.isBefore(now)) {
+    return {text: 'Past', color: 'marble'};
+  } else if (now.isBetween(e.subtract(1, 'w'), e)) {
+    return {text: 'Final week', color: 'orange'};
+  } else {
+    return {text: 'Now on', color: 'green'};
+  }
+}

--- a/common/views/components/Index/index.js
+++ b/common/views/components/Index/index.js
@@ -23,6 +23,7 @@ import Pagination from '../Pagination/Pagination';
 import Promo from '../Promo/Promo';
 import Picture from '../Picture/Picture';
 import ImageGallery from '../ImageGallery/ImageGallery';
+import ExhibitionPageHeader from '../PageHeaders/ExhibitionPageHeader/ExhibitionPageHeader';
 
 export {
   BackToTop,
@@ -49,5 +50,6 @@ export {
   Pagination,
   Promo,
   Picture,
-  ImageGallery
+  ImageGallery,
+  ExhibitionPageHeader
 };

--- a/common/views/components/PageHeaders/ExhibitionPageHeader/ExhibitionPageHeader.config.js
+++ b/common/views/components/PageHeaders/ExhibitionPageHeader/ExhibitionPageHeader.config.js
@@ -1,0 +1,1 @@
+export const hidden = true;

--- a/common/views/components/PageHeaders/ExhibitionPageHeader/ExhibitionPageHeader.js
+++ b/common/views/components/PageHeaders/ExhibitionPageHeader/ExhibitionPageHeader.js
@@ -1,0 +1,52 @@
+// @flow
+import {Fragment} from 'react';
+import Hero from '../Hero/Hero';
+import Icon from '../../Icon/Icon';
+import {formatDate, formatDateRangeWithMessage} from '../../../../utils/format-date';
+import {font, spacing} from '../../../../utils/classnames';
+import type {Picture as PictureProps} from '../../../../model/picture';
+
+type Props = {|
+  title: string,
+  images: PictureProps[],
+  start: Date,
+  end: ?Date
+|}
+
+const ExhibitionPageHeader = ({ title, start, end, images }: Props) => {
+  const dateMessageAndColour = formatDateRangeWithMessage({start, end: (end || new Date())});
+
+  return (
+    <Hero
+      images={images}
+      whiteBox={
+        <Fragment>
+          <div className='flex flex--v-center flex--h-space-between'>
+            <span className={`
+              ${font({s: 'HNM4', m: 'HNM3'})}
+              ${spacing({s: 6}, {margin: ['right']})}
+            `}>Free admission</span>
+            <span className={`flex flex--v-center ${font({s: 'HNM4'})}`}>
+              <span className={`flex flex--v-center ${spacing({s: 1}, {margin: ['right']})}`}>
+                <Icon name='statusIndicator' extraClasses={`icon--match-text icon--${dateMessageAndColour.color}`} />
+              </span>
+              <span>{dateMessageAndColour.text}</span>
+            </span>
+          </div>
+          <h1 className={font({s: 'WB5', m: 'WB4', xl: 'WB3'})}>{title}</h1>
+          {end &&
+            <span className={font({s: 'HNL4', m: 'HNL3', l: 'HNL3', xl: 'HNL2'})}>
+              <time dateTime={start}>{formatDate(start)}</time>
+              &ndash;
+              <time dateTime={end}>{formatDate(end)}</time>
+            </span>
+          }
+        </Fragment>
+      }>
+    </Hero>
+  );
+};
+
+export default ExhibitionPageHeader;
+
+export const hidden = true;

--- a/common/views/components/PageHeaders/Hero/Hero.config.js
+++ b/common/views/components/PageHeaders/Hero/Hero.config.js
@@ -1,0 +1,8 @@
+import {context as pictureContext} from '../../Picture/Picture.config';
+
+export const status = 'wip';
+export const label = 'Hero';
+export const context = {
+  images: pictureContext.images,
+  whiteBox: (<div><h1>Some content for the white box</h1></div>)
+};

--- a/common/views/components/PageHeaders/Hero/Hero.js
+++ b/common/views/components/PageHeaders/Hero/Hero.js
@@ -1,0 +1,46 @@
+// @flow
+import {spacing} from '../../../../utils/classnames';
+import Picture from '../../Picture/Picture';
+import WobblyEdge from '../../WobblyEdge/WobblyEdge';
+import Grid from '../../layout/Grid';
+import Container from '../../layout/Container';
+import type {Picture as PictureProps} from '../../../../model/picture';
+
+type Props = {|
+  images: PictureProps[],
+  whiteBox: React.Node
+|}
+
+const Hero = ({ images, whiteBox }: Props) => (
+  <div className='exhibition-hero'>
+    <Picture
+      images={images}
+      extraClasses='exhibition-hero__picture'
+      isFull={true} />
+
+    <div className={`
+      exhibition-hero__copy
+      ${spacing({l: 10}, {margin: ['bottom']})}
+    `}>
+      <div className='is-hidden-l is-hidden-xl'>
+        <WobblyEdge background='white' />
+      </div>
+      <Container>
+        <Grid sizes={{s: 12, m: 10, shiftM: 1, l: 12, xl: 12}}>
+          <div className={`
+            bg-white
+            inline-block
+            exhibition-hero__box
+            rounded-diagonal
+            ${spacing({s: 4}, {padding: ['top', 'bottom']})}
+            ${spacing({l: 4}, {padding: ['right', 'left']})}
+          `}>
+            {whiteBox}
+          </div>
+        </Grid>
+      </Container>
+    </div>
+  </div>
+);
+
+export default Hero;

--- a/common/views/components/Picture/Picture.config.js
+++ b/common/views/components/Picture/Picture.config.js
@@ -1,1 +1,43 @@
 export const hidden = true;
+export const context = {
+  images: [
+    {
+      'type': 'picture',
+      'contentUrl': 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/221ef6317dc2b0566ecd84870fae23763d9a60e4_c0074807-edit.jpg',
+      'width': 3200,
+      'height': 1500,
+      'alt': 'Photograph of the Medicine Man exhibition at Wellcome Collection showing a wall of oil paintings with two visitors standing in front.',
+      'title': 'Medicine Man exhibition',
+      'author': 'Benjamin Gilbert',
+      'source': {
+        'name': 'Wellcome Collection',
+        'link': null
+      },
+      'license': 'CC-BY',
+      'copyright': {
+        'holder': null,
+        'link': null
+      },
+      'minWidth': '600px'
+    },
+    {
+      'type': 'picture',
+      'contentUrl': 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/0d34260cedf78b0df30e48fd9eeb4aa88426cb4c_c0074807-edit.jpg',
+      'width': 3200,
+      'height': 3200,
+      'alt': 'Photograph of the Medicine Man exhibition at Wellcome Collection showing a wall of oil paintings with two visitors standing in front.',
+      'title': 'Medicine Man exhibition',
+      'author': 'Benjamin Gilbert',
+      'source': {
+        'name': 'Wellcome Collection',
+        'link': null
+      },
+      'license': 'CC-BY',
+      'copyright': {
+        'holder': null,
+        'link': null
+      },
+      'minWidth': '0'
+    }
+  ]
+};

--- a/common/views/components/WobblyEdge/WobblyEdge.config.js
+++ b/common/views/components/WobblyEdge/WobblyEdge.config.js
@@ -1,0 +1,4 @@
+// This is in wip as we need to give examples of where and how to use
+// and not use this component
+export const status = 'wip';
+export const label = 'Wobbly edge';

--- a/common/views/components/WobblyEdge/WobblyEdge.js
+++ b/common/views/components/WobblyEdge/WobblyEdge.js
@@ -2,14 +2,16 @@
 type Props = {|
   background: string,
   intensity?: number,
-  points?: number
+  points?: number,
+  isValley?: boolean
 |}
 
-const WobblyEdge = ({ intensity, points, background }: Props) => (
+const WobblyEdge = ({ intensity, points, background, isValley }: Props) => (
   <div
     className={`wobbly-edge wobbly-edge--${background} js-wobbly-edge`}
     data-max-intensity={intensity}
-    data-number-of-points={points}>
+    data-number-of-points={points}
+    data-is-valley={isValley}>
   </div>
 );
 

--- a/common/views/components/WobblyEdge/WobblyEdge.js
+++ b/common/views/components/WobblyEdge/WobblyEdge.js
@@ -1,0 +1,16 @@
+// @flow
+type Props = {|
+  background: string,
+  intensity?: number,
+  points?: number
+|}
+
+const WobblyEdge = ({ intensity, points, background }: Props) => (
+  <div
+    className={`wobbly-edge wobbly-edge--${background} js-wobbly-edge`}
+    data-max-intensity={intensity}
+    data-number-of-points={points}>
+  </div>
+);
+
+export default WobblyEdge;

--- a/common/views/components/layout/Container.js
+++ b/common/views/components/layout/Container.js
@@ -1,0 +1,13 @@
+// @flow
+
+type Props = {|
+  children: React.Node
+|};
+
+const Container = ({ children }: Props) => (
+  <div className='container'>
+    {children}
+  </div>
+);
+
+export default Container;

--- a/common/views/components/layout/Grid.js
+++ b/common/views/components/layout/Grid.js
@@ -1,0 +1,18 @@
+// @flow
+import {grid} from '../../../utils/classnames';
+import type {SizeMap} from '../../../utils/classnames';
+
+type Props = {|
+  children: React.Node,
+  sizes: SizeMap
+|}
+
+const Grid = ({children, sizes}: Props) => (
+  <div className='grid'>
+    <div className={grid(sizes)}>
+      {children}
+    </div>
+  </div>
+);
+
+export default Grid;

--- a/exhibitions/app/views/pages/exhibition.njk
+++ b/exhibitions/app/views/pages/exhibition.njk
@@ -26,46 +26,12 @@
         {% componentV2 'tags', tags %}
       </div>
 
-      <div class="exhibition-hero">
-        {% componentJsx 'Picture', {
-          images: exhibition.featuredImages.toJS(),
-          extraClasses: 'exhibition-hero__picture',
-          isFull: true
-        }%}
-
-        <div class="exhibition-hero__copy {{ {l:10} | spacingClasses({margin: ['bottom']}) }}">
-          <div class="is-hidden-l is-hidden-xl">
-            {% component 'wobbly-edge', {background: 'white'} %}
-          </div>
-
-          <div class="container">
-            <div class="grid">
-              <div class="{{ {s:12, m:10, shiftM:1, l:12, xl:12} | gridClasses }}">
-                <div class="bg-white inline-block exhibition-hero__box {{ {l:4} | spacingClasses({'padding': ['right', 'left']}) }} {{ {s:4} | spacingClasses({'padding': ['top', 'bottom']}) }} rounded-diagonal">
-                  <div class="flex flex--v-center flex--h-space-between">
-                    <span class="{{ {s:'HNM4', m:'HNM3'} | fontClasses }} {{ {s: 6} | spacingClasses({margin: ['right']}) }}">Free admission</span>
-                    <span class="flex flex--v-center {{ {s:'HNM4'} | fontClasses }}">
-                    {% set dateMessageAndColor = {start: exhibition.start, end: exhibition.end} | formatDateRangeWithMessage %}
-                      <span class="{{ {s:1} | spacingClasses({margin: ['right']}) }} flex flex--v-center">
-                      {% set statusColor = 'icon--' + dateMessageAndColor.color %}
-                        {% icon 'status_indicator', null, [statusColor, 'icon--match-text'] %}
-                    </span>
-                    <span>{{ dateMessageAndColor.text }}</span>
-                  </span>
-                  </div>
-                  <h1 class="{{ {s:'WB5', m:'WB4', xl:'WB3'} | fontClasses }}">{{ exhibition.title }}</h1>
-                  <span class="{{ {s:'HNL4', m:'HNL3', l:'HNL3', xl:'HNL2'} | fontClasses }}">
-                  {% if exhibition.end %}
-                    <time datetime="{{ exhibition.start }}">{{ exhibition.start | formatDate }}</time>&ndash;<time datetime="{{ exhibition.end }}">{{ exhibition.end | formatDate }}</time>
-                  {% endif %}
-                </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
+      {% componentJsx 'ExhibitionPageHeader', {
+        title: exhibition.title,
+        images: exhibition.featuredImages.toJS(),
+        start: exhibition.start,
+        end: exhibition.end
+      } %}
 
       <div class="is-hidden-s is-hidden-m">
         {% component 'wobbly-edge', {background: 'white', intensity: 30} %}


### PR DESCRIPTION
As we're thinking about our site in more conceptual and abstract terms, I think it would be safe to assume that we can have the concept of a page header, as we use it all over the place.

So far we seem to have
* Hero e.g. https://wellcomecollection.org/exhibitions/WeobUyQAAKdwjbEO
* Text only: https://wellcomecollection.org/event-series/WoK-NioAACkANeWK
* Text with texture: https://wellcomecollection.org/events/Wqkd1yUAAB8sW4By

Thinking with these concepts we might be able to support different content types having configurable headings etc passing on the power to the content team.

And maybe some thoughts about when we do and don’t use them (I've left the components in a state of WIP until they have this)?

The articles header is it’s own thing as it’s actually part of the body blocks.
This might or might not be correct.

![screen shot 2018-03-29 at 16 05 32](https://user-images.githubusercontent.com/31692/38096559-0ed54f1c-336b-11e8-9dbe-ecc23d0100a6.png)
