### PR TITLE
add validator bar instead of showing nonsense contet to live userse

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -112,7 +112,7 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
       url,
       title,
       image: promoImage.image,
-      description: (promoThin && promoThin.caption) || 'PROMO TEXT MISSING',
+      description: (promoThin && promoThin.caption) || '',
       start,
       end,
       statusOverride

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -60,12 +60,11 @@ const ExhibitionPromo = ({
             ${spacing({s: 1}, {margin: ['bottom']})}
           `}>{title}</h2>
 
-          <p className={`${font({s: 'HNL4'})} no-margin no-padding`}>
-            {!format && !statusOverride && start && end &&
+          {!format && !statusOverride && start && end &&
+            <p className={`${font({s: 'HNL4'})} no-margin no-padding`}>
               <Fragment><time dateTime={start}>{formatDate(start)}</time>—<time dateTime={end}>{formatDate(end)}</time></Fragment>
-            }
-            {format && description}
-          </p>
+            </p>
+          }
 
           <StatusIndicator start={start} end={end || new Date()} statusOverride={statusOverride} />
         </div>

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -43,6 +43,38 @@
         };
       </script>
       <script type="text/javascript" src="//static.cdn.prismic.io/prismic.min.js"></script>
+      <script>
+        (function () {
+          var validationBar = document.createElement('div');
+          validationBar.style.position = 'fixed';
+          validationBar.style.width = '375px';
+          validationBar.style.padding = '15px';
+          validationBar.style.background = '#ffce3c';
+          validationBar.style.bottom = '75px';
+          validationBar.style.fontSize = '12px';
+
+          window.addEventListener('load', function() {
+            const validationFails = [];
+            if (!document.querySelector('meta[name="description"]').content) {
+              validationFails.push(`
+                Warning:
+                This piece of content is missing it's description.
+                This is helps with search engine results and sharing on social channels. <br />
+                (If this is from Prismic, it's the promo text)
+              `);
+            }
+
+            if (validationFails.length > 0) {
+              validationFails.forEach(function(validationFail) {
+                var div = document.createElement('div');
+                div.innerHTML = validationFail;
+                validationBar.appendChild(div);
+              });
+              document.body.appendChild(validationBar);
+            }
+          });
+        })();
+      </script>
     {% endif %}
   </head>
   <body {% if isPreview %}class="is-preview"{% endif %} data-page-state='{{ (pageConfig.pageState or {}) | dump | safe }}'>

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -59,7 +59,7 @@
               validationFails.push(`
                 Warning:
                 This piece of content is missing it's description.
-                This is helps with search engine results and sharing on social channels. <br />
+                This is helps with search engine results and sharing on social channels.
                 (If this is from Prismic, it's the promo text)
               `);
             }

--- a/whats_on/app/views/pages/exhibition.njk
+++ b/whats_on/app/views/pages/exhibition.njk
@@ -132,11 +132,14 @@
         </div>
       </div>
     </div>
+
     {# We append the IDs here because that's how we need to query Prismic at the moment #}
-    {% component 'async', {
-      endpoint: '/exhibitions/' + exhibition.id + '/exhibits?query=ids:' + (exhibitIds | join(',')),
-      prefixEndpoint: false
-    } %}
+    {% if exhibitIds.length > 0 %}
+      {% component 'async', {
+        endpoint: '/exhibitions/' + exhibition.id + '/exhibits?query=ids:' + (exhibitIds | join(',')),
+        prefixEndpoint: false
+      } %}
+    {% endif %}
 
     {% if exhibition.relatedGalleries.length > 0 %}
       <div class="container">


### PR DESCRIPTION
## Who is this for?
Editors and viewers of the site

## What is it doing for them?
* Adds a validator bar that only show on preview. The first validation is looking for the meta description text, which comes from the promo text. 
* Removes the PROMO TEXT IS MISSING 💩 
* Simplifies the exhibition promo by not showing promo text on any of them.

Point 3 is contentious - if we still want to show the text there (and be strangely inconsistent) we can add a field to the promo which is something like `display`.

@jennpb ☝️ ?

![screen shot 2018-05-23 at 09 51 52](https://user-images.githubusercontent.com/31692/40414272-b3e460f4-5e6f-11e8-918b-739080f02863.png)

