### PR TITLE
make articlebody more basic and less right raily

### DIFF
--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -148,51 +148,96 @@
       </div>
     </div>
 
-    <div class="row bg-cream {{ {s:3} | spacingClasses({padding: ['top']}) }} {{ {s:8} | spacingClasses({padding: ['bottom']}) }} ">
-      <div class="container">
-        <div class="grid grid--no-gutters">
-          <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 7} | gridClasses }}">
-            {% if article.bodyParts.length > 0  %}
-              {% for author in article.author.toJS() %}
-                {% if author.person %}
-                  {% component 'author', {
-                    name: author.person.name,
-                    twitterHandle: author.person.twitterHandle,
-                    modifiers: ['border-bottom'] if loop.last else [],
-                    image: author.person.image
-                  } %}
-                {% endif %}
-              {% endfor %}
-            {% endif %}
 
-            <div class="article">
-              {% block articleBody %}
-                {% component 'article-body', {articleBody: article.bodyParts, contentType: article.contentType} %}
-              {% endblock %}
+    {% if featuresCohort | isFlagEnabled('basicBody', featureFlags) %}
+      <div class="row bg-cream {{ {s:3} | spacingClasses({padding: ['top']}) }} {{ {s:8} | spacingClasses({padding: ['bottom']}) }} ">
+        <div class="container">
+          <div class="grid">
+            <div class="basic-page {{ {s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2} | gridClasses }}">
+              {% if article.bodyParts.length > 0  %}
+                {% for author in article.author.toJS() %}
+                  {% if author.person %}
+                    {% component 'author', {
+                      name: author.person.name,
+                      twitterHandle: author.person.twitterHandle,
+                      modifiers: ['border-bottom'] if loop.last else [],
+                      image: author.person.image
+                    } %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            </div>
 
-              {% for author in article.author.toJS() %}
-                {% if author.person %}
-                  {% component 'author', {
-                    name: author.person.name,
-                    twitterHandle: author.person.twitterHandle,
-                    modifiers: ['border-left'],
-                    description: author.person.description,
-                    image: author.person.image
-                  } %}
-                {% endif %}
-              {% endfor %}
+            <div class="basic-page {{ {s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2} | gridClasses }}">
+              {% component 'basic-body', {pageBody: article.bodyParts, contentType: article.contentType} %}
+            </div>
 
-              {% componentV2 'divider', null, {'stub': true, 'black': true}, {extraClasses: [{s:4} | spacingClasses({margin: ['top']})]} %}
-
-              {% if article.tags.length > 0 %}
-                {% component 'tags', { tags: article.tags } %}
+            <div class="basic-page {{ {s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2} | gridClasses }}">
+              {% if article.bodyParts.length > 0  %}
+                {% for author in article.author.toJS() %}
+                  {% if author.person %}
+                    {% component 'author', {
+                      name: author.person.name,
+                      twitterHandle: author.person.twitterHandle,
+                      modifiers: ['border-left'],
+                      description: author.person.description,
+                      image: author.person.image
+                    } %}
+                  {% endif %}
+                {% endfor %}
               {% endif %}
             </div>
 
           </div>
         </div>
       </div>
-    </div>
+    {% else %}
+      <div class="row bg-cream {{ {s:3} | spacingClasses({padding: ['top']}) }} {{ {s:8} | spacingClasses({padding: ['bottom']}) }} ">
+        <div class="container">
+          <div class="grid grid--no-gutters">
+            <div class="{{ {s: 12, m: 10, shiftM: 1, l: 7, xl: 7} | gridClasses }}">
+              {% if article.bodyParts.length > 0  %}
+                {% for author in article.author.toJS() %}
+                  {% if author.person %}
+                    {% component 'author', {
+                      name: author.person.name,
+                      twitterHandle: author.person.twitterHandle,
+                      modifiers: ['border-bottom'] if loop.last else [],
+                      image: author.person.image
+                    } %}
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+
+              <div class="article">
+                {% block articleBody %}
+                  {% component 'article-body', {articleBody: article.bodyParts, contentType: article.contentType} %}
+                {% endblock %}
+
+                {% for author in article.author.toJS() %}
+                  {% if author.person %}
+                    {% component 'author', {
+                      name: author.person.name,
+                      twitterHandle: author.person.twitterHandle,
+                      modifiers: ['border-left'],
+                      description: author.person.description,
+                      image: author.person.image
+                    } %}
+                  {% endif %}
+                {% endfor %}
+
+                {% componentV2 'divider', null, {'stub': true, 'black': true}, {extraClasses: [{s:4} | spacingClasses({margin: ['top']})]} %}
+
+                {% if article.tags.length > 0 %}
+                  {% component 'tags', { tags: article.tags } %}
+                {% endif %}
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
   </article>
 
   {% block transporters %}


### PR DESCRIPTION
Makes the article use the right rail.

## What we gain?
We gain that when we have content that isn't right-raily, it doesn't look odd *.

## What we lose
What we don't have at the moment is the idea of supporting image, which, if we designed, could have easily **.

__TODO:__
- [x] Stick behind a switch

## *
![screencapture-localhost-3000-articles-wo7akioaahw6avxm-2018-04-09-13_38_02](https://user-images.githubusercontent.com/31692/38498131-549a54dc-3bfb-11e8-8e00-867f64d8b5fe.jpg)

## **
![screencapture-localhost-3000-articles-wruxjh8aab4a1gxe-2018-04-09-13_33_53](https://user-images.githubusercontent.com/31692/38498143-5c322b66-3bfb-11e8-879d-bc9b497d8d5f.jpg)
