### PR TITLE
order content old => new then new => old

### DIFF
--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -129,7 +129,7 @@ export async function getEvent(id: string, previewReq: ?Request): Promise<?Event
 export async function getArticleList(page = 1, {pageSize = 10, predicates = []} = {}) {
   const fetchLinks = peopleFields.concat(seriesFields);
   // TODO: This order is not really doing what we expect it to do.
-  const orderings = '[document.first_publication_date desc, my.articles.publishDate desc, my.webcomics.publishDate desc]';
+  const orderings = '[my.articles.publishDate, my.webcomics.publishDate, document.first_publication_date desc]';
   const prismic = await prismicApi();
   const articlesList = await prismic.query([
     Prismic.Predicates.any('document.type', ['articles', 'webcomics']),


### PR DESCRIPTION
Get all the `null` `publishDate`s to the front, and then order by `first_publication_date desc` which reorders  the `null` publishDate.

The downside is the tail end of the content will be ordered `asc`.