### PR TITLE
Offset the transporter by the same amount as if it were in an .article

### DIFF
--- a/common/styles/components/_body_part.scss
+++ b/common/styles/components/_body_part.scss
@@ -34,7 +34,8 @@ $center-width-large: (6/7) * 100%; // calculates the halfway point of the contai
     padding: 0 map-get($container-padding, 'large');
   }
 
-  .article & {
+  .article &,
+  .digital-story-transporter & {
     @include respond-to('large') {
       left: $center-width-large;
       margin-right: calc((#{$narrow-width} + #{map-get($gutter-width, 'large')}) * -1);


### PR DESCRIPTION
The transporter at the bottom of a digital story is currently too far over to the left. This fixes that.

![screen shot 2018-04-27 at 16 22 11](https://user-images.githubusercontent.com/1394592/39370576-2de9733c-4a37-11e8-817b-f1def6846fba.png)
