### PR TITLE
Check font declaration exists

### DIFF
--- a/common/styles/utilities/_mixins.scss
+++ b/common/styles/utilities/_mixins.scss
@@ -160,15 +160,15 @@
   letter-spacing: $letter-spacing;
   line-height: $line-height;
 
-  @if($font-family-subset) {
+  @if ($font-family-subset != '') {
     font-family: #{$font-family-subset + ',' + $font-family-base};
   }
 
-  @if($font-family-web and $font-family-subset) {
+  @if ($font-family-web and ($font-family-subset != '')) {
     .fonts-loaded & {
       font-family: #{$font-family-web + ',' + $font-family-subset + ',' + $font-family-base};
     }
-  } @else if ($font-family-web) {
+  } @else if ($font-family-web != '') {
     .fonts-loaded & {
       font-family: #{$font-family-web + ',' + $font-family-base};
     }


### PR DESCRIPTION
An empty string (possible after we added fonts to js config) breaks css font declarations.

Checking for empty strings in the sass stops this from happening.

![screen shot 2018-06-13 at 15 29 15](https://user-images.githubusercontent.com/1394592/41357717-ac8c8b96-6f1e-11e8-8345-428e7a71591b.png)
