### PR TITLE
Oembed and canonical urls

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -385,12 +385,13 @@ WorkPage.getInitialProps = async (context) => {
     title: json.title || json.description,
     description: json.description || '',
     type: 'website',
-    url: `https://wellcomecollection.org/works/${json.id}`,
+    canonicalUrl: `https://wellcomecollection.org/works/${json.id}`,
     imageUrl: iiifImage ? iiifImage({size: '800,'}) : null,
     analyticsCategory: 'collections',
     siteSection: 'images',
     previousQueryString,
-    work: (json: Work)
+    work: (json: Work),
+    oEmbedUrl: `https://wellcomecollection.org/oembed/works/${json.id}`
   };
 };
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -197,7 +197,8 @@ class Works extends Component<Props> {
       title: 'Image catalogue search | Wellcome Collection',
       description: 'Search through the Wellcome Collection image catalogue',
       analyticsCategory: 'collections',
-      siteSection: 'images'
+      siteSection: 'images',
+      canonicalUrl: `https://wellcomecollection.org/works${query && `?query=${query}`}`
     };
   };
 

--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -1,4 +1,4 @@
-// @ flow
+// @flow
 import {Component} from 'react';
 import Head from 'next/head';
 import NastyJs from '../Header/NastyJs';
@@ -6,7 +6,7 @@ import Header from '../Header/Header';
 import {striptags} from '../../../utils/striptags';
 import {formatDate} from '../../../utils/format-date';
 import Footer from '../Footer/Footer';
-import type {PlacesOpeningHours} from '@weco/common/model/opening-hours';
+import type {PlacesOpeningHours} from '../../../model/opening-hours';
 import analytics from '../../../utils/analytics';
 
 // TODO: Hashed files
@@ -16,7 +16,7 @@ import analytics from '../../../utils/analytics';
 // TODO: Set the props
 
 // Taken from: http://ogp.me/#no_vertical
-type OgType = 'article' | 'website';
+export type OgType = 'article' | 'website';
 type OgData = {|
   type: OgType,
   url: string,
@@ -25,10 +25,11 @@ type OgData = {|
   imageUrl: string,
   imageAltText?: string,
   video?: string,
-  publishTime?: Date,
+  publishedTime?: Date,
   modifiedTime?: Date,
   section?: string, // e.g. technology
-  tags?: string[]
+  tags?: string[],
+  videoUrl?: string
 |};
 // TODO: Convert image sizes to og:1200, tw:800
 export const OpenGraph = ({
@@ -42,7 +43,7 @@ export const OpenGraph = ({
   videoUrl,
   section,
   tags
-}: OgData) => ([
+}: OgData): React.Element<'meta'>[] => ([
   <meta key='og:site_name' property='og:site_name' content='Wellcome Collection' />,
   <meta key='og:type' property='og:type' content={type} />,
   <meta key='og:url' property='og:url' content={url} />,
@@ -52,13 +53,13 @@ export const OpenGraph = ({
   <meta key='og:image' property='og:image' content={imageUrl} itemProp='image' />,
   <meta key='og:image:width' property='og:image:width' content='1200' />,
 
-  publishedTime && <meta key='og:article:published_time' property='og:article:published_time' content={formatDate(publishedTime)} />,
-  modifiedTime && <meta key='og:article:modified_time' property='og:article:modified_time' content={formatDate(modifiedTime)} />,
-  section && <meta key='og:article:section' property='og:article:section' content={section} />,
-  videoUrl && <meta key='og:video' property='og:video' content={videoUrl} />
+  publishedTime ? <meta key='og:article:published_time' property='og:article:published_time' content={formatDate(publishedTime)} /> : null,
+  modifiedTime ? <meta key='og:article:modified_time' property='og:article:modified_time' content={formatDate(modifiedTime)} /> : null,
+  section ? <meta key='og:article:section' property='og:article:section' content={section} /> : null,
+  videoUrl ? <meta key='og:video' property='og:video' content={videoUrl} /> : null
 ].concat((tags || []).map(tag =>
   <meta key={`og:tag:${tag}`} property='og:article:tag' content={tag} />
-)).filter(_ => _));
+)).filter(Boolean));
 
 export const TwitterCard = ({
   type,
@@ -67,15 +68,15 @@ export const TwitterCard = ({
   description = '',
   imageUrl,
   imageAltText
-}: OgData) => ([
+}: OgData): React.Element<'meta'>[] => ([
   <meta key='twitter:card' name='twitter:card' content='summary_large_image' />,
   <meta key='twitter:site' name='twitter:site' content='@ExploreWellcome' />,
   <meta key='twitter:url' name='twitter:url' content={url} />,
   <meta key='twitter:title' name='twitter:title' content={title} />,
   <meta key='twitter:description' name='twitter:description' content={striptags(description)} />,
   <meta key='twitter:image' name='twitter:image' content={imageUrl} />,
-  imageAltText && <meta name='twitter:image:alt' content={imageAltText} />
-].filter(_ => _));
+  imageAltText ? <meta name='twitter:image:alt' content={imageAltText} /> : null
+].filter(Boolean));
 
 const navLinks = [{
   href: 'https://wellcomecollection.org/visit',
@@ -99,10 +100,10 @@ const navLinks = [{
   siteSection: 'whatwedo'
 }];
 
-type SiteSection = 'images' | 'explore' | 'whats-on';
+export type SiteSection = 'images' | 'explore' | 'whats-on';
 type Props = {|
   children: React.Node,
-  type: string,
+  type: OgType,
   url: string,
   title: string,
   description: string,
@@ -115,9 +116,9 @@ type Props = {|
   isPreview?: boolean,
   openingTimes: {
     groupedVenues: {
-      [key]: PlacesOpeningHours
+      [string]: PlacesOpeningHours
     },
-    upcomingExceptionalOpeningPeriods: Date[][]
+    upcomingExceptionalOpeningPeriods: {dates: Date[], type: string}[]
   }
 |}
 
@@ -203,7 +204,10 @@ class DefaultPageLayout extends Component<Props> {
               upcomingExceptionalOpeningPeriods={openingTimes.upcomingExceptionalOpeningPeriods} />
           }
           {!openingTimes &&
-            <Footer openingHoursId='footer' />
+            <Footer
+              groupedVenues={{}}
+              upcomingExceptionalOpeningPeriods={[]}
+              openingHoursId='footer' />
           }
         </div>
       </div>
@@ -213,7 +217,9 @@ class DefaultPageLayout extends Component<Props> {
 
 class DPLWithLoader extends Component<Props> {
   componentDidMount = () => {
+    // $FlowFixMe
     const lazysizes = require('lazysizes');
+    // $FlowFixMe
     const FontFaceObserver = require('fontfaceobserver');
 
     const WB = new FontFaceObserver('Wellcome Bold Web', {weight: 'bold'});
@@ -222,11 +228,13 @@ class DPLWithLoader extends Component<Props> {
     const LR = new FontFaceObserver('Lettera Regular Web');
 
     Promise.all([WB.load(), HNL.load(), HNM.load(), LR.load()]).then(() => {
+      // $FlowFixMe
       document.documentElement.classList.add('fonts-loaded');
     }).catch(console.log);
 
     lazysizes.init();
 
+    // $FlowFixMe
     document.documentElement.classList.add('enhanced');
   }
 

--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -104,13 +104,12 @@ export type SiteSection = 'images' | 'explore' | 'whats-on';
 type Props = {|
   children: React.Node,
   type: OgType,
-  url: string,
+  canonicalUrl: string,
   title: string,
   description: string,
   imageUrl: string,
   siteSection: SiteSection,
   analyticsCategory: string,
-  pageMeta?: React.Node,
   featuresCohort?: string,
   featureFlags?: string[],
   isPreview?: boolean,
@@ -119,7 +118,8 @@ type Props = {|
       [string]: PlacesOpeningHours
     },
     upcomingExceptionalOpeningPeriods: {dates: Date[], type: string}[]
-  }
+  },
+  oEmbedUrl?: string
 |}
 
 class DefaultPageLayout extends Component<Props> {
@@ -137,7 +137,7 @@ class DefaultPageLayout extends Component<Props> {
     const {
       title,
       type,
-      url,
+      canonicalUrl,
       description,
       imageUrl,
       siteSection,
@@ -145,7 +145,8 @@ class DefaultPageLayout extends Component<Props> {
       featuresCohort,
       featureFlags,
       isPreview,
-      openingTimes
+      openingTimes,
+      oEmbedUrl
     } = this.props;
 
     return (
@@ -159,14 +160,14 @@ class DefaultPageLayout extends Component<Props> {
 
           <OpenGraph
             type={type}
-            url={url}
+            url={canonicalUrl}
             title={title}
             description={description}
             imageUrl={imageUrl}
           />
           <TwitterCard
             type={type}
-            url={url}
+            url={canonicalUrl}
             title={title}
             description={description}
             imageUrl={imageUrl} />
@@ -188,7 +189,12 @@ class DefaultPageLayout extends Component<Props> {
             featureFlags: ${JSON.stringify(featureFlags)}
           }
         `}} />
-          {url && <link rel='canonical' href={url} />}
+          {canonicalUrl && <link rel='canonical' href={canonicalUrl} />}
+          {oEmbedUrl && <link
+            rel='alternate'
+            type='application/json+oembed'
+            href={oEmbedUrl}
+            title={title} />}
         </Head>
 
         <div className={isPreview ? 'is-preview' : undefined}>

--- a/common/views/components/ErrorPage/ErrorPage.js
+++ b/common/views/components/ErrorPage/ErrorPage.js
@@ -1,0 +1,8 @@
+// @flow
+import PageWrapper from '../PageWrapper/PageWrapper';
+
+const ErrorPage = () => (
+  <div></div>
+);
+
+export default PageWrapper(ErrorPage);

--- a/common/views/components/Footer/Footer.js
+++ b/common/views/components/Footer/Footer.js
@@ -10,14 +10,20 @@ import type {PlacesOpeningHours} from '../../../model/opening-hours';
 
 type Props = {|
   openingHoursId: string,
-  extraClasses: string,
   groupedVenues: {
     [string]: PlacesOpeningHours
   },
-  upcomingExceptionalOpeningPeriods: {dates: Date[], type: string}[]
+  upcomingExceptionalOpeningPeriods: {dates: Date[], type: string}[],
+  // TODO: make this openingHoursExtraClasses (or something else)
+  extraClasses?: string
 |}
 
-const Footer = ({openingHoursId, extraClasses, groupedVenues, upcomingExceptionalOpeningPeriods}: Props) => (
+const Footer = ({
+  openingHoursId,
+  extraClasses,
+  groupedVenues,
+  upcomingExceptionalOpeningPeriods
+}: Props) => (
   <div className={`footer row bg-black ${spacing({s: 5, m: 10}, {padding: ['top']})}`}>
     <div className='container'>
       <div className='grid'>

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -56,7 +56,7 @@ type Props = {|
   title: string,
   description: string,
   type: OgType,
-  url: string,
+  canonicalUrl: string,
   imageUrl: string,
   siteSection: SiteSection,
   analyticsCategory: string,
@@ -67,7 +67,8 @@ type Props = {|
     upcomingExceptionalOpeningPeriods: {dates: Date[], type: string}[]
   },
   flags: { [string]: Boolean },
-  statusCode: ?number
+  statusCode: ?number,
+  oEmbedUrl?: string
 |}
 
 // TODO: Make this universally available
@@ -139,11 +140,12 @@ const PageWrapper = (Comp: NextComponent) => {
         title,
         description,
         type,
-        url,
+        canonicalUrl,
         imageUrl,
         siteSection,
         analyticsCategory,
         openingTimes,
+        oEmbedUrl,
         ...props
       } = this.props;
 
@@ -156,11 +158,12 @@ const PageWrapper = (Comp: NextComponent) => {
           title={title}
           description={description}
           type={type}
-          url={url}
+          canonicalUrl={canonicalUrl}
           imageUrl={imageUrl}
           siteSection={siteSection}
           analyticsCategory={analyticsCategory}
-          openingTimes={openingTimes}>
+          openingTimes={openingTimes}
+          oEmbedUrl={oEmbedUrl}>
           <Comp {...props} />
         </DefaultPageLayout>
       );


### PR DESCRIPTION
Realised that the `url` prop is actually being overriden by the Next JS props, thus pushing an object to the page.

This fixes that and adds the `oEmbedUrl`.

Waiting on #2919 