### PR TITLE
use promo text as description universally

### DIFF
--- a/events/app/views/pages/event.njk
+++ b/events/app/views/pages/event.njk
@@ -1,16 +1,17 @@
 {% extends 'layout/default.njk' %}
 
+{% set description = event.promo.caption | safe | striptags %}
 {% block pageMeta %}
   {% set metaContent = {
-  type: 'website',
-  title: event.title,
-  image: event.promo.image.contentUrl,
-  description: event.promo.caption,
-  url: pageConfig.canonicalUri
+    type: 'website',
+    title: event.title,
+    image: event.promo.image.contentUrl,
+    description: description,
+    url: pageConfig.canonicalUri
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
-  <meta name="description" content="{{ event.description | safe | striptags }}" />
+  <meta name="description" content="{{ description }}" />
 {% endblock %}
 
 {% block body %}

--- a/server/views/pages/page.njk
+++ b/server/views/pages/page.njk
@@ -1,15 +1,16 @@
 {% extends 'layout/default.njk' %}
 
+{% set description = page.promo.caption | safe | striptags %}
 {% block pageMeta %}
   {% set metaContent = {
     type: 'article',
     title: page.title,
     url: pageConfig.canonicalUri,
-    description: page.description
+    description: description
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
-  <meta name="description" content="{{ page.description | safe | striptags }}" />
+  <meta name="description" content="{{ description }}" />
 {% endblock %}
 
 {% block body %}

--- a/whats_on/app/views/pages/exhibition.njk
+++ b/whats_on/app/views/pages/exhibition.njk
@@ -1,15 +1,17 @@
 {% extends 'layout/default.njk' %}
+
+{% set description = exhibition.promo.description %}
 {% block pageMeta %}
   {% set metaContent = {
     type: 'website',
     title: exhibition.title,
     image: exhibition.featuredImageList[0] and exhibition.featuredImageList[0].contentUrl,
-    description: exhibition.promo.caption,
+    description: description,
     url: pageConfig.canonicalUri
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
-  <meta name="description" content="{{ exhibition.description | prismicAsText }}" />
+  <meta name="description" content="{{ description }}" />
 {% endblock %}
 
 {% block body %}

--- a/whats_on/app/views/pages/installation.njk
+++ b/whats_on/app/views/pages/installation.njk
@@ -1,14 +1,16 @@
 {% extends 'layout/default.njk' %}
+
+{% set description = installation.promo.caption | safe | striptags %}
 {% block pageMeta %}
   {% set metaContent = {
     type: 'website',
     title: installation.title,
-    description: installation.promo.caption,
+    description: description,
     url: pageConfig.canonicalUri
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
-  <meta name="description" content="{{ installation.description | prismicAsText | safe | striptags }}" />
+  <meta name="description" content="{{ description }}" />
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
References #2490 

## Who is this for?
🎰 

## What is it doing for them?
Adds the promo text as the meta description.

This should probably be done for the JSON LD - the installation JSON ld needs to be done, so I will do it there.