### PR TITLE
add webcomic series tag to body squabbles

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -57,6 +57,11 @@ export const renderArticle = async(ctx, next) => {
   const isPreview = Boolean(ctx.params.preview);
   const article = await getArticle(id, isPreview ? ctx.request : null);
 
+  const tags = article.contentType === 'comic' ? article.series.map(series => ({
+    url: `/webcomic-series/${series.id}`,
+    text: `Part of ${series.name}`
+  })) : [];
+
   if (article) {
     if (format === 'json') {
       ctx.body = article;
@@ -73,7 +78,8 @@ export const renderArticle = async(ctx, next) => {
         }), trackingInfo),
         article: article,
         page: article,
-        isPreview: isPreview
+        isPreview: isPreview,
+        tags
       });
     }
   }

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -228,8 +228,10 @@
 
                 {% componentV2 'divider', null, {'stub': true, 'black': true}, {extraClasses: [{s:4} | spacingClasses({margin: ['top']})]} %}
 
-                {% if article.tags.length > 0 %}
-                  {% component 'tags', { tags: article.tags } %}
+                {% if tags.length > 0 %}
+                  <div class="{{ {s: 2} | spacingClasses({ margin: ['top'] }) }}">
+                    {% componentJsx 'Tags', { tags: tags } %}
+                  </div>
                 {% endif %}
               </div>
 


### PR DESCRIPTION
## Who was this for?
People who want to see more body squabbles, but can't as we hide it from them.

## What is it doing for them?
A test to see if we point it out that this is part of a series, people will see more of them.
A list would be better, but this was already lying around on the article page.
The test results are easy - do we get more traffic to the body squabbles series page.

If this proves good over the next week - we can think of a better execution.

## Checklist
- [x] Simple as it can be?
- [x] Tested?

![screen shot 2018-05-01 at 17 19 40](https://user-images.githubusercontent.com/31692/39481718-432d7a9c-4d64-11e8-8558-e4a76616ddf5.png)
