### PR TITLE
Test raven data.request.url for 'googleusercontent'

### DIFF
--- a/server/views/partials/monitoring.njk
+++ b/server/views/partials/monitoring.njk
@@ -9,6 +9,12 @@
       bingPreview
     ];
 
+    // Unsure how this is consistently slipping through our
+    // whitlistUrls and ignoreUrls -- possibly a browser plugin.
+    var reallyIgnoredUrls = [
+      /googleusercontent/
+    ];
+
     function shouldIgnore(regexArray, stringToMatch) {
       return regexArray.some(function(regex) {
         return regex.test(stringToMatch);
@@ -19,6 +25,12 @@
 
     Raven.config('https://f756b8d4b492473782987a054aa9a347@sentry.io/133634', {
       shouldSendCallback: function(data) {
+        if (data.request && data.request.url) {
+          var shouldReallyIgnoreUrls = shouldIgnore(reallyIgnoredUrls, data.request.url);
+
+          if (shouldReallyIgnoreUrls) return false;
+        }
+
         return !shouldIgnoreBrowsers;
       },
       whitelistUrls: [/wellcomecollection\.org/],


### PR DESCRIPTION
Pages that Sentry reports having errored with the URL 'https://translate.googleusercontent.com/translate_c' are still showing up in our dashboard in spite of our whitelist and blacklist settings. (e.g. [this error in Sentry]).(https://sentry.io/wellcome/wellcomecollection-website-client/issues/607078821/?query=is:unresolved).

Here we're trying to check what data _would_ be sent to Sentry, and preventing if from doing so if the `data.reqest.url` contains 'googleusercontent'.