### PR TITLE
add unleash for feature flags

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -33,6 +33,7 @@
     "react-ga": "^2.4.1",
     "react-transition-group": "^2.2.1",
     "search-query-parser": "^1.3.0",
+    "unleash-client": "^3.1.0",
     "url-template": "^2.0.8"
   }
 }

--- a/common/services/unleash/feature-flags.js
+++ b/common/services/unleash/feature-flags.js
@@ -1,0 +1,24 @@
+// Leave this service with common requires as it's needed where we don't have
+// compilation
+const { Strategy, initialize } = require('unleash-client');
+
+class ActiveForUserInCohort extends Strategy {
+  constructor() {
+    super('ActiveForUserInCohort');
+  }
+
+  isEnabled({ cohorts }, { cohort }) {
+    return cohorts.split(',').indexOf(cohort) !== -1;
+  }
+}
+
+function init(options) {
+  return initialize(Object.assign(options, {
+    strategies: [new ActiveForUserInCohort()]
+  }));
+}
+
+module.exports = {
+  initialize: init,
+  ActiveForUserInCohort
+};

--- a/common/services/unleash/feature-flags.js
+++ b/common/services/unleash/feature-flags.js
@@ -14,6 +14,8 @@ class ActiveForUserInCohort extends Strategy {
 
 function init(options) {
   return initialize(Object.assign(options, {
+    url: 'https://weco-feature-flags.herokuapp.com/api/',
+    refreshInterval: 60 * 1000,
     strategies: [new ActiveForUserInCohort()]
   }));
 }

--- a/common/test/services/unleash/feature-flags.test.js
+++ b/common/test/services/unleash/feature-flags.test.js
@@ -1,0 +1,18 @@
+const { isEnabled } = require('unleash-client');
+
+test('search for single tags and single ids', async () => {
+  const { initialize } = require('unleash-client');
+  initialize({
+    url: 'https://weco-feature-flags.herokuapp.com/api/',
+    appName: 'test',
+    instanceId: 'test-instance',
+    refreshInterval: 60 * 1000
+  });
+
+  await new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve();
+    }, 500);
+  });
+  expect(isEnabled('testSwitch')).toBe(true);
+});

--- a/common/test/services/unleash/feature-flags.test.js
+++ b/common/test/services/unleash/feature-flags.test.js
@@ -3,10 +3,8 @@ import { initialize } from '../../../services/unleash/feature-flags';
 
 test('Test that flags are working', async () => {
   initialize({
-    url: 'https://weco-feature-flags.herokuapp.com/api/',
     appName: 'test',
-    instanceId: 'test-instance',
-    refreshInterval: 60 * 1000
+    instanceId: 'test-instance'
   });
 
   await new Promise((resolve, reject) => {

--- a/common/test/services/unleash/feature-flags.test.js
+++ b/common/test/services/unleash/feature-flags.test.js
@@ -1,7 +1,7 @@
-const { isEnabled } = require('unleash-client');
+import { isEnabled } from 'unleash-client';
+import { initialize } from '../../../services/unleash/feature-flags';
 
-test('search for single tags and single ids', async () => {
-  const { initialize } = require('unleash-client');
+test('Test that flags are working', async () => {
   initialize({
     url: 'https://weco-feature-flags.herokuapp.com/api/',
     appName: 'test',
@@ -12,7 +12,11 @@ test('search for single tags and single ids', async () => {
   await new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve();
-    }, 500);
+    }, 1500);
   });
-  expect(isEnabled('testSwitch')).toBe(true);
+
+  expect(
+    isEnabled('testSwitch', {
+      cohort: 'small'
+    })).toBe(true);
 });

--- a/common/yarn.lock
+++ b/common/yarn.lock
@@ -2780,6 +2780,10 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -3887,6 +3891,10 @@ ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
+murmurhash3js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
+
 mv@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
@@ -4445,6 +4453,10 @@ pkg-up@2.0.0, pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pkginfo@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -4889,6 +4901,31 @@ request@2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
+
+request@^2.79.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 request@^2.83.0:
   version "2.85.0"
@@ -5704,6 +5741,15 @@ unique-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
   dependencies:
     crypto-random-string "^1.0.0"
+
+unleash-client@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/unleash-client/-/unleash-client-3.1.0.tgz#05a3b645344af7a98de992b9f434a5ab0cee0dd3"
+  dependencies:
+    ip "^1.1.5"
+    murmurhash3js "^3.0.1"
+    pkginfo "^0.4.1"
+    request "^2.79.0"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Ref #2801 

## Who is this for?
The team wanting to run tests

## What is it doing for them?
Adds (unleash)[https://github.com/Unleash/unleash] (created by Schibsted).
This has some great functionality, especially around % releases.

It feels like we would be able to create a system more customised to us by starting with a system built for the purpose we're using it for.

We also decouple ourselves from Prismic, and it get's the flags out of the way of the editors.

See the repo for the service, needs work, but works.
https://github.com/wellcometrust/feature-flags