### PR TITLE
Add pharmacy of colour promo to 'try these too' on the what's on page

### DIFF
--- a/common/views/components/InstallationPromo/InstallationPromo.js
+++ b/common/views/components/InstallationPromo/InstallationPromo.js
@@ -9,16 +9,19 @@ type Props = {|
   description: string,
   image: Picture,
   start: Date,
-  end: ?Date
+  end: ?Date,
+  position?: number
 |}
 
-const InstallationPromo = ({ id, title, description, image, start, end }: Props) => {
+const InstallationPromo = ({ id, title, description, image, start, end, position = 0 }: Props) => {
   return (
     <a
       data-component='InstallationPromo'
+      data-component-state={JSON.stringify({ position: position })}
       data-track-event={JSON.stringify({
         category: 'component',
-        action: 'InstallationPromo:click'
+        action: 'InstallationPromo:click',
+        label: `id: ${id}, position: ${position}`
       })}
       id={id}
       href={`/installations/${id}`}

--- a/common/views/components/InstallationPromo/InstallationPromo.js
+++ b/common/views/components/InstallationPromo/InstallationPromo.js
@@ -26,28 +26,33 @@ const InstallationPromo = ({ id, title, description, image, start, end, position
       id={id}
       href={`/installations/${id}`}
       className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'>
-      <Image
-        width={image.width || 0}
-        contentUrl={image.contentUrl || ''}
-        lazyload={true}
-        sizesQueries='(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(41.76vw - 50px), calc(75vw - 18px)'
-        alt='' />
+      <div className='relative'>
+        <Image
+          width={image.width || 0}
+          contentUrl={image.contentUrl || ''}
+          lazyload={true}
+          sizesQueries='(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(41.76vw - 50px), calc(75vw - 18px)'
+          alt='' />
+        <div style={{position: 'absolute', bottom: 0}}>
+          <span className={`
+            line-height-1 bg-yellow
+            ${font({s: 'HNM5'})}
+            ${spacing({s: 1}, {padding: ['top', 'bottom', 'left', 'right']})}
+          `} style={{display: 'block', float: 'left', marginRight: '1px', marginTop: '1px', whiteSpace: 'nowrap'}}>
+            {!end && 'Permanent installation' || 'Installation'}
+          </span>
+        </div>
+      </div>
       <div className={`
       ${spacing({s: 2}, {padding: ['top']})}
       ${spacing({s: 3}, {padding: ['left', 'right']})}
       ${spacing({s: 4}, {padding: ['bottom']})}
       flex flex--column flex-1`}>
-
-        <p className={`no-padding ${spacing({s: 2}, {margin: ['bottom']})} ${font({s: 'HNM5'})}`}>
-          {!end && 'Permanent installation' || 'Installation'}
-        </p>
-
         <h2 className={`promo-link__title ${font({s: 'WB5'})} ${spacing({s: 0}, {margin: ['top']})}`}>{title}</h2>
 
         <p className={`${font({s: 'HNL4'})} ${spacing({s: 2}, {margin: ['bottom']})} no-padding`}>
           {description}
         </p>
-
       </div>
     </a>
   );

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -225,7 +225,7 @@ function createExhibitionPromos(allResults: Object): Array<ExhibitionPromo> {
   return allResults.map((e): ExhibitionPromo => {
     return {
       id: e.id,
-      url: `/exhibitions/${e.id}`,
+      url: `/${e.type}/${e.id}`,
       format: e.data.format && parseExhibitionFormat(e.data.format),
       title: asText(e.data.title),
       image: e.data.promo && parseImagePromo(e.data.promo).image,
@@ -485,7 +485,7 @@ export async function getExhibitionAndEventPromos(query, collectionOpeningTimes)
   // set 'everything' as default time period, when no startDate is provided
   const toDate = !query.startDate ? undefined : query.endDate; ;
   const dateRange = [fromDate, toDate];
-  const allExhibitionsAndEvents = await getAllOfType(['exhibitions', 'events'], {
+  const allExhibitionsAndEvents = await getAllOfType(['exhibitions', 'events', 'installations'], {
     pageSize: 100,
     fetchLinks: eventFields.concat(exhibitionFields),
     orderings: '[my.events.times.startDateTime desc, my.exhibitions.start]'
@@ -497,6 +497,9 @@ export async function getExhibitionAndEventPromos(query, collectionOpeningTimes)
   const currentTemporaryExhibitionPromos = filterCurrentExhibitions(temporaryExhibitionPromos, todaysDate);
   const upcomingTemporaryExhibitionPromos = filterUpcomingExhibitions(temporaryExhibitionPromos, todaysDate);
   const eventPromos = filterPromosByDate(createEventPromos(allExhibitionsAndEvents.results.filter(e => e.type === 'events')), fromDate, toDate).sort((a, b) => a.start.localeCompare(b.start));
+
+  // TODO: get rid of this snowflake when what's on/homepage are capable of handling manual lists.
+  const colourOfPharmacyPromo = createExhibitionPromos(allExhibitionsAndEvents.results.filter(e => e.id === 'WyuWLioAACkACeYv'));
 
   // eventPromosSplitAcrossMonths and monthControls only required for the 'everything' view
   const eventPromosSplitAcrossMonths = duplicatePromosByMonthYear(eventPromos);
@@ -524,6 +527,7 @@ export async function getExhibitionAndEventPromos(query, collectionOpeningTimes)
     dates,
     permanentExhibitionPromos,
     temporaryExhibitionPromos,
+    colourOfPharmacyPromo,
     currentTemporaryExhibitionPromos,
     upcomingTemporaryExhibitionPromos,
     eventPromos,

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -499,7 +499,7 @@ export async function getExhibitionAndEventPromos(query, collectionOpeningTimes)
   const eventPromos = filterPromosByDate(createEventPromos(allExhibitionsAndEvents.results.filter(e => e.type === 'events')), fromDate, toDate).sort((a, b) => a.start.localeCompare(b.start));
 
   // TODO: get rid of this snowflake when what's on/homepage are capable of handling manual lists.
-  const colourOfPharmacyPromo = createExhibitionPromos(allExhibitionsAndEvents.results.filter(e => e.id === 'WyuWLioAACkACeYv'));
+  const colourOfPharmacyPromo = createExhibitionPromos(allExhibitionsAndEvents.results.filter(e => e.id === 'WyuWLioAACkACeYv'))[0];
 
   // eventPromosSplitAcrossMonths and monthControls only required for the 'everything' view
   const eventPromosSplitAcrossMonths = duplicatePromosByMonthYear(eventPromos);

--- a/server/views/pages/homepage.njk
+++ b/server/views/pages/homepage.njk
@@ -82,6 +82,11 @@
           {% componentJsx 'ExhibitionPromo', exhibition | objectAssign({position: position}) %}
         </div>
       {% endfor %}
+
+      <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
+        {% set position = position + 1 %}
+        {% componentJsx 'InstallationPromo', exhibitionAndEventPromos.colourOfPharmacyPromo | objectAssign({position: position}) %}
+      </div>
     </div>
   </div>
 

--- a/whats_on/app/views/pages/whats-on.njk
+++ b/whats_on/app/views/pages/whats-on.njk
@@ -30,44 +30,53 @@
   {% set whatsOnData = {activeId: exhibitionAndEventPromos.active, id: 'whatsOnFilter' } %}
   {% componentV2 'whats-on-list-header', exhibitionAndEventPromos.listHeader, {}, whatsOnData %}
 
-  <div class="css-grid__container {{ {s:3, m:5, l:5} | spacingClasses({padding: ['top', 'bottom']}) }}">
+  <div class="css-grid__container {{ {s:3, m:5, l:5} | spacingClasses({padding: ['top']}) }}">
     <div class="css-grid {{ {s:2, m:4} | spacingClasses({margin: ['top', 'bottom']}) }}">
-
       {% if exhibitionAndEventPromos.active === 'everything' %}
         {% include 'partials/separate_exhibition_event_promos.njk' %}
       {% else %}
         {% include 'partials/mixed_exhibition_event_promos.njk' %}
       {% endif %}
+    </div>
+  </div>
 
-      {% macro permanentPromos(heading, promos, size) %}
-        <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }}">
-          {% componentV2 'divider', null, {'dashed': true} %}
-        </div>
+  {% componentJsx 'SectionHeader', {
+    title: 'Try these too'
+  } %}
 
-        <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }}">
-          <h2 class="{{ {s:'WB6', m:'WB5', l:'WB4'} | fontClasses }} {{ {s:0} | spacingClasses({margin: ['top', 'bottom']}) }}">{{heading}}</h2>
-        </div>
+  <div class="css-grid__container">
+    <div class="css-grid {{ {s:2, m:4} | spacingClasses({margin: ['top', 'bottom']}) }}">
+      <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }} css-grid__scroll-container container--scroll touch-scroll">
+        <div class="css-grid grid--scroll">
+          {% for promo in tryTheseTooPromos %}
+            <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses }}">
+              {% componentV2 'facility-promo', promo, {}, {sizes: '(min-width: 1420px) 475px, (min-width: 960px) 34.32vw, (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'} %}
+            </div>
+          {% endfor %}
 
-        <div class="{{ {s: 12, m: 12, l: 12, xl:12} | cssGridClasses }} css-grid__scroll-container container--scroll touch-scroll">
-          <div class="css-grid grid--scroll">
-            {% if size === 'large' %}
-              {% set gridClasses = {s: 12, m: 6, l: 4, xl:4} | cssGridClasses %}
-            {% else %}
-              {% set gridClasses = {s: 12, m: 6, l: 3, xl:3} | cssGridClasses %}
-            {% endif %}
-
-            {% for promo in promos %}
-              <div class="{{gridClasses}}">
-                {% componentV2 'facility-promo', promo, {}, {sizes: '(min-width: 1420px) 475px, (min-width: 960px) 34.32vw, (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'} %}
-              </div>
-            {% endfor %}
+          <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses }}">
+            {% componentJsx 'InstallationPromo', exhibitionAndEventPromos.colourOfPharmacyPromo %}
           </div>
         </div>
-      {% endmacro %}
+      </div>
+    </div>
+  </div>
 
-      {{ permanentPromos('Try these too', tryTheseTooPromos | concat(exhibitionAndEventPromos.colourOfPharmacyPromo), 'large') }}
+  {% componentJsx 'SectionHeader', {
+    title: 'Eat and shop'
+  } %}
 
-      {{ permanentPromos('Eat and shop', eatShopPromos, 'small') }}
+  <div class="css-grid__container">
+    <div class="css-grid {{ {s:2, m:4} | spacingClasses({margin: ['top', 'bottom']}) }}">
+      <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }} css-grid__scroll-container container--scroll touch-scroll">
+        <div class="css-grid grid--scroll">
+          {% for promo in eatShopPromos %}
+            <div class="{{ {s: 12, m: 6, l: 3, xl:3} | cssGridClasses }}">
+              {% componentV2 'facility-promo', promo, {}, {sizes: '(min-width: 1420px) 475px, (min-width: 960px) 34.32vw, (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'} %}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/whats_on/app/views/pages/whats-on.njk
+++ b/whats_on/app/views/pages/whats-on.njk
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block body %}
-   <script type="application/ld+json">
+  <script type="application/ld+json">
     [{% for exhibition in exhibitionAndEventPromos.temporaryExhibitionPromos %}
       {{ exhibition | jsonLd('exhibitionPromoLd') | safe }},
     {% endfor %}
@@ -65,10 +65,9 @@
         </div>
       {% endmacro %}
 
-      {{ permanentPromos('Try these too', tryTheseTooPromos, 'large') }}
+      {{ permanentPromos('Try these too', tryTheseTooPromos | concat(exhibitionAndEventPromos.colourOfPharmacyPromo), 'large') }}
 
       {{ permanentPromos('Eat and shop', eatShopPromos, 'small') }}
-      </div>
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Closes #2971 

![screen shot 2018-07-20 at 15 29 16](https://user-images.githubusercontent.com/1394592/43007957-bab3f6a2-8c31-11e8-9b05-289a6f2273ba.png)

__TODO__
- [x] Add  the `pharmacyOfColourPromo` to the homepage (before ~/after~ finalising the homepage ordering – #2972). Agreed with @jennpb to put this at the end of the list of promos on the homepage (for now).