### PR TITLE
Do the divider nth-child dance at the correct breakpoint

### DIFF
--- a/common/styles/grids/_grid_dividers.scss
+++ b/common/styles/grids/_grid_dividers.scss
@@ -72,13 +72,7 @@
     }
   }
 
-  @include respond-to('xlarge') {
-    &.grid--theme-4 {
-      .grid__cell:nth-child(3):before {
-        display: block;
-      }
-    }
-
+  @include respond-to('large') {
     &.grid--theme-6 {
       .grid__cell:nth-child(3):before,
       .grid__cell:nth-child(5):before {
@@ -87,6 +81,14 @@
 
       .grid__cell:nth-child(4):before {
         display: none;
+      }
+    }
+  }
+
+  @include respond-to('xlarge') {
+    &.grid--theme-4 {
+      .grid__cell:nth-child(3):before {
+        display: block;
       }
     }
   }


### PR DESCRIPTION
The 6 promos at the bottom of the /explore page have dividers in the wrong place between the medium and large breakpoints (because they used to be laid out differently).

__before__
![screen shot 2018-05-22 at 18 04 50](https://user-images.githubusercontent.com/1394592/40378196-b84e8988-5dea-11e8-9e0c-20fc6bd0910a.png)

__after__
![screen shot 2018-05-22 at 18 04 58](https://user-images.githubusercontent.com/1394592/40378189-b3e1b442-5dea-11e8-98ea-85013ad9b318.png)
