### PR TITLE
Style eventbrite button correctly

### DIFF
--- a/eventbrite/app/views/components/eventbrite-button/eventbrite-button.njk
+++ b/eventbrite/app/views/components/eventbrite-button/eventbrite-button.njk
@@ -2,7 +2,10 @@
   <a class="{{- [
     'js-eventbrite-ticket-button',
     'btn',
-    'btn--primary'
+    'btn--primary',
+    'font-HNM4-s',
+    'flex-inline',
+    'flex-v-center'
   ].join(' ') }}"
      data-eventbrite-ticket-id="{{ ticket.eventbriteId }}"
      {% if ticket.onSaleStatus === 'available' %}


### PR DESCRIPTION
Makes the eventbrite button look like a primary button, without using the `Button` component (so as to avoid hacking in the `data-eventbrite-id` attribute.

![screen shot 2018-05-01 at 11 45 01](https://user-images.githubusercontent.com/1394592/39470716-2c5dfc38-4d37-11e8-97b3-ccd820152af1.png)
