### PR TITLE
Tertiary button

### DIFF
--- a/catalogue/webapp/pages/catalogue/work.js
+++ b/catalogue/webapp/pages/catalogue/work.js
@@ -13,6 +13,7 @@ import License from '@weco/common/views/components/License/License';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
+import Button from '@weco/common/views/components/Buttons/Button/Button';
 import {Fragment} from 'react';
 
 export type Link = {|
@@ -247,47 +248,37 @@ const WorkPage = ({work}: Props) => {
                 Download
               </h2>
 
-              <a
-                className={classNames([
-                  spacing({s: 2}, {margin: ['bottom']}),
-                  font({s: 'HNM5', m: 'HNM4'}),
-                  'plain-link font-green font-hover-turquoise flex flex--v-center'
-                ])}
-                href={convertImageUri(work.items[0].locations[0].url, 'full')}
-                target='_blank'
-                download={`${work.id}.jpg`}
-                rel='noopener noreferrer'
-                data-track-event={JSON.stringify({
-                  'category': 'component',
-                  'action': 'download-button:click',
-                  'label': `id: work.id , size:original, title:${work.title.substring(50)}`
-                })}>
-                <Icon name='download' extraClasses='icon--green' />
-                <div className={spacing({s: 1}, {margin: ['left']})}>
-                  Download full size
-                </div>
-              </a>
+              <div className={spacing({s: 1}, {margin: ['bottom']})}>
+                <Button
+                  extraClasses='btn--tertiary'
+                  url={convertImageUri(work.items[0].locations[0].url, 'full')}
+                  target='_blank'
+                  download={`${work.id}.jpg`}
+                  rel='noopener noreferrer'
+                  eventTracking={JSON.stringify({
+                    'category': 'component',
+                    'action': 'download-button:click',
+                    'label': `id: work.id , size:original, title:${work.title.substring(50)}`
+                  })}
+                  icon='download'
+                  text='Download full size' />
+              </div>
 
-              <a
-                className={classNames([
-                  spacing({s: 4}, {margin: ['bottom']}),
-                  font({s: 'HNM5', m: 'HNM4'}),
-                  'plain-link font-green font-hover-turquoise flex flex--v-center'
-                ])}
-                href={convertImageUri(work.items[0].locations[0].url, 760)}
-                target='_blank'
-                download={`${work.id}.jpg`}
-                rel='noopener noreferrer'
-                data-track-event={JSON.stringify({
-                  'category': 'component',
-                  'action': 'download-button:click',
-                  'label': `id: work.id , size:760, title:${work.title.substring(50)}`
-                })}>
-                <Icon name='download' extraClasses='icon--green' />
-                <div className={spacing({s: 1}, {margin: ['left']})}>
-                  Download small (760px)
-                </div>
-              </a>
+              <div className={spacing({s: 3}, {margin: ['bottom']})}>
+                <Button
+                  extraClasses='btn--tertiary'
+                  url={convertImageUri(work.items[0].locations[0].url, 760)}
+                  target='_blank'
+                  download={`${work.id}.jpg`}
+                  rel='noopener noreferrer'
+                  eventTracking={JSON.stringify({
+                    'category': 'component',
+                    'action': 'download-button:click',
+                    'label': `id: work.id , size:760, title:${work.title.substring(50)}`
+                  })}
+                  icon='download'
+                  text='Download small (760px)' />
+              </div>
 
               <div className={spacing({s: 4}, {margin: ['bottom']})}>
                 <p className={classNames([

--- a/common/views/components/Buttons/Button/Button.js
+++ b/common/views/components/Buttons/Button/Button.js
@@ -11,6 +11,9 @@ type Props = {|
   eventTracking?: string,
   id?: string,
   disabled?: boolean,
+  target?: string,
+  download?: string,
+  rel?: string,
   clickHandler?: (event: Event) => void
 |}
 
@@ -22,6 +25,9 @@ const Button = ({
   text,
   eventTracking,
   disabled,
+  target,
+  download,
+  rel,
   clickHandler
 }: Props) => {
   const HtmlTag = url ? 'a' : 'button';
@@ -31,6 +37,9 @@ const Button = ({
   return (
     <HtmlTag
       href={url}
+      target={target}
+      download={download}
+      rel={rel}
       id={id}
       className={`btn ${extraClasses || ''} ${font(fontClasses)} flex-inline flex--v-center`}
       data-track-event={eventTracking}

--- a/common/views/components/CopyUrl/CopyUrl.js
+++ b/common/views/components/CopyUrl/CopyUrl.js
@@ -105,6 +105,9 @@ class CopyUrl extends Component<Props, State> {
           isLabelHidden={true}
           fontStyles={{s: 'HNL5', m: 'HNL4'}} />
 
+        {/* TODO: update this button to be `<Button extraClasses: 'btn--tertiary' />
+        once we're fully reactified */}
+
         <button aria-live='polite'
           onClick={this.handleButtonClick}
           data-copy-text={url}

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -74,33 +74,31 @@
             Download
           </h2>
 
+          <div class="{{ {s:1} | spacingClasses({margin: ['bottom']}) }}">
+            {% componentJsx 'Button', {
+              extraClasses: 'btn--tertiary',
+              url: work.imgLink | convertImageUri('full', false),
+              download: work.id + '.jpg',
+              rel: 'noopener noreferrer',
+              target: '_blank',
+              eventTracking: '{"category": "component", "action": "download-button:click", "label": "id:' +  work.id + ', size:original, title:' + work.title | truncate(50) + '"}',
+              icon: 'download',
+              text: 'Download full size'
+            } %}
+          </div>
 
-
-          <a
-            class="btn btn--tertiary {{ {s:2} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5' , m:'HNM4'} | fontClasses }} flex-inline flex--v-center"
-            href="{{ work.imgLink | convertImageUri('full', false) }}"
-            download="{{ work.id }}.jpg"
-            rel="noopener noreferrer"
-            target="_blank"
-            data-track-event='{"category": "component", "action": "download-button:click", "label": "id:{{ work.id }}, size:original, title:{{ work.title | truncate(50) }}"}'>
-            {% icon 'download', null, ['icon--green'] %}
-            <div class="{{{s: 1} | spacingClasses({ margin: ['left'] })}}">
-              Download full size
-            </div>
-          </a>
-
-          <a
-            class="btn btn--tertiary {{ {s:4} | spacingClasses({margin: ['bottom']}) }} {{ {s:'HNM5' , m:'HNM4'} | fontClasses }} flex-inline flex--v-center"
-            href="{{ work.imgLink | convertImageUri(760, false) }}"
-            download="{{ work.id }}.jpg"
-            rel="noopener noreferrer"
-            target="_blank"
-            data-track-event='{"category": "component", "action": "download-button:click", "label": "id:{{ work.id }}, size:760, title:{{ work.title | truncate(50) }}"}'>
-            {% icon 'download', null, ['icon--green'] %}
-            <div class="{{{s: 1} | spacingClasses({ margin: ['left'] })}}">
-              Download small (760px)
-            </div>
-          </a>
+          <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
+            {% componentJsx 'Button', {
+              extraClasses: 'btn--tertiary',
+              url: work.imgLink | convertImageUri(760, false),
+              download: work.id + '.jpg',
+              rel: 'noopener noreferrer',
+              target: '_blank',
+              eventTracking: '{"category": "component", "action": "download-button:click", "label": "id:' +  work.id + ', size:760, title:' + work.title | truncate(50) + '"}',
+              icon: 'download',
+              text: 'Download small (760px)'
+            } %}
+          </div>
 
           <div class="{{ {s:4} | spacingClasses({margin: ['bottom']}) }}">
             <p class="{{ {s:'HNL5', m:'HNL4'} | fontClasses }} {{ {s:1} | spacingClasses({margin: ['bottom']}) }}">Credit: {{ work.credit }}</p>


### PR DESCRIPTION
References:

> [Why don't we have `TertiaryButton` again?](https://github.com/wellcometrust/wellcomecollection.org/pull/2585#pullrequestreview-117230382)

We have a `<Button extraClasses='btn--tertiary' />` and this is, indeed, more appropriate (but needed some extra props to be added).

Have updated the work.njk and work.js templates to use this. The CopyUrl doesn't yet use the `Button` component, but should do in the future.
