### PR TITLE
Fix greedy Safari useragent regex

### DIFF
--- a/server/views/partials/monitoring.njk
+++ b/server/views/partials/monitoring.njk
@@ -1,7 +1,7 @@
 <script src="https://cdn.ravenjs.com/3.25.2/raven.min.js" async onload="setupMonitoring()"></script>
 <script>
   function setupMonitoring() {
-    var oldSafari = /^.*Version\/[0-8].*Safari.*$/;
+    var oldSafari = /^.*Version\/[0-8]\..*Safari.*$/;
     var bingPreview = /^.*BingPreview.*$/;
 
     var ignoredUserAgentRegex = [


### PR DESCRIPTION
The Sentry `oldSafari` regex test was too greedy (it should only have filtered out Safari versions 0–8, but it restarted filtering at version 10).

This only allows one number before the dot.

http://rubular.com/r/O6UxOzW87G