### PR TITLE
Use more useful analytics dimensions

### DIFF
--- a/common/model/analytics-dimensions.js
+++ b/common/model/analytics-dimensions.js
@@ -1,0 +1,16 @@
+// @flow
+type SeriesDimension = {|
+  id: string,
+  title: string
+|}
+
+export type AnalyticsDimensions = {|
+  version: 1 | 2,
+  format: ?string,
+  series: SeriesDimension[],
+  positionInSeries: ?number,
+  testCohort: ?string,
+  dataType: 'list' | 'item',
+  referringComponent: ?Object,
+  pageState: ?Object
+|}

--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -23,8 +23,8 @@ ga('create', 'UA-55614-24', 'auto', 'v2');
 ga('create', 'UA-55614-6', 'auto');
 ga('set', 'dimension1', '2');
 
-{% if pageConfig.category %}
-  ga('set', 'dimension2', '{{ pageConfig.category }}');
+{% if pageConfig.format %}
+  ga('set', 'dimension2', '{{ pageConfig.format }}');
 {% endif %}
 
 {% if pageConfig.seriesUrl %}
@@ -34,6 +34,10 @@ ga('set', 'dimension1', '2');
 
 {% if pageConfig.positionInSeries %}
   ga('set', 'dimension4', '{{ pageConfig.positionInSeries }}');
+{% endif %}
+
+{% if featuresCohort and featuresCohort !== 'default' %}
+  ga('set', 'dimension5', '{{ featuresCohort }}');
 {% endif %}
 
 {% if pageConfig.contentType %}
@@ -54,11 +58,6 @@ localStorage.removeItem('wc_referring_component_list');
 if (referringComponentListString) {
   ga('set', 'dimension7', referringComponentListString);
 }
-
-{# Test dimension #}
-{% if featuresCohort and featuresCohort !== 'default' %}
-  ga('set', 'dimension5', '{{ featuresCohort }}');
-{% endif %}
 
 ga('require', 'GTM-NXMJ6D9');
 ga('send', 'pageview');


### PR DESCRIPTION
## Who is this for?
👩‍🔬 

## What is it doing for them?
We're updating the dimensions to be consistent, and useful.

# Version
V1 / V2. Slowly becoming redundant, but super useful to know where the last of our V1 content is from

# Category => Format (CHANGING)
Currently has a number of things, including `public-program`, `publicprogram`, `editorial`, `collections`, `info`, `information`. Not used in reporting.

After chatting to @hthair we thought having format in here would be useful.

We have exhibition formats (perm / temp), we have event formats (discussion, workshop etc), and we've been talking about potentially using [editorial's commissioning model](https://wellcomecollection.org/pages/Wvl00yAAAB8A3y8p) to have editorial formats (Digital Story, essays, Behind-the-scenes, Galleries). 

# Series
Either event or editorial series.
Stories as a CSV with {series.title}:{series.id}

# PositionInSeries
If part of a digital story, where? (unsure if it's reported on).

# Test dimension => Test cohort (CHANGING)
Previously used to add test dimensions.
Now used for the cohort a user is in.

# Content type (CHANGING)
1 of two values, `list` or `item`.

# Referring component
Use to tell you which component led to this page view e.g. `ExhibitionPromo: index =1, Page: dateRangeName = today`

# Page state
e.g.  Page: dateRangeName = today