### PR TITLE
add a cache for opening times on nextjs apps

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -21,6 +21,7 @@
     "lazysizes": "^4.0.1",
     "lodash.debounce": "^4.0.8",
     "lodash.groupby": "^4.6.0",
+    "lscache": "^1.1.0",
     "moment": "^2.20.1",
     "moment-timezone": "^0.5.14",
     "next": "^5.0.0",

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -1,11 +1,22 @@
 import {Component} from 'react';
 import {getCollectionOpeningTimes} from '@weco/common/services/prismic/opening-times';
 import DefaultPageLayout from '@weco/common/views/components/DefaultPageLayout/DefaultPageLayout';
+import lscache from 'lscache';
+
+async function getCachedCollectionOpeningTimes() {
+  let cachedResponse = lscache.get('opening-times');
+  if (cachedResponse === null) {
+    cachedResponse = await getCollectionOpeningTimes();
+    lscache.set('opening-times', cachedResponse, 5 /* minutes */);
+  }
+
+  return cachedResponse;
+}
 
 const PageWrapper = Comp => {
   return class Global extends Component<Props> {
     static async getInitialProps(args) {
-      const openingTimes = await getCollectionOpeningTimes();
+      const openingTimes = await getCachedCollectionOpeningTimes();
       const galleriesLibrary = openingTimes && openingTimes.placesOpeningHours.filter(venue => {
         return venue.name.toLowerCase() === 'galleries' || venue.name.toLowerCase() === 'library';
       });

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -7,9 +7,8 @@ async function getCachedCollectionOpeningTimes() {
   let cachedResponse = lscache.get('opening-times');
   if (cachedResponse === null) {
     cachedResponse = await getCollectionOpeningTimes();
-    lscache.set('opening-times', cachedResponse, 5 /* minutes */);
+    lscache.set('opening-times', cachedResponse, 60 /* minutes */);
   }
-
   return cachedResponse;
 }
 

--- a/common/yarn.lock
+++ b/common/yarn.lock
@@ -3624,6 +3624,10 @@ lru-cache@^4.0.1, lru-cache@^4.1.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lscache@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lscache/-/lscache-1.1.0.tgz#cbcf2df9ccf634f3c8f9c659bcbe044d6f73b860"
+
 make-dir@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.2.0.tgz#6d6a49eead4aae296c53bbf3a1a008bd6c89469b"


### PR DESCRIPTION
Fixes #2472 

## Who is this for?
Users not wanting to download opening times every page load.

## What is it doing for them?
We add a cache. We still don't have the benefit of the `intervalCache` from the last app, where other users will benefit from the cache of others, but given that we don't page refresh all that often, we should be _ok_. I'd like to release against what we have, and we can optimise from there, but adding in HTTP calls is a big no no, so let's stay clear if we can.

What's the reason for using the `PageWrapper`? It does feel as though we could have the logic in the `DefaultPageLayout`? 
