### PR TITLE
use direct image link for downloading image

### DIFF
--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -76,9 +76,10 @@
 
           <a
             class="{{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5' , m:'HNM4'} | fontClasses }} plain-link font-green font-hover-turquoise flex flex--v-center"
-            href="/download?uri={{ work.imgLink | convertImageUri('full', false) | urlencode }}"
+            href="{{ work.imgLink | convertImageUri('full', false) }}"
             download="{{ work.id }}.jpg"
             rel="noopener noreferrer"
+            target="_blank"
             data-track-event='{"category": "component", "action": "download-button:click", "label": "id:{{ work.id }}, size:original, title:{{ work.title | truncate(50) }}"}'>
             {% icon 'download', null, ['icon--green'] %}
             <div class="{{{s: 1} | spacingClasses({ margin: ['left'] })}}">
@@ -88,9 +89,10 @@
 
           <a
             class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5' , m:'HNM4'} | fontClasses }} plain-link font-green font-hover-turquoise flex flex--v-center"
-            href="/download?uri={{ work.imgLink | convertImageUri(760, false) | urlencode }}"
+            href="{{ work.imgLink | convertImageUri(760, false) }}"
             download="{{ work.id }}.jpg"
             rel="noopener noreferrer"
+            target="_blank"
             data-track-event='{"category": "component", "action": "download-button:click", "label": "id:{{ work.id }}, size:760, title:{{ work.title | truncate(50) }}"}'>
             {% icon 'download', null, ['icon--green'] %}
             <div class="{{{s: 1} | spacingClasses({ margin: ['left'] })}}">


### PR DESCRIPTION
## Who was this for?
My general sanity check because of the alerts going off in dotorg-explosions.

## What is it doing for them?
Moving the download link to not use our webapp as a proxy.
If we do want to do this, it might be worth thinking about creating a new service.

Now that I've removed it and used it, I wonder if this experience is actually better, which makes me realise we chose an experience without asking the people who use it.

Something to note when testing the catalogue.

## Checklist
- [x] ~Demoed to the relevant people?~
- [x] Simple as it can be?
- [x] ~Tested?~
