### PR TITLE
Don’t throw if it’s a preview link

### DIFF
--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -39,7 +39,10 @@ export function notFound() {
 
     await next();
     if (404 === ctx.response.status && !ctx.response.body) {
-      ctx.throw(404);
+
+      if (!isPreview) {
+        ctx.throw(404);
+      }
 
       ctx.render('pages/error', {
         isPreview,


### PR DESCRIPTION
Because the prismic js isn’t loaded, the cookie not set and the preview doesn’t work

## Who is this for?
People who want to see prismic previews

## What is it doing for them?
showing them the  preview instead of 'not found'