### PR TITLE
don't throw error before render

### DIFF
--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -17,8 +17,6 @@ export function serverError(beaconError) {
         Raven.captureException(err, {extra: {url: ctx.request.href, statusCode: ctx.status}});
       }
 
-      ctx.throw(err);
-
       ctx.render('pages/error', {
         isPreview,
         errorStatus: ctx.status,


### PR DESCRIPTION
Stops the page rendering and thus prismic preview not working