### PR TITLE
route root domains to V2

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -60,30 +60,35 @@ http {
     location ~ ^/event-series/Wo1YeCoAACoAZFoN$ {
       return 301 https://wellcomecollection.org/events/Wqkd1yUAAB8sW4By;
     }
-    location ~ ^/assets|^/async|^/explore|^/progress/?$|^/flags|^/works|^/series|^/preview|^/download|^/articles/W|^/events/W|^/eventbrite|^/webcomics|^/webcomic-series|^/event-series|^/installations|^/info|^/catalogue|^/pages|^/newsletter|^/opening-times {
 
+    # Content types
+    location ~ ^/explore|^/works|^/series|^/eventbrite|^/webcomics|^/webcomic-series|^/event-series|^/installations|^/pages {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
-    location ~ ^/exhibitions/W {
+    # Root routes
+    location ~ ^/visit-us|^/what-we-do|^/venue-hire|^/access|^/youth|^/schools {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
-    location ~ ^/exhibitions/?$ {
+    location ~ ^/newsletter|^/opening-times {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
-    location ~ ^/whats-on/exhibitions/all-exhibitions/?$ {
-      return 301 https://wellcomecollection.org/exhibitions;
-    }
-    location ~ ^/events/?$ {
+    # Utility
+    location ~ ^/preview|^/download|^/progress|^/flags|^/assets|^/async {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
-    location ~ ^/whats-on/events/all-events/?$ {
-      return 301 https://wellcomecollection.org/events;
+    location ~ ^/exhibitions/W|^/exhibitions {
+      proxy_set_header        Host $host;
+      proxy_pass              http://v2;
     }
-    location ~ ^/whats-on/?$ {
+    location ~ ^/events$|^/events/W {
+      proxy_set_header        Host $host;
+      proxy_pass              http://v2;
+    }
+    location ~ ^/whats-on {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
@@ -94,7 +99,7 @@ http {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
-    location ~ ^/articles$ {
+    location ~ ^/articles$|^/articles/W {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }


### PR DESCRIPTION
## Who is this for?
🐓 

## What is it doing for them?
Routing the root domains, bar `/press` through to V2.
And a bit of a tidy to get rid of that massive line.
