### PR TITLE
Catch the Eventbrite fetch

### DIFF
--- a/client/js/components/eventbrite-ticket-button.js
+++ b/client/js/components/eventbrite-ticket-button.js
@@ -5,19 +5,23 @@ export function eventbriteTicketButton(el) {
   fastdom.measure(() => {
     const eventbriteId = el.getAttribute('data-eventbrite-ticket-id');
 
-    fetch(`/eventbrite/button/events/${eventbriteId}/ticket_classes`)
-      .then(resp => resp.json())
-      .then(ticketButton => {
-        fastdom.mutate(() => {
-          // This is a nasty hack to update the event info bar
-          if (ticketButton.onSaleStatus === 'sold_out') {
-            const el = document.getElementById('js-event-booking-info');
-            if (el) {
-              el.parentNode.removeChild(el);
+    try {
+      fetch(`/eventbrite/button/events/${eventbriteId}/ticket_classes`)
+        .then(resp => resp.json())
+        .then(ticketButton => {
+          fastdom.mutate(() => {
+            // This is a nasty hack to update the event info bar
+            if (ticketButton.onSaleStatus === 'sold_out') {
+              const el = document.getElementById('js-event-booking-info');
+              if (el) {
+                el.parentNode.removeChild(el);
+              }
             }
-          }
-          el.innerHTML = ticketButton.html;
+            el.innerHTML = ticketButton.html;
+          });
         });
-      });
+    } catch (error) {
+      // Probably safest to do nothing if fetch fails
+    }
   });
 }

--- a/client/js/components/eventbrite-ticket-button.js
+++ b/client/js/components/eventbrite-ticket-button.js
@@ -5,23 +5,21 @@ export function eventbriteTicketButton(el) {
   fastdom.measure(() => {
     const eventbriteId = el.getAttribute('data-eventbrite-ticket-id');
 
-    try {
-      fetch(`/eventbrite/button/events/${eventbriteId}/ticket_classes`)
-        .then(resp => resp.json())
-        .then(ticketButton => {
-          fastdom.mutate(() => {
-            // This is a nasty hack to update the event info bar
-            if (ticketButton.onSaleStatus === 'sold_out') {
-              const el = document.getElementById('js-event-booking-info');
-              if (el) {
-                el.parentNode.removeChild(el);
-              }
+    fetch(`/eventbrite/button/events/${eventbriteId}/ticket_classes`)
+      .then(resp => resp.json())
+      .then(ticketButton => {
+        fastdom.mutate(() => {
+          // This is a nasty hack to update the event info bar
+          if (ticketButton.onSaleStatus === 'sold_out') {
+            const el = document.getElementById('js-event-booking-info');
+            if (el) {
+              el.parentNode.removeChild(el);
             }
-            el.innerHTML = ticketButton.html;
-          });
+          }
+          el.innerHTML = ticketButton.html;
         });
-    } catch (error) {
-      // Probably safest to do nothing if fetch fails
-    }
+      }).catch(_ => {
+        // Probably safest to do nothing if fetch fails
+      });
   });
 }

--- a/client/js/components/eventbrite-ticket-status.js
+++ b/client/js/components/eventbrite-ticket-status.js
@@ -5,15 +5,13 @@ export function eventbriteTicketStatus(el) {
   fastdom.measure(() => {
     const eventbriteId = el.getAttribute('data-eventbrite-ticket-id');
 
-    try {
-      fetch(`/eventbrite/button/events/${eventbriteId}/ticket_status`).then(resp => resp.json()).then(ticketButton => {
-        fastdom.mutate(() => {
-          el.innerHTML = ticketButton.html;
-        });
+    fetch(`/eventbrite/button/events/${eventbriteId}/ticket_status`).then(resp => resp.json()).then(ticketButton => {
+      fastdom.mutate(() => {
+        el.innerHTML = ticketButton.html;
       });
-    } catch (error) {
+    }).catch(_ => {
       // Fallback to non-enhanced version
       // button will read 'Book free tickets'
-    }
+    });
   });
 }

--- a/client/js/components/eventbrite-ticket-status.js
+++ b/client/js/components/eventbrite-ticket-status.js
@@ -5,10 +5,15 @@ export function eventbriteTicketStatus(el) {
   fastdom.measure(() => {
     const eventbriteId = el.getAttribute('data-eventbrite-ticket-id');
 
-    fetch(`/eventbrite/button/events/${eventbriteId}/ticket_status`).then(resp => resp.json()).then(ticketButton => {
-      fastdom.mutate(() => {
-        el.innerHTML = ticketButton.html;
+    try {
+      fetch(`/eventbrite/button/events/${eventbriteId}/ticket_status`).then(resp => resp.json()).then(ticketButton => {
+        fastdom.mutate(() => {
+          el.innerHTML = ticketButton.html;
+        });
       });
-    });
+    } catch (error) {
+      // Fallback to non-enhanced version
+      // button will read 'Book free tickets'
+    }
   });
 }


### PR DESCRIPTION
Prevents a client JS error if the `fetch` to Eventbrite fails. Fixes [this](https://sentry.io/wellcome/wellcomecollection-website-client/issues/599321149/?query=is:unresolved), [this](https://sentry.io/wellcome/wellcomecollection-website-client/issues/568014561/?query=is:unresolved) and [this](https://sentry.io/wellcome/wellcomecollection-website-client/issues/568799189/?query=is:unresolved) error in Sentry.