### PR TITLE
Use a secondary link for opening hours

### DIFF
--- a/whats_on/app/views/components/whats-on-list-header/whats-on-list-header.njk
+++ b/whats_on/app/views/components/whats-on-list-header/whats-on-list-header.njk
@@ -27,7 +27,10 @@
                 {% endif %}
               </div>
             {% endif %}
-            <a class="{{ {s:'HNL5', m:'HNL4'} | fontClasses }}" href="https://wellcomecollection.org/info/opening-times">Opening times</a>
+            {% componentJsx 'SecondaryLink', {
+              url: 'https://wellcomecollection.org/info/opening-times',
+              text: 'Opening times'
+            } %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes #2264

Because the (new) secondary link style uses the same font variant as the 'Galleries closed today' copy, this problem (misalignment) goes away 🎉

![screen shot 2018-04-30 at 17 16 24](https://user-images.githubusercontent.com/1394592/39373262-f60f2e5e-4a3e-11e8-84ce-fd7bce3f800f.png)
