### PR TITLE
Polyfill Arry.from

### DIFF
--- a/client/js/app.js
+++ b/client/js/app.js
@@ -2,6 +2,7 @@
 import 'core-js/fn/object/assign';
 import 'core-js/fn/promise';
 import 'core-js/fn/map';
+import 'core-js/fn/array/from';
 import 'whatwg-fetch';
 import lazysizes from 'lazysizes';
 


### PR DESCRIPTION
Babel automatically adds the `Array.from` as part of the transform of spread in e.g. `[...a]`, but you have to polyfill it.

Adding the core-js Array.from polyfill seems like the most consistent approach with what we already have.

[More here](https://github.com/necolas/react-native-web/issues/409) and [here](https://github.com/babel/babel/issues/5682).