### PR TITLE
add tracking to email address

### DIFF
--- a/events/app/views/partials/event_without_schedule.njk
+++ b/events/app/views/partials/event_without_schedule.njk
@@ -160,7 +160,12 @@
               {% componentJsx 'SecondaryLink', {
                 extraClasses: 'block font-charcoal ' + {s:1} | spacingClasses({margin: ['top']}),
                 text: event.bookingEnquiryTeam.email,
-                url: 'mailto:' + event.bookingEnquiryTeam.email + '?subject=' + event.title
+                url: 'mailto:' + event.bookingEnquiryTeam.email + '?subject=' + event.title,
+                eventTracking: {
+                  category: 'component',
+                  action: 'booking-tickets-email:click',
+                  label: 'event-page'
+                } | dump,
               } %}
             </div>
           {% endif %}


### PR DESCRIPTION
So we can tell if people are using the button or email.

So far looks like no-one has used the email, but I also don't know how GA works with screen readers etc.