### PR TITLE
Use appendChild instead of append

### DIFF
--- a/client/js/components/newsletter-signup.js
+++ b/client/js/components/newsletter-signup.js
@@ -20,12 +20,12 @@ export default (el) => {
 
     if (!emailInputEl.validity.valid) {
       el.classList.add('is-error');
-      el.append(emailErrorMessage);
+      el.appendChild(emailErrorMessage);
     }
 
     if (!isAnyChecked()) {
       el.classList.add('is-error');
-      el.append(checkboxErrorMessage);
+      el.appendChild(checkboxErrorMessage);
     }
 
     if (!el.classList.contains('is-error')) {
@@ -43,7 +43,7 @@ export default (el) => {
       el.removeChild(checkboxErrorMessage);
     } else if (!isAnyChecked() && isSubmitAttempted) {
       el.classList.add('is-error');
-      el.append(checkboxErrorMessage);
+      el.appendChild(checkboxErrorMessage);
     }
   }
 
@@ -53,7 +53,7 @@ export default (el) => {
       el.removeChild(emailErrorMessage);
     } else if (!emailInputEl.validity.valid && isSubmitAttempted) {
       el.classList.add('is-error');
-      el.append(emailErrorMessage);
+      el.appendChild(emailErrorMessage);
     }
   }
 


### PR DESCRIPTION
Using the better supported `appendChild` method to prevent [this](https://sentry.io/wellcome/wellcomecollection-website-client/issues/589669902/?query=is:unresolved) and [this](https://sentry.io/wellcome/wellcomecollection-website-client/issues/567617424/?query=is:unresolved) Sentry error.