### PR TITLE
Use a polyfill for 'closest' that works

### DIFF
--- a/client/js/polyfills.js
+++ b/client/js/polyfills.js
@@ -1,5 +1,5 @@
 export default {
-  init: () => {
+  init() {
     // https://developer.mozilla.org/en/docs/Web/API/Element/matches
     if (!Element.prototype.matches) {
         Element.prototype.matches =
@@ -15,19 +15,17 @@ export default {
                 return i > -1;
             };
     }
-
     // https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
-    if (window.Element && !Element.prototype.closest) {
-        Element.prototype.closest =
-        function(s) {
-            var matches = (this.document || this.ownerDocument).querySelectorAll(s),
-                i,
-                el = this;
+    // Note, this relies on Element.prototype.matches being available (polyfilled above)
+    if (!Element.prototype.closest) {
+        Element.prototype.closest = function(s) {
+            var el = this;
+            if (!document.documentElement.contains(el)) return null;
             do {
-                i = matches.length;
-                while (--i >= 0 && matches.item(i) !== el) {};
-            } while ((i < 0) && (el = el.parentElement));
-            return el;
+                if (el.matches(s)) return el;
+                el = el.parentElement || el.parentNode;
+            } while (el !== null && el.nodeType === 1);
+            return null;
         };
     }
 


### PR DESCRIPTION
The `closest` polyfill we were using wasn't doing its job in IE11; this is the cause of our [most seen JS error](https://sentry.io/wellcome/wellcomecollection-website-client/issues/345745353/?query=is:unresolved) (3K occurrences). The [MDN recommended polyfill](https://developer.mozilla.org/en-US/docs/Web/API/Element/closest#Polyfill) works as expected (tested in Browserstack).

The old polyfill (on the same MDN page) carried this caveat:
> However, if you really do require IE 8 support, then the following polyfill will do the job very slowly, but eventually. However, it will only support CSS 2.1 selectors in IE 8, and it can cause severe lag spikes in production websites

So we'll be good to be rid of it.