### PR TITLE
Declare normal letter-spacing if not defined

### DIFF
--- a/common/styles/utilities/_mixins.scss
+++ b/common/styles/utilities/_mixins.scss
@@ -147,19 +147,16 @@
   $font-family-web: unquote(map-get($font, 'font-family-web') or '');
   $font-size: px-to-rem(map-get($font, 'font-size'));
   $font-weight: map-get($font, 'font-weight');
-  $letter-spacing: map-get($font, 'letter-spacing');
+  $letter-spacing: map-get($font, 'letter-spacing') or normal;
   $line-height: px-to-unitless(map-get($font, 'line-height'), map-get($font, 'font-size'));
 
   font-family: $font-family-base;
   font-size: $font-size;
   line-height: $line-height;
+  letter-spacing: $letter-spacing;
 
   @if ($font-weight) {
     font-weight: $font-weight;
-  }
-
-  @if ($letter-spacing) {
-    letter-spacing: $letter-spacing;
   }
 
   @if ($font-family-subset != '') {


### PR DESCRIPTION
Fixes #2443.

If `letter-spacing` isn't specified in the font config object, we have to specify `normal`, otherwise we could inherit the (undesired) previous breakpoint's `letter-spacing` value.

![screen shot 2018-06-25 at 11 24 30](https://user-images.githubusercontent.com/1394592/41845301-f405f1a6-786a-11e8-9583-277f9905f821.png)
