### PR TITLE
Target the correct elements

### DIFF
--- a/client/js/components/segmented-control.js
+++ b/client/js/components/segmented-control.js
@@ -6,7 +6,7 @@ import fastdom from '../utils/fastdom-promise';
 export default (el) => {
   const showHideEl = el.querySelector('.js-segmented-control-show-hide');
   const controlDrawerLinks = el.querySelector('.js-segmented-control__drawer-list');
-  const controlLinks = el.querySelector('.js-segmented-control__list');
+  const controlLinks = el.querySelector('.js-segmented-control__link');
   const controlButtonText = el.querySelector('.js-segmented-control__button-text');
   const fullPage = showHide({el: showHideEl});
   const trap = focusTrap(el);


### PR DESCRIPTION
We were searching for an `href` on a `ul`.

[Fixes Sentry JS issue #5](https://sentry.io/wellcome/wellcomecollection-website-client/issues/478906462/)