### PR TITLE
make basic page background a passable component

### DIFF
--- a/common/views/components/Templates/BasicPage/BasicPage.js
+++ b/common/views/components/Templates/BasicPage/BasicPage.js
@@ -5,11 +5,13 @@ import BasicHeader from '../../PageHeaders/BasicHeader/BasicHeader';
 import BasicBody from '../../BasicBody/BasicBody';
 import type {Node} from 'react';
 import type {UiImageProps} from '../../Images/Images';
+import type WobblyBackground from './WobblyBackground';
 
 type Props = {|
   title: string,
   body: {type: string, value: any}[],
   mainImageProps: ?UiImageProps,
+  Background: | WobblyBackground,
   DateInfo: Node,
   Description: Node,
   InfoBar: Node,
@@ -32,6 +34,7 @@ const BasicPage = ({
   title,
   body,
   mainImageProps,
+  Background,
   DateInfo,
   Description,
   InfoBar,
@@ -39,22 +42,7 @@ const BasicPage = ({
 }: Props) => {
   return (
     <Fragment>
-      <div className='row relative'>
-        <div className='overflow-hidden full-width bg-cream' style={{
-          top: 0,
-          position: 'fixed',
-          height: '50vw',
-          maxHeight: '66vh',
-          zIndex: -1
-        }}>
-          <div className='absolute full-width' style={{ bottom: 0 }}>
-            <div className='wobbly-edge wobbly-edge--white js-wobbly-edge'
-              data-is-valley='true'
-              data-max-intensity='100'>
-            </div>
-          </div>
-        </div>
-      </div>
+      {Background}
       <BasicHeader
         title={title}
         mainImageProps={mainImageProps}

--- a/common/views/components/Templates/BasicPage/InstallationPage.js
+++ b/common/views/components/Templates/BasicPage/InstallationPage.js
@@ -6,6 +6,7 @@ import DateRange from '../../DateRange/DateRange';
 import StatusIndicator from '../../StatusIndicator/StatusIndicator';
 import HTMLDate from '../../HTMLDate/HTMLDate';
 import Contributor from '../../Contributor/Contributor';
+import WobblyBackground from './WobblyBackground';
 import type {UiInstallation} from '../../../../model/installations';
 
 type Props = {|
@@ -19,6 +20,7 @@ const InstallationPage = ({ installation }: Props) => {
 
   return (
     <BasicPage
+      Background={WobblyBackground()}
       DateInfo={DateInfo}
       Description={<p>{description}</p>}
       InfoBar={<StatusIndicator start={installation.start} end={(installation.end || new Date())} />}

--- a/common/views/components/Templates/BasicPage/WobblyBackground.js
+++ b/common/views/components/Templates/BasicPage/WobblyBackground.js
@@ -1,0 +1,20 @@
+// @flow
+const WobblyBackground = () => (
+  <div className='row relative'>
+    <div className='absolute overflow-hidden full-width bg-cream' style={{
+      top: 0,
+      height: '50vw',
+      maxHeight: '66vh',
+      zIndex: -1
+    }}>
+      <div className='absolute full-width' style={{ bottom: 0 }}>
+        <div className='wobbly-edge wobbly-edge--white js-wobbly-edge'
+          data-is-valley='true'
+          data-max-intensity='100'>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+export default WobblyBackground;


### PR DESCRIPTION
## Who was this for?
Devs / designers wanting to create a page for some type of future content, and not wanting to create a new page type.

## What is it doing for them?
Allowing us to pass a background component to the `BasicPage`.

This means that the installations, events, and pages (and potentially books) will hydrate the `BasicPage` template.

![screenshot-user-images githubusercontent com-2018 05 11-17-02-17](https://user-images.githubusercontent.com/31692/39934358-70de115a-553d-11e8-9068-38d21ff2f892.png)
