### PR TITLE
Check localStorage i/o before use

### DIFF
--- a/client/js/tracking.js
+++ b/client/js/tracking.js
@@ -1,6 +1,8 @@
 /* global ga */
 
-import { on } from './util';
+import { on, testLocalStorage } from './util';
+
+const hasWorkingLocalStorage = testLocalStorage();
 
 const maybeTrackEvent = (hasAnalytics) => {
   if (hasAnalytics) {
@@ -92,9 +94,12 @@ export default {
         // We set the component list data in localStorage,
         // which we then retrieve on the next pageview,
         // and pass along to GA there
+        if (!hasWorkingLocalStorage) return;
+
         const el = event.target.closest('[data-component]');
         const componentList = (el ? getComponentList(el) : []).concat([{Page: pageState}]);
         const componentListString = JSON.stringify(componentList);
+
         if (componentList.length > 0) {
           window.localStorage.setItem('wc_referring_component_list', componentListString);
         }

--- a/client/js/util.js
+++ b/client/js/util.js
@@ -141,3 +141,16 @@ export function getDocumentHeight() {
 export function getWindowHeight() {
   return window.innerHeight;
 }
+
+export function testLocalStorage() { // Test localStorage i/o
+  const test = 'test';
+
+  try {
+    window.localStorage.setItem(test, test);
+    window.localStorage.removeItem(test);
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+};

--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -8,8 +8,23 @@ type Props = {|
   featuresCohort: ?string,
 |}
 
+function testLocalStorage() { // Test localStorage i/o
+  const test = 'test';
+
+  try {
+    window.localStorage.setItem(test, test);
+    window.localStorage.removeItem(test);
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const hasWorkingLocalStorage = testLocalStorage();
+
 export default ({ category, contentType, pageState, featuresCohort }: Props) => {
-  const referringComponentListString = window.localStorage.getItem('wc_referring_component_list');
+  const referringComponentListString = hasWorkingLocalStorage && window.localStorage.getItem('wc_referring_component_list');
   window.localStorage.removeItem('wc_referring_component_list');
 
   if (!window.GA_INITIALIZED) {

--- a/server/views/partials/analytics.njk
+++ b/server/views/partials/analytics.njk
@@ -48,8 +48,23 @@ ga('set', 'dimension1', '2');
   ga('set', 'exp', '{{ pageConfig.gaExp }}');
 {% endif %}
 
+function testLocalStorage() { // Test localStorage i/o
+  var test = 'test';
+
+  try {
+    window.localStorage.setItem(test, test);
+    window.localStorage.removeItem(test);
+
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+var hasWorkingLocalStorage = testLocalStorage();
+
 {# see `tracking.js` where this storage item is set #}
-var referringComponentListString = localStorage.getItem('wc_referring_component_list');
+var referringComponentListString = hasWorkingLocalStorage && localStorage.getItem('wc_referring_component_list');
 localStorage.removeItem('wc_referring_component_list');
 if (referringComponentListString) {
   ga('set', 'dimension7', referringComponentListString);


### PR DESCRIPTION
We're getting [some 'Access Denied' errors](https://sentry.io/wellcome/wellcomecollection-website-client/issues/446535915/?query=is:unresolved) when attempting to write to IE11 `localStorage`. This wraps a read/write test to `localStorage` in a `try/catch` to gobble the errors and bail on any `localStorage` operations if necessary.

It pains me that I've had to write the same function three times.

WET: Write Everything Thrice.