### PR TITLE
Books contributors

### DIFF
--- a/common/model/contributors.js
+++ b/common/model/contributors.js
@@ -11,8 +11,6 @@ export type Organisation = {|
   url: ?string
 |};
 
-type ContributorType = | 'organisations' | 'people';
-
 type ContributorRole = {|
   id: string,
   title: string
@@ -20,12 +18,12 @@ type ContributorRole = {|
 
 export type PersonContributor = {|
   ...Person,
-  type: ContributorType
+  type: 'people'
 |}
 
 export type OrganisationContributor = {|
   ...Organisation,
-  type: ContributorType
+  type: 'organisations'
 |}
 
 export type Contributor = {|

--- a/common/model/people.js
+++ b/common/model/people.js
@@ -1,10 +1,11 @@
 // @flow
 import type { Picture } from './picture';
+import type {HTMLString} from '../services/prismic/types';
 
 export type Person = {|
   id: string;
   name: string,
   twitterHandle: ?string,
-  description: ?string,
+  description: ?HTMLString,
   image: Picture
 |}

--- a/common/services/prismic/books.js
+++ b/common/services/prismic/books.js
@@ -32,7 +32,7 @@ export function parseBookDoc(document: PrismicDocument): Book {
     datePublished: data.datePublished && parseTimestamp(data.datePublished),
     authorName: data.authorName && asText(data.authorName),
     authorImage: data.authorImage && data.authorImage.url,
-    authorDescription: data.authorDescription && asHtml(data.authorDescription),
+    authorDescription: data.authorDescription,
     promo,
     body: data.body ? parseBody(data.body) : []
   };

--- a/common/views/components/BasePage/BookPage.js
+++ b/common/views/components/BasePage/BookPage.js
@@ -3,13 +3,37 @@ import {Fragment} from 'react';
 import BasePage from './BasePage';
 import HTMLDate from '../HTMLDate/HTMLDate';
 import PrimaryLink from '../Links/PrimaryLink/PrimaryLink';
+import Contributors from '../Contributors/Contributors';
 import type {Book} from '../../../model/books';
+import type {Contributor, PersonContributor} from '../../../model/contributors';
 
 type Props = {|
   book: Book
 |}
 
 const BookPage = ({ book }: Props) => {
+  // TODO: (drupal migration) this should be linked in Prismic
+  const person: PersonContributor = {
+    type: 'people',
+    id: 'xxx',
+    name: book.authorName || '',
+    image: {
+      contentUrl: book.authorImage || '',
+      width: 800,
+      height: null
+    },
+    twitterHandle: null,
+    // parse this as string
+    description: book.authorDescription
+  };
+  const contributor: Contributor = {
+    contributor: person,
+    description: null,
+    role: {
+      id: 'WcUWeCgAAFws-nGh',
+      title: 'Author'
+    }
+  };
   const DateInfo = book.datePublished && <HTMLDate date={book.datePublished} />;
 
   return (
@@ -29,6 +53,11 @@ const BookPage = ({ book }: Props) => {
       FeaturedMedia={null}
       title={book.title || 'TITLE MISSING'}
       body={book.body || []}>
+      <Fragment>
+        {contributor &&
+          <Contributors contributors={[contributor]} />
+        }
+      </Fragment>
     </BasePage>
   );
 };

--- a/common/views/components/BasePage/InstallationPage.js
+++ b/common/views/components/BasePage/InstallationPage.js
@@ -1,11 +1,10 @@
 // @flow
 import {Fragment} from 'react';
-import {spacing} from '../../../utils/classnames';
 import BasePage from './BasePage';
 import DateRange from '../DateRange/DateRange';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
 import HTMLDate from '../HTMLDate/HTMLDate';
-import Contributor from '../Contributor/Contributor';
+import Contributors from '../Contributors/Contributors';
 import WobblyBackground from '../BaseHeader/WobblyBackground';
 import {UiImage} from '../Images/Images';
 import type {UiInstallation} from '../../../model/installations';
@@ -52,16 +51,9 @@ const InstallationPage = ({ installation }: Props) => {
       body={installation.body}>
 
       <Fragment>
-        <div className={`${spacing({s: 2}, {padding: ['top']})} border-top-width-1 border-color-smoke`}>
-          {installation.contributors.length > 0 &&
-            <h2 className='h2'>Contributors</h2>
-          }
-          {installation.contributors.map(({contributor, role, description}) => (
-            <Fragment key={contributor.id}>
-              <Contributor contributor={contributor} role={role} description={description} />
-            </Fragment>
-          ))}
-        </div>
+        {installation.contributors.length > 0 &&
+          <Contributors contributors={installation.contributors} />
+        }
       </Fragment>
     </BasePage>
   );

--- a/common/views/components/Contributors/Contributors.js
+++ b/common/views/components/Contributors/Contributors.js
@@ -1,0 +1,22 @@
+// @flow
+import {Fragment} from 'react';
+import {spacing} from '../../../utils/classnames';
+import Contributor from '../Contributor/Contributor';
+import type {Contributor as ContributorType} from '../../../model/contributors';
+
+type Props = {|
+  contributors: ContributorType[]
+|}
+
+const Contributors = ({contributors}: Props) => (
+  <div className={`${spacing({s: 2}, {padding: ['top']})} border-top-width-1 border-color-smoke`}>
+    <h2 className='h2'>Contributors</h2>
+    {contributors.map(({contributor, role, description}) => (
+      <Fragment key={contributor.id}>
+        <Contributor contributor={contributor} role={role} description={description} />
+      </Fragment>
+    ))}
+  </div>
+);
+
+export default Contributors;


### PR DESCRIPTION
References #2490 

## Who is this for?
🐛 

## What is it doing for them?
Shows contributors on the BookPage.
We need to think about how we might migrate the 💩 Drupal people into new shiny Prismic people as contributors.
![screen shot 2018-05-23 at 14 53 26](https://user-images.githubusercontent.com/31692/40429051-98f7c5c2-5e99-11e8-86bc-b6206b79b9ec.png)

