### PR TITLE
only use the event once we know it exists

### DIFF
--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -120,12 +120,10 @@ export async function getEvent(id: string, previewReq: ?Request): Promise<?Event
   const fetchLinks = eventFields.concat(peopleFields, contributorFields, seriesFields);
   const event = await getTypeById(previewReq, ['events'], id, {fetchLinks});
 
-  const scheduleIds = event.data.schedule.map(event => event.event.id);
-
-  const eventScheduleDocs = scheduleIds.length > 0 && await getTypeByIds(previewReq, ['events'], scheduleIds, {fetchLinks});
-
   if (!event) { return null; }
 
+  const scheduleIds = event.data.schedule.map(event => event.event.id);
+  const eventScheduleDocs = scheduleIds.length > 0 && await getTypeByIds(previewReq, ['events'], scheduleIds, {fetchLinks});
   return parseEventDoc(event, eventScheduleDocs);
 }
 


### PR DESCRIPTION
We should be 404ing when an event doesn't exist, this creates a 500 as we try to access the event object before we know we've got it.

Got it from the alerting.