### PR TITLE
Prepare info page for migration

### DIFF
--- a/common/model/info-pages.js
+++ b/common/model/info-pages.js
@@ -6,5 +6,10 @@ export type InfoPage = {|
   id: string,
   title: string,
   promo: ?ImagePromo,
-  body: any[]
+  body: any[],
+  // TODO (drupal migration): This is used while we add the credit and
+  // alt for Drupal content
+  drupalPromoImage: ?string,
+  drupalNid: ?string,
+  drupalPath: ?string
 |}

--- a/common/services/prismic/info-pages.js
+++ b/common/services/prismic/info-pages.js
@@ -11,7 +11,10 @@ export function parseInfoPage(document: PrismicDocument) {
     id: document.id,
     title: document.data.title ? parseTitle(document.data.title) : 'TITLE MISSING',
     body: document.data.body ? parseBody(document.data.body) : [],
-    promo: document.data.promo && parseImagePromo(document.data.promo)
+    promo: document.data.promo && parseImagePromo(document.data.promo),
+    drupalPromoImage: document.data.promoImage && document.data.promoImage.url,
+    drupalNid: document.data.drupalNid,
+    drupalPath: document.data.drupalPath
   };
 }
 

--- a/common/services/prismic/info-pages.js
+++ b/common/services/prismic/info-pages.js
@@ -6,13 +6,37 @@ import type {PrismicDocument} from './types';
 import {infoPagesFields} from './fetch-links';
 
 export function parseInfoPage(document: PrismicDocument) {
+  // TODO (drupal migration): Just deal with normal promo once we deprecate the
+  // drupal stuff
+  const promo = document.data.promo && parseImagePromo(document.data.promo);
+  const drupalPromoImage = document.data.drupalPromoImage && document.data.drupalPromoImage.url ? document.data.drupalPromoImage : null;
+  const drupalisedPromo = drupalPromoImage ? {
+    caption: promo && promo.caption,
+    image: {
+      contentUrl: document.data.drupalPromoImage.url,
+      width: document.data.drupalPromoImage.width,
+      height: document.data.drupalPromoImage.height
+    }
+  } : promo;
+
+  const body = document.data.body ? parseBody(document.data.body) : [];
+  const drupalisedBody: any[] = drupalPromoImage ? [{
+    weight: 'default',
+    type: 'picture',
+    value: {
+      contentUrl: document.data.drupalPromoImage.url,
+      width: document.data.drupalPromoImage.width,
+      height: document.data.drupalPromoImage.height
+    }
+  }].concat(body) : body;
+
   return {
     type: 'info-pages',
     id: document.id,
     title: document.data.title ? parseTitle(document.data.title) : 'TITLE MISSING',
-    body: document.data.body ? parseBody(document.data.body) : [],
-    promo: document.data.promo && parseImagePromo(document.data.promo),
-    drupalPromoImage: document.data.promoImage && document.data.promoImage.url,
+    body: drupalisedBody,
+    promo: drupalisedPromo,
+    drupalPromoImage: drupalPromoImage,
     drupalNid: document.data.drupalNid,
     drupalPath: document.data.drupalPath
   };

--- a/prismic-model/js/info-pages.js
+++ b/prismic-model/js/info-pages.js
@@ -1,6 +1,8 @@
 import title from './parts/title';
 import body from './parts/body';
 import promo from './parts/promo';
+import link from './parts/link';
+import text from './parts/text';
 
 const Page = {
   Page: {
@@ -9,6 +11,11 @@ const Page = {
   },
   Promo: {
     promo
+  },
+  Migration: {
+    drupalPromoImage: link('Drupal promo image'),
+    drupalNid: text('Drupal node ID'),
+    drupalPath: text('Drupal path')
   }
 };
 

--- a/prismic-model/js/info-pages.js
+++ b/prismic-model/js/info-pages.js
@@ -12,8 +12,10 @@ const Page = {
   Promo: {
     promo
   },
+
+  // TODO (drupal migration): Remove this
   Migration: {
-    drupalPromoImage: link('Drupal promo image'),
+    drupalPromoImage: link('Drupal promo image', 'web'),
     drupalNid: text('Drupal node ID'),
     drupalPath: text('Drupal path')
   }

--- a/prismic-model/js/parts/link.js
+++ b/prismic-model/js/parts/link.js
@@ -1,7 +1,7 @@
 // @flow
 type LinkType = | 'web' | 'document' | 'media';
 
-export default function (label: string, linkType: LinkType, linkMask: string[] = []) {
+export default function (label: string, linkType: ?LinkType, linkMask: string[] = []) {
   return {
     'type': 'Link',
     'config': {

--- a/prismic-model/js/parts/text.js
+++ b/prismic-model/js/parts/text.js
@@ -1,0 +1,12 @@
+// @flow
+
+// This should be used sparingly as you can't free text search on it, only
+// exact match
+export default function(label: string) {
+  return {
+    type: 'Text',
+    config: {
+      label
+    }
+  };
+}

--- a/prismic-model/json/info-pages.json
+++ b/prismic-model/json/info-pages.json
@@ -170,6 +170,7 @@
       "type": "Link",
       "config": {
         "label": "Drupal promo image",
+        "select": "web",
         "customtypes": []
       }
     },

--- a/prismic-model/json/info-pages.json
+++ b/prismic-model/json/info-pages.json
@@ -164,5 +164,26 @@
         }
       }
     }
+  },
+  "Migration": {
+    "drupalPromoImage": {
+      "type": "Link",
+      "config": {
+        "label": "Drupal promo image",
+        "customtypes": []
+      }
+    },
+    "drupalNid": {
+      "type": "Text",
+      "config": {
+        "label": "Drupal node ID"
+      }
+    },
+    "drupalPath": {
+      "type": "Text",
+      "config": {
+        "label": "Drupal path"
+      }
+    }
   }
 }

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -14,6 +14,7 @@ import {PromoListFactory} from '../model/promo-list';
 import {PaginationFactory} from '../model/pagination';
 import {getInfoPage} from '../../common/services/prismic/info-pages';
 import {getCollectionOpeningTimes} from '../../common/services/prismic/opening-times';
+import {isPreview as getIsPreview} from '../../common/services/prismic/api';
 
 export const renderOpeningTimes = async(ctx, next) => {
   const path = ctx.request.url;
@@ -277,7 +278,8 @@ export async function renderInfoPage(ctx, next) {
         inSection: 'what-we-do',
         category: 'info'
       }),
-      page: infoPage
+      page: infoPage,
+      isPreview: getIsPreview(ctx.request)
     });
   }
 


### PR DESCRIPTION
References #2526 

## Who was this for?
All of us, to get away from Drupal

## What is it doing for them?
It's allowing us to import Drupal content without importing the media.
The process will be:

* Import with links to Drupal content
* Create a list that content editors can use to go through content that still has a Drupal image attached.
* Over time, this list should shrink to 0, at which time we deprecate the hack.
* Or we deprecate the hack, Drupal images in the body will just fall away, and promo images will be replaced with a placeholder.

An example of this can be seen on the schools info page: WtYmMiAAAOYZI206


## Checklist
- [ ] Demoed to the relevant people?
- [x] Simple as it can be?
- [x] Tested?
