### PR TITLE
add root press redirect

### DIFF
--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -80,6 +80,13 @@ r.get('/tag/press', renderTagPage(
   'Press releases'
 ));
 
+// root paths that we want to support.
+// Each service should probably deal with their own
+r.get('/press', async (ctx, next) => {
+  ctx.params.id = 'WuxrKCIAAP9h3hmw';
+  return renderPage(ctx, next);
+});
+
 // API
 r.get('/works', search);
 r.get('/works/:id', work);


### PR DESCRIPTION
Fixes/References #2490 

## Who is this for?
🗞 

## What is it doing for them?
Letting them see our press releases.
After talking to @jennpb we thought we can manage the URLs in code as we only want a few.

Once we're happy that that page looks like it should, we can set the router nginx config to be `/press` over `/press/.*` 