### PR TITLE
Event series in multi content

### DIFF
--- a/common/model/event-series.js
+++ b/common/model/event-series.js
@@ -1,0 +1,13 @@
+// @flow
+import type {HTMLString} from '../services/prismic/types';
+import type {BackgroundTexture} from './background-texture';
+import type {ImagePromo} from './image-promo';
+
+export type EventSeries = {|
+  type: 'event-series',
+  id: string,
+  title: string,
+  description: ?HTMLString,
+  backgroundTexture: ?BackgroundTexture,
+  promo: ?ImagePromo
+|}

--- a/common/model/events.js
+++ b/common/model/events.js
@@ -191,24 +191,12 @@ export const eventExample = ({
     {
       id: 'WfyK-yoAANuggY31',
       title: 'Your reality is Broken',
-      description: 'Perception is fundamental to who we are and ' +
-        'how we experience life. But how much can ' +
-        'we actually trust our senses? A scientific, ' +
-        'philosophical and creative approach to this ' +
-        'question will invite you on a journey into your ' +
-        'inner and outer experiences of the world.'
+      description: null
     },
     {
       id: 'WcPx8ygAAH4Q9WgN',
       title: 'Friday night spectacular',
-      description: 'Focusing on a theme or topic, we fill ' +
-        'the building with artists, scientists, performers, ' +
-        'writers, speakers and enthusiasts, and invite you to ' +
-        'delve into a subject in all its many aspects. With ' +
-        'the bar and restaurant open all night, it’s a great ' +
-        'place for meeting with friends, looking at your favourite ' +
-        'ideas in spectrum of different ways, or just learning ' +
-        'something new on a Friday night.'
+      description: null
     }
   ],
   place: {

--- a/common/model/multi-content.js
+++ b/common/model/multi-content.js
@@ -3,4 +3,5 @@
 // to allow us to enumerate on it.
 // TODO: Find a way to enforce ☝️
 import type {Page} from './pages';
-export type MultiContent = | Page;
+import type {EventSeries} from './event-series';
+export type MultiContent = | Page | EventSeries;

--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -14,3 +14,8 @@ export const installationFields = [
   'installations.end'
 ];
 export const pagesFields = ['pages.title'];
+export const eventSeriesFields = [
+  'event-series.title',
+  'event-series.description',
+  'event-series.backgroundTexture'
+];

--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -3,6 +3,7 @@
 import Prismic from 'prismic-javascript';
 import {getDocuments} from './api';
 import { parsePage } from './pages';
+import { parseEventSeries } from './events';
 import { pagesFields } from './fetch-links';
 import type {MultiContent} from '../../model/multi-content';
 import type {StructuredSearchQuery} from './search';
@@ -10,8 +11,11 @@ import type {PaginatedResults} from './types';
 
 function parseMultiContent(documents): MultiContent[] {
   return documents.map(document => {
-    if (document.type === 'pages') {
-      return parsePage(document);
+    switch (document.type) {
+      case 'pages':
+        return parsePage(document);
+      case 'event-series':
+        return parseEventSeries(document);
     }
   }).filter(Boolean);
 }
@@ -27,7 +31,6 @@ export async function getMultiContent(
   const tagPredicate = tag.length > 0 ? Prismic.Predicates.any('document.tags', tag) : null;
   const typesPredicate = types.length > 0 ? Prismic.Predicates.in('document.type', types) : null;
   const typePredicate = type.length > 0 ? Prismic.Predicates.any('document.type', type) : null;
-
   const predicates = [
     idsPredicate,
     idPredicate,

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -3,7 +3,7 @@ import {getDocument} from './api';
 import {parseBody, parseImagePromo, parseTitle, parseTimestamp} from './parsers';
 import type {Page} from '../../model/pages';
 import type {PrismicDocument} from './types';
-import {pagesFields} from './fetch-links';
+import {pagesFields, eventSeriesFields} from './fetch-links';
 
 export function parsePage(document: PrismicDocument) {
   const {data} = document;
@@ -37,7 +37,7 @@ export function parsePage(document: PrismicDocument) {
 
 export async function getPage(req: Request, id: string): Promise<?Page> {
   const page = await getDocument(req, id, {
-    fetchLinks: pagesFields
+    fetchLinks: pagesFields.concat(eventSeriesFields)
   });
 
   if (page) {

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -10,6 +10,7 @@ import type { BackgroundTexture, PrismicBackgroundTexture } from '../../model/ba
 import type { CaptionedImageProps } from '../../views/components/Images/Images';
 import { licenseTypeArray } from '../../model/license';
 import { parsePage } from './pages';
+import { parseEventSeries } from '../../../events/app/node_modules/@weco/common/services/prismic/events';
 
 const placeHolderImage = {
   contentUrl: 'https://via.placeholder.com/1600x900?text=Placeholder',
@@ -340,8 +341,11 @@ export function parseBody(fragment: PrismicFragment[]) {
           value: {
             title: asText(slice.primary.title),
             items: slice.items.map(item => {
-              if (item.content.type === 'pages') {
-                return parsePage(item.content);
+              switch (item.content.type) {
+                case 'pages':
+                  return parsePage(item.content);
+                case 'event-series':
+                  return parseEventSeries(item.content);
               }
             }).filter(Boolean)
           }

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -10,7 +10,7 @@ import type { BackgroundTexture, PrismicBackgroundTexture } from '../../model/ba
 import type { CaptionedImageProps } from '../../views/components/Images/Images';
 import { licenseTypeArray } from '../../model/license';
 import { parsePage } from './pages';
-import { parseEventSeries } from '../../../events/app/node_modules/@weco/common/services/prismic/events';
+import { parseEventSeries } from './events';
 
 const placeHolderImage = {
   contentUrl: 'https://via.placeholder.com/1600x900?text=Placeholder',

--- a/common/views/components/SearchResults/SearchResults.js
+++ b/common/views/components/SearchResults/SearchResults.js
@@ -10,18 +10,29 @@ type Props = {|
 const SearchResults = ({ items }: Props) => (
   <div className='grid'>
     {items.map(item => (
-      item.type === 'pages' &&
       <div className={[
         grid({s: 12, m: 12, l: 12, xl: 12}),
         spacing({s: 2}, {margin: ['bottom']})
       ].join(' ')} key={item.id}>
-        <BasicPromo
-          promoType='PagePromo'
-          url={`/pages/${item.id}`}
-          title={item.title}
-          description={item.promo && item.promo.caption}
-          imageProps={item.promo && item.promo.image}
-        />
+        {item.type === 'pages' &&
+          <BasicPromo
+            promoType='PagePromo'
+            url={`/pages/${item.id}`}
+            title={item.title}
+            description={item.promo && item.promo.caption}
+            imageProps={item.promo && item.promo.image}
+          />
+        }
+
+        {item.type === 'event-series' &&
+          <BasicPromo
+            promoType='EventSeriesPromo'
+            url={`/pages/${item.id}`}
+            title={item.title}
+            description={item.promo && item.promo.caption}
+            imageProps={item.promo && item.promo.image}
+          />
+        }
       </div>
     ))}
   </div>

--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -61,7 +61,7 @@ export async function renderEventSeries(ctx, next) {
     ctx.render('pages/event-series', {
       pageConfig: createPageConfig({
         path: ctx.request.url,
-        title: asText(uiEventSeries.title),
+        title: uiEventSeries.title,
         description: asText(uiEventSeries.description),
         inSection: 'whatson',
         category: 'public-programme',


### PR DESCRIPTION
## Who is this for?
People wanting to attach an event series to another piece of content.

## What is it doing for them?
Putting the event series in the multi content list.

I imagine we might want to display this slightly differently, potentially event creating an event-series Promo that is aware of the content it has e.g. current events.

As we're mainly doing manual attachment of content, this seems more valuable that looking at automated queries, which I think will be useful for the homepage, but we can look at that then.

![screen shot 2018-05-15 at 16 59 51](https://user-images.githubusercontent.com/31692/40068823-71004456-5861-11e8-8bbb-a8a33ff46fee.png)

