### PR TITLE
Use Array.from() instead of spread

### DIFF
--- a/common/views/components/ChapterIndicator/ChapterIndicator.js
+++ b/common/views/components/ChapterIndicator/ChapterIndicator.js
@@ -19,7 +19,8 @@ export type Props = {|
 
 function buildMarkup(showSingle, commissionedLength, position, showTotal, color) {
   const repeat = new Array(showSingle ? 1 : commissionedLength);
-  return [...repeat].map((item, index) => {
+
+  return Array.from(repeat).map((item, index) => {
     const srcUrl = index < position || showTotal
       ? `data:image/gif;base64,R0lGODlhAQAEAIAAA${colorDataUris[color]}`
       : `data:image/gif;base64,R0lGODlhAQAEAIAAA${colorDataUris['white']}`;


### PR DESCRIPTION
Updating the babel config to use the `next/babel` preset removed the ability to create a new empty array with a length defined and spread over it straight away. The ability to spread over arrays that have items (and not _just_ a length property) remains.

Using `Array.from()` is probably the more appropriate/readable method to accomplish this in any event.

This gives us back our delightful chapter indicator bars.

Fixes #3071.