### PR TITLE
parse quote footer correctly

### DIFF
--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -66,12 +66,15 @@ function parseBodyPart(slice) {
       };
 
     case 'quote':
+      const footer = slice.primary.citation && slice.primary.source
+        ? `${slice.primary.citation} — ${slice.primary.source}`
+        : slice.primary.citation || slice.primary.source || null;
       return {
         type: 'quote',
         weight: 'default',
         value: {
           body: slice.primary.quote,
-          footer: slice.primary.citation && slice.primary.source ? `${slice.primary.citation} - ${slice.primary.source}` : null,
+          footer: footer,
           quote: asHtml(slice.primary.quote),
           citation: `${slice.primary.citation} - ${slice.primary.source}`,
           citationLink: slice.primary.citationLink && slice.primary.citationLink.url


### PR DESCRIPTION
## Who is this for?
People trying to cite quotes

## What is it doing for them?
Shows `citation - source` or `citation` or `source`.
