### PR TITLE
Standalone design QA amends

### DIFF
--- a/common/styles/components/_divider.scss
+++ b/common/styles/components/_divider.scss
@@ -36,6 +36,6 @@
 
 .divider--dashed {
   height: 10px;
-  background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20xmlns%3Axlink%3D%22http%3A//www.w3.org/1999/xlink%22%20viewBox%3D%220%200%205%2010%22%3E%0A%09%3Cline%20fill%3D%22none%22%20stroke%3D%22%23000000%22%20class%3D%22st0%22%20x1%3D%220.5%22%20y1%3D%2210%22%20x2%3D%220.5%22%20y2%3D%220%22%20/%3E%0A%3C/svg%3E%0A');
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzIDEwIj48cmVjdCB3aWR0aD0iMSIgaGVpZ2h0PSIxMCIvPjwvc3ZnPg==');
   background-repeat: repeat;
 }

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -347,6 +347,10 @@
     color: color('green');
   }
 
+  @include respond-to('medium') {
+    min-height: 440px;
+  }
+
   @supports (display: grid) {
     display: flex;
   }

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -78,7 +78,7 @@ const EventPromo = ({
       <div className={`
           flex flex--column flex-1 flex--h-space-between
           ${spacing({s: 2}, {padding: ['top']})}
-          ${spacing({s: 3}, {padding: ['left', 'right']})}
+          ${spacing({s: 2}, {padding: ['left', 'right']})}
           ${spacing({s: 4}, {padding: ['bottom']})}
         `}>
 

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -55,7 +55,7 @@ const ExhibitionPromo = ({
       <div className={`
           flex flex--column flex-1 flex--h-space-between
           ${spacing({s: 2}, {padding: ['top']})}
-          ${spacing({s: 3}, {padding: ['left', 'right']})}
+          ${spacing({s: 2}, {padding: ['left', 'right']})}
           ${spacing({s: 4}, {padding: ['bottom']})}
         `}>
 

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -1,6 +1,6 @@
 // @flow
 import Button from '../Buttons/Button/Button';
-import {grid, spacing} from '../../../utils/classnames';
+import {grid, spacing, font} from '../../../utils/classnames';
 
 const NewsletterPromo = () => (
   <div className='row bg-cream'>
@@ -8,7 +8,7 @@ const NewsletterPromo = () => (
       <div className='grid'>
         <div className={`${grid({s: 12, m: 12, l: 12, xl: 12})} ${spacing({s: 4}, {padding: ['top', 'bottom']})}`}>
           <h2 className='h2'>Stay connected with email updates from Wellcome Collection</h2>
-          <p>Be the first to know about our upcoming exhibitions, events and other activities, with extra options for youth, schools and access events.</p>
+          <p className={font({s: 'HNL4'})}>Be the first to know about our upcoming exhibitions, events and other activities, with extra options for youth, schools and access events.</p>
           <Button
             type='primary'
             extraClasses='btn--primary'

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -6,7 +6,7 @@ const NewsletterPromo = () => (
   <div className='row bg-cream'>
     <div className='container'>
       <div className='grid'>
-        <div className={`${grid({s: 12, m: 12, l: 12, xl: 12})} ${spacing({s: 4}, {padding: ['top', 'bottom']})}`}>
+        <div className={`${grid({s: 12, m: 12, l: 12, xl: 12})} ${spacing({s: 4}, {padding: ['top']})} ${spacing({s: 8}, {padding: ['bottom']})}`}>
           <h2 className='h2'>Stay connected with email updates from Wellcome Collection</h2>
           <p className={font({s: 'HNL4'})}>Be the first to know about our upcoming exhibitions, events and other activities, with extra options for youth, schools and access events.</p>
           <Button

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -28,7 +28,7 @@
 
   <div class="css-grid__container">
     <div class="css-grid">
-      <div class="{{ {s:12, m:12, l:10, xl:9} | cssGridClasses }}">
+      <div class="{{ {s:12, m:12, l:10, xl:9} | cssGridClasses }} {{ {s: 3, m: 4} | spacingClasses({margin: ['bottom']}) }}">
         <h1 class="{{ {s: 'WB4', m:'WB3'} | fontClasses }}">The free museum and library for the incurably curious</h1>
       </div>
       <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }}">

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -28,7 +28,7 @@
 
   <div class="css-grid__container">
     <div class="css-grid">
-      <div class="{{ {s:12, m:12, l:7, xl:6} | cssGridClasses }}">
+      <div class="{{ {s:12, m:12, l:10, xl:9} | cssGridClasses }}">
         <h1 class="{{ {s: 'WB4', m:'WB3'} | fontClasses }}">The free museum and library for the incurably curious</h1>
       </div>
       <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }}">


### PR DESCRIPTION
Addressing the standalone issues on under the Zeplin 'QA' tag.

- [x] 1. Title to span more columns (It won't always be possible to keep the text in the lock-up in the design (it will break on to three lines occasionally) but I'll increase the columns so that it'll match this lock-up as often as possible.)
- [x] 4. Increase vertical space between bottom of title and top of section divide.
- [x] 5. Can we update the divider to be denser. 1px line / 2px space?
- [x] 6. Reduce left padding to 12px
- [x] 8. Introduce minimum height for promo cards to encourage a consistent height based around a maximum two row title. (There may be exceptions that run on to 3?)
- [x] 10. Helvetica type too large
- [x] 11. Needs more vertical space between the bottom on the button and the footer

![screen shot 2018-06-18 at 15 47 49](https://user-images.githubusercontent.com/1394592/41543588-0160b798-730f-11e8-9768-b9260ea408dc.png)


Will pick up the remaining issues in separate tickets.