### PR TITLE
Remove cream bg from image on article page

### DIFF
--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -33,7 +33,7 @@
               {% set sizes ='(min-width: 1420px) 680px, (min-width: 960px) 50vw, (min-width: 600px) calc(83.24vw - 69px), calc(100vw - 36px)' %}
             {% endif %}
 
-            <div class="bg-cream {{ {l: 2} | spacingClasses({ padding: ['bottom'] }) }}">
+            <div class="{{ {l: 2} | spacingClasses({ padding: ['bottom'] }) }}">
               <div class="{{ {s: 1} | spacingClasses({margin: ['bottom']}) }}">
                 {% set caption = bodyPart.value.caption | prismicAsText %}
                 {% if bodyPart.value.caption and caption !== '' %}


### PR DESCRIPTION
In the (rare) instance that an image caption overlaps with the image gallery area, the captioned image _not_ having its own background looks less broken.

**Before**
![screen shot 2018-06-21 at 14 29 40](https://user-images.githubusercontent.com/1394592/41722329-1f8bbc1a-7560-11e8-898b-bed0019f2930.png)

**After**
![screen shot 2018-06-21 at 14 29 56](https://user-images.githubusercontent.com/1394592/41722349-2f73dcc0-7560-11e8-92d9-69b1c95f23ff.png)
