### PR TITLE
redirect pages that had visit-us or what-we-do in the URL

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -119,6 +119,20 @@ http {
       proxy_intercept_errors  on;
       error_page 404 = @v1;
     }
+    location ~ ^/what-we-do/.* {
+      proxy_set_header        HTTP_X_FORWARDED_PROTO https;
+      proxy_set_header        Host $host;
+      proxy_pass              http://v2;
+      proxy_intercept_errors  on;
+      error_page 404 = @v1;
+    }
+    location ~ ^/visit-us/.* {
+      proxy_set_header        HTTP_X_FORWARDED_PROTO https;
+      proxy_set_header        Host $host;
+      proxy_pass              http://v2;
+      proxy_intercept_errors  on;
+      error_page 404 = @v1;
+    }
     location @v1 {
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
       proxy_set_header           Host $host;


### PR DESCRIPTION
References #2490 

## Who is this for?
🦊 

## What is it doing for them?
Redirects pages that either had `/visit-us/*` or `/what-we-do/*` to the V2, with the fallback of V1.
This feels safer than just all of V1 => V2. It is also an alternative to #2661 which we have issues with because of Prismic.