### PR TITLE
add Host header to weapp nginx and remove logging

### DIFF
--- a/nginx_webapp/nginx.conf
+++ b/nginx_webapp/nginx.conf
@@ -32,7 +32,8 @@ http {
     add_header      x-wc-nginx-webapp true;
 
     location / {
-      proxy_pass http://app:3000;
+      proxy_set_header Host $host;
+      proxy_pass       http://app:3000;
     }
 
     location /management/healthcheck {

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -7,8 +7,6 @@ export function serverError(beaconError) {
       Boolean(ctx.request.url.match('/preview')) ||
       Boolean(ctx.request.host.match('preview.wellcomecollection.org'));
 
-    console.info('serverError', ctx.request.host, isPreview)
-
     try {
       await next();
     } catch (err) {
@@ -35,8 +33,6 @@ export function notFound() {
     const isPreview =
       Boolean(ctx.request.url.match('/preview')) ||
       Boolean(ctx.request.host.match('preview.wellcomecollection.org'));
-
-    console.info('notFound', ctx.request.host, isPreview)
 
     await next();
     if (404 === ctx.response.status && !ctx.response.body) {


### PR DESCRIPTION
From all the debugging on the installations preview, realised this was the issue, so the app in the container was getting the ECS URL of `app:3000`.