### PR TITLE
Add meta data to homepage

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -70,7 +70,7 @@ export async function renderHomepage(ctx, next) {
   ctx.render('pages/homepage', {
     pageConfig: createPageConfig({
       path: path,
-      title: 'Wellcome Collection',
+      title: null,
       inSection: 'index',
       canonicalUri: `${ctx.globals.rootDomain}`
     }),

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -30,7 +30,7 @@
   <div class="css-grid__container">
     <div class="css-grid">
       <div class="{{ {s:12, m:12, l:7, xl:6} | cssGridClasses }}">
-        <h1 class="{{ {s: 'WB4', m:'WB3'} | fontClasses }}">The free destination for the incurably curious</h1>
+        <h1 class="{{ {s: 'WB4', m:'WB3'} | fontClasses }}">The free museum and library for the incurably curious</h1>
       </div>
       <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }}">
         {% componentV2 'divider', null, {'dashed': true} %}

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -4,7 +4,7 @@
   type: 'website',
   image: 'https://iiif.wellcomecollection.org/image/prismic:fc1e68b0528abbab8429d95afb5cfa4c74d40d52_tf_180516_2060224.jpg/full/1200,/0/default.jpg',
   url: pageConfig.canonicalUri,
-  description: 'The free destination for the incurably curious: the London museum that invites you to explore what it means to be human.'
+  description: 'Visit our free museum and library in central London connecting science, medicine, life and art. Explore our exhibitions, live events, gallery tours, restaurant, cafe, bookshop, and cafe. Fully accessible. Open late on Thursday evenings.'
 } %}
 
 {% block pageMeta %}

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -5,7 +5,7 @@
   type: 'website',
   image: exhibitionAndEventPromos.permanentExhibitionPromos[0].image.contentUrl,
   url: pageConfig.canonicalUri,
-  description: ''
+  description: 'The free destination for the incurably curious: the London museum that invites you to explore what it means to be human.'
 } %}
 
 {% block pageMeta %}

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -1,9 +1,8 @@
 {% extends 'layout/default.njk' %}
 
-{# TODO description and more appropriate image? #}
 {% set metaContent = {
   type: 'website',
-  image: exhibitionAndEventPromos.permanentExhibitionPromos[0].image.contentUrl,
+  image: 'https://iiif.wellcomecollection.org/image/prismic:fc1e68b0528abbab8429d95afb5cfa4c74d40d52_tf_180516_2060224.jpg/full/1200,/0/default.jpg',
   url: pageConfig.canonicalUri,
   description: 'The free destination for the incurably curious: the London museum that invites you to explore what it means to be human.'
 } %}

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -1,6 +1,32 @@
 {% extends 'layout/default.njk' %}
-{# //TODO page meta / json-ld  #}
+
+{# TODO description and more appropriate image? #}
+{% set metaContent = {
+  type: 'website',
+  image: exhibitionAndEventPromos.permanentExhibitionPromos[0].image.contentUrl,
+  url: pageConfig.canonicalUri,
+  description: ''
+} %}
+
+{% block pageMeta %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
+  <meta name="description" content="{{ metaContent.description }}" />
+{% endblock %}
+
 {% block body %}
+   <script type="application/ld+json">
+    [{% for exhibition in exhibitionAndEventPromos.temporaryExhibitionPromos %}
+      {{ exhibition | jsonLd('exhibitionPromoLd') | safe }},
+    {% endfor %}
+    {% for event in exhibitionAndEventPromos.eventPromos %}
+      {{ event | jsonLd('eventPromoLd') | safe }},
+    {% endfor %}
+    {% for exhibition in exhibitionAndEventPromos.permanentExhibitionPromos %}
+      {{ exhibition | jsonLd('exhibitionPromoLd') | safe }}{{ ',' if not loop.last }}
+    {% endfor %}]
+  </script>
+
   <div class="css-grid__container">
     <div class="css-grid">
       <div class="{{ {s:12, m:12, l:7, xl:6} | cssGridClasses }}">


### PR DESCRIPTION
## Who is this for?
👥 

## What is it doing for them?
Adding meta data and json-ld so that search results pages/shares on social media are more informative/useful

It's using the Medicine Now promo image for the twitter card etc. - we might want to use something else?

We have the description from the old site