### PR TITLE
add backfillQuery and requiredCount to content list

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -306,6 +306,8 @@ export function parseBody(fragment: PrismicFragment[]) {
           weight: 'default',
           value: {
             title: asText(slice.primary.title),
+            requiredCount: slice.primary.requiredCount,
+            backfillQuery: slice.primary.backfillQuery,
             items: slice.items.map(item => {
               if (item.content.type === 'info-pages') {
                 return parseInfoPage(item.content);

--- a/common/views/components/ContentList/ContentList.js
+++ b/common/views/components/ContentList/ContentList.js
@@ -5,11 +5,26 @@ import {grid} from '../../../utils/classnames';
 
 type Props = {|
   title: ?string,
-  items: MultiContent[]
+  items: MultiContent[],
+  requiredCount?: number,
+  backfillQuery: ?string
 |}
 
-const ContentList = ({ title, items }: Props) => {
+const ContentList = ({
+  title,
+  items,
+  requiredCount = 0,
+  backfillQuery
+}: Props) => {
   const itemIds = items.map(i => i.id);
+  const backfillCount = requiredCount - items.length;
+
+  const query = [
+    itemIds.length > 0 ? `ids:${itemIds.join(',')}` : null,
+    backfillQuery  || '',
+    backfillCount > 0 ? `count:${backfillCount}` : null
+  ].filter(Boolean).join(' ');
+
   return (
     <Fragment>
       <div className='grid'>
@@ -21,7 +36,7 @@ const ContentList = ({ title, items }: Props) => {
       <div
         data-component='ContentListItems'
         className='async-content component-list-placeholder'
-        data-endpoint={`/async/content-list?query=ids:${itemIds.join(',')}`}
+        data-endpoint={'/async/content-list?query=' + encodeURIComponent(query)}
         data-prefix-endpoint={false}
         data-modifiers={[]}>
       </div>

--- a/prismic-model/js/parts/body.js
+++ b/prismic-model/js/parts/body.js
@@ -4,6 +4,8 @@ import captionedImageSlice from './captioned-image-slice';
 import captionedImageGallerySlice from './captioned-image-gallery-slice';
 import title from './title';
 import link from './link';
+import number from './number';
+import text from './text';
 
 // I've left slice here as we shouldn't really use it.
 type SliceProps = {|
@@ -49,7 +51,11 @@ export default {
       editorialImage: captionedImageSlice(),
       editorialImageGallery: captionedImageGallerySlice(),
       contentList: slice('Content list', {
-        nonRepeat: { title },
+        nonRepeat: {
+          title,
+          requiredCount: number('Total'),
+          backfillQuery: text('Backfill query')
+        },
         repeat: {
           content: link('Content item', 'document', ['info-pages'])
         }

--- a/prismic-model/json/info-pages.json
+++ b/prismic-model/json/info-pages.json
@@ -115,6 +115,18 @@
                   "single": "heading1",
                   "useAsTitle": true
                 }
+              },
+              "requiredCount": {
+                "type": "Number",
+                "config": {
+                  "label": "Total"
+                }
+              },
+              "backfillQuery": {
+                "type": "Text",
+                "config": {
+                  "label": "Backfill query"
+                }
               }
             },
             "repeat": {

--- a/server/controllers/async-controllers.js
+++ b/server/controllers/async-controllers.js
@@ -72,10 +72,14 @@ export const seriesTransporter = async(ctx, next) => {
 };
 
 export const contentList = async (ctx, next) => {
-  const query = searchQuery.parse(ctx.query.query, { keywords: ['ids'] });
+  const query = searchQuery.parse(ctx.query.query, { keywords: ['ids', 'tags', 'count'] });
+
   // searchQueryParser automatically changes comma seperated lists into arrays
-  const ids = typeof query.ids === 'string' ? query.ids.split(',') : query.ids;
-  const multiContent = await getMultiContent(ctx.request, {ids});
+  // Also deal with null values
+  const ids = typeof query.ids === 'string' ? query.ids.split(',') : (query.ids || []);
+  const tags = typeof query.tags === 'string' ? query.tags.split(',') : (query.tags || []);
+
+  const multiContent = await getMultiContent(ctx.request, {ids, tags});
   ctx.body = {
     html: ReactDOMServer.renderToString(
       React.createElement(ContentListItems, { items: multiContent.results })


### PR DESCRIPTION
References #2490 

## Who was this for?
Editors when they want to create pages that have dynamically updated lists e.g. tags, content types, some other query we make available.

## What is it doing for them?
Giving them a field to put in a query to make the lists update on the page when the content updates.


## Checklist
- [ ] Demoed to the relevant people?
- [x] Simple as it can be?
- [x] Tested?

![dynamic-content-list](https://user-images.githubusercontent.com/31692/39478969-ca433a20-4d5b-11e8-91cb-d4095810af72.png)

![query](https://user-images.githubusercontent.com/31692/39478970-ca5dfbd0-4d5b-11e8-9a91-9f8ec85d202c.png)

