### PR TITLE
use isDocumentLink over isEmptyObject

### DIFF
--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -8,7 +8,6 @@ import {pagesFields} from './fetch-links';
 export function parsePage(document: PrismicDocument) {
   // TODO (drupal migration): Just deal with normal promo once we deprecate the
   // drupal stuff
-  console.info('erejhwgrhj');
   const promo = document.data.promo && parseImagePromo(document.data.promo);
   const drupalPromoImage = document.data.drupalPromoImage && document.data.drupalPromoImage.url ? document.data.drupalPromoImage : null;
   const drupalisedPromo = drupalPromoImage ? {

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -8,6 +8,7 @@ import {pagesFields} from './fetch-links';
 export function parsePage(document: PrismicDocument) {
   // TODO (drupal migration): Just deal with normal promo once we deprecate the
   // drupal stuff
+  console.info('erejhwgrhj');
   const promo = document.data.promo && parseImagePromo(document.data.promo);
   const drupalPromoImage = document.data.drupalPromoImage && document.data.drupalPromoImage.url ? document.data.drupalPromoImage : null;
   const drupalisedPromo = drupalPromoImage ? {

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -212,7 +212,7 @@ export function parseImagePromo(
   minWidth: ?string = null
 ): ?ImagePromo {
   const maybePromo = frag && frag.find(slice => slice.slice_type === 'editorialImage');
-  const hasImage = maybePromo && maybePromo.primary.image && !isEmptyObj(maybePromo.primary.image) || false;
+  const hasImage = (maybePromo && maybePromo.primary.image && isImageLink(maybePromo.primary.image)) || false;
 
   return maybePromo && ({
     caption: asText(maybePromo.primary.caption),
@@ -264,8 +264,16 @@ export function parseBackgroundTexture(backgroundTexture: PrismicBackgroundTextu
   };
 }
 
+// If a link is non-existant, it can either be returned as `null`, or as an
+// empty link object, which is why we use this
 export function isDocumentLink(fragment: ?PrismicFragment): boolean {
   return Boolean(fragment && fragment.isBroken === false);
+}
+
+// when images have crops, event if the image isn't attached, we get e.g.
+// { '32:15': {}, '16:9': {}, square: {} }
+export function isImageLink(fragment: ?PrismicFragment): boolean {
+  return Boolean(fragment && fragment.dimensions);
 }
 
 export function parseBody(fragment: PrismicFragment[]) {


### PR DESCRIPTION
## Who was this for?
People who want promos with no images.

## What is it doing for them?
The object returned by "No image" is `{ '32:15': {}, '16:9': {}, square: {} }`.

This is making me think, soon, is time to start writing some generic parsers, and we should try choose 1 type for images, and then refactor out the rest.


## Checklist
- [x] Demoed to the relevant people?
- [x] Simple as it can be?
- [x] Tested?
