### PR TITLE
Add 'result' to query string cache keys

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Fixes/References #
 
-## Who was this for?
+## Who is this for?
 
 
 ## What is it doing for them?

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -50,6 +50,9 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         # Wellcome Images redirect
         "MIROPAC",
         "MIRO",
+        # dotmailer gives us a 'result' (if we run out of params,
+        # consider making new urls for newsletter pages instead)
+        "result"
       ]
 
       cookies {


### PR DESCRIPTION
## Who was this for?
1. People who want the heading above to be in the present tense
2. People who like seeing confirmation of newsletter subscriptions/errors

## What is it doing for them?
Changing the tense of the first heading and stopping Cloudfront from ignoring the 'result' query.