### PR TITLE
Only transition specified properties

### DIFF
--- a/common/styles/components/_body_text.scss
+++ b/common/styles/components/_body_text.scss
@@ -25,7 +25,7 @@
   a:visited {
     text-decoration: none;
     border-bottom: 2px solid color('green');
-    transition: all $transition-properties;
+    transition: color $transition-properties, border-bottom $transition-properties;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
Setting `transition: all` on the link styles had the effect of transitioning their font-size at different breakpoints, which looks broken.