### PR TITLE
make sure we specify a v1 route

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -119,6 +119,11 @@ http {
       proxy_intercept_errors  on;
       error_page 404 = @v1;
     }
+    location @v1 {
+      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
+      proxy_set_header           Host $host;
+      proxy_pass                 http://v1;
+    }
 
     # v1
     location ~ ^/admin/.* {


### PR DESCRIPTION
Didn't actually specify the `@v1` location.
As this happens on runtime, the compile didn't pick up on it.


