### PR TITLE
add excerpt

### DIFF
--- a/common/views/components/Excerpt/Excerpt.js
+++ b/common/views/components/Excerpt/Excerpt.js
@@ -1,0 +1,42 @@
+// @flow
+import {Fragment} from 'react';
+import {font, spacing} from '../../../utils/classnames';
+import type {Book} from '../../../model/books';
+
+type Props = {|
+  title: string,
+  content: string,
+  source: ?Book,
+  audio: ?string
+|}
+const Excerpt = ({
+  title,
+  content,
+  source,
+  audio
+}: Props) => (
+  <Fragment>
+    <h2 className='h2'>{title}</h2>
+    <div className='bg-white'>
+      {/*
+        TODO: This should definitely not be in here, but has to be because
+        of the way the article body is currently built
+      */}
+      <div className='body-part__extend-to-right'>
+        <div className={`${spacing({s: 3}, {padding: ['top', 'bottom'], margin: ['bottom']})}`}>
+          <pre className={`${spacing({s: 3}, {padding: ['left', 'right']})} ${font({s: 'LR3'})} pre  border-color-smoke border-left-width-5`}>{content}</pre>
+        </div>
+      </div>
+    </div>
+    {audio && <audio controls src={audio} style={{ width: '100%' }}></audio>}
+    {source &&
+      <p>
+        <a href={`/books/${source.id}`} className={`${font({s: 'HNL5'})}`}>
+          {source.title}
+        </a>
+      </p>
+    }
+  </Fragment>
+);
+
+export default Excerpt;

--- a/common/views/components/Index/index.js
+++ b/common/views/components/Index/index.js
@@ -13,6 +13,7 @@ import Divider from '../Divider/Divider';
 import EventPromo from '../EventPromo/EventPromo';
 import EventScheduleItem from '../EventScheduleItem/EventScheduleItem';
 import ExceptionalOpeningHoursTable from '../ExceptionalOpeningHoursTable/ExceptionalOpeningHoursTable';
+import Excerpt from '../Excerpt/Excerpt';
 import ExhibitionPageHeader from '../PageHeaders/ExhibitionPageHeader/ExhibitionPageHeader';
 import ExhibitionPromo from '../ExhibitionPromo/ExhibitionPromo';
 import FeaturedText from '../FeaturedText/FeaturedText';
@@ -65,6 +66,7 @@ export {
   EventPromo,
   EventScheduleItem,
   ExceptionalOpeningHoursTable,
+  Excerpt,
   ExhibitionPageHeader,
   ExhibitionPromo,
   FeaturedText,

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -80,10 +80,17 @@ function parseBodyPart(slice) {
 
     case 'excerpt':
       return {
-        type: 'pre',
-        name: '',
+        type: 'excerpt',
         weight: 'standalone',
-        value: asText(slice.primary.content)
+        value: {
+          title: asText(slice.primary.title),
+          content: asText(slice.primary.content),
+          source: slice.primary.source.data && {
+            id: slice.primary.source.id,
+            title: asText(slice.primary.source.data.title)
+          },
+          audio: slice.primary.audio.url
+        }
       };
 
     case 'instagramEmbed':

--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -35,7 +35,12 @@
 
             <div class="bg-cream {{ {l: 2} | spacingClasses({ padding: ['bottom'] }) }}">
               <div class="{{ {s: 1} | spacingClasses({margin: ['bottom']}) }}">
-                {% componentJsx 'CaptionedImageNew', bodyPart.value | objectAssign({sizesQueries: sizes}) %}
+                {% set caption = bodyPart.value.caption | prismicAsText %}
+                {% if bodyPart.value.caption and caption !== '' %}
+                  {% componentJsx 'CaptionedImageNew', bodyPart.value | objectAssign({ sizesQueries: sizes }) %}
+                {% else %}
+                  {% componentJsx 'UiImage', bodyPart.value.image | objectAssign({ sizesQueries: sizes }) %}
+                {% endif %}
               </div>
             </div>
           {% elif bodyPart.type === 'video-embed' %}
@@ -101,6 +106,8 @@
             {% endif %}
           {% elif bodyPart.type === 'quote' %}
             {% componentJsx 'ShameQuote', bodyPart.value %}
+          {% elif bodyPart.type === 'excerpt' %}
+            {% componentJsx 'Excerpt', bodyPart.value %}
           {% elif bodyPart.type === 'pre' %}
             <div class="bg-white">
               <div class="body-part__extend-to-right">


### PR DESCRIPTION
## Who is this for?
Editors adding excerpts

## What is it doing for them?
Turns out we didn't do the excerpt at all.
This adds the UI in for Excerpts. 

* Also chooses between `UiImage` and `CaptionedImage`in the body dependant on whether the image has a caption. This is to get rid of the bug of showing the image caption with no text. What I would like to do is use the `parseImage` to return `CaptionedImage | UiImage` as we shouldn't really serve up all the captioned image stuff if there is no caption.
