### PR TITLE
add oembed to works page

### DIFF
--- a/common/views/components/WorkEmbed/WorkEmbed.js
+++ b/common/views/components/WorkEmbed/WorkEmbed.js
@@ -19,7 +19,7 @@ const WorkEmbed = ({
   );
   const iiifInfoUrl = iiifImageLocation && iiifImageLocation.url;
   const iiifImage = iiifImageTemplate(iiifInfoUrl);
-  const imageUrl = iiifImage({width: 800});
+  const imageUrl = iiifImage({size: '800,'});
 
   return (
     <Fragment>

--- a/common/views/components/WorkImage/WorkImage.js
+++ b/common/views/components/WorkImage/WorkImage.js
@@ -19,27 +19,28 @@ const WorkImage = ({
   );
   const iiifInfoUrl = iiifImageLocation && iiifImageLocation.url;
   const iiifImage = iiifImageTemplate(iiifInfoUrl);
-  const imageUrl = iiifImage({width: 800});
+  const imageUrl = iiifImage({size: '800,'});
 
   return (
     <Fragment>
-      <UiImage
-        contentUrl={imageUrl}
-        width={800}
-        height={0}
-        alt=''
-        tasl={{
-          title: work.title,
-          author: work.creators.map(creator => creator.label).join(', '),
-          copyrightHolder: null,
-          copyrightLink: null,
-          sourceLink: work.credit,
-          sourceName: `https://wellcomecollection.org/works/${work.id}`,
-          license: work.thumbnail && work.thumbnail.license.licenseType
-        }}
-        sizesQueries=''
-        showTasl={false} />
-
+      <a href={`https://wellcomecollection.org/works/${work.id}`}>
+        <UiImage
+          contentUrl={imageUrl}
+          width={800}
+          height={0}
+          alt=''
+          tasl={{
+            title: work.title,
+            author: work.creators.map(creator => creator.label).join(', '),
+            copyrightHolder: null,
+            copyrightLink: null,
+            sourceLink: work.credit,
+            sourceName: `https://wellcomecollection.org/works/${work.id}`,
+            license: work.thumbnail && work.thumbnail.license.licenseType
+          }}
+          sizesQueries=''
+          showTasl={false} />
+      </a>
       <WorkCredit work={work} />
     </Fragment>
   );

--- a/server/controllers/work.js
+++ b/server/controllers/work.js
@@ -10,6 +10,7 @@ import {worksLandingPromos, henryImage} from '../data/works';
 import getLicenseInfo from '../filters/get-license-info';
 import {getLinkObjects} from '../filters/get-link-objects';
 import WorkImage from '../../common/views/components/WorkImage/WorkImage';
+import {iiifImageTemplate} from '../../common/utils/convert-image-uri';
 
 function imageUrlFromMiroId(id) {
   const cleanedMiroId = id.match(/(^\w{1}[0-9]*)+/g, '')[0];
@@ -200,6 +201,15 @@ export const search = async (ctx, next) => {
 export const renderOembed = async (ctx, next) => {
   const {id} = ctx.params;
   const work = await getWork(id);
+  const [iiifImageLocation] = work.items.map(
+    item => item.locations.find(
+      location => location.locationType === 'iiif-image'
+    )
+  );
+  const iiifInfoUrl = iiifImageLocation && iiifImageLocation.url;
+  const iiifImage = iiifImageTemplate(iiifInfoUrl);
+  const thumbnail = iiifImage({size: '800,'});
+
   ctx.body = {
     url: `https://works.wellcomecollection.org/works/${work.id}`,
     author_name: 'Wellcome Collection',
@@ -210,6 +220,8 @@ export const renderOembed = async (ctx, next) => {
     provider_name: 'Wellcome Collection',
     provider_url: 'https://wellcomecollection.org',
     version: '1.0',
+    thumbnail_url: thumbnail,
+    thumbnail_width: 800,
     html: ReactDOMServer.renderToString(
       React.createElement(WorkImage, { work })
     ),

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -12,6 +12,11 @@
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
 
   <meta name="description" content="{{ work.description }}" />
+  <link
+    rel="alternate"
+    type="application/json+oembed"
+    href="https://wellcomecollection.org/oembed/works/{{ work.id }}"
+    title="{{work.title}}" />
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
## Who is this for?
People wanting to embed our catalogue images into their content.

## What is it doing for them?
Giving them a basic oEmbed output that is the image, wrapped in a link to the work.

If we added coords to the zoomer, we could use it as the cropper.

<img width="718" alt="screen shot 2018-06-13 at 09 55 18" src="https://user-images.githubusercontent.com/31692/41340709-e89b1ab4-6eef-11e8-8b68-255212facc2e.png">
