### PR TITLE
remove promo images from pages body

### DIFF
--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -20,21 +20,12 @@ export function parsePage(document: PrismicDocument) {
   } : promo;
 
   const body = document.data.body ? parseBody(document.data.body) : [];
-  const drupalisedBody: any[] = drupalPromoImage ? [{
-    weight: 'default',
-    type: 'picture',
-    value: {
-      contentUrl: document.data.drupalPromoImage.url,
-      width: document.data.drupalPromoImage.width,
-      height: document.data.drupalPromoImage.height
-    }
-  }].concat(body) : body;
 
   return {
     type: 'pages',
     id: document.id,
     title: document.data.title ? parseTitle(document.data.title) : 'TITLE MISSING',
-    body: drupalisedBody,
+    body: body,
     promo: drupalisedPromo,
     drupalPromoImage: drupalPromoImage,
     drupalNid: document.data.drupalNid,


### PR DESCRIPTION
## Who was this for?
The content team

## What is it doing for them?
removes the images from `Pages` as they have no credit info and alt text.

# Before
![screen shot 2018-05-14 at 11 55 48](https://user-images.githubusercontent.com/31692/39993574-37ed45e0-576e-11e8-9a56-3b9b1d6492e1.png)

# After
![screen shot 2018-05-14 at 11 55 58](https://user-images.githubusercontent.com/31692/39993575-3806bcaa-576e-11e8-977c-75f4b7c5133c.png)

