### PR TITLE
Only load root scope classes once

### DIFF
--- a/common/styles/critical.scss
+++ b/common/styles/critical.scss
@@ -1,5 +1,6 @@
 // Utilities
 @import 'utilities/all';
+@import 'utilities/root-scope-classes';
 
 // Vendor
 @import 'vendor/normalize';

--- a/common/styles/utilities/all.scss
+++ b/common/styles/utilities/all.scss
@@ -2,4 +2,3 @@
 @import 'utilities/variables';
 @import 'utilities/mixins';
 @import 'utilities/functions';
-@import 'utilities/root-scope-classes';


### PR DESCRIPTION
## Who is this for?
Users.

## What is it doing for them?
Reducing page weight.

The `root-scope-classes` were being called in from both the `critical` and the `non-critical` scss partials. This puts it in the critical alone.

__before__
![screen shot 2018-05-15 at 16 20 51](https://user-images.githubusercontent.com/1394592/40066506-28f9ee46-585c-11e8-8ed5-3d3eeb5d6cbb.png)

__after__
![screen shot 2018-05-15 at 16 21 10](https://user-images.githubusercontent.com/1394592/40066514-2e6f7c06-585c-11e8-89f0-48ab2311ae5a.png)
