### PR TITLE
move exhibitions list to what_on service

### DIFF
--- a/common/model/exhibitions.js
+++ b/common/model/exhibitions.js
@@ -5,6 +5,7 @@ import type {Installation, UiInstallation} from './installations';
 import type {ImagePromo} from './image-promo';
 import type {Place} from './place';
 import type {Contributor} from './contributors';
+import type {Image} from './image';
 
 export type Exhibit = {|
   exhibitType: | 'installations',
@@ -28,8 +29,18 @@ export type Exhibition = {|
   exhibits: Exhibit[]
 |}
 
+export type ExhibitionPromo = {|
+  id: string,
+  url: string,
+  title: string,
+  image: Image,
+  description: string,
+  start: Date,
+  end: ?Date,
+|}
+
 export type UiExhibition = {| ...Exhibition,  ...{|
-  promo: ?ImagePromo,
+  promo: ExhibitionPromo,
   galleryLevel: number, // this should be deprecated for place
   textAndCaptionsDocument: any, // TODO: <= not this
   featuredImageList: Picture[],

--- a/common/model/image.js
+++ b/common/model/image.js
@@ -1,0 +1,10 @@
+// @flow
+import type {Tasl} from './tasl';
+
+export type Image = {|
+  contentUrl: string,
+  width: number,
+  height: number,
+  alt: string,
+  tasl: Tasl
+|}

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -54,7 +54,10 @@ export async function getDocuments(
   opts: PrismicQueryOpts
 ): Promise<PaginatedResults<PrismicDocument>> {
   const api = await getPrismicApi(req);
-  const docs: PrismicApiSearchResponse = await api.query(predicates, opts);
+  const docs: PrismicApiSearchResponse = await api.query(
+    predicates.concat([Prismic.Predicates.not('document.tags', ['delist'])]),
+    opts
+  );
   const paginatedResults = {
     currentPage: docs.page,
     pageSize: docs.results_per_page,

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -18,6 +18,7 @@ import {
   parseTimestamp,
   parsePlace,
   parsePromoListItem,
+  parsePromoToCaptionedImage,
   asText,
   isDocumentLink
 } from './parsers';
@@ -47,14 +48,22 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
   const sizeInKb = Math.round(document.data.textAndCaptionsDocument.size / 1024);
   const textAndCaptionsDocument = isDocumentLink(document.data.textAndCaptionsDocument) ? Object.assign({}, document.data.textAndCaptionsDocument, {sizeInKb}) : null;
 
+  const id = document.id;
+  const url = `/exhibitions/${id}`;
+  const title = parseTitle(data.title);
+  const description = parseDescription(data.description);
+  const start = parseTimestamp(data.start);
+  const end = data.end && parseTimestamp(data.end);
+  const promoImage = parsePromoToCaptionedImage(data.promo);
+
   return {
-    id: document.id,
-    title: parseTitle(data.title),
-    description: parseDescription(data.description),
+    id: id,
+    title: title,
+    description: description,
     intro: asText(data.intro),
     contributors: data.contributors ? parseContributors(data.contributors) : [],
-    start: parseTimestamp(data.start),
-    end: data.end && parseTimestamp(data.end),
+    start: start,
+    end: end,
     place: isDocumentLink(data.place) && parsePlace(data.place),
     exhibits: data.exhibits ? parseExhibits(data.exhibits) : [],
 
@@ -64,7 +73,15 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
       but flow has problems with spreading.
       https://github.com/facebook/flow/issues/3608
     */
-    promo: null, // TODO
+    promo: {
+      id,
+      url,
+      title,
+      image: promoImage.image,
+      description: asText(promoImage.caption) || 'PROMO TEXT MISSING',
+      start,
+      end
+    }, // TODO
     galleryLevel: document.data.galleryLevel,
     textAndCaptionsDocument: textAndCaptionsDocument,
     featuredImageList: promos,
@@ -72,6 +89,32 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
     relatedEvents: promoList.filter(x => x.type === 'event').map(parsePromoListItem),
     relatedGalleries: promoList.filter(x => x.type === 'gallery').map(parsePromoListItem),
     relatedArticles: promoList.filter(x => x.type === 'article').map(parsePromoListItem)
+  };
+}
+
+export async function getExhibitions(req: Request, id: string): Promise<PaginatedResults<UiExhibition>> {
+  const paginateResults = await getDocuments(
+    req,
+    [Prismic.Predicates.at('document.type', 'exhibitions')],
+    {
+      fetchLinks: peopleFields.concat(
+        contributorsFields,
+        placesFields,
+        installationFields
+      ),
+      orderings: '[my.exhibitions.start]'
+    }
+  );
+
+  const uiExhibitions: UiExhibition[] = paginateResults.results.map(parseExhibitionDoc);
+  // { ..paginatedResults, results: uiExhibitions } should work, but Flow still
+  // battles with spreading.
+  return {
+    currentPage: paginateResults.currentPage,
+    pageSize: paginateResults.pageSize,
+    totalResults: paginateResults.totalResults,
+    totalPages: paginateResults.totalPages,
+    results: uiExhibitions
   };
 }
 

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -90,7 +90,8 @@ export function parsePicture(captionedImage: Object, minWidth: ?string = null): 
 }
 
 const defaultContributorImage = 'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F3ed09488-1992-4f8a-9f0c-de2d296109f9_group+21.png';
-export function parseCaptionedImage(frag: PrismicFragment): CaptionedImageProps {
+type Crop = | '16:9' | '32:15' | 'square';
+export function parseCaptionedImage(frag: PrismicFragment, crop?: Crop): CaptionedImageProps {
   if (isEmptyObj(frag.image)) {
     return {
       image: placeHolderImage,
@@ -101,7 +102,8 @@ export function parseCaptionedImage(frag: PrismicFragment): CaptionedImageProps 
       }]
     };
   }
-  const image = frag.image;
+
+  const image = crop ? frag.image[crop] : frag.image;
   const tasl = parseTaslFromString(image.copyright);
 
   return {
@@ -114,6 +116,12 @@ export function parseCaptionedImage(frag: PrismicFragment): CaptionedImageProps 
     },
     caption: frag.caption
   };
+}
+
+export function parsePromoToCaptionedImage(frag: PrismicFragment): CaptionedImageProps {
+  // We could do more complicated checking here, but this is what we always use.
+  const promo = frag[0];
+  return parseCaptionedImage(promo.primary, '16:9');
 }
 
 function parsePersonContributor(frag: PrismicFragment): PersonContributor {

--- a/common/utils/format-date.js
+++ b/common/utils/format-date.js
@@ -16,6 +16,10 @@ export function formatDate(date: Date): string {
   return london(date).format('D MMMM YYYY');
 }
 
+export function formatDateRange(date: Date): string {
+  return london(date).format('D MMMM YYYY');
+}
+
 export function formatTime(date: Date): string {
   return london(date).format('HH:mm');
 }

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -1,0 +1,109 @@
+// @flow
+import {Fragment} from 'react';
+import {spacing, font} from '../../../utils/classnames';
+import {formatDate, formatDateRangeWithMessage} from '../../../utils/format-date';
+import {UiImage} from '../Images/Images';
+import Icon from '../Icon/Icon';
+import type {ExhibitionPromo as Props} from '../../../model/exhibitions';
+
+const ExhibitionPromo = ({
+  id, url, title, image, description, start, end
+}: Props) => {
+  const dateMessageAndColor = formatDateRangeWithMessage({start, end: (end || new Date())});
+  return (
+    <a data-component='ExhibitionPromo'
+      data-track-event={JSON.stringify({category: 'component', action: 'ExhibitionPromo:click'})}
+      id={id}
+      href={url}
+      className='plain-link promo-link bg-cream rounded-top rounded-bottom overflow-hidden flex flex--column'>
+      <UiImage
+        contentUrl={image.contentUrl}
+        width={image.width}
+        height={image.height}
+        alt={image.alt}
+        tasl={image.tasl}
+        sizesQueries='(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'
+        showTasl={false} />
+
+      <div className={`
+          flex flex--column flex-1
+          ${spacing({s: 2}, {padding: ['top']})}
+          ${spacing({s: 3}, {padding: ['left', 'right']})}
+          ${spacing({s: 4}, {padding: ['bottom']})}
+        `}>
+        <p className={`no-padding ${spacing({s: 2}, {margin: ['bottom']})} ${font({s: 'HNM5'})}`}>
+          {end && 'Exhibition'}
+          {!end && 'Permanent exhibition'}
+        </p>
+
+        <h2 className={`promo-link__title ${font({s: 'WB5'})} ${spacing({s: 0}, {margin: ['top']})}`}>{title}</h2>
+
+        <p className={`${font({s: 'HNL4'})} ${spacing({s: 2}, {margin: ['bottom']})} no-padding`}>
+          {end &&
+            <Fragment><time dateTime={start}>{formatDate(start)}</time>—<time dateTime={end}>{formatDate(end)}</time></Fragment>
+          }
+          {!end && description}
+        </p>
+
+        <div className='flex flex--h-space-between flex--wrap margin-top-auto'>
+          <span className={`${font({s: 'HNM5'})} flex flex--v-center`}>
+            <span className={`${spacing({s: 1}, {margin: ['right']})} flex flex--v-center"`}>
+              <Icon name='statusIndicator' extraClasses={`icon--match-text icon--${dateMessageAndColor.color}`} />
+            </span>
+            {dateMessageAndColor.text}
+          </span>
+        </div>
+      </div>
+    </a>
+  );
+};
+
+export default ExhibitionPromo;
+
+// <a data-component="ExhibitionPromo"
+//    data-track-event="{{ {category: 'component', action: 'ExhibitionPromo:click' } | dump }}"
+//    id="{{model.id}}"
+//    href="{{ model.url }}"
+//    class="plain-link promo-link bg-cream rounded-top rounded-bottom overflow-hidden flex flex--column">
+
+//   {% componentV2 'image', model.image, {}, {lazyload: true, sizesQueries: sizes, defaultSize: data.defaultSize} %}
+
+//   <div class="{{- [
+//       {s:2} | spacingClasses({padding: ['top']}),
+//       {s:3} | spacingClasses({padding: ['left', 'right']}),
+//       {s:4} | spacingClasses({padding: ['bottom']})
+//     ].join(' ') }} flex flex--column flex-1">
+
+//     <p class="no-padding {{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5'} | fontClasses }}">
+//       {% if not model.end %}
+//         Permanent exhibition
+//       {% else %}
+//         Exhibition
+//       {% endif %}
+//     </p>
+
+//     <h2 class="promo-link__title {{ {s:'WB5'} | fontClasses }}  {{ {s:0} | spacingClasses({margin: ['top']}) }}">{{ model.title }}</h2>
+
+//     <p class="{{ {s:'HNL4'} | fontClasses }} {{ {s:2} | spacingClasses({margin: ['bottom']}) }} no-padding">
+//       {% if model.start and model.end %}
+//         <time datetime="{{model.start}}">{{ model.start | formatDate }}</time>&ndash;<time datetime="{{model.end}}">{{ model.end | formatDate }}</time>
+//       {% else %}
+//         {{ model.description | striptags | safe }}
+//       {% endif %}
+//     </p>
+
+//     <div class="flex flex--h-space-between flex--wrap margin-top-auto">
+//       <span class="{{- [
+//           {s:'HNM5'} | fontClasses
+//         ].join(' ') }} flex flex--v-center">
+//         {% set dateMessageAndColor = {start: model.start, end: model.end} | formatDateRangeWithMessage %}
+//         <span class="{{ {s:1} | spacingClasses({margin: ['right']}) }} flex flex--v-center">
+//           {% set statusColor = 'icon--' + dateMessageAndColor.color %}
+//           {% icon 'status_indicator', null, [statusColor, 'icon--match-text'] %}
+//         </span>
+//         {{ dateMessageAndColor.text }}
+//       </span>
+//     </div>
+
+//   </div>
+// </a>

--- a/common/views/components/Icon/Icon.js
+++ b/common/views/components/Icon/Icon.js
@@ -14,7 +14,7 @@ const Icon = ({name, title, extraClasses, attrs = {}}: Props) => (
     className={`icon ${extraClasses || ''}`}
     aria-hidden={title && 'true'}>
     <canvas className='icon__canvas' height='26' width='26'></canvas>
-    <svg className="icon__svg"
+    <svg className='icon__svg'
       {...title ? { role: 'img' } : { 'aria-hidden': true }}
       {...attrs}>
       {title && <title>{title}</title>}

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -7,24 +7,17 @@ import Tasl from '../Tasl/Tasl';
 import Icon from '../Icon/Icon';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import type {Node} from 'react';
-import type {Tasl as TaslProps} from '../../../model/tasl';
+import type {Image as ImageProps} from '../../../model/image';
 import type {HTMLString} from '../../../services/prismic/types';
-
-export type ImageProps = {|
-  contentUrl: string,
-  width: number,
-  height: number,
-  alt: string,
-  tasl: TaslProps
-|}
 
 export type UiImageProps = {|
   ...ImageProps,
-  extraClasses: string,
   // TODO: Could this take a grid sizing object, and work out the queries
   // automatically?
   // Grid sizing object = {| ['s', 'm', 'l', 'xl']: number |}
-  sizesQueries: string
+  sizesQueries: string,
+  extraClasses?: string,
+  showTasl?: boolean
 |}
 
 export const UiImage = ({
@@ -34,7 +27,8 @@ export const UiImage = ({
   alt,
   tasl,
   sizesQueries,
-  extraClasses = ''
+  extraClasses = '',
+  showTasl = true
 }: UiImageProps) => {
   return (
     <Fragment>
@@ -54,7 +48,7 @@ export const UiImage = ({
         })}
         sizes={sizesQueries}
         alt={alt} />
-      <Tasl {...tasl} />
+      {showTasl && <Tasl {...tasl} />}
     </Fragment>
   );
 };

--- a/common/views/components/Index/index.js
+++ b/common/views/components/Index/index.js
@@ -35,6 +35,7 @@ import ContentList from '../ContentList/ContentList';
 import BasicBody from '../BasicBody/BasicBody';
 import Quote from '../Quote/Quote';
 import Contributor from '../Contributor/Contributor';
+import ExhibitionPromo from '../ExhibitionPromo/ExhibitionPromo';
 
 export {
   BackToTop,
@@ -73,5 +74,6 @@ export {
   ContentList,
   BasicBody,
   Quote,
-  Contributor
+  Contributor,
+  ExhibitionPromo
 };

--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -1,6 +1,6 @@
 import searchQuery from 'search-query-parser';
 import {getInstallation} from '@weco/common/services/prismic/installations';
-import {getExhibition, getExhibitionExhibits} from '@weco/common/services/prismic/exhibitions';
+import {getExhibitions, getExhibition, getExhibitionExhibits} from '@weco/common/services/prismic/exhibitions';
 import {isPreview as isPrismicPreview} from '@weco/common/services/prismic/api';
 import {model, prismic} from 'common';
 
@@ -64,6 +64,23 @@ export async function renderInstallation(ctx, next) {
       installation,
       tags,
       isPreview
+    });
+  }
+}
+
+export async function renderExhibitions(ctx, next) {
+  const paginatedResults = await getExhibitions(ctx.request, ctx.params.id);
+  if (paginatedResults) {
+    ctx.render('pages/exhibitions', {
+      pageConfig: createPageConfig({
+        path: '/exhibitions',
+        title: 'Exhibitions',
+        inSection: 'whatson',
+        category: 'public-programme',
+        contentType: 'listing',
+        canonicalUri: 'https://wellcomecollection.org/exhibitions'
+      }),
+      paginatedResults
     });
   }
 }

--- a/whats_on/app/routes.js
+++ b/whats_on/app/routes.js
@@ -2,6 +2,7 @@ import Router from 'koa-router';
 import {
   renderWhatsOn,
   renderInstallation,
+  renderExhibitions,
   renderExhibition,
   renderExhibits
 } from './controllers';
@@ -10,6 +11,7 @@ const r = new Router({ sensitive: true });
 
 r.get('/whats-on', renderWhatsOn);
 r.get('/installations/:id', renderInstallation);
+r.get('/exhibitions', renderExhibitions);
 r.get('/exhibitions/:id', renderExhibition);
 r.get('/exhibitions/:id/exhibits', renderExhibits);
 

--- a/whats_on/app/views/pages/exhibitions.njk
+++ b/whats_on/app/views/pages/exhibitions.njk
@@ -1,0 +1,74 @@
+{% extends 'layout/default.njk' %}
+{% set pageDescription = 'Explore the connections between science, medicine, life and art through our permanent and temporary exhibitions. Admission is always free.' %}
+{% set results = paginatedResults.results %}
+{% set metaContent = {
+  type: 'website',
+  title: 'Exhibitions',
+  image: results[0].image.contentUrl,
+  url: pageConfig.canonicalUri,
+  description: pageDescription
+} %}
+
+{% block pageMeta %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
+  <meta name="description" content="{{ pageDescription }}" />
+{% endblock %}
+
+{% block body %}
+   <script type="application/ld+json">
+    {# [{% for exhibition in results %}
+      {% set featuredImage = {contentUrl: exhibition.image.contentUrl} %}
+      {% set exhib = exhibition | objectAssign({safeDescription: exhibition.description | safe | striptags, featuredImage: featuredImage}) %}
+      {{ exhib | jsonLd('exhibitionLd') | safe }}{{ ',' if not loop.last }}
+    {% endfor %}] #}
+  </script>
+
+  {% componentV2 'list-header', {name: 'Exhibitions', description: pageDescription, total: paginatedResults.results.length} %}
+
+  {% if paginatedExhibitions.pagination.pageCount > 1  %}
+    <div class="css-grid__container">
+      <div class="css-grid">
+        <div class="{{ {s:12, m:12, l:12, xl:12} | cssGridClasses }}">
+          <div class="{{ {s:5, m:5, l:5} | spacingClasses({padding: ['top']}) }}  {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }} flex flex--v-center font-pewter {{ {s:'LR3', m:'LR2'} | fontClasses }}">
+            {{ paginatedExhibitions.pagination.range.beginning }} - {{ paginatedExhibitions.pagination.range.end }}
+          </div>
+          {% componentV2 'divider', null, {'keyline': true, 'pumice': true} %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="css-grid__container {{ {s:4} | spacingClasses({padding: ['top']}) }} ">
+    <div class="css-grid">
+        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }}">
+          <div class="flex-inline flex--v-center">
+            <span class="{{ {s:'HNM5', m:'HNM4'} | fontClasses }}">Free admission</span>
+          </div>
+        </div>
+        {% for exhibition in paginatedResults.results %}
+          <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
+            {% componentJsx 'ExhibitionPromo', exhibition.promo %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  <div class="css-grid__container  {{ {s:2, m:2, l:2} | spacingClasses({padding: ['top']}) }} {{ {s:3, m:3, l:3} | spacingClasses({padding: ['bottom']}) }} ">
+    <div class="css-grid">
+      {% if paginatedExhibitions.pagination.pageCount > 1  %}
+        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }} text-align-right">
+          {% componentJsx 'Pagination', paginatedExhibitions.pagination %}
+        </div>
+      {% endif %}
+      {% if paginatedExhibitions.currentPage === paginatedExhibitions.totalPages %}
+        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }} {{ {s:4} | spacingClasses({margin: ['top']}) }} text-align-right">
+          {# {% componentJsx 'PrimaryLink', { name: 'Past exhibitions', url: 'https://wellcomecollection.org/exhibitions/past' } %} #}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+
+{% endblock %}


### PR DESCRIPTION
Fixes/References #

## Who was this for?
Developers who hate cognitive load from switching thinking the whole time.

## What is it doing for them?
This should move over all off exhibitions to the whats_on service - meaning we use that for exhibitions, whats on etc. Events will have to be moved over.

Another thing it's starting to help with is getting our common structure in place.
Quite nicely it seems modelling goes into `/common/model`.

It feels like `UiComponent` types should probably only exist in Components, and has properties that are different from the object it's representing on instantiation in it's parent template.

An example being an `Image` and `UiImage` where we need to pass in `sizesQueries`, that's something that is reliant on the caller of that component.

Once this is working I can remove the old code, but need this up and available first.

## Checklist
- [x] Demoed to the relevant people?
- [X] Simple as it can be?
- [x] Tested?
