### PR TITLE
put promos on articles

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -234,17 +234,14 @@ export function parseImagePromo(
   cropType: CropType = '16:9',
   minWidth: ?string = null
 ): ?ImagePromo {
-  const maybePromo = frag && frag.find(slice => slice.slice_type === 'editorialImage');
-  const hasImage = (maybePromo && maybePromo.primary.image && isImageLink(maybePromo.primary.image)) || false;
-  const link = maybePromo && maybePromo.primary.link;
+  const promoSlice = frag && frag.find(slice => slice.slice_type === 'editorialImage');
+  const link = promoSlice && promoSlice.primary.link;
+  // We introduced enforcing 16:9 half way through, so we have to do a check for it.
+  const promoImage = promoSlice && cropType ? (promoSlice.primary.image[cropType] || promoSlice.primary.image) : promoSlice && promoSlice.primary.image;
 
-  return maybePromo && ({
-    caption: asText(maybePromo.primary.caption),
-    image: hasImage ? parsePicture({
-      image:
-        // We introduced enforcing 16:9 half way through, so we have to do a check for it.
-        cropType ? (maybePromo.primary.image[cropType] || maybePromo.primary.image) : maybePromo.primary.image
-    }, minWidth) : null,
+  return promoSlice && ({
+    caption: asText(promoSlice.primary.caption),
+    image: checkAndParseImage(promoImage),
     link
   }: ImagePromo);
 }

--- a/common/utils/json-ld.js
+++ b/common/utils/json-ld.js
@@ -15,7 +15,7 @@ export function contentLd(content) {
   return objToJsonLd({
     headline: content.headline,
     author: (content.author && content.author.map(a => a.person).map(personLd)) || 'unknown',
-    image: imageLd(content.thumbnail),
+    image: content.promo && imageLd(content.promo.image),
     datePublished: content.datePublished,
     dateModified: content.datePublished,
     publisher: orgLd(wellcomeCollection),
@@ -151,7 +151,7 @@ function personLd(person) {
 
 function imageLd(image) {
   return image && objToJsonLd({
-    url: image.contentUrl || image.url,
+    url: convertImageUri(image.contentUrl || image.url, 1200),
     width: image.width,
     height: image.height
   }, 'ImageObject');

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -195,6 +195,7 @@ export async function renderExplore(ctx, next) {
       canonicalUri: `${ctx.globals.rootDomain}/explore`
     }),
     promos: promos,
+    articles: contentList.results,
     curatedList
   });
 

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -13,10 +13,10 @@ import {isEmptyObj} from '../utils/is-empty-obj';
 import type {Series} from '../model/series';
 import type {LicenseType} from '../model/license';
 import {licenseTypeArray} from '../model/license';
-// $FlowFixMe
 import {
   parseContributors as parseContributorsProperly,
   parseImagePromo as parseImagePromoProperly
+// $FlowFixMe
 } from '../../common/services/prismic/parsers';
 
 // This is just JSON

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -14,7 +14,10 @@ import type {Series} from '../model/series';
 import type {LicenseType} from '../model/license';
 import {licenseTypeArray} from '../model/license';
 // $FlowFixMe
-import {parseContributors as parseContributorsProperly} from '../../common/services/prismic/parsers';
+import {
+  parseContributors as parseContributorsProperly,
+  parseImagePromo as parseImagePromoProperly
+} from '../../common/services/prismic/parsers';
 
 // This is just JSON
 type PrismicDoc = Object;
@@ -172,6 +175,7 @@ export function parseArticleDoc(doc: PrismicDoc): Article {
   const seriesWithCommissionedLength = series.find(series => series.commissionedLength);
   const positionInSeries = seriesWithCommissionedLength && getPositionInPrismicSeries(series[0].id, doc.data.series) || null;
   const featuredBodyParts = parseFeaturedBody(doc.data.body);
+  const promoElement = parseImagePromoProperly(doc.data.promo);
 
   const article: Article = {
     contentType: 'article',
@@ -186,7 +190,8 @@ export function parseArticleDoc(doc: PrismicDoc): Article {
     mainMedia: [featuredMedia],
     description: description,
     positionInSeries: positionInSeries,
-    featuredBodyParts: featuredBodyParts
+    featuredBodyParts: featuredBodyParts,
+    promo: promoElement
   };
 
   return article;
@@ -206,6 +211,7 @@ export function parseWebcomicDoc(doc: PrismicDoc): Article {
   const description = asText(promo.primary.caption); // TODO: Do not use description
   const contributors = parseContributors(doc.data.contributors);
   const series = parseSeries(doc.data.series);
+  const promoElement = parseImagePromoProperly(doc.data.promo);
 
   const article: Article = {
     contentType: 'comic',
@@ -217,7 +223,8 @@ export function parseWebcomicDoc(doc: PrismicDoc): Article {
     series: series,
     bodyParts: [],
     mainMedia: mainMedia,
-    description: description
+    description: description,
+    promo: promoElement
   };
 
   return article;

--- a/server/utils/body-parser.js
+++ b/server/utils/body-parser.js
@@ -465,7 +465,6 @@ export function findWpImageGallery(node) {
           }) || [];
           return imgs;
         }).reduce((acc, imgs) => acc.concat(imgs));
-      console.info(images);
 
       return createBodyPart({
         type: 'imageGallery',

--- a/server/utils/json-ld.js
+++ b/server/utils/json-ld.js
@@ -15,7 +15,7 @@ export function contentLd(content) {
   return objToJsonLd({
     headline: content.headline,
     author: (content.author && content.author.map(a => a.person).map(personLd)) || 'unknown',
-    image: imageLd(content.thumbnail),
+    image: content.promo && imageLd(content.promo.image),
     datePublished: content.datePublished,
     dateModified: content.datePublished,
     publisher: orgLd(wellcomeCollection),
@@ -151,7 +151,7 @@ function personLd(person) {
 
 function imageLd(image) {
   return image && objToJsonLd({
-    url: image.contentUrl || image.url,
+    url: convertImageUri(image.contentUrl || image.url, 1200),
     width: image.width,
     height: image.height
   }, 'ImageObject');

--- a/server/utils/prismic-parser.js
+++ b/server/utils/prismic-parser.js
@@ -241,7 +241,7 @@ export function prismicParser(slug: string, article: Article) {
   const mainMediaImage = article.mainMedia.find(media => media.type === 'picture');
   const mainMedia = mainMediaVideo ? convertVideo(mainMediaVideo, 'featured') : (mainMediaImage ? convertImage(mainMediaImage, 'featured') : null);
 
-  const promoImage = mainMediaVideo ? mainMediaImage : article.thumbnail;
+  const promoImage = mainMediaVideo ? mainMediaImage : article.promo.image;
   const promo = convertPromo(promoImage, article.description);
 
   const credits = article.author ? [convertAuthor(article.author)] : [];

--- a/server/views/components/twitter-card/twitter-card.njk
+++ b/server/views/components/twitter-card/twitter-card.njk
@@ -4,4 +4,6 @@
 <meta name="twitter:title" content="{{ metaContent.title }}" />
 <meta name="twitter:description" content="{{ (metaContent.description | striptags | safe | truncate(200)) or metaContent.title }}" />
 <meta name="twitter:image" content="{{ metaContent.image | convertImageUri(800, false) }}" />
-{#<meta name="twitter:image:alt" content=" {{ article.thumbnailAlt }}" />#}{# TODO not available from wordpress #}
+{% if metaContent.imageAlt %}
+  <meta name="twitter:image:alt" content=" {{ article.thumbnailAlt }}" />
+{% endif %}

--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -4,7 +4,8 @@
   {% set metaContent = {
     type: 'article',
     title: article.headline,
-    image: article.thumbnail.contentUrl,
+    image: article.promo.image.contentUrl,
+    imageAlt: article.promo.image.alt,
     url: pageConfig.canonicalUri,
     description: article.description
   } %}

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -29,14 +29,14 @@
         <div class="{{ {s:12, m:12, l:12, xl:12} | gridClasses }}">
           {% componentJsx 'Promo', {
             sizes: '(min-width: 1420px) 812px, (min-width: 600px) 58.5vw, calc(100vw - 36px)',
-            url: promos.first().url,
-            contentType: promos.first().contentType,
-            image: promos.first().image,
-            title: promos.first().title,
-            weight: promos.first().weight,
-            description: promos.first().description,
-            series: promos.first().series,
-            positionInSeries: promos.first().positionInSeries
+            url: articles[0].url,
+            contentType: articles[0].contentType,
+            image: articles[0].promo.image,
+            title: articles[0].headline,
+            weight: 'lead',
+            description: articles[0].promo.caption,
+            series: articles[0].series,
+            positionInSeries: articles[0].positionInSeries
           } %}
         </div>
       </div>
@@ -47,18 +47,18 @@
     </div>
     <div class="container container--scroll container--scroll-cream touch-scroll">
       <div class="grid grid--dividers grid--scroll grid--theme-4">
-        {% for promo in promos.slice(1, 5).toJS() %}
+        {% for article in articles.slice(1, 5) %}
           <div class="grid__cell">
             {% componentJsx 'Promo', {
               sizes: '(min-width: 1340px) 282px, (min-width: 600px) calc(47.22vw - 37px), calc(75vw - 18px)',
-              url: promo.url,
-              contentType: promo.contentType,
-              image: promo.image,
-              title: promo.title,
-              weight: promo.weight,
-              description: promo.description,
-              series: promo.series,
-              positionInSeries: promo.positionInSeries
+              url: article.url,
+              contentType: article.contentType,
+              image: article.promo.image,
+              title: article.headline,
+              weight: article.weight,
+              description: article.promo.caption,
+              series: article.series,
+              positionInSeries: article.positionInSeries
             } %}
           </div>
         {% endfor %}
@@ -125,18 +125,18 @@
   <div class="row {{ {s:4} | spacingClasses({padding: ['top']}) }} ">
     <div class="container container--scroll touch-scroll">
       <div class="grid grid--scroll grid--dividers grid--theme-6">
-        {% for promo in promos.slice(5, 11).toJS() %}
+        {% for article in articles.slice(5, 11) %}
           <div class="grid__cell">
             {% componentJsx 'Promo', {
               sizes: '(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(75vw - 18px)',
-              url: promo.url,
-              contentType: promo.contentType,
-              image: promo.image,
-              title: promo.title,
-              weight: promo.weight,
-              description: promo.description,
-              series: promo.series,
-              positionInSeries: promo.positionInSeries
+              url: article.url,
+              contentType: article.contentType,
+              image: article.promo.image,
+              title: article.headline,
+              weight: article.weight,
+              description: article.promo.caption,
+              series: article.series,
+              positionInSeries: article.positionInSeries
             } %}
           </div>
         {% endfor %}


### PR DESCRIPTION
Fixes #2760

## Who is this for?
Devs and users wanting consistent promos

## What is it doing for them?
In light of #2760 - we need to really start moving things over to the new system / naming / parsing.
Articles are probably going to be last on this list, so this is just a partial upgrade.
