### PR TITLE
Contributors heading

### DIFF
--- a/common/test/components/Contributors.test.js
+++ b/common/test/components/Contributors.test.js
@@ -1,0 +1,55 @@
+import {getContributorsTitle} from '../../views/components/Contributors/Contributors';
+
+const facilitator = {
+  role: {
+    title: 'Facilitator'
+  }
+};
+
+const guide = {
+  role: {
+    title: 'Guide'
+  }
+};
+
+const speaker = {
+  role: {
+    title: 'Speaker'
+  }
+};
+
+test('1 contributor, 1 role', async () => {
+  const title = getContributorsTitle([facilitator]);
+
+  expect(title).toBe('facilitator');
+});
+
+test('multi contributor, 1 role', async () => {
+  const title = getContributorsTitle([
+    facilitator,
+    facilitator
+  ]);
+
+  expect(title).toBe('facilitators');
+});
+
+test('multi contributor, multi role', async () => {
+  const title = getContributorsTitle([
+    facilitator,
+    guide,
+    speaker
+  ]);
+
+  expect(title).toBe('facilitator, guide and speaker');
+});
+
+test('multi contributor, multi role, roles matching', async () => {
+  const title = getContributorsTitle([
+    facilitator,
+    guide,
+    guide,
+    speaker
+  ]);
+
+  expect(title).toBe('facilitator, guides and speaker');
+});

--- a/common/views/components/BasePage/BookPage.js
+++ b/common/views/components/BasePage/BookPage.js
@@ -108,7 +108,8 @@ const BookPage = ({ book }: Props) => {
     >
       <Fragment>
         {contributors.length > 0 &&
-          <Contributors contributors={contributors} />
+          <Contributors
+            contributors={contributors} />
         }
 
         <Fragment>

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -46,7 +46,9 @@ const EventPage = ({ event }: Props) => {
     >
       <Fragment>
         {event.contributors.length > 0 &&
-          <Contributors contributors={event.contributors} />
+          <Contributors
+            titlePrefix='About your'
+            contributors={event.contributors} />
         }
       </Fragment>
     </BasePage>

--- a/common/views/components/BasePage/InstallationPage.js
+++ b/common/views/components/BasePage/InstallationPage.js
@@ -57,7 +57,8 @@ const InstallationPage = ({ installation }: Props) => {
     >
       <Fragment>
         {installation.contributors.length > 0 &&
-          <Contributors contributors={installation.contributors} />
+          <Contributors
+            contributors={installation.contributors} />
         }
       </Fragment>
     </BasePage>

--- a/common/views/components/Contributors/Contributors.js
+++ b/common/views/components/Contributors/Contributors.js
@@ -5,13 +5,54 @@ import Contributor from '../Contributor/Contributor';
 import type {Contributor as ContributorType} from '../../../model/contributors';
 
 type Props = {|
-  contributors: ContributorType[]
+  contributors: ContributorType[],
+  titlePrefix?: string,
+  excludeTitle?: boolean
 |}
 
+export function getContributorsTitle(
+  contributors: ContributorType[]
+): string {
+  // We've been guarenteed that we'll only get speaker, guide, and facilitator,
+  // so the pluralisation works here.
+  const roleCounts = contributors.map(contributor => contributor.role && contributor.role.title)
+    .filter(Boolean)
+    .reduce((acc, role) => {
+      if (!acc.hasOwnProperty(role)) {
+        acc[role] = 0;
+      }
+      acc[role]++;
+      return acc;
+    }, {});
+
+  // This is basic, but makes sense
+  if (roleCounts.hasOwnProperty('Partner')) {
+    return 'In partnership with';
+  }
+
+  return Object.keys(roleCounts).reduce((acc, role, i, roles) => {
+    const postFix =
+        // The second last of many
+        roles.length !== 1 && i === roles.length - 2 ? ' and '
+        // Not the last of many
+          : roles.length !== 1 && i < roles.length - 2 ? ', '
+          // There's only 1
+            : '';
+
+    const pluralisedS = roleCounts[role] > 1 ? 's' : '';
+    return acc + role.toLowerCase() + pluralisedS + postFix;
+  }, '');
+}
+
 const Contributors = ({
-  contributors
+  contributors,
+  titlePrefix = 'About the',
+  excludeTitle
 }: Props) => (
   <div className={`${spacing({s: 2}, {padding: ['top']})} border-top-width-1 border-color-smoke`}>
+    {!excludeTitle && <h2 className='h2'>
+      {`${titlePrefix} ${getContributorsTitle(contributors)}`}
+    </h2>}
     {contributors.map(({contributor, role, description}) => (
       <Fragment key={contributor.id}>
         <Contributor contributor={contributor} role={role} description={description} />


### PR DESCRIPTION
Working with Alice W on how we pull in collaborators and how we give people context.

Turns out they have a guideline document (which is actually law) on the headings of the page.
1 being "About your [contributor.role](s)".

It's an easy thing to automate, and she said it would be of much relief if we did.

It will also create consistency, which is an important thing with accessibility. If you look at #2871 there is already inconsistencies creeping in Drupal style from copy and paste (your vs our).

We can definitely add in an override when this doesn't cater for the needs of the content team, but after talking to them, this feels like a good place to start and iterate on.

For those who don't read JavaScript.

It goes as such:
## About {the/your} {role}(s), {role}(s) and {role}(s)

![screen shot 2018-06-21 at 17 28 07](https://user-images.githubusercontent.com/31692/41732274-87897e98-7578-11e8-9df4-5ac1a025db37.png)

