### PR TITLE
Section header

### DIFF
--- a/cardigan_beta/stories/components/SectionHeader.js
+++ b/cardigan_beta/stories/components/SectionHeader.js
@@ -1,0 +1,18 @@
+import { storiesOf } from '@storybook/react';
+import { withReadme }  from 'storybook-readme';
+import SectionHeader from '../../../common/views/components/SectionHeader/SectionHeader';
+import Readme from '../../../common/views/components/SectionHeader/README.md';
+import { text } from '@storybook/addon-knobs/react';
+
+const stories = storiesOf('Components', module);
+
+const SectionHeaderExample = () => {
+  const title = text('Title', 'You may have missed');
+  const linkText = text('Link text', 'More articles');
+  return (
+    <SectionHeader title={title} linkUrl='#' linkText={linkText} />
+  );
+};
+
+stories
+  .add('Section header', withReadme(Readme, SectionHeaderExample));

--- a/common/styles/components/_divider.scss
+++ b/common/styles/components/_divider.scss
@@ -30,10 +30,6 @@
   height: 2px;
 }
 
-.divider--thick {
-  height: 22px;
-}
-
 .divider--dashed {
   height: 10px;
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzIDEwIj48cmVjdCB3aWR0aD0iMSIgaGVpZ2h0PSIxMCIvPjwvc3ZnPg==');

--- a/common/styles/components/_slider__in-content.scss
+++ b/common/styles/components/_slider__in-content.scss
@@ -35,7 +35,7 @@ $slider-control-margin: 18px;
 }
 
 .slider-controls--in-content {
-  bottom: $spacing-unit * 6;
+  bottom: $spacing-unit;
 
   .slider-control--prev,
   .slider-control--next {

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -143,8 +143,8 @@
   display: flex;
 }
 
-.flex-m-up {
-  @include respond-to('medium') {
+.flex-l-up {
+  @include respond-to('large') {
     display: flex;
   }
 }

--- a/common/styles/utilities/compiled_variables/_fonts.scss
+++ b/common/styles/utilities/compiled_variables/_fonts.scss
@@ -25,7 +25,7 @@ $fonts: (
     'font-family-subset': "'Wellcome Bold Web Subset'",
     'font-family-web': "'Wellcome Bold Web'",
     'font-size': 33px,
-    'line-height': 48px
+    'line-height': 42px
   ),
   'WB5': (
     'font-family-base': "'Arial Black', Gadget, sans-serif",

--- a/common/views/components/Divider/Divider.config.js
+++ b/common/views/components/Divider/Divider.config.js
@@ -6,6 +6,5 @@ export const variants = [
   {name: 'stub', context: {extraClasses: 'divider--black divider--stub'}},
   {name: 'keyline', context: {extraClasses: 'divider--pumice divider--keyline'}},
   {name: 'thin', context: {extraClasses: 'divider--black divider--thin'}},
-  {name: 'thick', context: {extraClasses: 'divider--pumice divider--thick'}},
   {name: 'dashed', context: {extraClasses: 'divider--dashed'}}
 ];

--- a/common/views/components/Index/index.js
+++ b/common/views/components/Index/index.js
@@ -46,6 +46,7 @@ import Quote from '../Quote/Quote';
 import SearchBox from '../SearchBox/SearchBox';
 import SearchResults from '../SearchResults/SearchResults';
 import SecondaryLink from '../Links/SecondaryLink/SecondaryLink';
+import SectionHeader from '../SectionHeader/SectionHeader';
 import ShameQuote from '../ShameQuote/ShameQuote';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
 import Tags from '../Tags/Tags';
@@ -104,6 +105,7 @@ export {
   SearchBox,
   SearchResults,
   SecondaryLink,
+  SectionHeader,
   ShameQuote,
   StatusIndicator,
   Tags,

--- a/common/views/components/SectionHeader/README.md
+++ b/common/views/components/SectionHeader/README.md
@@ -1,0 +1,3 @@
+A `SectionHeader` is visually comprised of a dashed divider above a title and an optional `PrimaryLink`.
+
+It should be used to separate sections of promos, where the `PrimaryLink` would link to more of the type of promos listed.

--- a/common/views/components/SectionHeader/SectionHeader.js
+++ b/common/views/components/SectionHeader/SectionHeader.js
@@ -14,7 +14,7 @@ type Props = {|
 
 const SectionHeader = ({title, linkText, linkUrl}: Props) => {
   return (
-    <div className={`${spacing({s: 6}, {margin: ['bottom']})} ${spacing({s: 8, m: 10}, {margin: ['top']})} `}>
+    <div className={`row ${spacing({s: 6}, {margin: ['bottom']})} ${spacing({s: 8, m: 10}, {margin: ['top']})} `}>
       <div className='container'>
         <div className='grid'>
           <div className={`${grid({s: 12, m: 12, l: 12, xl: 12})} ${spacing({s: 1}, {margin: ['bottom']})}`}>

--- a/common/views/components/SectionHeader/SectionHeader.js
+++ b/common/views/components/SectionHeader/SectionHeader.js
@@ -1,0 +1,37 @@
+// @flow
+import {spacing, grid, font} from '../../../utils/classnames';
+import Divider from '../Divider/Divider';
+import PrimaryLink from '../Links/PrimaryLink/PrimaryLink';
+
+type Props = {|
+  title: string,
+  linkText?: string,
+  linkUrl?: string
+|}
+
+// TODO: Allow the component to take a PrimaryLink as a prop
+// (not possible while we're using it in Nunjucks land).
+
+const SectionHeader = ({title, linkText, linkUrl}: Props) => {
+  return (
+    <div className={`${spacing({s: 6}, {margin: ['bottom']})} ${spacing({s: 8, m: 10}, {margin: ['top']})} `}>
+      <div className='container'>
+        <div className='grid'>
+          <div className={`${grid({s: 12, m: 12, l: 12, xl: 12})} ${spacing({s: 1}, {margin: ['bottom']})}`}>
+            <Divider extraClasses='divider--dashed' />
+          </div>
+          <div className={grid({s: 12, m: 12, l: 12, xl: 12})}>
+            <div className='flex-l-up flex--v-end flex--h-space-between'>
+              <h2 className={`${font({s: 'WB5', m: 'WB4'})} ${spacing({l: 1}, {padding: ['right']})} ${spacing({s: 0}, {margin: ['top']})} ${spacing({s: 1}, {margin: ['bottom']})}`}>{title}</h2>
+              {linkText && linkUrl &&
+                <PrimaryLink name={linkText} url={linkUrl} />
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SectionHeader;

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -64,9 +64,6 @@
         {% endfor %}
       </div>
     </div>
-    <div class="container container--no-collapse">
-      {% componentV2 'divider', null, {'thick': true, 'black': true}, {extraClasses: [{s:5} | spacingClasses({margin: ['bottom']})]} %}
-    </div>
   </div>
 
   {% for section in curatedList.data.section %}
@@ -98,29 +95,17 @@
               </div>
             </div>
           </div>
-          <div class="{{ {s:4} | spacingClasses({margin:['top']}) }}">
-            <div class="container container--no-collapse">
-              {% componentV2 'divider', null, {'thick': true, 'black': true} %}
-            </div>
-          </div>
         </div>
       {% endif %}
     {% endif %}
   {% endfor %}
 
   {# Chronological #}
-  <div class="row">
-    <div class="container">
-      <div class="grid">
-        <div class="{{ {s:12, m:12, l:12, xl: 12} | gridClasses }}">
-          <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">You may have missed</h2>
-        </div>
-        <div class="{{ {s:12, m:12, l:8} | gridClasses }}">
-          {% componentJsx 'PrimaryLink', { name: 'More articles', url: '/articles' } %}
-        </div>
-      </div>
-    </div>
-  </div>
+  {% componentJsx 'SectionHeader', {
+    title: 'You may have missed',
+    linkText: 'More articles',
+    linkUrl: '/articles'
+  } %}
 
   <div class="row {{ {s:4} | spacingClasses({padding: ['top']}) }} ">
     <div class="container container--scroll touch-scroll">

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -28,21 +28,17 @@
 
   <div class="css-grid__container">
     <div class="css-grid">
-      <div class="{{ {s:12, m:12, l:10, xl:9} | cssGridClasses }} {{ {s: 3, m: 4} | spacingClasses({margin: ['bottom']}) }}">
-        <h1 class="{{ {s: 'WB4', m:'WB3'} | fontClasses }}">The free museum and library for the incurably curious</h1>
-      </div>
-      <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }}">
-        {% componentV2 'divider', null, {'dashed': true} %}
+      <div class="{{ {s:12, m:12, l:10, xl:9} | cssGridClasses }}">
+        <h1 class="{{ {s: 'WB4', m:'WB3'} | fontClasses }} {{ {s: 3} | spacingClasses({margin: ['bottom']}) }}">The free museum and library for the incurably curious</h1>
       </div>
     </div>
   </div>
 
-  <div class="container">
-    <div class="{{ {s: 6} | spacingClasses({padding: ['top']}) }} flex-m-up flex--v-center flex--h-space-between">
-      <h2 class="h2">This week at Wellcome Collection</h2>
-      {% componentJsx 'PrimaryLink', { name: 'All exhibitions and events', url: '/whats-on' } %}
-    </div>
-  </div>
+  {% componentJsx 'SectionHeader', {
+    title: 'This week at Wellcome Collection',
+    linkText: 'All exhibitions and events',
+    linkUrl: '/whats-on'
+  } %}
 
   <div class="css-grid__container">
     <div class="css-grid">
@@ -82,12 +78,11 @@
     </div>
   </div>
 
-  <div class="container">
-    <div class="{{ {s: 6} | spacingClasses({padding: ['top']}) }} flex-m-up flex--v-center flex--h-space-between">
-      <h2 class="h2">Latest articles, comics and more</h2>
-      {% componentJsx 'PrimaryLink', { name: 'All stories', url: '/explore' } %}
-    </div>
-  </div>
+  {% componentJsx 'SectionHeader', {
+    title: 'Latest articles, comics and more',
+    linkText: 'All stories',
+    linkUrl: '/explore'
+  } %}
 
   <div class="css-grid__container">
     <div class="css-grid">


### PR DESCRIPTION
Componentising the `<SectionHeader />` as a thing that can head up a block of promos, with an optional link off to more of the same.

This is the current 'rule' – it may evolve.

![screen shot 2018-06-22 at 16 08 51](https://user-images.githubusercontent.com/1394592/41784097-97d26e40-7636-11e8-9bc3-ad7839fd15b8.png)
