### PR TITLE
Send WI urls containing newline character straight to /works

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -202,6 +202,9 @@ http {
     server_name wellcomeimages.org *.wellcomeimages.org;
 
     location / {
+      # Send URLs containing '%0A' (newline character that will cause a 500) to /works
+      rewrite '^/indexplus/.*t%0A.*$' https://wellcomecollection.org/works
+
       rewrite '^/indexplus/page/About Us\.html$' https://wellcomecollection.org/what-we-do/about-wellcome-collection?wellcomeImagesUrl=$request_uri permanent;
       rewrite '^/indexplus/page/Contact Us\.html$' https://wellcomecollection.org/what-we-do/collection-enquiries?wellcomeImagesUrl=$request_uri permanent;
       rewrite '^/indexplus/page/Privacy Statement\.html$' https://wellcome.ac.uk/about-us/terms-use?wellcomeImagesUrl=$request_uri permanent;


### PR DESCRIPTION
An attempt to catch the newline character (`%0A`) in some Wellcome Images URLs before it causes a 5xx error. Unsure if it will work, but can't see that it would hurt trying?