### PR TITLE
Bail out of renderExhibits if there aren't any IDs

### DIFF
--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -123,6 +123,7 @@ export async function renderExhibition(ctx, next) {
 
 export async function renderExhibits(ctx, next) {
   const query = searchQuery.parse(ctx.query.query, { keywords: ['ids'] });
+  if (!query.ids) return;
   // searchQueryParser automatically changes comma seperated lists into arrays
   const ids = typeof query.ids === 'string' ? query.ids.split(',') : query.ids;
   const exhibits = await getExhibitionExhibits(ctx.request, {ids});


### PR DESCRIPTION
Prevents a 500 for e.g. https://wellcomecollection.org/exhibitions/WgV_ACUAAIu2P_ZM/exhibits?query=ids:

(404s instead).
