### PR TITLE
Sanitize tracking data prior to JSON stringifying

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -288,13 +288,13 @@ export const WorkPage = ({
                   eventTracking={JSON.stringify({
                     category: 'component',
                     action: 'download-button:click',
-                    label: `id: work.id , size:original, title:${work.title.substring(50)}`
+                    label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
                   })}
                   clickHandler={() => {
                     ReactGA.event({
                       category: 'component',
                       action: 'download-button:click',
-                      label: `id: work.id , size:original, title:${work.title.substring(50)}`
+                      label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
                     });
                   }}
                   icon='download'

--- a/server/views/pages/work.njk
+++ b/server/views/pages/work.njk
@@ -86,7 +86,7 @@
               download: work.id + '.jpg',
               rel: 'noopener noreferrer',
               target: '_blank',
-              eventTracking: '{"category": "component", "action": "download-button:click", "label": "id:' +  work.id + ', size:original, title:' + work.title | truncate(50) + '"}',
+              eventTracking: '{"category": "component", "action": "download-button:click", "label": "id:' +  work.id + ', size:original, title:' + work.title | truncate(50) | urlencode + '"}',
               icon: 'download',
               text: 'Download full size'
             } %}
@@ -99,7 +99,7 @@
               download: work.id + '.jpg',
               rel: 'noopener noreferrer',
               target: '_blank',
-              eventTracking: '{"category": "component", "action": "download-button:click", "label": "id:' +  work.id + ', size:760, title:' + work.title | truncate(50) + '"}',
+              eventTracking: '{"category": "component", "action": "download-button:click", "label": "id:' +  work.id + ', size:760, title:' + work.title | truncate(50) | urlencode + '"}',
               icon: 'download',
               text: 'Download small (760px)'
             } %}


### PR DESCRIPTION
Titles of works that contain quotes were causing `JSON.stringify` (which we call on tracking data) to break. Fixes [this Sentry error](https://sentry.io/wellcome/wellcomecollection-website-client/issues/605641288/?query=is:unresolved).