### PR TITLE
remove event ordering on event series

### DIFF
--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -18,7 +18,7 @@ export function parseEventSeries(document: PrismicDocument): EventSeries {
   return {
     type: 'event-series',
     id: document.id,
-    title: data.title ? parseTitle(data.title) : 'TITLE MISSING',
+    title: data.title ? parseTitle(data.title) : '',
     description: data.description && parseDescription(data.description),
     backgroundTexture: prismicBackgroundTexture ? parseBackgroundTexture(prismicBackgroundTexture) : null,
     promo

--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -52,11 +52,11 @@ export async function renderEventSeries(ctx, next) {
   const [ events, uiEventSeries ] = await Promise.all([eventsPromise, uiEventSeriesPromise]);
 
   if (events.results.length > 0) {
-    const promos = createEventPromos(events.results).reverse();
+    const promos = createEventPromos(events.results);
     const paginatedResults = convertPrismicResultsToPaginatedResults(promos);
     const paginatedEvents = paginatedResults(promos);
     const upcomingEvents = Object.assign({}, paginatedEvents, {results: promos.filter(e => london(e.end).isAfter(london()))});
-    const pastEvents = {results: promos.filter(e => london(e.end).isBefore(london())).slice(0, 3).reverse()};
+    const pastEvents = {results: promos.filter(e => london(e.end).isBefore(london())).slice(0, 3)};
 
     ctx.render('pages/event-series', {
       pageConfig: createPageConfig({


### PR DESCRIPTION
Fixes #2840 

Ordering in JS can cause some unexpected results, and also have thing work differently in different parts of the site, so let's keep it in the API requests.

