### PR TITLE
Ignore 'blocked a frame' error in sentry

### DIFF
--- a/server/views/partials/monitoring.njk
+++ b/server/views/partials/monitoring.njk
@@ -29,7 +29,7 @@
         return !shouldIgnoreBrowsers && !shouldIgnoreUrls;
       },
       ignoreErrors: [
-        /SecurityError\: Blocked a frame with origin "https:\/\/wellcomecollection\.org" from accessing a frame with origin "https:\/\/vars\.hotjar\.com"\. Protocols, domains, and ports must match\.$/
+        /Blocked a frame with origin/,
       ]
     }).install();
   }


### PR DESCRIPTION
## Who is this for?
Devs supporting users by fixing their errors.

## What is it doing for them?
Getting sentry into a less noisy state so we can respond better to actual problems.
