### PR TITLE
add tags to info pages

### DIFF
--- a/prismic-model/js/info-pages.js
+++ b/prismic-model/js/info-pages.js
@@ -1,10 +1,17 @@
 import title from './parts/title';
 import body from './parts/body';
 import promo from './parts/promo';
+import list from './parts/list';
+import link from './parts/link';
 
 const Page = {
   Page: {
     title,
+    // We label this as `Site section` for the time that we only support this
+    // type of tag
+    tags: list('Site section', {
+      tag: link('Site section', 'document', ['tags'])
+    }),
     body
   },
   Promo: {

--- a/prismic-model/js/tag-types.js
+++ b/prismic-model/js/tag-types.js
@@ -1,0 +1,11 @@
+
+// @flow
+import title from './parts/title';
+
+const TagTypes = {
+  'Tag type': {
+    title
+  }
+};
+
+export default TagTypes;

--- a/prismic-model/js/tags.js
+++ b/prismic-model/js/tags.js
@@ -1,0 +1,13 @@
+
+// @flow
+import title from './parts/title';
+import link from './parts/link';
+
+const Tags = {
+  Tag: {
+    type: link('Tag type', 'document', ['tag-types']),
+    title
+  }
+};
+
+export default Tags;

--- a/prismic-model/json/info-pages.json
+++ b/prismic-model/json/info-pages.json
@@ -8,6 +8,24 @@
         "useAsTitle": true
       }
     },
+    "tags": {
+      "type": "Group",
+      "fieldset": "Site section",
+      "config": {
+        "fields": {
+          "tag": {
+            "type": "Link",
+            "config": {
+              "label": "Site section",
+              "select": "document",
+              "customtypes": [
+                "tags"
+              ]
+            }
+          }
+        }
+      }
+    },
     "body": {
       "fieldset": "Body content",
       "type": "Slices",

--- a/prismic-model/json/tag-types.json
+++ b/prismic-model/json/tag-types.json
@@ -1,0 +1,12 @@
+{
+  "Tag type": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Title",
+        "single": "heading1",
+        "useAsTitle": true
+      }
+    }
+  }
+}

--- a/prismic-model/json/tags.json
+++ b/prismic-model/json/tags.json
@@ -1,0 +1,22 @@
+{
+  "Tag": {
+    "type": {
+      "type": "Link",
+      "config": {
+        "label": "Tag type",
+        "select": "document",
+        "customtypes": [
+          "tag-types"
+        ]
+      }
+    },
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Title",
+        "single": "heading1",
+        "useAsTitle": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
References #2526

## Who was this for?
People who would still like to use our informational pages after we turn Drupal off.

## What is it doing for them?
Allowing us to tag up pages with site sections.


## Checklist
- [ ] Demoed to the relevant people?
- [x] Simple as it can be?
- [x] Tested?
