### PR TITLE
add contributors heading to model

### DIFF
--- a/prismic-model/js/installations.js
+++ b/prismic-model/js/installations.js
@@ -5,6 +5,7 @@ import promo from './parts/promo';
 import timestamp from './parts/timestamp';
 import place from './parts/place';
 import body from './parts/body';
+import heading from './parts/heading';
 
 const Installations = {
   Installation: {
@@ -15,6 +16,7 @@ const Installations = {
     body
   },
   Contributors: {
+    contributorsTitle: heading('Contributors heading'),
     contributors
   },
   Promo: {

--- a/prismic-model/js/parts/heading.js
+++ b/prismic-model/js/parts/heading.js
@@ -1,0 +1,10 @@
+// @flow
+export default function heading(label: string = 'Title') {
+  return  {
+    'type': 'StructuredText',
+    'config': {
+      'label': label,
+      'single': 'heading1'
+    }
+  };
+}

--- a/prismic-model/json/installations.json
+++ b/prismic-model/json/installations.json
@@ -252,6 +252,13 @@
     }
   },
   "Contributors": {
+    "contributorsTitle": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Contributors heading",
+        "single": "heading1"
+      }
+    },
     "contributors": {
       "type": "Group",
       "fieldset": "Contributors",


### PR DESCRIPTION
ref #2871 

For talk about the naming etc of how we might add UI elements into the CMS.
There is not implementation UI here.

Questions:

- [ ] When naming things that are more interface-y - do we call them `heading`s, or `title`s?
- [ ] Do we want to prefix these fields with something like: `uiContributorsHeading`?