### PR TITLE
add dynamic orderings to search results

### DIFF
--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -24,7 +24,7 @@ export async function getMultiContent(
   req: Request,
   structuredSearchQuery: StructuredSearchQuery
 ): Promise<PaginatedResults<MultiContent>> {
-  const {types, type, id, ids, tags, tag, pageSize} = structuredSearchQuery;
+  const {types, type, id, ids, tags, tag, pageSize, orderings} = structuredSearchQuery;
   const idsPredicate = ids.length > 0 ? Prismic.Predicates.at('document.id', ids) : null;
   const idPredicate = id.length > 0 ? Prismic.Predicates.in('document.id', id) : null;
   const tagsPredicate = tags.length > 0 ? Prismic.Predicates.at('document.tags', tags) : null;
@@ -39,13 +39,10 @@ export async function getMultiContent(
     typesPredicate,
     typePredicate
   ].filter(Boolean);
-  // TODO: provide a mechanism for overriding
-  const defaultOrderings = ['my.pages.datePublished desc'];
-
   const apiResponse = await getDocuments(req, predicates, {
     fetchLinks: pagesFields,
     pageSize: pageSize || 100,
-    orderings: `[${defaultOrderings.join(',')}]`
+    orderings: `[${(orderings || []).join(',')}]`
   });
   const multiContent = parseMultiContent(apiResponse.results);
 

--- a/common/services/prismic/search.js
+++ b/common/services/prismic/search.js
@@ -10,7 +10,8 @@ export type StructuredSearchQuery = {|
   id: string[],
   tags: string[],
   tag: string[],
-  pageSize: number
+  pageSize: number,
+  orderings: string[]
 |}
 
 export async function search(req: Request, stringQuery: string) {
@@ -27,7 +28,7 @@ export function parseQuery(query: string): StructuredSearchQuery {
       'types', 'type',
       'ids', 'id',
       'tags', 'tag',
-      'size'
+      'pageSize', 'orderings'
     ]
   });
   const arrayedStructuredQuery = Object.entries(structuredQuery).reduce((acc, entry) => {
@@ -47,6 +48,7 @@ export function parseQuery(query: string): StructuredSearchQuery {
     id: arrayedStructuredQuery.id || [],
     tags: arrayedStructuredQuery.tags || [],
     tag: arrayedStructuredQuery.tag || [],
+    orderings: arrayedStructuredQuery.orderings || [],
     pageSize: arrayedStructuredQuery.pageSize
   };
 }

--- a/common/views/components/BasicBody/BasicBody.js
+++ b/common/views/components/BasicBody/BasicBody.js
@@ -49,7 +49,6 @@ const BasicBody = ({ body }: Props) => {
             <AsyncSearchResults
               title={slice.value.title}
               query={slice.value.items.map(({id}) => `id:${id}`).join(' ')}
-              pageSize={slice.value.items.length}
             />}
           {slice.type === 'searchResults' && <AsyncSearchResults {...slice.value} />}
           {slice.type === 'videoEmbed' && <VideoEmbed {...slice.value} />}

--- a/common/views/components/SearchResults/AsyncSearchResults.js
+++ b/common/views/components/SearchResults/AsyncSearchResults.js
@@ -4,14 +4,12 @@ import {grid} from '../../../utils/classnames';
 
 type Props = {|
   title: ?string,
-  query: string,
-  pageSize: number
+  query: string
 |}
 
 const AsyncSearchResults = ({
   title,
-  query,
-  pageSize
+  query
 }: Props) => {
   return (
     <Fragment>
@@ -24,7 +22,7 @@ const AsyncSearchResults = ({
       <div
         data-component='ContentListItems'
         className='async-content component-list-placeholder'
-        data-endpoint={'/async/search?query=' + encodeURIComponent(query + ` pageSize:${pageSize}`)}
+        data-endpoint={'/async/search?query=' + encodeURIComponent(query)}
         data-prefix-endpoint={false}
         data-modifiers={[]}>
       </div>

--- a/prismic-model/js/parts/body.js
+++ b/prismic-model/js/parts/body.js
@@ -4,7 +4,6 @@ import captionedImageSlice from './captioned-image-slice';
 import captionedImageGallerySlice from './captioned-image-gallery-slice';
 import title from './title';
 import link from './link';
-import number from './number';
 import text from './text';
 import embed from './embed';
 
@@ -81,7 +80,6 @@ export default {
       searchResults: slice('(β) Search results', {
         nonRepeat: {
           title,
-          pageSize: number('Size'),
           query: text('Query')
         }
       })


### PR DESCRIPTION
## Who is this for?
🚓 


## What is it doing for them?
Makes `orderings` and `pageSize` explicit from Prismic.
e.g. `tag:press pageSize:10 orderings:"my.pages.datePublished desc"`

Also fixes the bug of having orderings on things that don't have that field order randomly?