### PR TITLE
add metadata to books

### DIFF
--- a/common/views/components/BasePage/BookPage.js
+++ b/common/views/components/BasePage/BookPage.js
@@ -12,10 +12,11 @@ import {grid, spacing} from '../../../utils/classnames';
 import type {Book} from '../../../model/books';
 
 type Props = {|
-  book: Book
+  book: Book,
+  booksMetadataFlag: boolean
 |}
 
-const BookMetadata = ({book}: Props) => (
+const BookMetadata = ({book}: {| book: Book |}) => (
   <dl className='grid'>
     <dt className={'no-margin ' + grid({ s: 2, m: 2, l: 2, xl: 2 })}>Price</dt>
     <dd className={'no-margin ' + grid({ s: 10, m: 10, l: 10, xl: 10 })}>{book.price}</dd>
@@ -32,7 +33,7 @@ const BookMetadata = ({book}: Props) => (
 );
 
 // TODO: Add subtitle
-const BookPage = ({ book }: Props) => {
+const BookPage = ({ book, booksMetadataFlag }: Props) => {
   // TODO: (drupal migration) this should be linked in Prismic
   const person = book.authorName && {
     type: 'people',
@@ -105,11 +106,12 @@ const BookPage = ({ book }: Props) => {
         {contributor &&
           <Contributors contributors={[contributor]} />
         }
-
-        <div className={`${spacing({s: 2}, {padding: ['top']})} border-top-width-1 border-color-smoke`}>
-          <h2 className='h2'>More information</h2>
-          <BookMetadata book={book} />
-        </div>
+        { booksMetadataFlag &&
+            <div className={`${spacing({s: 2}, {padding: ['top']})} ${spacing({s: 2}, {margin: ['top']})} border-top-width-1 border-color-smoke`}>
+              <h2 className='h2'>More information</h2>
+              <BookMetadata book={book} />
+            </div>
+        }
 
         {book.orderLink && <PrimaryLink url={book.orderLink} name='Order online' />}
       </Fragment>

--- a/common/views/components/BasePage/BookPage.js
+++ b/common/views/components/BasePage/BookPage.js
@@ -5,13 +5,31 @@ import BaseHeader from '../BaseHeader/BaseHeader';
 import Body from '../Body/Body';
 import HTMLDate from '../HTMLDate/HTMLDate';
 import Contributors from '../Contributors/Contributors';
+import PrimaryLink from '../Links/PrimaryLink/PrimaryLink';
 import {UiImage} from '../Images/Images';
 import WobblyBackground from '../BaseHeader/WobblyBackground';
+import {grid, spacing} from '../../../utils/classnames';
 import type {Book} from '../../../model/books';
 
 type Props = {|
   book: Book
 |}
+
+const BookMetadata = ({book}: Props) => (
+  <dl className='grid'>
+    <dt className={'no-margin ' + grid({ s: 2, m: 2, l: 2, xl: 2 })}>Price</dt>
+    <dd className={'no-margin ' + grid({ s: 10, m: 10, l: 10, xl: 10 })}>{book.price}</dd>
+
+    <dt className={'no-margin ' + grid({ s: 2, m: 2, l: 2, xl: 2 })}>Format</dt>
+    <dd className={'no-margin ' + grid({ s: 10, m: 10, l: 10, xl: 10 })}>{book.format}</dd>
+
+    <dt className={'no-margin ' + grid({ s: 2, m: 2, l: 2, xl: 2 })}>Extent</dt>
+    <dd className={'no-margin ' + grid({ s: 10, m: 10, l: 10, xl: 10 })}>{book.extent}</dd>
+
+    <dt className={'no-margin ' + grid({ s: 2, m: 2, l: 2, xl: 2 })}>ISBN</dt>
+    <dd className={'no-margin ' + grid({ s: 10, m: 10, l: 10, xl: 10 })}>{book.isbn}</dd>
+  </dl>
+);
 
 // TODO: Add subtitle
 const BookPage = ({ book }: Props) => {
@@ -87,6 +105,13 @@ const BookPage = ({ book }: Props) => {
         {contributor &&
           <Contributors contributors={[contributor]} />
         }
+
+        <div className={`${spacing({s: 2}, {padding: ['top']})} border-top-width-1 border-color-smoke`}>
+          <h2 className='h2'>More information</h2>
+          <BookMetadata book={book} />
+        </div>
+
+        <PrimaryLink url={book.orderLink} name='Order online' />
       </Fragment>
     </BasePage>
   );

--- a/common/views/components/BasePage/BookPage.js
+++ b/common/views/components/BasePage/BookPage.js
@@ -111,7 +111,7 @@ const BookPage = ({ book }: Props) => {
           <BookMetadata book={book} />
         </div>
 
-        <PrimaryLink url={book.orderLink} name='Order online' />
+        {book.orderLink && <PrimaryLink url={book.orderLink} name='Order online' />}
       </Fragment>
     </BasePage>
   );

--- a/server/views/pages/book.njk
+++ b/server/views/pages/book.njk
@@ -18,6 +18,7 @@
   <script type="application/ld+json">
 
   </script>
-  {% componentJsx 'BookPage', { book: book } %}
+  {% set booksMetadataFlag = (featuresCohort | isFlagEnabled('booksMetadata', featureFlags)) %}
+  {% componentJsx 'BookPage', { book: book, booksMetadataFlag: booksMetadataFlag } %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes #2817 

## Who is this for?
People who like to know how many pages are in a book, and how hard it's cover is before purchasing.
:trollface: 

## What is it doing for them?
Giving them this information.

# Design system
We could think about how we add extra metadata to pages.
e.g. should the contributors and meta information and any other added meta block have the same container i.e. `MetablockContainer`.

![screen shot 2018-06-13 at 08 48 57](https://user-images.githubusercontent.com/31692/41337251-a67086d2-6ee6-11e8-943e-f665dca79256.png)
 