### PR TITLE
use square image from prismic for contributors

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -176,11 +176,13 @@ const defaultContributorImage = {
 };
 
 function parsePersonContributor(frag: PrismicFragment): PersonContributor {
+  // As we don't have square images retrospectively, we fallback.
+  const image = frag.data.image.square || frag.data.image;
   return {
     type: 'people',
     id: frag.id,
     name: frag.data.name || '',
-    image: checkAndParseImage(frag.data.image) || defaultContributorImage,
+    image: checkAndParseImage(image) || defaultContributorImage,
     description: frag.data.description,
     twitterHandle: null
   };


### PR DESCRIPTION
As it's part of the design system, we use the square crop from prismic.
The editors can change and perfect that crop in prismic.

![screen shot 2018-07-17 at 12 39 43](https://user-images.githubusercontent.com/31692/42815237-c266a932-89be-11e8-9517-c20145e25cad.png)
