### PR TITLE
remove pocket site verification

### DIFF
--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -21,7 +21,6 @@
     <meta name="msapplication-config" content="{{ '/assets/icons/' | getHashedFile('browserconfig.xml') }}" />
     <meta name="msapplication-TileColor" content="#944aa0" />
     <meta name="theme-color" content="#000000" />
-    <meta name="pocket-site-verification" content="d84a421f986e53289df52e116596d5" />
 
     <script src="{{ '/assets/libs/' | getHashedFile('picturefill.min.js') }}" async></script>
     {% component 'head-js', { file: ('/assets/js/' | getHashedFile('app.js')) } %}


### PR DESCRIPTION
This was added to be able to get support from pocket on why our articles aren't being parsed correctly in their system.

We now have a support ticket open, and should have some clarity on it.