### PR TITLE
Space out event-series promos

### DIFF
--- a/events/app/views/pages/event-series.njk
+++ b/events/app/views/pages/event-series.njk
@@ -53,7 +53,9 @@
         <div class="grid">
           {% for event in paginatedEvents.results %}
             <div class="{{ {s: 12, m: 6, l: 4, xl:4} | gridClasses}}">
-              {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+              <div class="{{ {s: 3} | spacingClasses({margin: ['bottom']}) }}">
+                {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+              </div>
             </div>
           {% endfor %}
         </div>
@@ -79,7 +81,9 @@
         <div class="grid">
           {% for event in pastEvents.results %}
             <div class="{{ {s: 12, m: 6, l: 4, xl:4} | gridClasses}}">
-              {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+              <div class="{{ {s: 3} | spacingClasses({margin: ['bottom']}) }}">
+                {% componentV2 'event-promo', event, {}, {sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)' } %}
+              </div>
             </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
Fixes #2542

Adds some spacing below each event-series promo.

![screen shot 2018-04-27 at 16 56 36](https://user-images.githubusercontent.com/1394592/39372345-fb9925d0-4a3b-11e8-99cd-bda089eb7294.png)
