### PR TITLE
move to using only testA and testB

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -5,9 +5,8 @@ events { worker_connections 1024; }
 http {
   ### A/B test
   split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
-    33%     "testA";
-    33%     "testB";
-    34%     "";
+    50%     "testA";
+    50%     "testB";
   }
   map $cookie_WC_featuresCohort $cohort {
     ""      $cohort_split_test;

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -4,9 +4,8 @@ events { worker_connections 1024; }
 http {
   ### A/B test
   split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
-    33%     "testA";
-    33%     "testB";
-    34%     "";
+    50%     "testA";
+    50%     "testB";
   }
   map $cookie_WC_featuresCohort $cohort {
     ""      $cohort_split_test;

--- a/nginx_webapp/nginx.conf
+++ b/nginx_webapp/nginx.conf
@@ -5,9 +5,8 @@ events { worker_connections 1024; }
 http {
   ### A/B test
   split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
-    33%     "testA";
-    33%     "testB";
-    34%     "";
+    50%     "testA";
+    50%     "testB";
   }
   map $cookie_WC_featuresCohort $cohort {
     ""      $cohort_split_test;


### PR DESCRIPTION
When this was created it was created as `""` for baseline, and then two variants `testA` and `testB`.
In reality we've been sing `testA` as a baseline, and `testB` as the variant.

Given that we often have just enough traffic for A/B testing, having MV testing yet doesn't seem to be of much use. We will have this when we move to Unleash anyway.