### PR TITLE
fixed newsletter  flag logic

### DIFF
--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -125,7 +125,7 @@
       {% endblock %}
     </div>
 
-    {% if featuresCohort == 'wellcomeUser' and pageConfig.title !== 'Newsletter' %}
+    {% if featuresCohort | isFlagEnabled('newsletter', featureFlags) and pageConfig.title !== 'Newsletter' %}
       {% componentJsx 'NewsletterPromo' %}
     {% endif %}
 

--- a/server/views/pages/newsletter.njk
+++ b/server/views/pages/newsletter.njk
@@ -7,7 +7,7 @@
     isConfirmed: isConfirmed
   } %}
 
-  {% if featuresCohort == 'wellcomeUser' %}
+  {% if featuresCohort | isFlagEnabled('newsletter', featureFlags) %}
     <div class="{{ {s: 4} | spacingClasses({margin: ['top']}) }}">
       <div class="row {{ {s: 8} | spacingClasses({padding: ['bottom']}) }}">
         <div class='container'>


### PR DESCRIPTION
Just noticed the newsletter signup is not showing for default users even though the flag was switched on. This fixes it.