### PR TITLE
Api v2 test flags store

### DIFF
--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -27,8 +27,8 @@
     "nodemon": "^1.17.5",
     "postcss-easy-import": "^3.0.0",
     "postcss-loader": "^2.1.4",
-    "react": "^16.3.2",
-    "react-dom": "^16.3.2",
+    "react": "^16.4.1",
+    "react-dom": "^16.4.1",
     "sass-loader": "^7.0.1"
   }
 }

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -16,7 +16,6 @@ import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import SecondaryLink from '@weco/common/views/components/Links/SecondaryLink/SecondaryLink';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
-import type {Flags} from '@weco/common/model/flags';
 
 export type Link = {|
   text: string;
@@ -165,14 +164,12 @@ type Work = Object;
 type Props = {|
   work: Work,
   previousQueryString: ?string,
-  page: ?number,
-  flags: Flags
+  page: ?number
 |}
 
 const WorkPage = ({
   work,
-  previousQueryString,
-  flags
+  previousQueryString
 }: Props) => {
   const [iiifImageLocation] = work.items.map(
     item => item.locations.find(

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -13,7 +13,6 @@ import WorkPromo from '@weco/common/views/components/WorkPromo/WorkPromo';
 import Pagination, {PaginationFactory} from '@weco/common/views/components/Pagination/Pagination';
 import type {Props as PaginationProps} from '@weco/common/views/components/Pagination/Pagination';
 import type {EventWithInputValue} from '@weco/common/views/components/HTMLInput/HTMLInput';
-import type {Flags} from '@weco/common/model/flags';
 
 // TODO: Setting the event parameter to type 'Event' leads to
 // an 'Indexable signature not found in EventTarget' Flow
@@ -24,8 +23,7 @@ type Props = {|
   page: ?number,
   works: {| results: [], totalResults: number |},
   pagination: PaginationProps,
-  handleSubmit: (EventWithInputValue) => void,
-  flags: Flags
+  handleSubmit: (EventWithInputValue) => void
 |}
 
 const WorksComponent = ({
@@ -33,8 +31,7 @@ const WorksComponent = ({
   page,
   works,
   pagination,
-  handleSubmit,
-  flags
+  handleSubmit
 }: Props) => (
   <Fragment>
     <PageDescription title='Search our images' extraClasses='page-description--hidden' />
@@ -214,7 +211,6 @@ class Works extends Component<Props> {
     return (
       <WorksComponent
         page={this.props.page}
-        flags={this.props.flags}
         query={this.props.query}
         works={this.props.works}
         pagination={this.props.pagination}

--- a/catalogue/webapp/yarn.lock
+++ b/catalogue/webapp/yarn.lock
@@ -5761,9 +5761,18 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.2.0, react-dom@^16.3.2:
+react-dom@^16.2.0:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-dom@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -5795,9 +5804,18 @@ react-transition-group@^2.2.1:
     loose-envify "^1.3.1"
     prop-types "^15.6.1"
 
-"react@^15.6.2 || ^16.0", react@^16.2.0, react@^16.3.2:
+"react@^15.6.2 || ^16.0", react@^16.2.0:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react/-/react-16.3.2.tgz#fdc8420398533a1e58872f59091b272ce2f91ea9"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react@^16.4.1:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -11,7 +11,7 @@ const pageStoreHandler = {
     return isServer ? serverStore.get(prop) : clientStore.get(prop);
   },
   set: function() {
-    throw Error('Please don\'t try to set props on me （/｡＼).');
+    throw Error('Please don\'t try to set props on me （/｡＼)');
   }
 };
 export const pageStore = new Proxy({}, pageStoreHandler);

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -4,9 +4,17 @@ import DefaultPageLayout from '@weco/common/views/components/DefaultPageLayout/D
 
 const isServer = typeof window === 'undefined';
 // As this is a store, it's mutable
-const clientStore = isServer ? null : {
-  openingTimes: null
+const clientStore = isServer ? null : new Map();
+const serverStore = isServer ? new Map() : null;
+const pageStoreHandler = {
+  get: function(_, prop) {
+    return isServer ? serverStore.get(prop) : clientStore.get(prop);
+  },
+  set: function() {
+    throw Error('Please don\'t try to set props on me （/｡＼).');
+  }
 };
+export const pageStore = new Proxy({}, pageStoreHandler);
 
 async function fetchOpeningTimes() {
   const openingTimes = await getCollectionOpeningTimes();
@@ -36,8 +44,13 @@ async function fetchOpeningTimes() {
 const PageWrapper = Comp => {
   return class Global extends Component<Props> {
     static async getInitialProps(context) {
-      const openingTimes = clientStore ? clientStore.openingTimes : await fetchOpeningTimes();
-      const flags = clientStore ? clientStore.flags : context.query.flags;
+      const openingTimes = clientStore ? clientStore.get('openingTimes') : await fetchOpeningTimes();
+      const flags = clientStore ? clientStore.get('flags') : context.query.flags;
+
+      if (serverStore) {
+        serverStore.set('openingTimes', openingTimes);
+        serverStore.set('flags', flags);
+      }
 
       return {
         openingTimes,
@@ -49,12 +62,12 @@ const PageWrapper = Comp => {
     constructor(props) {
       super(props);
 
-      if (clientStore && !clientStore.appData) {
-        clientStore.openingTimes = props.openingTimes;
+      if (clientStore && !clientStore.get('openingTimes')) {
+        clientStore.set('openingTimes', props.openingTimes);
       }
 
-      if (clientStore && !clientStore.flags) {
-        clientStore.flags = props.flags;
+      if (clientStore && !clientStore.get('flags')) {
+        clientStore.set('flags', props.flags);
       }
     }
 
@@ -68,7 +81,6 @@ const PageWrapper = Comp => {
         siteSection,
         analyticsCategory,
         openingTimes,
-        flags,
         ...props
       } = this.props;
 
@@ -82,7 +94,7 @@ const PageWrapper = Comp => {
           siteSection={siteSection}
           analyticsCategory={analyticsCategory}
           openingTimes={openingTimes}>
-          <Comp {...props} flags={flags} />
+          <Comp {...props} />
         </DefaultPageLayout>
       );
     }

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -11,7 +11,7 @@ const pageStoreHandler = {
     return isServer ? serverStore.get(prop) : clientStore.get(prop);
   },
   set: function() {
-    throw Error('Please don\'t try to set props on me （/｡＼)');
+    throw Error('Page store: Please don\'t try to set props on me （/｡＼)');
   }
 };
 export const pageStore = new Proxy({}, pageStoreHandler);


### PR DESCRIPTION
## Who is this for?
Devs who want to use flags, hopefully easily

## What is it doing for them?
Allowing us to use a `pageStore` for the flags.
We can use the React Context to use them in the templates too - I tried it, but didn't want to introduce it without a use case as I haven't tested bundle size / performance of it.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
https://reactjs.org/docs/context.html#when-to-use-context