### PR TITLE
use tag URL to not pollute the existing URL on v1

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -56,21 +56,21 @@ r.get('/series/(W):id', renderSeries);
 r.get('/webcomic-series/:id', renderWebcomicSeries);
 r.get('/info/opening-times', renderOpeningTimes);
 r.get('/pages/:id', renderPage);
-r.get('/what-we-do', renderTagPage(
+r.get('/tag/what-we-do', renderTagPage(
   'what-we-do',
   '/what-we-do',
   'What we do',
   'what-we-do',
   'Activities, resources and projects from Wellcome Collection.'
 ));
-r.get('/visit-us', renderTagPage(
+r.get('/tag/visit-us', renderTagPage(
   'visit-us',
   '/visit-us',
   'Visit us',
   'visit-us',
   'Wellcome Collection is open 10.00-18.00 (11.00-18.00 Sundays) with late night opening on Thursday. The galleries and library are closed on Mondays.'
 ));
-r.get('/press', renderTagPage(
+r.get('/tag/press', renderTagPage(
   'press',
   '/press',
   'Press',


### PR DESCRIPTION
## Who was this for?
Us to help with the migration.

## What is it doing for them?
So as to not confuse what there are - let's move it here.
As stated, they are still temporary, and meant to be used to help facilitate the migration.
They will not work on the root domain, only preview.


## Checklist
- [x] Demoed to the relevant people?
- [x] Simple as it can be?
- [x] Tested?
