### PR TITLE
don't build docker container unless it responds correctly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
-            sleep 10
-            node ./healthcheck.js
+            docker run --network container:catalogue \
+              appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8080/contacts/test
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run wellcome/catalogue_webapp:${CIRCLE_SHA1}
+            docker run ---detach wellcome/catalogue_webapp:${CIRCLE_SHA1}
             curl http://localhost:3000/works
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,9 @@ jobs:
       - add_ssh_keys
       - setup_remote_docker
       - run:
-          name: Docker build
-          command: CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
-      - run:
           name: Docker test
           command: |
+            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
             ./integration_tests.sh
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run --network container:wellcome/catalogue_webapp \
+            docker run --network wellcome/catalogue_webapp \
               appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/works
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
           command: |
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
-            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
-            sleep 10
+            # CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
+            docker run -d -p 3000:3000 wellcome/catalogue_webapp:${CIRCLE_SHA1} yarn start
             node ./healthcheck.js
             # docker run --network container:catalogue \
             #   appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8080/contacts/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
   catalogue:
     docker:
       - image: circleci/node:8.11.3
+      - image: appropriate/curl:latest
     working_directory: ~/wellcomecollection.org/catalogue/webapp
     steps:
       - restore_cache:
@@ -25,8 +26,7 @@ jobs:
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
-            docker run --network container:catalogue \
-              appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/workssss
+            docker run -d -p 3000:3000 wellcome/catalogue_webapp:${CIRCLE_SHA1} ./integration_tests.sh
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ jobs:
       - run:
           name: Docker test
           command: |
-            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
+            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
-            docker run --network wellcome/catalogue_webapp \
+            docker run --network container:catalogue \
               appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/workssss
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
           command: |
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
+            sleep 1000
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             # context isn't huge. It's then copied in the Docker container to
             # ../../common
             mkdir -p ./.dist/common
-            cp ../../common ./.dist/common
+            cp -r ../../common ./.dist/common
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
             docker run -d wellcome/catalogue_webapp:${CIRCLE_SHA1} ./integration_tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
             # ../../common
             mkdir -p ./.dist/common
             cp -r ../../common ./.dist/common
+            pwd
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
             docker run -d wellcome/catalogue_webapp:${CIRCLE_SHA1} ./integration_tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,11 @@ jobs:
           name: Docker test
           command: |
             set -x
+            # We do this to make here and not in docker to make sure the Docker
+            # context isn't huge. It's then copied in the Docker container to
+            # ../../common
+            mkdir -p ./.dist/common
+            cp ../../common ./.dist/common
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
             docker run -d wellcome/catalogue_webapp:${CIRCLE_SHA1} ./integration_tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run --network container:catalogue_webapp \
+            docker run --network container:wellcome/catalogue_webapp \
               appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/works
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run -it wellcome/catalogue_webapp:${CIRCLE_SHA1}
             curl http://localhost:3000/works
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run ---detach wellcome/catalogue_webapp:${CIRCLE_SHA1}
+            docker run -it wellcome/catalogue_webapp:${CIRCLE_SHA1}
             curl http://localhost:3000/works
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           command: |
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
-            docker-compose up --detach
+            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
             node ./healthcheck.js
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           name: Docker test
           command: |
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
+            docker-compose up --detach
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run --network wellcome/catalogue_webapp \
+            docker run --network container:catalogue \
               appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/works
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
   catalogue:
     docker:
       - image: circleci/node:8.11.3
+      - image: appropriate/curl
     working_directory: ~/wellcomecollection.org/catalogue/webapp
     steps:
       - restore_cache:
@@ -25,7 +26,8 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            ./integration_tests.sh
+            docker run wellcome/catalogue_webapp:${CIRCLE_SHA1}
+            curl http://localhost:3000/works
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             # CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
             docker run -d -p 3000:3000 wellcome/catalogue_webapp:${CIRCLE_SHA1} yarn start
+            yarn add requestretry
             node ./healthcheck.js
             # docker run --network container:catalogue \
             #   appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8080/contacts/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
-            docker run -d -p 3000:3000 wellcome/catalogue_webapp:${CIRCLE_SHA1} ./integration_tests.sh
+            docker run -d wellcome/catalogue_webapp:${CIRCLE_SHA1} ./integration_tests.sh
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,7 @@ jobs:
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
-            sleep 5
-            docker inspect --format='{{json .State.Health}}' wellcome/catalogue_webapp:${CIRCLE_SHA1}
+            node ./healthcheck.js
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
   catalogue:
     docker:
       - image: circleci/node:8.11.3
-      - image: appropriate/curl
     working_directory: ~/wellcomecollection.org/catalogue/webapp
     steps:
       - restore_cache:
@@ -26,7 +25,8 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            curl http://localhost:3000/works
+            docker run --network wellcome/catalogue_webapp \
+              appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/workssss
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,6 @@ jobs:
           name: Docker test
           command: |
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
-            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
-            ./integration_tests.sh
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
   catalogue:
     docker:
       - image: circleci/node:8.11.3
-      - image: appropriate/curl:latest
     working_directory: ~/wellcomecollection.org/catalogue/webapp
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ jobs:
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
+            sleep 5
+            docker inspect --format='{{json .State.Health}}' wellcome/catalogue_webapp:${CIRCLE_SHA1}
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run --network container:catalogue
             ./integration_tests.sh
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run --network container:catalogue \
-              appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/works
+            docker run --network container:catalogue
+            ./integration_tests.sh
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,8 @@ jobs:
       - run:
           name: Docker test
           command: |
-            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
+            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --build --detach
             ./integration_tests.sh
-      - run:
-          name: Docker build
-          command: CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
+            sleep 10
             node ./healthcheck.js
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,15 +23,8 @@ jobs:
           name: Docker test
           command: |
             set -x
-            # We do this to make here and not in docker to make sure the Docker
-            # context isn't huge. It's then copied in the Docker container to
-            # ../../common
-            mkdir -p ./.dist/common
-            cp -r ../../common ./.dist/common
-            pwd
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             docker-compose up --detach
-            docker run -d wellcome/catalogue_webapp:${CIRCLE_SHA1} ./integration_tests.sh
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ jobs:
       - add_ssh_keys
       - setup_remote_docker
       - run:
+          name: Docker test
+          command: |
+            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
+            ./integration-tests.sh
+      - run:
           name: Docker build
           command: CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           name: Docker test
           command: |
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
-            ./integration-tests.sh
+            ./integration_tests.sh
       - run:
           name: Docker build
           command: CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,12 @@ jobs:
       - add_ssh_keys
       - setup_remote_docker
       - run:
+          name: Docker build
+          command: CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
+      - run:
           name: Docker test
           command: |
-            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --build --detach
+            CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
             ./integration_tests.sh
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,10 @@ jobs:
             set -x
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose up --detach
-            docker run --network container:catalogue \
-              appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8080/contacts/test
+            sleep 10
+            node ./healthcheck.js
+            # docker run --network container:catalogue \
+            #   appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:8080/contacts/test
       - run:
           name: Docker push
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
             set -x
             docker-compose up --detach
-            docker run --network container:catalogue \
+            docker run --network container:catalogue_webapp \
               appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/works
       - run:
           name: Docker push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,10 @@ jobs:
           name: Docker test
           command: |
             CONTAINER_TAG=${CIRCLE_SHA1} docker-compose build
+            set -x
             docker-compose up --detach
-            sleep 1000
+            docker run --network container:catalogue \
+              appropriate/curl --retry 10 --retry-delay 1 --retry-connrefused http://localhost:3000/works
       - run:
           name: Docker push
           command: |

--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -3,8 +3,9 @@ FROM node:9.11.1-alpine
 ENV NODE_ENV=production
 
 WORKDIR /usr/src/app/webapp
-COPY ./ ./
-COPY ./.dist/common ../../common
+COPY ./catalogue/webapp .
+COPY ./common ../../common
+RUN apk --update --no-cache add curl
 RUN yarn install
 RUN yarn build
 

--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -3,8 +3,8 @@ FROM node:9.11.1-alpine
 ENV NODE_ENV=production
 
 WORKDIR /usr/src/app/webapp
-COPY ./catalogue/webapp .
-COPY ./common ../../common
+COPY ./ ./
+COPY ./.dist/common ../../common
 RUN yarn install
 RUN yarn build
 

--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -8,5 +8,8 @@ COPY ./common ../../common
 RUN yarn install
 RUN yarn build
 
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:3000/works || exit 1
+
 EXPOSE 3000
 CMD ["yarn", "start"]

--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:9.11.1-alpine
+FROM appropriate/curl:latest
 
 ENV NODE_ENV=production
 

--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:9.11.1-alpine
-FROM appropriate/curl:latest
 
 ENV NODE_ENV=production
 

--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -8,8 +8,5 @@ COPY ./common ../../common
 RUN yarn install
 RUN yarn build
 
-HEALTHCHECK --interval=5m --timeout=3s \
-  CMD curl -f http://localhost:3000/works || exit 1
-
 EXPOSE 3000
 CMD ["yarn", "start"]

--- a/catalogue/webapp/Dockerfile_test
+++ b/catalogue/webapp/Dockerfile_test
@@ -1,0 +1,24 @@
+FROM appropriate/curl
+
+RUN WORKS="$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000/works)" \
+    WORKS_WITH_QUERY="$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000/works\?query=botany)" \
+    WORK="$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000/works/pzy7xab4)" \
+    if [ "${WORKS}" != 200 ] \
+    then \
+      echo "/works responded with ${WORKS} not 200${NC}" \
+      exit 1 \
+    fi \
+    if [ "${WORKS_WITH_QUERY}" != "200" ] \
+    then \
+      echo "/works?query=botany responded with ${WORKS_WITH_QUERY} not 200${NC}" \
+      exit 1 \
+    fi \
+    if [ "${WORK}" != "200" ] \
+    then \
+      echo "/works/pzy7xab4 responded with ${WORK} not 200${NC}" \
+      exit 1 \
+    fi \
+    if [ "${WORKS}" = "200" ] && [ "${WORKS_WITH_QUERY}" = "200" ] && [ "${WORK}" = "200" ] \
+    then \
+      echo "All docker integration tests have passed 🐋" \
+    fi \

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.3'
 services:
   catalogue:
+    container: catalogue
     image: wellcome/catalogue_webapp:${CONTAINER_TAG:-test}
     build:
       context: ../..

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   catalogue:
-    container: catalogue
+    container_name: catalogue
     image: wellcome/catalogue_webapp:${CONTAINER_TAG:-test}
     build:
       context: ../..

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -9,6 +9,6 @@ services:
       - "3000:3000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost"]
-      interval: 1m30s
-      timeout: 10s
+      interval: 5s
+      timeout: 5s
       retries: 3

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -1,7 +1,6 @@
 version: '3.3'
 services:
   catalogue:
-    container_name: catalogue
     image: wellcome/catalogue_webapp:${CONTAINER_TAG:-test}
     build:
       context: ../..

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       dockerfile: ./catalogue/webapp/Dockerfile
     ports:
       - "3000:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -12,4 +12,3 @@ services:
       interval: 1m30s
       timeout: 10s
       retries: 3
-      start_period: 40s

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -8,8 +8,3 @@ services:
       dockerfile: ./catalogue/webapp/Dockerfile
     ports:
       - "3000:3000"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost"]
-      interval: 5s
-      timeout: 5s
-      retries: 3

--- a/catalogue/webapp/docker-compose.yml
+++ b/catalogue/webapp/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.3'
 services:
   catalogue:
+    container_name: catalogue
     image: wellcome/catalogue_webapp:${CONTAINER_TAG:-test}
     build:
       context: ../..

--- a/catalogue/webapp/healthcheck.js
+++ b/catalogue/webapp/healthcheck.js
@@ -1,24 +1,14 @@
-const http = require('http');
+var request = require('requestretry');
 
-const options = {
-  host: 'localhost',
-  port: '3000',
-  path: '/works',
-  timeout: 2000
-};
-
-const request = http.request(options, (res) => {
-  console.log(`STATUS: ${res.statusCode}`);
-  if (res.statusCode === 200) {
-    process.exit(0);
-  } else {
-    process.exit(1);
+request({
+  url: 'http://localhost:3000/works',
+  json: true,
+  maxAttempts: 5,
+  retryDelay: 5000,
+  retryStrategy: request.RetryStrategies.HTTPOrNetworkError
+}, function(err, response, body) {
+  if (err) { console.error(err); process.exit(1); }
+  if (response) {
+    console.log('The number of request attempts: ' + response.attempts);
   }
 });
-
-request.on('error', function(err) {
-  console.log(err);
-  process.exit(1);
-});
-
-request.end();

--- a/catalogue/webapp/healthcheck.js
+++ b/catalogue/webapp/healthcheck.js
@@ -1,0 +1,23 @@
+var http = require('http');
+
+var options = {
+  host: 'localhost',
+  port: '2368',
+  timeout: 2000
+};
+
+var request = http.request(options, (res) => {
+  console.log(`STATUS: ${res.statusCode}`);
+  if (res.statusCode === 200) {
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
+});
+
+request.on('error', function(err) {
+  console.log(err);
+  process.exit(1);
+});
+
+request.end();

--- a/catalogue/webapp/healthcheck.js
+++ b/catalogue/webapp/healthcheck.js
@@ -1,12 +1,13 @@
-var http = require('http');
+const http = require('http');
 
-var options = {
+const options = {
   host: 'localhost',
-  port: '2368',
+  port: '3000',
+  path: '/works',
   timeout: 2000
 };
 
-var request = http.request(options, (res) => {
+const request = http.request(options, (res) => {
   console.log(`STATUS: ${res.statusCode}`);
   if (res.statusCode === 200) {
     process.exit(0);

--- a/catalogue/webapp/integration_tests.sh
+++ b/catalogue/webapp/integration_tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+WORKS="$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000/works)"
+WORKS_WITH_QUERY="$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000/works\?query=botany)"
+WORK="$(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:3000/works/pzy7xab4)"
+
+if [ "${WORKS}" != 200 ]
+then
+  echo "/works responded with ${WORKS} not 200${NC}"
+  exit 1
+fi
+
+if [ "${WORKS_WITH_QUERY}" != "200" ]
+then
+  echo "/works?query=botany responded with ${WORKS_WITH_QUERY} not 200${NC}"
+  exit 1
+fi
+
+if [ "${WORK}" != "200" ]
+then
+  echo "/works/pzy7xab4 responded with ${WORK} not 200${NC}"
+  exit 1
+fi
+
+if [ "${WORKS}" = "200" ] && [ "${WORKS_WITH_QUERY}" = "200" ] && [ "${WORK}" = "200" ]
+then
+  echo "All docker integration tests have passed 🐋"
+fi

--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -29,6 +29,7 @@
     "postcss-loader": "^2.1.4",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
+    "requestretry": "^1.13.0",
     "sass-loader": "^7.0.1"
   }
 }

--- a/catalogue/webapp/yarn.lock
+++ b/catalogue/webapp/yarn.lock
@@ -2483,7 +2483,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -4248,7 +4248,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.5.1, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.5.1, lodash@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -6047,7 +6047,7 @@ request@2, request@^2.83.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.79.0:
+request@^2.74.0, request@^2.79.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -6096,6 +6096,15 @@ request@~2.79.0:
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
+
+requestretry@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/requestretry/-/requestretry-1.13.0.tgz#213ec1006eeb750e8b8ce54176283d15a8d55d94"
+  dependencies:
+    extend "^3.0.0"
+    lodash "^4.15.0"
+    request "^2.74.0"
+    when "^3.7.7"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -7307,6 +7316,10 @@ whatwg-url@^6.4.0:
     lodash.sortby "^4.7.0"
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
+
+when@^3.7.7:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
Not sure it's the best approach - but it is properly integration testing.
Basically is the Docker container has built a rotten app, we don't deploy it to Hub.

Maybe worth looking if we can somehow have the tests run in JS?