### PR TITLE
use the cdn source for the daily guided tours promo image

### DIFF
--- a/server/data/facility-promos.js
+++ b/server/data/facility-promos.js
@@ -121,7 +121,7 @@ export const dailyTourPromo: EventPromo = {
   interpretations: [],
   image: {
     type: 'picture',
-    contentUrl: 'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F7657f9e9-0733-444d-b1b2-6ae0bafa0ff9_c7c94c39161dcfe15d9abd8b40256ea2b40f52b9_c0139861.jpg',
+    contentUrl: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/7657f9e9-0733-444d-b1b2-6ae0bafa0ff9_c7c94c39161dcfe15d9abd8b40256ea2b40f52b9_c0139861.jpg',
     width: 2996,
     height: 2000,
     alt: ''


### PR DESCRIPTION
Means it gets converted properly to loris uri, with the proper size variations

## Who is this for?
Anyone who views the homepage


## What is it doing for them?
Means they only have to download a 44KB image and not a 5.6MB one
