### PR TITLE
add search events by interpretation type

### DIFF
--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -6,6 +6,7 @@ import { parsePage } from './pages';
 import { parseEventSeries } from './events';
 import { parseBook } from './books';
 import { pagesFields } from './fetch-links';
+import { parseEventDoc as parseEvent } from '../../../server/services/prismic-parsers';
 import type {MultiContent} from '../../model/multi-content';
 import type {StructuredSearchQuery} from './search';
 import type {PaginatedResults} from './types';
@@ -19,6 +20,8 @@ function parseMultiContent(documents): MultiContent[] {
         return parseEventSeries(document);
       case 'books':
         return parseBook(document);
+      case 'events':
+        return parseEvent(document);
     }
   }).filter(Boolean);
 }
@@ -34,13 +37,19 @@ export async function getMultiContent(
   const tagPredicate = tag.length > 0 ? Prismic.Predicates.any('document.tags', tag) : null;
   const typesPredicate = types.length > 0 ? Prismic.Predicates.in('document.type', types) : null;
   const typePredicate = type.length > 0 ? Prismic.Predicates.any('document.type', type) : null;
+
+  const interpretationType = structuredSearchQuery['my.events.interpretations.interpretationType'];
+  const interpretationTypePredicate =
+    interpretationType.length > 0 ? Prismic.Predicates.any('my.events.interpretations.interpretationType', interpretationType) : null;
+  console.info(interpretationType);
   const predicates = [
     idsPredicate,
     idPredicate,
     tagsPredicate,
     tagPredicate,
     typesPredicate,
-    typePredicate
+    typePredicate,
+    interpretationTypePredicate
   ].filter(Boolean);
   const apiResponse = await getDocuments(req, predicates, {
     fetchLinks: pagesFields,

--- a/common/services/prismic/search.js
+++ b/common/services/prismic/search.js
@@ -11,7 +11,8 @@ export type StructuredSearchQuery = {|
   tags: string[],
   tag: string[],
   pageSize: number,
-  orderings: string[]
+  orderings: string[],
+  'my.events.interpretations.interpretationType': string[]
 |}
 
 export async function search(req: Request, stringQuery: string) {
@@ -28,7 +29,10 @@ export function parseQuery(query: string): StructuredSearchQuery {
       'types', 'type',
       'ids', 'id',
       'tags', 'tag',
-      'pageSize', 'orderings'
+      'pageSize', 'orderings',
+      // TODO: Make this dynamic as it's very much not sustainable.
+      // We can probably do this from the prismic models.
+      'my.events.interpretations.interpretationType'
     ]
   });
   const arrayedStructuredQuery = Object.entries(structuredQuery).reduce((acc, entry) => {
@@ -49,6 +53,7 @@ export function parseQuery(query: string): StructuredSearchQuery {
     tags: arrayedStructuredQuery.tags || [],
     tag: arrayedStructuredQuery.tag || [],
     orderings: arrayedStructuredQuery.orderings || [],
-    pageSize: arrayedStructuredQuery.pageSize
+    pageSize: arrayedStructuredQuery.pageSize,
+    'my.events.interpretations.interpretationType': arrayedStructuredQuery['my.events.interpretations.interpretationType'] || []
   };
 }

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -358,8 +358,8 @@ export async function renderSearch(ctx, next) {
   const content = await search(ctx.request, query);
   const promoList = content.results.map(content => {
     return content.promo && {
-      url: `/books/${content.id}`,
-      contentType: 'Books',
+      url: `/events/${content.id}`,
+      contentType: 'Event',
       image: content.promo.image,
       title: content.title,
       description: content.promo.caption
@@ -368,13 +368,13 @@ export async function renderSearch(ctx, next) {
 
   ctx.render('pages/list', {
     pageConfig: createPageConfig({
-      path: `/books`,
-      title: 'Our books',
-      inSection: 'what-we-do'
+      path: `/search?query=${query}`,
+      title: 'Search',
+      inSection: 'search'
     }),
     list: {
-      name: 'Books',
-      description: 'Wellcome Collection publishes books that relate to our exhibitions, collections and areas of interest.',
+      name: 'Search results',
+      description: 'Search for events, exhibitions, books and more from Wellcome Collection',
       items: List(promoList)
     },
     pagination: null,

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -352,6 +352,36 @@ export async function renderBooks(ctx, next) {
   });
 };
 
+export async function renderSearch(ctx, next) {
+  const {query} = ctx.request.query;
+
+  const content = await search(ctx.request, query);
+  const promoList = content.results.map(content => {
+    return content.promo && {
+      url: `/books/${content.id}`,
+      contentType: 'Books',
+      image: content.promo.image,
+      title: content.title,
+      description: content.promo.caption
+    };
+  }).filter(Boolean);
+
+  ctx.render('pages/list', {
+    pageConfig: createPageConfig({
+      path: `/books`,
+      title: 'Our books',
+      inSection: 'what-we-do'
+    }),
+    list: {
+      name: 'Books',
+      description: 'Wellcome Collection publishes books that relate to our exhibitions, collections and areas of interest.',
+      items: List(promoList)
+    },
+    pagination: null,
+    moreLink: null
+  });
+};
+
 export async function renderBook(ctx, next) {
   const {id} = ctx.params;
   const book = await getBook(ctx.request, id);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -18,7 +18,8 @@ import {
   renderPage,
   searchForDrupalRedirect,
   renderBooks,
-  renderBook
+  renderBook,
+  renderSearch as renderSearchPage
 } from '../controllers/content';
 
 const r = new Router({
@@ -61,6 +62,7 @@ r.get('/webcomic-series/:id', renderWebcomicSeries);
 r.get('/pages/:id', renderPage);
 r.get('/books', renderBooks);
 r.get('/books/:id', renderBook);
+r.get('/search', renderSearchPage);
 r.get('/newsletter', renderNewsletterPage);
 
 // root paths that we want to support.


### PR DESCRIPTION
References #2765 

## Who is this for?
People who'd like to see a subset of our events.

## What is it doing for them?
Allows us to use the search param to get back more specific results.

e.g. https://wellcomecollection.org/search?query=my.events.interpretations.interpretationType:WlYq1SQAACYAWiuX%20my.events.interpretations.interpretationType:WmXl4iQAACUAnyDr%20my.events.interpretations.interpretationType:WmXhziQAACQAnw7i%20my.events.interpretations.interpretationType:Wn3STCoAACgAIedR

^ This becomes quite unwieldy, so might need some might need some wielding.

TODO before launch: 
- [ ] Refactor events code to be more like the rest of the code base and living in the `whats_on` app
- [ ] Render event promos, rather than generic ones
- [ ] Make the field searching more generic and scalable as a solution
- [ ] Create a new service to host this

![screencapture-localhost-3000-search-2018-06-04-17_04_16](https://user-images.githubusercontent.com/31692/40928449-577ea8e8-6819-11e8-9a9c-d8dcbbd3eb8d.jpg)

