### PR TITLE
stop overlapping images on works listing

### DIFF
--- a/common/styles/components/_promo.scss
+++ b/common/styles/components/_promo.scss
@@ -62,6 +62,7 @@
 .promo__image-container--constrained {
   display: flex;
   align-items: flex-end;
+  overflow: hidden;
   height: 0;
   padding-top: 150%;
 


### PR DESCRIPTION
Looks like we lost the overflow: hidden during the promo refactor and now tall images overlap others. This puts the style back.

Before:
![screen shot 2018-05-31 at 11 05 47](https://user-images.githubusercontent.com/6051896/40776639-3ee64b78-64c3-11e8-9471-9e9f72504e6b.png)

After:
![screen shot 2018-05-31 at 11 06 15](https://user-images.githubusercontent.com/6051896/40776654-475f8d82-64c3-11e8-854d-b53e664d77ef.png)

