### PR TITLE
Ignore translate.googleusercontent.com URL

### DIFF
--- a/server/views/partials/monitoring.njk
+++ b/server/views/partials/monitoring.njk
@@ -22,6 +22,7 @@
         return !shouldIgnoreBrowsers;
       },
       whitelistUrls: [/wellcomecollection\.org/],
+      ignoreUrls: [/translate.googleusercontent.com/],
       ignoreErrors: [
         /Blocked a frame with origin/,
         /document\.getElementsByClassName\.ToString/ // https://github.com/SamsungInternet/support/issues/56


### PR DESCRIPTION
There are a number of Sentry errors reported as coming from this URL: https://translate.googleusercontent.com/translate_c

I don't know why this wouldn't be filtered by our `whitelistUrls` block in the config.

This would also need adding to the Next JS Sentry implementation if approved.
