### PR TITLE
remove checklist from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,3 @@ Fixes/References #
 
 
 ## What is it doing for them?
-
-
-## Checklist
-- [ ] Demoed to the relevant people?
-- [ ] Simple as it can be?
-- [ ] Tested?


### PR DESCRIPTION
## Who was this for?
People reading what we do on Slack

## What is it doing for them?
Make it easier to read by only including relevant info.
I'm also not sure checklists make people do things.

## Lots of info
![screen shot 2018-05-04 at 17 15 02](https://user-images.githubusercontent.com/31692/39638648-ce2dcc6c-4fbe-11e8-8379-bde21dc9b734.png)

## Relevant info
![screen shot 2018-05-04 at 17 16 38](https://user-images.githubusercontent.com/31692/39638689-f3d77e68-4fbe-11e8-9fbb-81bcbd17bbe2.png)

(☝️ How meta)

