### PR TITLE
WIP: added test to get varients from Prismic

### DIFF
--- a/common/test/services/prismic/api.test.js
+++ b/common/test/services/prismic/api.test.js
@@ -1,0 +1,11 @@
+import util from 'util';
+import Prismic from 'prismic-javascript';
+const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
+
+test('Experiments', async () => {
+  const api = await Prismic.getApi(apiUri);
+  const currentExperiment = api.currentExperiment();
+  const doc = await api.getByID('Ww_grCEAAGpwlPul', {ref: 'WxAqYCEAAIillfBs~WxAffyAAACiw0Nox'});
+  console.info(doc.data.title);
+  console.log(util.inspect(currentExperiment, false, null));
+});


### PR DESCRIPTION
## Who is this for?
Content producers who would like to test multiple variants against each other.

## What is it doing for them?
This uses the Prismic experiments to serve different content that the content producers can create.
We'll need to work out some core metrics (which we have already).

An example would be testing different images on promos, that would have the goal of having more people click on it.

All of this is supported in GA / Prismic - we just need to build it into our process.