### PR TITLE
add padding where padding once was (frame header)

### DIFF
--- a/events/app/views/pages/event-series.njk
+++ b/events/app/views/pages/event-series.njk
@@ -32,8 +32,8 @@
         } %}
       </div>
     </div>
-    <div class="relative container container--with-frame bg-white {{ {s:5, m:7} | spacingClasses({padding: ['top']}) }} {{ {s: 1} | spacingClasses({padding: ['bottom']}) }}">
-      <div class="grid">
+    <div class="relative container container--with-frame bg-white {{ {s: 1} | spacingClasses({padding: ['bottom']}) }}">
+      <div class="grid {{ {s:5, m:7} | spacingClasses({padding: ['top']}) }}">
         <div class="{{ {s: 12, m: 10, l: 8, xl: 9} | gridClasses }}">
           <h1 class="{{ {s: 'WB5', m: 'WB4', l: 'WB3'} | fontClasses }} {{ {s: 3} | spacingClasses({margin: ['bottom']}) }} {{ {s: 0} | spacingClasses({margin: ['top']}) }}">{{  pageConfig.title }}</h1>
         </div>

--- a/events/app/views/partials/event_with_schedule.njk
+++ b/events/app/views/partials/event_with_schedule.njk
@@ -9,8 +9,8 @@
       } %}
     </div>
   </div>
-  <div class="relative container container--with-frame bg-white {{ {s:5, m:7} | spacingClasses({padding: ['top']}) }} {{ {s: 1} | spacingClasses({padding: ['bottom']}) }}">
-    <div class="grid">
+  <div class="relative container container--with-frame bg-white {{ {s: 1} | spacingClasses({padding: ['bottom']}) }}">
+    <div class="grid {{ {s:5, m:7} | spacingClasses({padding: ['top']}) }}">
       <div class="{{ {s: 12, m: 10, l: 8, xl: 9} | gridClasses }}">
         <h1 class="{{ {s: 'WB5', m: 'WB4', l: 'WB3'} | fontClasses }} {{ {s: 3} | spacingClasses({margin: ['bottom']}) }} {{ {s: 0} | spacingClasses({margin: ['top']}) }}">{{  event.title }}</h1>
         <div class="{{ {s: 2, l: 10} | spacingClasses({margin: ['bottom']}) }}">


### PR DESCRIPTION
Before
https://wellcomecollection.org/event-series/WifrbikAAGSyDtHk

After
![screen shot 2018-05-24 at 16 21 47](https://user-images.githubusercontent.com/31692/40495224-a1de145e-5f6e-11e8-825f-07e6b9938d3f.png)

not sure when we started not being able to put padding on containers?
