### PR TITLE
Use a regex instead of a string to filter ToString error

### DIFF
--- a/server/views/partials/monitoring.njk
+++ b/server/views/partials/monitoring.njk
@@ -24,7 +24,7 @@
       whitelistUrls: [/wellcomecollection\.org/],
       ignoreErrors: [
         /Blocked a frame with origin/,
-        'document.getElementsByClassName.ToString is not a function' // https://github.com/SamsungInternet/support/issues/56
+        /document\.getElementsByClassName\.ToString/ // https://github.com/SamsungInternet/support/issues/56
       ]
     }).install();
   }


### PR DESCRIPTION
Unsure why the `ignoreErrors` block isn't filtering the string `document.getElementsByClassName.ToString is not a function` from Sentry. Trying with a (shortened) regex instead (for consistency with `/Blocked a frame with origin/`, which appears to be working).

