### PR TITLE
add basic places info to events

### DIFF
--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -5,7 +5,13 @@ export const peopleFields = [
   'people.description'
 ];
 export const contributorsFields = ['editorial-contributor-roles.title'];
-export const placesFields = ['places.title', 'places.level', 'places.capacity'];
+export const placesFields = [
+  'places.title',
+  'places.description',
+  'places.info',
+  'places.level',
+  'places.capacity'
+];
 export const installationFields = [
   'installations.title',
   'installations.description',

--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -1,7 +1,15 @@
 import {model, prismic} from 'common';
 import {getUiEventSeries} from '@weco/common/services/prismic/events';
 const {createPageConfig} = model;
-const {getPaginatedEventPromos, getEventsInSeries, asText, asHtml, createEventPromos, convertPrismicResultsToPaginatedResults, london} = prismic;
+const {
+  getPaginatedEventPromos,
+  getEventsInSeries,
+  asText,
+  asHtml,
+  createEventPromos,
+  convertPrismicResultsToPaginatedResults,
+  london
+} = prismic;
 
 export async function renderEvent(ctx, next) {
   const id = `${ctx.params.id}`;

--- a/events/app/views/partials/event_without_schedule.njk
+++ b/events/app/views/partials/event_without_schedule.njk
@@ -290,6 +290,14 @@
         <div class="{{[].join(' ') }}">{{ event.format.description | safe }}</div>
       {% endif %}
 
+      {% if event.place %}
+        <h2>Where we'll be</h2>
+          <p>
+            {{ event.place.title }} is on Level {{ event.place.level }}.
+            {{ event.place.info }}
+          </p>
+      {% endif %}
+
       {% for series in event.series %}
         <h2>Part of <a href="/event-series/{{ series.id }}">{{ series.title }}</a></h2>
         <div>{{ series.description | safe }}</div>

--- a/prismic-model/json/places.json
+++ b/prismic-model/json/places.json
@@ -7,6 +7,20 @@
         "label" : "title"
       }
     },
+    "description" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "paragraph",
+        "label" : "Description"
+      }
+    },
+    "info" : {
+      "type" : "StructuredText",
+      "config" : {
+        "single" : "paragraph",
+        "label" : "Info"
+      }
+    },
     "geolocation" : {
       "type" : "GeoPoint",
       "config" : {

--- a/server/content-model/events.js
+++ b/server/content-model/events.js
@@ -68,7 +68,9 @@ export type Place = {|
   title: string,
   geolocation: ?Geolocation,
   level: number,
-  capacity: ?number
+  capacity: ?number,
+  description: ?HTMLString,
+  info: ?HTMLString
 |}
 
 type IdentifierScheme = 'eventbrite-id';
@@ -224,6 +226,8 @@ export const eventExample = ({
     id: 'WdTMsycAAL20UYr1',
     title: 'Williams Lounge',
     level: -1,
+    description: null,
+    info: 'Head upstairs and follow the signs to the Studio.',
     geolocation: {
       latitude: 51.52585053479689,
       longitude: -0.13394683599472046

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -56,6 +56,8 @@ export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): UiEve
   const place = (doc.data.place && !isEmptyDocLink(doc.data.place)) ? ({
     id: doc.data.place.id,
     title: asText(doc.data.place.data.title),
+    description: asHtml(doc.data.place.data.description),
+    info: asHtml(doc.data.place.data.info),
     // geolocation, as it stands, can't be fetch via `fetchLinks`
     geolocation: null,
     // geolocation: {
@@ -63,7 +65,7 @@ export function parseEventDoc(doc: PrismicDoc, scheduleDocs?: PrismicDoc): UiEve
     //   longitude: place.place.data.geolocation.longitude
     // },
     level: doc.data.place.data.level,
-    capacity: doc.data.place.data.level
+    capacity: doc.data.place.data.capacity
   }: Place) : null;
 
   const interpretations = doc.data.interpretations.map(interpretation => !isEmptyDocLink(interpretation.interpretationType) ? ({

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -41,7 +41,7 @@ const eventFields = [
   'event-access-options.title', 'event-access-options.description', 'event-access-options.description',
   'teams.title', 'teams.email', 'teams.phone', 'teams.url',
   'event-formats.title', 'event-formats.description', 'event-formats.shortName',
-  'places.title', 'places.geolocation', 'places.level', 'places.capacity',
+  'places.title', 'places.description', 'places.info', 'places.level', 'places.capacity',
   'interpretation-types.title', 'interpretation-types.abbreviation',
   'interpretation-types.description', 'interpretation-types.primaryDescription',
   'audiences.title',


### PR DESCRIPTION
Ref: #2480 

Adds the manually entered place info onto the pages automatically.

Plan
- [ ] Get all the places
- [ ] Get place information into prismic
- [ ] Remove manually added content
- [ ] 💥 

__Notes__
There seems to be a bug in Prismic not pulling through the info, I am waiting to hear back from them.