### PR TITLE
add date published to basic pages for press releases

### DIFF
--- a/prismic-model/js/info-pages.js
+++ b/prismic-model/js/info-pages.js
@@ -5,6 +5,7 @@ import promo from './parts/promo';
 import link from './parts/link';
 import text from './parts/text';
 import list from './parts/list';
+import timestamp from './parts/timestamp';
 
 const Page = {
   Page: {
@@ -14,6 +15,7 @@ const Page = {
     tags: list('Site section', {
       tag: link('Site section', 'document', ['tags'])
     }),
+    datePublished: timestamp('Published date'),
     body
   },
   Promo: {

--- a/prismic-model/json/info-pages.json
+++ b/prismic-model/json/info-pages.json
@@ -26,6 +26,12 @@
         }
       }
     },
+    "datePublished": {
+      "type": "Timestamp",
+      "config": {
+        "label": "Published date"
+      }
+    },
     "body": {
       "fieldset": "Body content",
       "type": "Slices",


### PR DESCRIPTION
Fixes/References #2490 

## Who was this for?
People who want to see the dates of press releases

## What is it doing for them?
Allows us to add to add the date to press releases

## Checklist
- [x] Simple as it can be?
- [x] Tested?
