### PR TITLE
Page template headers

### DIFF
--- a/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
+++ b/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
@@ -3,22 +3,23 @@
 import {Fragment} from 'react';
 import {spacing, grid, font} from '../../../../utils/classnames';
 import {UiImage} from '../../Images/Images';
+import TexturedBackground from '../../Templates/BasicPage/TexturedBackground';
 import type {Node} from 'react';
 import type {UiImageProps} from '../../Images/Images';
 import type WobblyBackground from '../../Templates/BasicPage/WobblyBackground';
-import type TexturedBackground from '../../Templates/BasicPage/TexturedBackground';
+import type TexturedBackgroundType from '../../Templates/BasicPage/TexturedBackground';
 
 type Props = {|
   title: string,
   mainImageProps: ?UiImageProps,
-  Background: ?(WobblyBackground | TexturedBackground),
-  TagBar: Node,
-  DateInfo: Node,
-  InfoBar: Node,
-  Description: ?Node
+  Background: ?(WobblyBackground | TexturedBackgroundType),
+  TagBar?: Node,
+  DateInfo?: Node,
+  InfoBar?: Node,
+  Description?: Node
 |}
 
-const defaultBackgroundTexture = 'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg';
+const backgroundTexture = 'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg';
 const BasicHeader = ({
   title,
   mainImageProps,
@@ -27,49 +28,58 @@ const BasicHeader = ({
   DateInfo,
   Description,
   InfoBar
-}: Props) => (
-  <Fragment>
-    {Background}
-    <div className='row' style={{
-      backgroundImage: Background ? null : `url(${defaultBackgroundTexture})`,
-      backgroundSize: Background ? null : '150%'
-    }}>
-      <div className={`container ${spacing({s: 5, m: 7}, {padding: ['top']})} ${spacing({s: 1}, {padding: ['bottom']})}`}>
-        <div className='grid'>
-          <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
-            {TagBar}
-          </div>
-          <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
-            <h1 className={`
+}: Props) => {
+  const BackgroundComponent = Background ||
+    (mainImageProps ? TexturedBackground({backgroundTexture}) : null);
+
+  return (
+    <Fragment>
+      {BackgroundComponent}
+      <div className='row' style={{
+        backgroundImage: BackgroundComponent ? null : `url(${backgroundTexture})`,
+        backgroundSize: BackgroundComponent ? null : '150%'
+      }}>
+        <div className={`container ${spacing({s: 5, m: 7}, {padding: ['top']})} ${spacing({s: 1}, {padding: ['bottom']})}`}>
+          <div className='grid'>
+            <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
+              {TagBar}
+            </div>
+            <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
+              <h1 className={`
               h1 inline-block bg-white no-margin
               ${spacing({ s: 2 }, { padding: ['left', 'right'] })}
               ${spacing({ s: 1 }, { padding: ['bottom', 'top'] })}
             `}>{title}</h1>
 
-            <div className={`${font({s: 'HNL3'})}`}>
-              {DateInfo}
+              {DateInfo &&
+                <div className={`${font({s: 'HNL3'})}`}>
+                  {DateInfo}
+                </div>
+              }
+
+              {Description &&
+                <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top']})} first-para-no-margin`}>
+                  {Description}
+                </div>
+              }
+
+              {InfoBar &&
+                <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top', 'bottom']})}`}>
+                  {InfoBar}
+                </div>
+              }
+
+              {mainImageProps &&
+                <div className={`${spacing({ s: 2 }, { margin: ['top'] })}`}>
+                  <UiImage {...mainImageProps} />
+                </div>
+              }
             </div>
-
-            {Description &&
-              <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top']})} first-para-no-margin`}>
-                {Description}
-              </div>
-            }
-
-            <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top', 'bottom']})}`}>
-              {InfoBar}
-            </div>
-
-            {mainImageProps &&
-              <div className='relative'>
-                <UiImage {...mainImageProps} />
-              </div>
-            }
           </div>
         </div>
       </div>
-    </div>
-  </Fragment>
-);
+    </Fragment>
+  );
+};
 
 export default BasicHeader;

--- a/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
+++ b/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
@@ -41,7 +41,7 @@ const BasicHeader = ({
           </div>
           <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
             <h1 className={`
-              h1 inline-block bg-white
+              h1 inline-block bg-white no-margin
               ${spacing({ s: 2 }, { padding: ['left', 'right'] })}
               ${spacing({ s: 1 }, { padding: ['bottom', 'top'] })}
             `}>{title}</h1>

--- a/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
+++ b/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
@@ -1,57 +1,71 @@
 
 // @flow
+import {Fragment} from 'react';
 import {spacing, grid, font} from '../../../../utils/classnames';
 import {UiImage} from '../../Images/Images';
 import type {Node} from 'react';
 import type {UiImageProps} from '../../Images/Images';
+import type WobblyBackground from '../../Templates/BasicPage/WobblyBackground';
+import type TexturedBackground from '../../Templates/BasicPage/TexturedBackground';
 
 type Props = {|
   title: string,
   mainImageProps: ?UiImageProps,
+  Background: ?(WobblyBackground | TexturedBackground),
   TagBar: Node,
   DateInfo: Node,
   InfoBar: Node,
   Description: ?Node
 |}
 
+const defaultBackgroundTexture = 'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg';
 const BasicHeader = ({
   title,
   mainImageProps,
+  Background,
   TagBar,
   DateInfo,
   Description,
   InfoBar
 }: Props) => (
-  <div className={`container ${spacing({s: 5, m: 7}, {padding: ['top']})} ${spacing({s: 1}, {padding: ['bottom']})}`}>
-    <div className='grid'>
-      <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
-        {TagBar}
-      </div>
-      <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
-        <h1 className='h1'>{title}</h1>
-
-        <div className={`${font({s: 'HNL3'})}`}>
-          {DateInfo}
-        </div>
-
-        {Description &&
-          <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top']})} first-para-no-margin`}>
-            {Description}
+  <Fragment>
+    {Background}
+    <div className='row' style={{
+      backgroundImage: Background ? null : `url(${defaultBackgroundTexture})`,
+      backgroundSize: Background ? null : '150%'
+    }}>
+      <div className={`container ${spacing({s: 5, m: 7}, {padding: ['top']})} ${spacing({s: 1}, {padding: ['bottom']})}`}>
+        <div className='grid'>
+          <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
+            {TagBar}
           </div>
-        }
+          <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
+            <h1 className='h1'>{title}</h1>
 
-        <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top', 'bottom']})}`}>
-          {InfoBar}
-        </div>
+            <div className={`${font({s: 'HNL3'})}`}>
+              {DateInfo}
+            </div>
 
-        {mainImageProps &&
-          <div className='relative'>
-            <UiImage {...mainImageProps} />
+            {Description &&
+              <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top']})} first-para-no-margin`}>
+                {Description}
+              </div>
+            }
+
+            <div className={`${font({s: 'HNL4'})} ${spacing({s: 3}, {margin: ['top', 'bottom']})}`}>
+              {InfoBar}
+            </div>
+
+            {mainImageProps &&
+              <div className='relative'>
+                <UiImage {...mainImageProps} />
+              </div>
+            }
           </div>
-        }
+        </div>
       </div>
     </div>
-  </div>
+  </Fragment>
 );
 
 export default BasicHeader;

--- a/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
+++ b/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
@@ -40,7 +40,11 @@ const BasicHeader = ({
             {TagBar}
           </div>
           <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
-            <h1 className='h1'>{title}</h1>
+            <h1 className={`
+              h1 inline-block bg-white
+              ${spacing({ s: 2 }, { padding: ['left', 'right'] })}
+              ${spacing({ s: 1 }, { padding: ['bottom', 'top'] })}
+            `}>{title}</h1>
 
             <div className={`${font({s: 'HNL3'})}`}>
               {DateInfo}

--- a/common/views/components/Templates/BasicPage/BasicPage.js
+++ b/common/views/components/Templates/BasicPage/BasicPage.js
@@ -14,15 +14,15 @@ type Props = {|
   body: Body,
   mainImageProps: ?UiImageProps,
   Background: ?(WobblyBackground | TexturedBackground),
-  TagBar: Node, // potentially make this only take Aync | Tags?
-  DateInfo: Node,
-  InfoBar: Node,
-  children: Node,
-  Description: ?Node
+  TagBar: ?Node, // potentially make this only take Aync | Tags?
+  DateInfo: ?Node,
+  InfoBar: ?Node,
+  Description: ?Node,
+  children?: ?Node
 |}
 
 export const BasicPageColumn = ({children}: {| children: Node |}) => (
-  <div className={`row ${spacing({s: 3}, {padding: ['top']})} ${spacing({s: 8}, {padding: ['bottom']})}`}>
+  <div className={`row ${spacing({s: 8}, {padding: ['bottom']})}`}>
     <div className='container'>
       <div className='grid'>
         <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
@@ -61,9 +61,11 @@ const BasicPage = ({
         </div>
       </BasicPageColumn>
 
-      <BasicPageColumn>
-        {children}
-      </BasicPageColumn>
+      {children &&
+        <BasicPageColumn>
+          {children}
+        </BasicPageColumn>
+      }
     </Fragment>
   );
 };

--- a/common/views/components/Templates/BasicPage/BasicPage.js
+++ b/common/views/components/Templates/BasicPage/BasicPage.js
@@ -12,7 +12,7 @@ type Props = {|
   title: string,
   body: Body,
   mainImageProps: ?UiImageProps,
-  Background: ?WobblyBackground,
+  Background: ?(WobblyBackground | TexturedBackground),
   TagBar: Node, // potentially make this only take Aync | Tags?
   DateInfo: Node,
   InfoBar: Node,
@@ -45,10 +45,10 @@ const BasicPage = ({
 }: Props) => {
   return (
     <Fragment>
-      {Background}
       <BasicHeader
         title={title}
         mainImageProps={mainImageProps}
+        Background={Background}
         TagBar={TagBar}
         DateInfo={DateInfo}
         Description={Description}

--- a/common/views/components/Templates/BasicPage/BasicPage.js
+++ b/common/views/components/Templates/BasicPage/BasicPage.js
@@ -7,6 +7,7 @@ import type {Node} from 'react';
 import type {UiImageProps} from '../../Images/Images';
 import type {Body} from '../../BasicBody/BasicBody';
 import type WobblyBackground from './WobblyBackground';
+import type TexturedBackground from './TexturedBackground';
 
 type Props = {|
   title: string,

--- a/common/views/components/Templates/BasicPage/Page.js
+++ b/common/views/components/Templates/BasicPage/Page.js
@@ -1,34 +1,30 @@
 // @flow
-import {Fragment} from 'react';
 import BasicPage from './BasicPage';
 import HTMLDate from '../../HTMLDate/HTMLDate';
 import type {Page} from '../../../../model/pages';
-import TexturedBackground from './TexturedBackground';
 
 type Props = {|
   page: Page
 |}
 
-const backgroundTexture = 'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg';
 const InstallationPage = ({ page }: Props) => {
   const DateInfo = page.datePublished && <HTMLDate date={page.datePublished} />;
   // TODO: Pass in the URL of the textured image, if it exists
   // TODO: Support video
-  const Background = page.body.length > 1 && page.body[0].type === 'picture'
-    ? TexturedBackground({ backgroundTexture }) : null;
+  const mainImageProps = page.body.length > 1 && page.body[0].type === 'picture'
+    ? page.body[0].value : null;
+  const body = mainImageProps ? page.body.slice(1, page.body.length)  : page.body;
 
   return (
     <BasicPage
-      Background={Background}
       DateInfo={DateInfo}
-      Description={null}
+      Background={null}
       TagBar={null}
       InfoBar={null}
+      Description={null}
       title={page.title}
-      mainImageProps={null}
-      body={page.body}>
-      <Fragment>
-      </Fragment>
+      mainImageProps={mainImageProps}
+      body={body}>
     </BasicPage>
   );
 };

--- a/common/views/components/Templates/BasicPage/Page.js
+++ b/common/views/components/Templates/BasicPage/Page.js
@@ -3,17 +3,23 @@ import {Fragment} from 'react';
 import BasicPage from './BasicPage';
 import HTMLDate from '../../HTMLDate/HTMLDate';
 import type {Page} from '../../../../model/pages';
+import TexturedBackground from './TexturedBackground';
 
 type Props = {|
   page: Page
 |}
 
+const backgroundTexture = 'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg';
 const InstallationPage = ({ page }: Props) => {
   const DateInfo = page.datePublished && <HTMLDate date={page.datePublished} />;
+  // TODO: Pass in the URL of the textured image, if it exists
+  // TODO: Support video
+  const Background = page.body.length > 1 && page.body[0].type === 'picture'
+    ? TexturedBackground({ backgroundTexture }) : null;
 
   return (
     <BasicPage
-      Background={null}
+      Background={Background}
       DateInfo={DateInfo}
       Description={null}
       TagBar={null}

--- a/common/views/components/Templates/BasicPage/TexturedBackground.js
+++ b/common/views/components/Templates/BasicPage/TexturedBackground.js
@@ -1,0 +1,22 @@
+// @flow
+type Props = {|
+  backgroundTexture: string
+|}
+
+const TexturedBackground = ({
+  backgroundTexture
+}: Props) => (
+  <div className='row relative'>
+    <div className='absolute overflow-hidden full-width bg-cream' style={{
+      top: 0,
+      height: '50vw',
+      maxHeight: '66vh',
+      zIndex: -1,
+      backgroundImage: `url(${backgroundTexture})`,
+      backgroundSize: '150%'
+    }}>
+    </div>
+  </div>
+);
+
+export default TexturedBackground;

--- a/prismic-model/json/installations.json
+++ b/prismic-model/json/installations.json
@@ -1,276 +1,275 @@
-  {
-    "Installation": {
-      "title": {
-        "type": "StructuredText",
-        "config": {
-          "label": "Title",
-          "single": "heading1",
-          "useAsTitle": true
-        }
-      },
-      "start": {
-        "type": "Timestamp",
-        "config": {
-          "label": "Start date"
-        }
-      },
-      "end": {
-        "type": "Timestamp",
-        "config": {
-          "label": "End date"
-        }
-      },
-      "place": {
-        "type": "Link",
-        "fieldset": "Place",
-        "config": {
-          "select": "document",
-          "customtypes": [
-            "places"
+{
+  "Installation": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Title",
+        "single": "heading1",
+        "useAsTitle": true
+      }
+    },
+    "start": {
+      "type": "Timestamp",
+      "config": {
+        "label": "Start date"
+      }
+    },
+    "end": {
+      "type": "Timestamp",
+      "config": {
+        "label": "End date"
+      }
+    },
+    "place": {
+      "type": "Link",
+      "fieldset": "Place",
+      "config": {
+        "select": "document",
+        "customtypes": [
+          "places"
+        ],
+        "label": "Where is it?"
+      }
+    },
+    "body": {
+      "fieldset": "Body content",
+      "type": "Slices",
+      "config": {
+        "labels": {
+          "text": [
+            {
+              "name": "featured",
+              "display": "Featured"
+            }
           ],
-          "label": "Where is it?"
-        }
-      },
-      "body": {
-        "fieldset": "Body content",
-        "type": "Slices",
-        "config": {
-          "labels": {
-            "text": [
-              {
-                "name": "featured",
-                "display": "Featured"
+          "editorialImage": [
+            {
+              "name": "supporting",
+              "display": "Supporting"
+            },
+            {
+              "name": "standalone",
+              "display": "Standalone"
+            }
+          ]
+        },
+        "choices": {
+          "text": {
+            "type": "Slice",
+            "fieldset": "Text",
+            "non-repeat": {
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em,heading2,list-item",
+                  "label": "Text"
+                }
               }
-            ],
-            "editorialImage": [
-              {
-                "name": "supporting",
-                "display": "Supporting"
-              },
-              {
-                "name": "standalone",
-                "display": "Standalone"
-              }
-            ]
+            }
           },
-          "choices": {
-            "text": {
-              "type": "Slice",
-              "fieldset": "Text",
-              "non-repeat": {
-                "text": {
-                  "type": "StructuredText",
-                  "config": {
-                    "multi": "paragraph,hyperlink,strong,em,heading2,list-item",
-                    "label": "Text"
-                  }
-                }
-              }
-            },
-            "editorialImage": {
-              "type": "Slice",
-              "fieldset": "Captioned image",
-              "non-repeat": {
-                "image": {
-                  "type": "Image",
-                  "config": {
-                    "label": "Image"
-                  }
-                },
-                "caption": {
-                  "type": "StructuredText",
-                  "config": {
-                    "single": "paragraph,hyperlink,strong,em",
-                    "label": "Caption"
-                  }
-                }
-              }
-            },
-            "editorialImageGallery": {
-              "type": "Slice",
-              "fieldset": "Image gallery",
-              "non-repeat": {
-                "title": {
-                  "type": "StructuredText",
-                  "config": {
-                    "label": "Title",
-                    "single": "heading1",
-                    "useAsTitle": true
-                  }
+          "editorialImage": {
+            "type": "Slice",
+            "fieldset": "Captioned image",
+            "non-repeat": {
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Image"
                 }
               },
-              "repeat": {
-                "image": {
-                  "type": "Image",
-                  "config": {
-                    "label": "Image"
-                  }
-                },
-                "caption": {
-                  "type": "StructuredText",
-                  "config": {
-                    "single": "paragraph,hyperlink,strong,em",
-                    "label": "Caption"
-                  }
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
+              }
+            }
+          },
+          "editorialImageGallery": {
+            "type": "Slice",
+            "fieldset": "Image gallery",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
                 }
               }
             },
-            "quote": {
-              "type": "Slice",
-              "fieldset": "Quote",
-              "non-repeat": {
-                "text": {
-                  "type": "StructuredText",
-                  "config": {
-                    "multi": "paragraph,hyperlink,strong,em",
-                    "label": "Quote"
-                  }
-                },
-                "citation": {
-                  "type": "StructuredText",
-                  "config": {
-                    "single": "paragraph,hyperlink,strong,em",
-                    "label": "Citation"
-                  }
-                }
-              }
-            },
-            "contentList": {
-              "type": "Slice",
-              "fieldset": "(β) Content list",
-              "non-repeat": {
-                "title": {
-                  "type": "StructuredText",
-                  "config": {
-                    "label": "Title",
-                    "single": "heading1",
-                    "useAsTitle": true
-                  }
+            "repeat": {
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Image"
                 }
               },
-              "repeat": {
-                "content": {
-                  "type": "Link",
-                  "config": {
-                    "label": "Content item",
-                    "select": "document",
-                    "customtypes": [
-                      "pages"
-                    ]
-                  }
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
+              }
+            }
+          },
+          "quote": {
+            "type": "Slice",
+            "fieldset": "Quote",
+            "non-repeat": {
+              "text": {
+                "type": "StructuredText",
+                "config": {
+                  "multi": "paragraph,hyperlink,strong,em",
+                  "label": "Quote"
+                }
+              },
+              "citation": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Citation"
+                }
+              }
+            }
+          },
+          "contentList": {
+            "type": "Slice",
+            "fieldset": "(β) Content list",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
                 }
               }
             },
-            "searchResults": {
-              "type": "Slice",
-              "fieldset": "(β) Search results",
-              "non-repeat": {
-                "title": {
-                  "type": "StructuredText",
-                  "config": {
-                    "label": "Title",
-                    "single": "heading1",
-                    "useAsTitle": true
-                  }
-                },
-                "pageSize": {
-                  "type": "Number",
-                  "config": {
-                    "label": "Size"
-                  }
-                },
-                "query": {
-                  "type": "Text",
-                  "config": {
-                    "label": "Query"
-                  }
+            "repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "pages"
+                  ]
+                }
+              }
+            }
+          },
+          "searchResults": {
+            "type": "Slice",
+            "fieldset": "(β) Search results",
+            "non-repeat": {
+              "title": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
+                }
+              },
+              "pageSize": {
+                "type": "Number",
+                "config": {
+                  "label": "Size"
+                }
+              },
+              "query": {
+                "type": "Text",
+                "config": {
+                  "label": "Query"
                 }
               }
             }
           }
         }
       }
-    },
-    "Contributors": {
-      "contributors": {
-        "type": "Group",
-        "fieldset": "Contributors",
-        "config": {
-          "fields": {
-            "role": {
-              "type": "Link",
-              "config": {
-                "label": "Role",
-                "select": "document",
-                "customtypes": [
-                  "editorial-contributor-roles"
-                ]
-              }
-            },
-            "contributor": {
-              "type": "Link",
-              "config": {
-                "label": "Contributor",
-                "select": "document",
-                "customtypes": [
-                  "people",
-                  "organisations"
-                ]
-              }
-            },
-            "description": {
-              "type": "StructuredText",
-              "config": {
-                "multi": "paragraph,hyperlink,strong,em",
-                "label": "How did they contribute to this?"
-              }
+    }
+  },
+  "Contributors": {
+    "contributors": {
+      "type": "Group",
+      "fieldset": "Contributors",
+      "config": {
+        "fields": {
+          "role": {
+            "type": "Link",
+            "config": {
+              "label": "Role",
+              "select": "document",
+              "customtypes": [
+                "editorial-contributor-roles"
+              ]
+            }
+          },
+          "contributor": {
+            "type": "Link",
+            "config": {
+              "label": "Contributor",
+              "select": "document",
+              "customtypes": [
+                "people",
+                "organisations"
+              ]
+            }
+          },
+          "description": {
+            "type": "StructuredText",
+            "config": {
+              "multi": "paragraph,hyperlink,strong,em",
+              "label": "How did they contribute to this?"
             }
           }
         }
       }
-    },
-    "Promo": {
-      "promo": {
-        "type": "Slices",
-        "config": {
-          "label": "Promo",
-          "choices": {
-            "editorialImage": {
-              "type": "Slice",
-              "fieldset": "Editorial image",
-              "config": {
-                "label": "Editorial image"
+    }
+  },
+  "Promo": {
+    "promo": {
+      "type": "Slices",
+      "config": {
+        "label": "Promo",
+        "choices": {
+          "editorialImage": {
+            "type": "Slice",
+            "fieldset": "Editorial image",
+            "config": {
+              "label": "Editorial image"
+            },
+            "non-repeat": {
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Promo text",
+                  "single": "paragraph"
+                }
               },
-              "non-repeat": {
-                "caption": {
-                  "type": "StructuredText",
-                  "config": {
-                    "label": "Promo text",
-                    "single": "paragraph"
-                  }
-                },
-                "image": {
-                  "type": "Image",
-                  "config": {
-                    "label": "Promo image",
-                    "thumbnails": [
-                      {
-                        "name": "32:15",
-                        "width": 3200,
-                        "height": 1500
-                      },
-                      {
-                        "name": "16:9",
-                        "width": 3200,
-                        "height": 1800
-                      },
-                      {
-                        "name": "square",
-                        "width": 3200,
-                        "height": 3200
-                      }
-                    ]
-                  }
+              "image": {
+                "type": "Image",
+                "config": {
+                  "label": "Promo image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
                 }
               }
             }
@@ -279,3 +278,4 @@
       }
     }
   }
+}


### PR DESCRIPTION
## Who is this for?
People who like pretty pages


## What is it doing for them?
Sets the rules of:
* First item of body is an image - used TexturedBackground. This stretches down the page, similar to the WobblyBackground.
* If not, just apply a texture behind the header.

__Next up__
I need to with with @GarethOrmerod on the spacing, as I can't quite figure out the annotations in Zeplin.

![headerimes](https://user-images.githubusercontent.com/31692/40104310-e2a7cac6-58e7-11e8-852e-a36c1e39ef49.png)
![headernoimage](https://user-images.githubusercontent.com/31692/40104311-e2bf53f8-58e7-11e8-8020-c68070d242b0.png)


