### PR TITLE
add tag list pages

### DIFF
--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -8,7 +8,8 @@ import type {MultiContent} from '../../model/multi-content';
 import type {PaginatedResults} from './types';
 
 type ContentQuery = {
-  ids: string[]
+  ids?: string[],
+  tags?: string[]
 };
 
 function parseMultiContent(documents): MultiContent[] {
@@ -19,8 +20,14 @@ function parseMultiContent(documents): MultiContent[] {
   }).filter(Boolean);
 }
 
-export async function getMultiContent(req: Request, { ids }: ContentQuery): Promise<PaginatedResults<MultiContent>> {
-  const predicates = [Prismic.Predicates.in('document.id', ids)];
+export async function getMultiContent(
+  req: Request,
+  { ids = [], tags = [] }: ContentQuery
+): Promise<PaginatedResults<MultiContent>> {
+  // TODO the document.tags predicate should probably be an `in` rather than `at`
+  const idsPredicate = ids.length > 0 ? [Prismic.Predicates.in('document.id', ids)] : [];
+  const tagsPredicate = tags.length > 0 ? [Prismic.Predicates.at('document.tags', tags)] : [];
+  const predicates = idsPredicate.concat(tagsPredicate);
   const apiResponse = await getDocuments(req, predicates, {
     fetchLinks: infoPagesFields
   });

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -14,8 +14,7 @@ import {
   renderWebcomicSeries,
   renderOpeningTimes,
   renderInfoPage,
-  renderDrupalInfoPage,
-  renderDrupalInfoPages
+  renderTagPage
 } from '../controllers/content';
 
 const r = new Router({
@@ -57,8 +56,8 @@ r.get('/series/(W):id', renderSeries);
 r.get('/webcomic-series/:id', renderWebcomicSeries);
 r.get('/info/opening-times', renderOpeningTimes);
 r.get('/info/:id', renderInfoPage);
-r.get('/drupal-list', renderDrupalInfoPages);
-r.get('/drupal/:id*', renderDrupalInfoPage);
+r.get('/what-we-do', renderTagPage('what-we-do'));
+r.get('/visit-us', renderTagPage('visit-us'));
 
 // API
 r.get('/works', search);


### PR DESCRIPTION
Fixes/References #2526 

## Who was this for?
People who want to see all of the content listed as "What we do" or "Visit us".
This works with preview due to the nice new Prismic API service. 

## What is it doing for them?
Gives them a list of pages tagged as "what-we-do" or "visit-us".
We are currently using the internal Prismic tags. 

This is because, at the moment, you cannot query multiple content types with tags and query all of it. For now it'll do, but we can't attach metadata to it - although I have a plan of tagging the custom type with the tag, pulling that out and using it as the tag's metadata. Let's see.

## Checklist
- [ ] Demoed to the relevant people?
- [x] Simple as it can be?
- [x] Tested?
