### PR TITLE
add support for promos without images

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -212,13 +212,15 @@ export function parseImagePromo(
   minWidth: ?string = null
 ): ?ImagePromo {
   const maybePromo = frag && frag.find(slice => slice.slice_type === 'editorialImage');
+  const hasImage = maybePromo && maybePromo.primary.image && isEmptyObj(maybePromo.primary.image) || false;
+
   return maybePromo && ({
     caption: asText(maybePromo.primary.caption),
-    image: parsePicture({
+    image: hasImage ? parsePicture({
       image:
         // We introduced enforcing 16:9 half way through, so we have to do a check for it.
         maybePromo.primary.image[cropType] || maybePromo.primary.image
-    }, minWidth)
+    }, minWidth) : null
   }: ImagePromo);
 }
 

--- a/common/views/components/BasicPromo/BasicPromo.js
+++ b/common/views/components/BasicPromo/BasicPromo.js
@@ -56,7 +56,10 @@ const BasicPromo = ({
       </div>
 
       {description &&
-        <span className={font({s: 'HNL5'})}>
+        <span className={[
+          spacing({s: 2}, {margin: ['top']}),
+          font({s: 'HNL5'})
+        ].join(' ')}>
           {description}
         </span>
       }


### PR DESCRIPTION
## Who was this for?
Those promos who have no companion images.

## What is it doing for them?
We're going to have to support promos without images (some but not all press releases will have them).

We need to have a nice hard look at our typing here to help us parse a little neater, but let's do that as a whole thing.


## Checklist
- [x] Simple as it can be?
- [x] Tested?

![No image promos](https://user-images.githubusercontent.com/31692/39528633-86aeb066-4e1c-11e8-8d97-12e63bd813be.jpg)

