### PR TITLE
add link property to promo

### DIFF
--- a/common/model/image-promo.js
+++ b/common/model/image-promo.js
@@ -1,6 +1,7 @@
 import type {Picture} from './picture';
 
 export type ImagePromo = {|
-  caption: string;
-  image: Picture;
+  caption: ?string,
+  image: ?Picture,
+  link: ?string,
 |}

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -9,6 +9,7 @@ import type { LicenseType } from '../../model/license';
 import type { Place } from '../../model/place';
 import type { BackgroundTexture, PrismicBackgroundTexture } from '../../model/background-texture';
 import type { CaptionedImageProps } from '../../views/components/Images/Images';
+import type { ImagePromo } from '../../model/image-promo';
 import { licenseTypeArray } from '../../model/license';
 import { parsePage } from './pages';
 import { parseEventSeries } from './events';
@@ -221,11 +222,6 @@ export function parseTaslFromString(pipedString: string): Tasl {
   }
 }
 
-export type ImagePromo = {|
-  caption: ?string;
-  image: ?Picture;
-|}
-
 // null is valid to use the default image,
 // which isn't on a property, but rather at the root
 type CropType = null | '16:9' | '32:15' | 'square';
@@ -236,6 +232,7 @@ export function parseImagePromo(
 ): ?ImagePromo {
   const maybePromo = frag && frag.find(slice => slice.slice_type === 'editorialImage');
   const hasImage = (maybePromo && maybePromo.primary.image && isImageLink(maybePromo.primary.image)) || false;
+  const link = maybePromo && maybePromo.primary.link;
 
   return maybePromo && ({
     caption: asText(maybePromo.primary.caption),
@@ -243,7 +240,8 @@ export function parseImagePromo(
       image:
         // We introduced enforcing 16:9 half way through, so we have to do a check for it.
         cropType ? (maybePromo.primary.image[cropType] || maybePromo.primary.image) : maybePromo.primary.image
-    }, minWidth) : null
+    }, minWidth) : null,
+    link
   }: ImagePromo);
 }
 
@@ -308,6 +306,11 @@ export function isDocumentLink(fragment: ?PrismicFragment): boolean {
 // { '32:15': {}, '16:9': {}, square: {} }
 export function isImageLink(fragment: ?PrismicFragment): boolean {
   return Boolean(fragment && fragment.dimensions);
+}
+
+// We always get returned a { link_type: 'Web' } but it might not have a URL
+export function isWebLink(fragment: ?PrismicFragment): boolean {
+  return Boolean(fragment && fragment.url);
 }
 
 export type Weight = 'default' | 'featured';

--- a/common/views/components/BasicPromo/BasicPromo.js
+++ b/common/views/components/BasicPromo/BasicPromo.js
@@ -8,6 +8,7 @@ type Props = {|
   url: string,
   title: string,
   description: ?string,
+  link: ?string,
   imageProps: ?ImageProps
 |}
 
@@ -16,6 +17,7 @@ const BasicPromo = ({
   url,
   title,
   description,
+  link,
   imageProps
 }: Props) => {
   const textGridSize = imageProps ? 9 : 12;
@@ -26,7 +28,7 @@ const BasicPromo = ({
         category: 'component',
         action: `${promoType}:click`
       })}
-      href={url}
+      href={link || url}
       className='grid plain-link'
     >
       {imageProps &&

--- a/common/views/components/SearchResults/SearchResults.js
+++ b/common/views/components/SearchResults/SearchResults.js
@@ -23,6 +23,7 @@ const SearchResults = ({ items }: Props) => (
             title={item.title || ''}
             description={item.promo && item.promo.caption}
             imageProps={item.promo && item.promo.image}
+            link={item.promo && item.promo.link}
           />
         }
 
@@ -33,6 +34,7 @@ const SearchResults = ({ items }: Props) => (
             title={item.title || ''}
             description={item.promo && item.promo.caption}
             imageProps={item.promo && item.promo.image}
+            link={item.promo && item.promo.link}
           />
         }
 
@@ -43,6 +45,7 @@ const SearchResults = ({ items }: Props) => (
             title={item.title || ''}
             description={item.promo && item.promo.caption}
             imageProps={item.promo && item.promo.image}
+            link={item.promo && item.promo.link}
           />
         }
       </div>

--- a/prismic-model/js/parts/image.js
+++ b/prismic-model/js/parts/image.js
@@ -6,6 +6,10 @@ export default function(label: string) {
     'config': {
       label,
       thumbnails: [ {
+        name: '32:15',
+        width: 3200,
+        height: 1500
+      }, {
         name: '16:9',
         width: 3200,
         height: 1800

--- a/prismic-model/js/parts/promo.js
+++ b/prismic-model/js/parts/promo.js
@@ -1,42 +1,28 @@
 // @flow
+import image from './image';
+import text from './text';
+
 export default {
-  'type': 'Slices',
-  'config': {
-    'label': 'Promo',
-    'choices': {
-      'editorialImage': {
-        'type': 'Slice',
-        'fieldset': 'Editorial image',
-        'config': {
-          'label': 'Editorial image'
+  type: 'Slices',
+  config: {
+    label: 'Promo',
+    choices: {
+      editorialImage: {
+        type: 'Slice',
+        fieldset: 'Editorial image',
+        config: {
+          label: 'Editorial image'
         },
         'non-repeat': {
-          'caption': {
-            'type': 'StructuredText',
-            'config': {
-              'label': 'Promo text',
-              'single': 'paragraph'
+          caption: {
+            type: 'StructuredText',
+            config: {
+              label: 'Promo text',
+              single: 'paragraph'
             }
           },
-          'image': {
-            'type': 'Image',
-            'config': {
-              'label': 'Promo image',
-              'thumbnails': [ {
-                'name': '32:15',
-                'width': 3200,
-                'height': 1500
-              }, {
-                'name': '16:9',
-                'width': 3200,
-                'height': 1800
-              }, {
-                'name': 'square',
-                'width': 3200,
-                'height': 3200
-              } ]
-            }
-          }
+          image: image('Promo image'),
+          link: text('Link override')
         }
       }
     }

--- a/prismic-model/json/books.json
+++ b/prismic-model/json/books.json
@@ -61,6 +61,11 @@
                   "label": "Image",
                   "thumbnails": [
                     {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
                       "name": "16:9",
                       "width": 3200,
                       "height": 1800
@@ -101,6 +106,11 @@
                 "config": {
                   "label": "Image",
                   "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
                     {
                       "name": "16:9",
                       "width": 3200,
@@ -348,6 +358,12 @@
                       "height": 3200
                     }
                   ]
+                }
+              },
+              "link": {
+                "type": "Text",
+                "config": {
+                  "label": "Link override"
                 }
               }
             }

--- a/prismic-model/json/exhibitions.json
+++ b/prismic-model/json/exhibitions.json
@@ -177,6 +177,12 @@
                     }
                   ]
                 }
+              },
+              "link": {
+                "type": "Text",
+                "config": {
+                  "label": "Link override"
+                }
               }
             }
           }

--- a/prismic-model/json/installations.json
+++ b/prismic-model/json/installations.json
@@ -77,6 +77,11 @@
                   "label": "Image",
                   "thumbnails": [
                     {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
                       "name": "16:9",
                       "width": 3200,
                       "height": 1800
@@ -117,6 +122,11 @@
                 "config": {
                   "label": "Image",
                   "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
                     {
                       "name": "16:9",
                       "width": 3200,
@@ -320,6 +330,12 @@
                       "height": 3200
                     }
                   ]
+                }
+              },
+              "link": {
+                "type": "Text",
+                "config": {
+                  "label": "Link override"
                 }
               }
             }

--- a/prismic-model/json/pages.json
+++ b/prismic-model/json/pages.json
@@ -60,6 +60,11 @@
                   "label": "Image",
                   "thumbnails": [
                     {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
                       "name": "16:9",
                       "width": 3200,
                       "height": 1800
@@ -100,6 +105,11 @@
                 "config": {
                   "label": "Image",
                   "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
                     {
                       "name": "16:9",
                       "width": 3200,
@@ -265,6 +275,12 @@
                       "height": 3200
                     }
                   ]
+                }
+              },
+              "link": {
+                "type": "Text",
+                "config": {
+                  "label": "Link override"
                 }
               }
             }


### PR DESCRIPTION
References #2492 

## Who is this for?
People who want to have content link to places other than the `pages/{id}`.

## What is it doing for them?
You can add a link to a promo, which will then override the Prismic link.
This is useful for, say, `/opening-hours` as well as `/books`. It can also be used for the shop.

I imagine though books is going to evolve into something more fleshed out (managed list page), but this is useful elsewhere as stated ☝️ .

<img width="750" alt="screen shot 2018-05-29 at 14 51 18" src="https://user-images.githubusercontent.com/31692/40663276-3c161726-6350-11e8-8b73-fa7def7052c9.png">
