### PR TITLE
Jiggle the min promo height

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -348,7 +348,7 @@
   }
 
   @include respond-to('medium') {
-    min-height: 440px;
+    min-height: 370px;
   }
 
   @supports (display: grid) {


### PR DESCRIPTION
Reducing the min-height of the promos slightly, to make them look less awkward when they get close to the medium/large breakpoint (in accordance with @GarethOrmerod's wishes).