### PR TITLE
Wrap PrismicHtmlBlock component in 'body-text' class

### DIFF
--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -127,7 +127,9 @@
               {% componentV2 'gif-video', bodyPart.value %}
             </div>
           {% elif bodyPart.type === 'text' %}
-            {% componentJsx 'PrismicHtmlBlock', {html: bodyPart.value} %}
+            <div class="body-text">
+              {% componentJsx 'PrismicHtmlBlock', {html: bodyPart.value} %}
+            </div>
           {% else %}
             <div class="body-text">
               {{ bodyPart.value | safe }}


### PR DESCRIPTION
Makes the article headings Wellcome Bold again.

<img width="497" alt="screen shot 2018-06-15 at 15 39 12" src="https://user-images.githubusercontent.com/1394592/41473843-5dbc15aa-70b2-11e8-831b-66b73716b0bf.png">
