### PR TITLE
allow imageless BasicPromos

### DIFF
--- a/common/views/components/BasicPromo/BasicPromo.js
+++ b/common/views/components/BasicPromo/BasicPromo.js
@@ -17,52 +17,57 @@ const BasicPromo = ({
   title,
   description,
   imageProps
-}: Props) => (
-  <a
-    data-component={promoType}
-    data-track-event={JSON.stringify({
-      category: 'component',
-      action: `${promoType}:click`
-    })}
-    href={url}
-    className='grid plain-link'
-  >
-    <div className={
-      grid({ s: 3, m: 3, l: 3, xl: 3 }) +
-      ` rounded-corners`
-    }>
-      {/* Find out why we can't just pass `imageProps` here */}
-      {imageProps && <Image
-        width={imageProps.width}
-        height={imageProps.height}
-        contentUrl={imageProps.contentUrl}
-        clipPathClass={imageProps.clipPathClass}
-        alt={imageProps.alt}
-        caption={imageProps.alt}
-        lazyload={imageProps.lazyload}
-        sizesQueries={imageProps.sizesQueries}
-        copyright={imageProps.copyright}
-        defaultSize={imageProps.defaultSize}
-        clickHandler={imageProps.clickHandler}
-        zoomable={imageProps.zoomable}
-        extraClasses={'rounded-corners'}
-      />}
-    </div>
+}: Props) => {
+  const textGridSize = imageProps ? 9 : 12;
+  return (
+    <a
+      data-component={promoType}
+      data-track-event={JSON.stringify({
+        category: 'component',
+        action: `${promoType}:click`
+      })}
+      href={url}
+      className='grid plain-link'
+    >
+      {imageProps &&
+        <div className={
+          grid({ s: 3, m: 3, l: 3, xl: 3 }) +
+          ` rounded-corners`
+        }>
+          {/* Find out why we can't just pass `imageProps` here */}
+          <Image
+            width={imageProps.width}
+            height={imageProps.height}
+            contentUrl={imageProps.contentUrl}
+            clipPathClass={imageProps.clipPathClass}
+            alt={imageProps.alt}
+            caption={imageProps.alt}
+            lazyload={imageProps.lazyload}
+            sizesQueries={imageProps.sizesQueries}
+            copyright={imageProps.copyright}
+            defaultSize={imageProps.defaultSize}
+            clickHandler={imageProps.clickHandler}
+            zoomable={imageProps.zoomable}
+            extraClasses={'rounded-corners'}
+          />
+        </div>
+      }
 
-    <div className={grid({ s: 9, m: 9, l: 9, xl: 9 })}>
-      <div className={`${font({s: 'WB5'})} ${spacing({s: 0}, {margin: ['top']})}`}>
-        {title}
-      </div>
-      {description &&
+      <div className={grid({ s: textGridSize, m: textGridSize, l: textGridSize, xl: textGridSize })}>
+        <div className={`${font({s: 'WB5'})} ${spacing({s: 0}, {margin: ['top']})}`}>
+          {title}
+        </div>
+        {description &&
         <span className={[
           spacing({s: 2}, {margin: ['top']}),
           font({s: 'HNL4'})
         ].join(' ')}>
           {description}
         </span>
-      }
-    </div>
-  </a>
-);
+        }
+      </div>
+    </a>
+  );
+};
 
 export default BasicPromo;


### PR DESCRIPTION
## Who is this for?
Promos who don't have images

## What is it doing for them?
Allows them to be displayed as they were created to be.

![screen shot 2018-05-16 at 08 07 14](https://user-images.githubusercontent.com/31692/40101773-58d607b0-58e0-11e8-9f33-6c7bf607e213.png)

