### PR TITLE
add books to root routes

### DIFF
--- a/common/views/components/BasePage/BookPage.js
+++ b/common/views/components/BasePage/BookPage.js
@@ -6,7 +6,6 @@ import Contributors from '../Contributors/Contributors';
 import {UiImage} from '../Images/Images';
 import WobblyBackground from '../BaseHeader/WobblyBackground';
 import type {Book} from '../../../model/books';
-import type {Contributor, PersonContributor} from '../../../model/contributors';
 
 type Props = {|
   book: Book
@@ -15,7 +14,7 @@ type Props = {|
 // TODO: Add subtitle
 const BookPage = ({ book }: Props) => {
   // TODO: (drupal migration) this should be linked in Prismic
-  const person: PersonContributor = {
+  const person = book.authorName && {
     type: 'people',
     id: 'xxx',
     name: book.authorName || '',
@@ -28,7 +27,7 @@ const BookPage = ({ book }: Props) => {
     // parse this as string
     description: book.authorDescription
   };
-  const contributor: Contributor = {
+  const contributor = person && {
     contributor: person,
     description: null,
     role: {
@@ -52,6 +51,7 @@ const BookPage = ({ book }: Props) => {
   /* https://github.com/facebook/flow/issues/2405 */
   /* $FlowFixMe */
   const FeaturedMedia = book.promo && <UiImage tasl={tasl} extraClasses='margin-v-auto inherit-max-height width-auto ' {...image} />;
+  console.info(contributor);
 
   return (
     <BasePage

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -72,6 +72,10 @@ http {
       proxy_set_header        Host $host;
       proxy_pass              http://v2;
     }
+    location ~ ^/books {
+      proxy_set_header        Host $host;
+      proxy_pass              http://v2;
+    }
     # Root routes
     location ~ ^/visit-us|^/what-we-do|^/venue-hire|^/access|^/youth|^/schools {
       proxy_set_header        Host $host;


### PR DESCRIPTION
* Checks if contributors > 1 before rendering contributor component
* Add's `/books` to router.

Annoyingly, as we only send `/what-we-do/*` and `/visit-us/*` through the druapl lookup for redirect, books don't get caught, and because the Drupal domain strategy doesn't put the content type in the URL, we can't filter this.

They will get caught when we make V2 the default, and fallback to V1.