### PR TITLE
Event series parse and render body

### DIFF
--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -4,17 +4,25 @@ import type {PrismicDocument} from './types';
 
 import {
   parseGenericFields,
-  parseBackgroundTexture
+  parseBackgroundTexture,
+  parseDescription,
+  parseBody
 } from './parsers';
 
 export function parseEventSeries(document: PrismicDocument): EventSeries {
   const genericFields = parseGenericFields(document);
   const backgroundTexture = document.data.backgroundTexture && document.data.backgroundTexture.data;
+  const body = document.data.body && parseBody(document.data.body);
 
   return {
     ...genericFields,
     type: 'event-series',
-    description: document.data.description,
-    backgroundTexture: backgroundTexture ? parseBackgroundTexture(backgroundTexture) : null
+    description: parseDescription(document.data.description),
+    backgroundTexture: backgroundTexture ? parseBackgroundTexture(backgroundTexture) : null,
+    body: body.length > 0 ? body : document.data.description ? [{
+      type: 'text',
+      weight: 'default',
+      value: parseDescription(document.data.description)
+    }] : []
   };
 }

--- a/common/views/components/BasePage/EventSeriesPage.js
+++ b/common/views/components/BasePage/EventSeriesPage.js
@@ -6,7 +6,6 @@ import Body from '../Body/Body';
 import WobblyBackground from '../BaseHeader/WobblyBackground';
 import Contributors from '../Contributors/Contributors';
 import SearchResults from '../SearchResults/SearchResults';
-import {parseDescription} from '../../../services/prismic/parsers';
 import type {EventSeries} from '../../../model/event-series';
 import type {UiEvent} from '../../../model/events';
 
@@ -20,18 +19,13 @@ const Page = ({
   events,
   series
 }: Props) => {
-  const body = series.description ? [{
-    type: 'text',
-    weight: 'default',
-    value: parseDescription(series.description)
-  }] : [];
   const FeaturedMedia = getFeaturedMedia({
     id: series.id,
     title: series.title,
     contributors: series.contributors,
     contributorsTitle: series.contributorsTitle,
     promo: series.promo,
-    body: body
+    body: series.body
   });
   const Header = (<BaseHeader
     title={series.title}
@@ -55,7 +49,7 @@ const Page = ({
     <BasePage
       id={series.id}
       Header={Header}
-      Body={<Body body={body} />}
+      Body={<Body body={series.body} />}
     >
       <Fragment>
         {series.contributors.length > 0 &&

--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -100,6 +100,7 @@ export async function renderEventSeries(ctx, next) {
         contentType: 'event-series',
         canonicalUri: `/event-series/${id}`
       }),
+      series: series,
       htmlDescription: asHtml(series.description),
       paginatedEvents: upcomingEvents,
       pastEvents: pastEvents,

--- a/events/app/views/pages/event-series.njk
+++ b/events/app/views/pages/event-series.njk
@@ -38,7 +38,7 @@
           <h1 class="{{ {s: 'WB5', m: 'WB4', l: 'WB3'} | fontClasses }} {{ {s: 3} | spacingClasses({margin: ['bottom']}) }} {{ {s: 0} | spacingClasses({margin: ['top']}) }}">{{  pageConfig.title }}</h1>
         </div>
         <div class="{{ {s: 12, m: 10, l: 8, xl: 9} | gridClasses }}">
-          {{ htmlDescription | safe }}
+          {{ series.body[0].value | prismicAsHtml | safe }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Allows us to render the old description way, and new body way across both templates.
This way we can migrate and deprecate the old description way without any of the frontend breaking.

Then remove the code to deal with the deprecation.
