### PR TITLE
Update input value when tag clicked

### DIFF
--- a/common/views/components/HTMLInput/HTMLInput.js
+++ b/common/views/components/HTMLInput/HTMLInput.js
@@ -38,7 +38,7 @@ const HTMLInput = ({
   fontStyles = {s: 'HNL3', m: 'HNL2'},
   onChange
 }: Props) => (
-  <label className='input__label flex flex--v-center' htmlFor={id}>
+  <label key={defaultValue} className='input__label flex flex--v-center' htmlFor={id}>
     <input
       required={required}
       ref={inputRef}

--- a/common/views/components/HTMLInput/HTMLInput.js
+++ b/common/views/components/HTMLInput/HTMLInput.js
@@ -23,6 +23,11 @@ type Props = {|
   onChange?: (EventWithInputValue) => void
 |}
 
+// `defaultValue` only gets set on initial load for a form.
+// After that, it won't get 'naturally' updated because the
+// intent was only to set an initial default value.
+// We get around this by passing a `key`
+// (the value itself) to the parent element.
 const HTMLInput = ({
   required,
   inputRef,


### PR DESCRIPTION
`defaultValue` only gets set set on initial load, because we are currently using an 'uncontrolled' React input.

A tidy and immediate solution is to give any updated value as a `key` to the input's wrapping element.

This lets us punt the question of input state down the park for a bit.

👟🏈

Fixes #2798