### PR TITLE
Add space for JSX

### DIFF
--- a/common/views/components/CaptionedImage/CaptionedImage.js
+++ b/common/views/components/CaptionedImage/CaptionedImage.js
@@ -43,7 +43,7 @@ const CaptionedImage = ({
               aria-label={`slide ${slideNumbers.current} of ${slideNumbers.total}`}>
               <span aria-hidden="true">{slideNumbers.current}/{slideNumbers.total}</span>
             </span>
-          }
+          }{' '}
           <span dangerouslySetInnerHTML={{__html: caption}} />
         </div>
       </figcaption>

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -21,7 +21,7 @@ const ImageGallery = ({id, title, items}: ImageGalleryProps) => {
           <div className='image-gallery__item' key={image.contentUrl}>
             <CaptionedImage
               caption={image.caption || ''}
-              slideNumbers={{ current: i, total: items.length }}>
+              slideNumbers={{ current: i + 1, total: items.length }}>
 
               {image.contentUrl && image.width && image.height && <Image
                 width={image.width}


### PR DESCRIPTION
Also fixing the index of the image captions

__before__:
![screen shot 2018-04-03 at 16 57 43](https://user-images.githubusercontent.com/1394592/38260678-2f35fae2-3760-11e8-89f9-e48cac6a66fe.png)

__after__:
![screen shot 2018-04-03 at 17 01 32](https://user-images.githubusercontent.com/1394592/38260917-bd63715a-3760-11e8-80a7-7bb369fb6efb.png)
