### PR TITLE
What's on default view testing

### DIFF
--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -462,11 +462,18 @@ function getListHeader(dates, collectionOpeningTimes) {
   };
 }
 
-export async function getExhibitionAndEventPromos(query, collectionOpeningTimes) {
+export async function getExhibitionAndEventPromos(query, collectionOpeningTimes, featuresCohort) {
+  // set either 'everything' or 'today' as default time period, when no startDate is provided, based on featuresCohort
+  function determineToDate(featuresCohort) {
+    if (featuresCohort === 'testB') {
+      return !query.startDate ? undefined : query.endDate;
+    } else {
+      return !query.startDate ? todaysDate.format('YYYY-MM-DD') : query.endDate;
+    }
+  };
   const todaysDate = london();
-  // set today as default time period if no startDate is provided
   const fromDate = !query.startDate ? todaysDate.format('YYYY-MM-DD') : query.startDate;
-  const toDate = !query.startDate ? todaysDate.format('YYYY-MM-DD') : query.endDate;
+  const toDate = determineToDate(featuresCohort);
   const dateRange = [fromDate, toDate];
   const allExhibitionsAndEvents = await getAllOfType(['exhibitions', 'events'], {
     pageSize: 100,

--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -18,7 +18,7 @@ const {
 } = prismic;
 
 export async function renderWhatsOn(ctx, next) {
-  const exhibitionAndEventPromos = await getExhibitionAndEventPromos(ctx.query, ctx.intervalCache.get('collectionOpeningTimes'));
+  const exhibitionAndEventPromos = await getExhibitionAndEventPromos(ctx.query, ctx.intervalCache.get('collectionOpeningTimes'), ctx.featuresCohort);
 
   ctx.render('pages/whats-on', {
     pageConfig: createPageConfig({


### PR DESCRIPTION
Using the traffic splitting we're doing (Baseline / A / B) to run a test on the what's on landing page.

Whether more events are viewed if the default view is everything.

The testB group will default to the everything view