### PR TITLE
only look for article tags if we have an article

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -57,15 +57,14 @@ export const renderArticle = async(ctx, next) => {
   const isPreview = Boolean(ctx.params.preview);
   const article = await getArticle(id, isPreview ? ctx.request : null);
 
-  const tags = article.contentType === 'comic' ? article.series.map(series => ({
-    url: `/webcomic-series/${series.id}`,
-    text: `Part of ${series.name}`
-  })) : [];
-
   if (article) {
     if (format === 'json') {
       ctx.body = article;
     } else {
+      const tags = article.contentType === 'comic' ? article.series.map(series => ({
+        url: `/webcomic-series/${series.id}`,
+        text: `Part of ${series.name}`
+      })) : [];
       const displayType = article.displayType;
       const trackingInfo = getEditorialAnalyticsInfo(article);
       ctx.render(`pages/${displayType || 'article'}`, {


### PR DESCRIPTION
## Who was this for?
People trying to access articles that don't exist

## What is it doing for them?
Giving them a 404, not 500.


## Checklist
- [x] Simple as it can be?
