### PR TITLE
push all /press through to v2

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -112,7 +112,7 @@ http {
     # This will eventually be every path
     # This makes sure there is no path from V2, then defaults to V1.
     # It does mean V1 controls the error page
-    location ~ ^/press/.* {
+    location ~ ^/press {
       proxy_set_header        HTTP_X_FORWARDED_PROTO https;
       proxy_set_header        Host $host;
       proxy_pass              http://v2;


### PR DESCRIPTION
Fixes/References #2571 
Waiting on https://github.com/wellcometrust/wellcomecollection.org/pull/2656

Moves all `/press` to v2 (and if 404, v1).