### PR TITLE
fix layout of event promos on what's on

### DIFF
--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -47,7 +47,7 @@ const EventPromo = ({
       id={id}
       href={url}
       className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'>
-      <div className={`promo__image-container`}>
+      <div className='relative'>
         {image && image.contentUrl && <UiImage
           contentUrl={image.contentUrl}
           width={image.width || 0}

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -29,7 +29,7 @@ const ExhibitionPromo = ({
       id={id}
       href={url}
       className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'>
-      <div className={`promo__image-container`}>
+      <div className='relative'>
         {image && image.contentUrl && <UiImage
           contentUrl={image.contentUrl}
           width={image.width}


### PR DESCRIPTION
Before:
![screen shot 2018-05-23 at 11 19 54](https://user-images.githubusercontent.com/6051896/40418851-62f055fc-5e7b-11e8-8982-5dcb3d3bbcd2.png)

After: 
![screen shot 2018-05-23 at 11 21 54](https://user-images.githubusercontent.com/6051896/40418926-9379797e-5e7b-11e8-94fd-dee31c5ce87d.png)

