### PR TITLE
Only show TASL if at least one necessary piece of info present

### DIFF
--- a/common/views/components/Tasl/Tasl.js
+++ b/common/views/components/Tasl/Tasl.js
@@ -95,7 +95,7 @@ const Tasl = withToggler(({
     toggle();
   }
 
-  return ( // TODO: remove js- and data-attributes once fully Reactified
+  return [title, sourceName, copyrightHolder].some(_ => _) && ( // TODO: remove js- and data-attributes once fully Reactified
     <div className={`
       ${isFull ? 'tasl--top' : 'tasl--bottom'}
       ${font({s: 'LR3', m: 'LR2'})}


### PR DESCRIPTION
Fixes #2603

## Who is this for?
Users.

## What is it doing for them?
Prevents empty TASL displaying on images.