### PR TITLE
add scroll to exhibition content

### DIFF
--- a/common/views/components/Index/index.js
+++ b/common/views/components/Index/index.js
@@ -23,6 +23,7 @@ import Pagination from '../Pagination/Pagination';
 import Promo from '../Promo/Promo';
 import Picture from '../Picture/Picture';
 import ImageGallery from '../ImageGallery/ImageGallery';
+import ScrollToInfo from '../ScrollToInfo/ScrollToInfo';
 
 export {
   BackToTop,
@@ -49,5 +50,6 @@ export {
   Pagination,
   Promo,
   Picture,
-  ImageGallery
+  ImageGallery,
+  ScrollToInfo
 };

--- a/common/views/components/ScrollToInfo/ScrollToInfo.js
+++ b/common/views/components/ScrollToInfo/ScrollToInfo.js
@@ -3,12 +3,13 @@
 import Icon from '../Icon/Icon';
 
 type Props = {|
-  elementId: string
+  elementId: string,
+  extraClasses?: string
 |}
 
-const ScrollToInfo = ({elementId}: Props) => (
+const ScrollToInfo = ({elementId, extraClasses}: Props) => (
   <a  href={`#${elementId}`}
-    className="scroll-to-info js-scroll-to-info plain-link flex--v-center flex--h-center flex btn btn--round flush-container-right js-work-media-control pointer-events-all"
+    className={`scroll-to-info js-scroll-to-info plain-link flex--v-center flex--h-center flex btn btn--round flush-container-right js-work-media-control pointer-events-all ${extraClasses || ''}`}
     data-track-event={`{"category": "component", "action": "scroll-to-info:click", "label": "scrolled-to-id:${elementId}"}`}>
     <Icon name='chevron' title='scroll to more information' extraClasses='icon--white' />
   </a>

--- a/exhibitions/app/views/pages/exhibition.njk
+++ b/exhibitions/app/views/pages/exhibition.njk
@@ -33,6 +33,12 @@
           isFull: true
         }%}
 
+        <div class="relative {{{s: 3} | spacingClasses({ margin: ['bottom'] })}}" style="z-index:20">
+          <div class="pointer-events-none">
+            {% componentJsx 'ScrollToInfo', { elementId: 'exhibition-content', extraClasses: 'bg-charcoal bg-hover-charcoal border-color-charcoal' } %}
+          </div>
+        </div>
+
         <div class="exhibition-hero__copy {{ {l:10} | spacingClasses({margin: ['bottom']}) }}">
           <div class="is-hidden-l is-hidden-xl">
             {% component 'wobbly-edge', {background: 'white'} %}
@@ -72,7 +78,7 @@
       </div>
     </div>
 
-    <div class="row {{ {s:5} | spacingClasses({margin: ['top']}) }}">
+    <div class="row {{ {s:5} | spacingClasses({margin: ['top']}) }}" id="exhibition-content">
       <div class="container">
         <div class="grid">
           <div class="{{ {s:12, m:10, shiftM:1, l:7, xl:7} | gridClasses }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }}">


### PR DESCRIPTION
![screen shot 2018-03-29 at 17 09 41](https://user-images.githubusercontent.com/31692/38100053-280bcfe8-3374-11e8-8cf3-dfe39649caa0.png)

References #1544

Doesn't work on articles, as the article header is a special case.
We should just keep an eye on whether it get's used... but that's for a component audit.
