### PR TITLE
Tidy feature-test function

### DIFF
--- a/client/js/util.js
+++ b/client/js/util.js
@@ -25,18 +25,19 @@ const setPropertyPrefixed = (el, property, value) => {
   el.style[property] = value;
 };
 
-const featureTest = (property, value, noPrefixes) => {
+const featureTest = (property: string, value: string, noPrefixes: boolean): boolean => {
   // Thanks Modernizr! https://github.com/phistuck/Modernizr/commit/3fb7217f5f8274e2f11fe6cfeda7cfaf9948a1f5
-  const prop = property + ':';
-  const el = document.createElement('test');
+  const prop = `${property}:`;
+  const el = document.createElement('div');
   const mStyle = el.style;
 
-  if (!noPrefixes) {
-    mStyle.cssText = prop + [ '-webkit-', '-moz-', '-ms-', '-o-', '' ].join(value + ';' + prop) + value + ';';
+  if (noPrefixes) {
+    mStyle.cssText = `${prop}${value}`;
   } else {
-    mStyle.cssText = prop + value;
+    mStyle.cssText = prop + [ '-webkit-', '-moz-', '-ms-', '-o-', '' ].join(value + ';' + prop) + value + ';';
   }
-  return mStyle[ property ].indexOf(value) !== -1;
+
+  return mStyle[property].indexOf(value) !== -1;
 };
 
 const addClassesToElements = (elements, className) => {


### PR DESCRIPTION
Our `featureTest` util that allows us to check if a browser supports a CSS property was creating a `<test>` element, which doesn't work in Chrome on iOS apparently ([Sentry error](https://sentry.io/wellcome/wellcomecollection-website-client/issues/603667340/?query=is:unresolved)).

This PR tidies the function and creates a `<div>` instead.
