### PR TITLE
Show three past events, not two

### DIFF
--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -56,7 +56,7 @@ export async function renderEventSeries(ctx, next) {
     const paginatedResults = convertPrismicResultsToPaginatedResults(promos);
     const paginatedEvents = paginatedResults(promos);
     const upcomingEvents = Object.assign({}, paginatedEvents, {results: promos.filter(e => london(e.end).isAfter(london()))});
-    const pastEvents = {results: promos.filter(e => london(e.end).isBefore(london())).slice(0, 2).reverse()};
+    const pastEvents = {results: promos.filter(e => london(e.end).isBefore(london())).slice(0, 3).reverse()};
 
     ctx.render('pages/event-series', {
       pageConfig: createPageConfig({


### PR DESCRIPTION
Fixes #2478

We weren't sending enough past events to the template.

![screen shot 2018-04-27 at 17 03 27](https://user-images.githubusercontent.com/1394592/39372681-f462ec32-4a3c-11e8-9b53-8876194cfab1.png)
