### PR TITLE
Account for the possibility that a clicked element's parent no longer exists

### DIFF
--- a/client/js/util.js
+++ b/client/js/util.js
@@ -107,8 +107,8 @@ export {
 };
 
 // Event delegation
-function getTarget(delegateEl: HTMLElement, eventEl: HTMLElement, possibleTarget: HTMLElement): ?HTMLElement {
-  if (eventEl === delegateEl) return;
+function getTarget(delegateEl: HTMLElement, eventEl?: HTMLElement, possibleTarget: HTMLElement): ?HTMLElement {
+  if (eventEl === delegateEl || !eventEl) return;
 
   if (eventEl === possibleTarget) {
     return possibleTarget;


### PR DESCRIPTION
Click event delegation on e.g. the close cross on the Google map needs to account for the possibility that as it traverses up through the DOM, the parentElement may no longer exist (because it's been removed by JS).

![screen shot 2018-06-29 at 15 45 51](https://user-images.githubusercontent.com/1394592/42098708-915790ae-7bb3-11e8-80f4-6df198bd31c1.png)

This fixes our [fourth most 'popular' JavaScript error](https://sentry.io/wellcome/wellcomecollection-website-client/issues/418754406/?query=is:unresolved)