### PR TITLE
set featuresCohort cookie on infra project

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -2,10 +2,23 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
+  ### A/B test
+  split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
+    33%     "testA";
+    33%     "testB";
+    34%     "";
+  }
+  map $cookie_WC_featuresCohort $cohort {
+    ""      $cohort_split_test;
+    default $cookie_WC_featuresCohort;
+  }
+  ###
+
   server {
     listen           80;
     listen           443 ssl;
     server_name      _;
+    add_header      Set-Cookie "WC_featuresCohort=$cohort;Path=/;Max-Age=86400";
 
     # These are the locations we know exist solely on v2
     location / {


### PR DESCRIPTION
The conversation with @hthair made me realise that we don't set the featuresCohort cookie on the infra app, which includes articles.