### PR TITLE
add basic metadata to books

### DIFF
--- a/common/model/books.js
+++ b/common/model/books.js
@@ -10,7 +10,7 @@ type Review = {|
 export type Book = {|
   id: string,
   title: ?string,
-  subtitle: ?HTMLString,
+  subtitle: ?string,
   orderLink: ?string,
   price: ?string,
   format: ?string,

--- a/common/services/prismic/books.js
+++ b/common/services/prismic/books.js
@@ -6,7 +6,9 @@ import {
   parseTitle,
   parseImagePromo,
   parseTimestamp,
-  asHtml
+  parseBody,
+  asHtml,
+  asText
 } from './parsers';
 
 export function parseBookDoc(document: PrismicDocument): Book {
@@ -15,7 +17,7 @@ export function parseBookDoc(document: PrismicDocument): Book {
   return {
     id: document.id,
     title: parseTitle(data.title),
-    subtitle: data.subtitle && asHtml(data.subtitle),
+    subtitle: data.subtitle && asText(data.subtitle),
     orderLink: data.orderLink && data.orderLink.url,
     price: data.price,
     format: data.format,
@@ -28,11 +30,11 @@ export function parseBookDoc(document: PrismicDocument): Book {
       };
     }),
     datePublished: data.datePublished && parseTimestamp(data.datePublished),
-    authorName: data.authorName,
+    authorName: data.authorName && asText(data.authorName),
     authorImage: data.authorImage && data.authorImage.url,
     authorDescription: data.authorDescription && asHtml(data.authorDescription),
     promo,
-    body: []
+    body: data.body ? parseBody(data.body) : []
   };
 }
 

--- a/common/views/components/Templates/BasicPage/BookPage.js
+++ b/common/views/components/Templates/BasicPage/BookPage.js
@@ -1,8 +1,8 @@
 // @flow
+import {Fragment} from 'react';
 import BasicPage from './BasicPage';
 import HTMLDate from '../../HTMLDate/HTMLDate';
-import WobblyBackground from './WobblyBackground';
-import {UiImage} from '../../Images/Images';
+import PrimaryLink from '../../Links/PrimaryLink/PrimaryLink';
 import type {Book} from '../../../../model/books';
 
 type Props = {|
@@ -11,17 +11,22 @@ type Props = {|
 
 const BookPage = ({ book }: Props) => {
   const DateInfo = book.datePublished && <HTMLDate date={book.datePublished} />;
-  const FeaturedMedia = book.promo && <UiImage {...book.promo.image} />;
 
   return (
     <BasicPage
       id={book.id}
-      Background={WobblyBackground()}
+      Background={null}
       TagBar={null}
       DateInfo={DateInfo}
       InfoBar={null}
-      Description={null}
-      FeaturedMedia={FeaturedMedia}
+      Description={
+        <Fragment>
+          {book.subtitle && <p>{book.subtitle}</p>}
+          {book.authorName && <p>by {book.authorName}</p>}
+          {book.orderLink && <PrimaryLink name={`Order online${book.price ? ` for ${book.price}` : ''}`} link={book.orderLink} />}
+        </Fragment>
+      }
+      FeaturedMedia={null}
       title={book.title || 'TITLE MISSING'}
       body={book.body || []}>
     </BasicPage>

--- a/common/views/components/Templates/BasicPage/BookPage.js
+++ b/common/views/components/Templates/BasicPage/BookPage.js
@@ -23,7 +23,7 @@ const BookPage = ({ book }: Props) => {
         <Fragment>
           {book.subtitle && <p>{book.subtitle}</p>}
           {book.authorName && <p>by {book.authorName}</p>}
-          {book.orderLink && <PrimaryLink name={`Order online${book.price ? ` for ${book.price}` : ''}`} link={book.orderLink} />}
+          {book.orderLink && <PrimaryLink name='Order online' url={book.orderLink} />}
         </Fragment>
       }
       FeaturedMedia={null}

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -13,6 +13,7 @@ import {london} from '../filters/format-date';
 import {PromoListFactory} from '../model/promo-list';
 import {PaginationFactory} from '../model/pagination';
 import {getPage, getPageFromDrupalPath} from '../../common/services/prismic/pages';
+import {getBook} from '../../common/services/prismic/books';
 import {getMultiContent} from '../../common/services/prismic/multi-content';
 import {getCollectionOpeningTimes} from '../../common/services/prismic/opening-times';
 import {isPreview as getIsPreview} from '../../common/services/prismic/api';
@@ -319,17 +320,17 @@ export async function renderPage(ctx, next) {
 
 export async function renderBook(ctx, next) {
   const {id} = ctx.params;
-  const page = await getPage(ctx.request, id);
+  const book = await getBook(ctx.request, id);
 
-  if (page) {
+  if (book) {
     ctx.render('pages/book', {
       pageConfig: createPageConfig({
         path: ctx.request.url,
-        title: page.title,
+        title: book.title,
         inSection: 'what-we-do',
         category: 'info'
       }),
-      page: page,
+      book: book,
       isPreview: getIsPreview(ctx.request)
     });
   }

--- a/server/views/pages/book.njk
+++ b/server/views/pages/book.njk
@@ -15,7 +15,7 @@
 {% block body %}
 
   <script type="application/ld+json">
-    {{ book | jsonLd('contentLd') | safe }}
+
   </script>
   {% componentJsx 'BookPage', { book: book } %}
 


### PR DESCRIPTION
## Who is this for?
📖 


## What is it doing for them?
Adds basic information into the `BasicHeader` description block.
We are obviously missing a lot, but this felt like a decent start using what we have.

It has made the decision though that we are happy to have `PrimaryLinks` in the `Description` block.  

![screen shot 2018-05-22 at 12 36 32](https://user-images.githubusercontent.com/31692/40360208-3e0b9238-5dbd-11e8-8e30-c7d492b00c71.png)

