### PR TITLE
Limit height of comic based on viewport

### DIFF
--- a/server/views/pages/article.njk
+++ b/server/views/pages/article.njk
@@ -60,7 +60,7 @@
         {% if (article.contentType === 'comic') %}
           {%
             componentJsx 'MainMedia',
-            (article.mainMedia | getPrincipleMainMedia) | objectAssign({ showWobblyEdge: false, license: 'CC-BY-NC' })
+            (article.mainMedia | getPrincipleMainMedia) | objectAssign({extraClasses: 'captioned-image--fit-vh', showWobblyEdge: false, license: 'CC-BY-NC' })
           %}
         {% elif mm.type === 'video-embed' %}
           {% componentV2 'main-media-video', article.mainMedia | getPrincipleMainMedia, {full: true}, mainMediaData %}


### PR DESCRIPTION
Re-introduce height limit (and black background) for the comic to ensure it can fit 100% in the viewport.

<img width="1088" alt="screen shot 2018-07-27 at 17 33 34" src="https://user-images.githubusercontent.com/1394592/43333798-5bc875b8-91c3-11e8-8b25-023c7efa14a7.png">

