### PR TITLE
Catalogue urls

### DIFF
--- a/catalogue/webapp/pages/catalogue/work.js
+++ b/catalogue/webapp/pages/catalogue/work.js
@@ -97,7 +97,7 @@ function getLicenseInfo(licenseType) {
 function createLinkObject(val: string, prepend?: string): Link {
   return {
     text: val,
-    url: prepend ? `/works?query=${encodeURIComponent(`${prepend}"${val}"`)}` : `/works?query=${encodeURI(`"${val}"`)}`
+    url: prepend ? `/catalogue/works?query=${encodeURIComponent(`${prepend}"${val}"`)}` : `/catalogue/works?query=${encodeURI(`"${val}"`)}`
   };
 }
 
@@ -180,7 +180,7 @@ const WorkPage = ({work}: Props) => {
   const descriptionArray = work.description && work.description.split('\n');
   const metaContent = getMetaContentArray(work, descriptionArray);
   const credit = work.items[0].locations[0].credit;
-  const attribution = constructAttribution(work, credit, `https://wellcomecollection.org/works/${work.id}`);
+  const attribution = constructAttribution(work, credit, `https://wellcomecollection.org/catalogue/works/${work.id}`);
 
   return (
     <Fragment>
@@ -248,7 +248,7 @@ const WorkPage = ({work}: Props) => {
               </h2>
 
               {/* TODO: the download links once this is in
-              https://github.com/wellcometrust/wellcomecollection.org/pull/2164/files#diff-f9d8c53a2dbf55f0c9190e6fbd99e45cR21 */}
+                https://github.com/wellcometrust/wellcomecollection.org/pull/2164/files#diff-f9d8c53a2dbf55f0c9190e6fbd99e45cR21 */}
               {/* the small one is 760 */}
               <a
                 className={classNames([
@@ -311,7 +311,7 @@ const WorkPage = ({work}: Props) => {
                 ])}>
                   Share
                 </h2>
-                <CopyUrl id={work.id} url={`https://wellcomecollection.org/works/${work.id}`} />
+                <CopyUrl id={work.id} url={`https://wellcomecollection.org/catalogue/works/${work.id}`} />
               </div>
             </div>
           </div>
@@ -336,7 +336,7 @@ WorkPage.getInitialProps = async (context) => {
     title: json.title || json.description,
     description: json.description || '',
     type: 'website',
-    url: `https://wellcomecollection.org/works/${json.id}`,
+    url: `https://wellcomecollection.org/catalogue/works/${json.id}`,
     imageUrl: iiifImage({size: '800,'}),
     analyticsCategory: 'collections',
     siteSection: 'images',

--- a/catalogue/webapp/pages/catalogue/work.js
+++ b/catalogue/webapp/pages/catalogue/work.js
@@ -1,7 +1,7 @@
 // @flow
 import fetch from 'isomorphic-unfetch';
 import {font, spacing, grid, classNames} from '@weco/common/utils/classnames';
-import {iiifImageTemplate} from '@weco/common/utils/convert-image-uri';
+import {iiifImageTemplate, convertImageUri} from '@weco/common/utils/convert-image-uri';
 import PageDescription from '@weco/common/views/components/PageDescription/PageDescription';
 import PageWrapper from '@weco/common/views/components/PageWrapper/PageWrapper';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
@@ -247,16 +247,14 @@ const WorkPage = ({work}: Props) => {
                 Download
               </h2>
 
-              {/* TODO: the download links once this is in
-                https://github.com/wellcometrust/wellcomecollection.org/pull/2164/files#diff-f9d8c53a2dbf55f0c9190e6fbd99e45cR21 */}
-              {/* the small one is 760 */}
               <a
                 className={classNames([
                   spacing({s: 2}, {margin: ['bottom']}),
                   font({s: 'HNM5', m: 'HNM4'}),
                   'plain-link font-green font-hover-turquoise flex flex--v-center'
                 ])}
-                href={`/download?uri=${encodeURIComponent('/link/to/image')}`}
+                href={convertImageUri(work.items[0].locations[0].url, 'full')}
+                target='_blank'
                 download={`${work.id}.jpg`}
                 rel='noopener noreferrer'
                 data-track-event={JSON.stringify({
@@ -276,7 +274,8 @@ const WorkPage = ({work}: Props) => {
                   font({s: 'HNM5', m: 'HNM4'}),
                   'plain-link font-green font-hover-turquoise flex flex--v-center'
                 ])}
-                href={`/download?uri=${encodeURIComponent('/link/to/image')}`}
+                href={convertImageUri(work.items[0].locations[0].url, 760)}
+                target='_blank'
                 download={`${work.id}.jpg`}
                 rel='noopener noreferrer'
                 data-track-event={JSON.stringify({

--- a/catalogue/webapp/pages/catalogue/works.js
+++ b/catalogue/webapp/pages/catalogue/works.js
@@ -132,7 +132,7 @@ const WorksComponent = ({
                     }}
                     datePublished={result.createdDate && result.createdDate.label}
                     title={result.title}
-                    url={`/works/${result.id}${getQueryParamsForWork(query)}`} />
+                    url={`/catalogue/works/${result.id}${getQueryParamsForWork(query)}`} />
                 </div>
               ))}
             </div>
@@ -168,7 +168,7 @@ class Works extends Component<Props> {
 
     // Update the URL, which in turn will update props
     Router.push({
-      pathname: '/works',
+      pathname: '/catalogue/works',
       query: {query: queryString, page: '1'}
     });
   }

--- a/catalogue/webapp/server.js
+++ b/catalogue/webapp/server.js
@@ -10,8 +10,8 @@ app.prepare().then(() => {
   const server = new Koa();
   const router = new Router();
 
-  router.get('/works/:id', async ctx => {
-    await app.render(ctx.req, ctx.res, '/work', {id: ctx.params.id});
+  router.get('/catalogue/works/:id', async ctx => {
+    await app.render(ctx.req, ctx.res, '/catalogue/work', {id: ctx.params.id});
     ctx.respond = false;
   });
 


### PR DESCRIPTION
Fixes/References #2472 

## Who was this for?
The team to test the new works page

## What is it doing for them?
Puts it on the `/catalogue` URL so we don't disrupt service. 


## Checklist
- [x] ~Demoed to the relevant people?~
- [x] Simple as it can be?
- [x] Tested?
