### PR TITLE
Pass tasl to InstallationPage's UiImage

### DIFF
--- a/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
+++ b/common/views/components/PageHeaders/BasicHeader/BasicHeader.js
@@ -72,7 +72,7 @@ const BasicHeader = ({
               }
 
               {FeaturedMedia &&
-                <div className={`${spacing({ s: 2 }, { margin: ['top'] })}`} key={'rasjhd'}>
+                <div className={`${spacing({ s: 2 }, { margin: ['top'] })} relative`} key={'rasjhd'}>
                   <Fragment>{FeaturedMedia}</Fragment>
                 </div>
               }

--- a/common/views/components/Templates/BasicPage/InstallationPage.js
+++ b/common/views/components/Templates/BasicPage/InstallationPage.js
@@ -16,7 +16,20 @@ type Props = {|
 
 const InstallationPage = ({ installation }: Props) => {
   const DateInfo = installation.end ? <DateRange start={installation.start} end={installation.end} /> : <HTMLDate date={installation.start} />;
-  const FeaturedMedia = installation.promo && <UiImage {...installation.promo.image} />;
+  const { image } = installation.promo;
+  const tasl = {
+    isFull: false,
+    contentUrl: image.contentUrl,
+    title: image.title,
+    author: image.author,
+    sourceName: image.source && image.source.name,
+    sourceLink: image.source && image.source.link,
+    license: image.license,
+    copyrightHolder: image.copyright && image.copyright.holder,
+    copyrightLink: image.copyright && image.copyright.link
+  };
+
+  const FeaturedMedia = installation.promo && <UiImage tasl={tasl} {...image} />;
 
   return (
     <BasicPage

--- a/common/views/components/Templates/BasicPage/InstallationPage.js
+++ b/common/views/components/Templates/BasicPage/InstallationPage.js
@@ -16,8 +16,8 @@ type Props = {|
 
 const InstallationPage = ({ installation }: Props) => {
   const DateInfo = installation.end ? <DateRange start={installation.start} end={installation.end} /> : <HTMLDate date={installation.start} />;
-  const { image } = installation.promo;
-  const tasl = {
+  const image = installation.promo && installation.promo.image;
+  const tasl = image && {
     isFull: false,
     contentUrl: image.contentUrl,
     title: image.title,
@@ -28,7 +28,8 @@ const InstallationPage = ({ installation }: Props) => {
     copyrightHolder: image.copyright && image.copyright.holder,
     copyrightLink: image.copyright && image.copyright.link
   };
-
+  /* https://github.com/facebook/flow/issues/2405 */
+  /* $FlowFixMe */
   const FeaturedMedia = installation.promo && <UiImage tasl={tasl} {...image} />;
 
   return (


### PR DESCRIPTION
Fixes #2633

Making TASL information display on the featured image for installations.

![screen shot 2018-05-18 at 12 28 27](https://user-images.githubusercontent.com/1394592/40232520-0694e526-5a97-11e8-8495-f8adbd4f9be9.png)


I'm wondering if we might benefit from a `parseTaslFromImage` helper, because we might run up against this more in future.