### PR TITLE
remove whats_on tests from circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,9 +209,6 @@ jobs:
           name: Build prod config
           command: pushd ../../ && ./build_prod_config.py && popd
       - run:
-          name: Test
-          command: yarn run test
-      - run:
           name: Build
           command: yarn run app:build
       - save_cache:


### PR DESCRIPTION
Ref: #2685

## Who is this for?
🏗 

## What is it doing for them?
The build system seems to have some for of caching that I can't figure out.
