### PR TITLE
check  for linked content data before parsing it

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -340,7 +340,11 @@ export function parseBody(fragment: PrismicFragment[]) {
           weight: getWeight(slice.slice_label),
           value: {
             title: asText(slice.primary.title),
-            items: slice.items.filter(item => !item.content.isBroken).map(item => {
+            items: slice.items.filter(
+              // We have to do a check for data here, as if it's a linked piece
+              // of content, we won't have this.
+              item => !item.content.isBroken && item.content.data
+            ).map(item => {
               switch (item.content.type) {
                 case 'pages':
                   return parsePage(item.content);


### PR DESCRIPTION
Between bad image typing, and fetched data from Prismic....
:rage4: 

I think we need to spend some time on Fire proofing rather than fire fighting.