### PR TITLE
add error to work page

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -349,6 +349,10 @@ WorkPage.getInitialProps = async (context) => {
   const res = await fetch(`https://api.wellcomecollection.org/catalogue/v${version}/works/${id}?includes=identifiers,items,thumbnail`);
   let json = await res.json();
 
+  if (res.status !== 200) {
+    return { statusCode: res.status };
+  }
+
   const [iiifImageLocation] = json.items.map(
     item => item.locations.find(
       location => location.locationType === 'iiif-image'

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -1,4 +1,5 @@
 import {Component} from 'react';
+import Error from 'next/error';
 import {getCollectionOpeningTimes} from '@weco/common/services/prismic/opening-times';
 import DefaultPageLayout from '@weco/common/views/components/DefaultPageLayout/DefaultPageLayout';
 
@@ -83,6 +84,10 @@ const PageWrapper = Comp => {
         openingTimes,
         ...props
       } = this.props;
+
+      if (this.props.statusCode && this.props.statusCode !== 200) {
+        return <Error statusCode={this.props.statusCode} />;
+      }
 
       return (
         <DefaultPageLayout


### PR DESCRIPTION
Stops throwing a 500 error if we don't have a work.
We'll also be able to update the 404 page when we get to it.