### PR TITLE
EventPage header date/info bar

### DIFF
--- a/cardigan_beta/stories/components/Links.js
+++ b/cardigan_beta/stories/components/Links.js
@@ -4,8 +4,11 @@ import SecondaryLink from '../../../common/views/components/Links/SecondaryLink/
 
 const stories = storiesOf('Components', module);
 stories.add('Primary link', () => (
-  <PrimaryLink url={`#`} name={`Take me to the moon`} />
+  <PrimaryLink url={`#`} name={`View all exhibitions`} />
+));
+stories.add('Primary link: jump', () => (
+  <PrimaryLink url={`#`} name={`See all dates/times to book`} isJumpLink={true} />
 ));
 stories.add('Secondary link', () => (
-  <SecondaryLink url={`#`} text={`I want to be forever yours`} />
+  <SecondaryLink url={`#`} text={`Our event terms and conditions`} />
 ));

--- a/common/model/events.js
+++ b/common/model/events.js
@@ -79,7 +79,6 @@ export type UiEvent = {|
   ...Event,
   type: 'events',
   upcomingDate: {|startDateTime: Date, endDateTime: Date|},
-  selectedDate: ?Date,
   dateRange: {
     firstDate: Date,
     lastDate: Date,

--- a/common/model/events.js
+++ b/common/model/events.js
@@ -78,7 +78,7 @@ export type Audience = {|
 export type UiEvent = {|
   ...Event,
   type: 'events',
-  upcomingDate: ?Date,
+  upcomingDate: {|startDateTime: Date, endDateTime: Date|},
   selectedDate: ?Date,
   dateRange: {
     firstDate: Date,

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -77,8 +77,7 @@ function determineDateRange(times) {
 
 export function parseEventDoc(
   document: PrismicDocument,
-  scheduleDocs: ?PrismicApiSearchResponse,
-  selectedDate: ?string
+  scheduleDocs: ?PrismicApiSearchResponse
 ): UiEvent {
   const data = document.data;
   const genericFields = parseGenericFields(document);
@@ -152,7 +151,6 @@ export function parseEventDoc(
       value: parseDescription(data.description)
     }] : [],
     upcomingDate: upcomingDate,
-    selectedDate: selectedDate ? london(selectedDate).toDate() : null,
     dateRange: determineDateRange(data.times)
   };
 }
@@ -172,13 +170,9 @@ const fetchLinks = [].concat(
 );
 
 type EventQueryProps = {|
-  id: string,
-  selectedDate: string
+  id: string
 |}
-export async function getEvent(req: Request, {
-  id,
-  selectedDate
-}: EventQueryProps): Promise<?UiEvent> {
+export async function getEvent(req: Request, {id}: EventQueryProps): Promise<?UiEvent> {
   const document = await getDocument(req, id, {
     fetchLinks: fetchLinks
   });
@@ -186,7 +180,7 @@ export async function getEvent(req: Request, {
   if (document && document.type === 'events') {
     const scheduleIds = document.data.schedule.map(event => event.event.id).filter(Boolean);
     const eventScheduleDocs = scheduleIds.length > 0 && await getTypeByIds(req, ['events'], scheduleIds, {fetchLinks});
-    const event = parseEventDoc(document, eventScheduleDocs || null, selectedDate || null);
+    const event = parseEventDoc(document, eventScheduleDocs);
 
     return event;
   }

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -47,16 +47,16 @@ function parseEventBookingType(eventDoc: PrismicDocument): ?string {
         : null;
 }
 
-function determineUpcomingDate(times) {
+function determineUpcomingDate(times: Date[]) {
   const todaysDate = london();
-  const eventArray = times.map((eventTime) => {
-    return london(eventTime.startDateTime);
-  })
-    .sort((a, b) => b.isBefore(a, 'day'));
-  const futureDates = eventArray.filter((date) => !date.isBefore(todaysDate));
-  return futureDates[0] ? futureDates[0].toDate()
-    : eventArray[0] ? eventArray[0].toDate()
-      : null;
+  const eventArray = times.sort((a, b) => london(b.startDateTime).isBefore(london(a.startDateTime), 'day'));
+  const futureDates = eventArray.filter(d => !london(d.startDateTime).isBefore(todaysDate));
+  const theDate = futureDates[0] || eventArray[0];
+
+  return {
+    startDateTime: theDate.startDateTime,
+    endDateTime: theDate.endDateTime
+  };
 }
 
 function determineDateRange(times) {
@@ -115,6 +115,7 @@ export function parseEventDoc(
       : null).filter(Boolean);
 
   const upcomingDate = determineUpcomingDate(data.times);
+
   return {
     type: 'events',
     ...genericFields,
@@ -150,7 +151,7 @@ export function parseEventDoc(
       weight: 'default',
       value: parseDescription(data.description)
     }] : [],
-    upcomingDate: upcomingDate ? london(upcomingDate).toDate() : null,
+    upcomingDate: upcomingDate,
     selectedDate: selectedDate ? london(selectedDate).toDate() : null,
     dateRange: determineDateRange(data.times)
   };

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -47,7 +47,7 @@ function parseEventBookingType(eventDoc: PrismicDocument): ?string {
         : null;
 }
 
-function determineUpcomingDate(times: Date[]) {
+function determineUpcomingDate(times) {
   const todaysDate = london();
   const eventArray = times.sort((a, b) => london(b.startDateTime).isBefore(london(a.startDateTime), 'day'));
   const futureDates = eventArray.filter(d => !london(d.startDateTime).isBefore(todaysDate));
@@ -180,7 +180,7 @@ export async function getEvent(req: Request, {id}: EventQueryProps): Promise<?Ui
   if (document && document.type === 'events') {
     const scheduleIds = document.data.schedule.map(event => event.event.id).filter(Boolean);
     const eventScheduleDocs = scheduleIds.length > 0 && await getTypeByIds(req, ['events'], scheduleIds, {fetchLinks});
-    const event = parseEventDoc(document, eventScheduleDocs);
+    const event = parseEventDoc(document, eventScheduleDocs || null);
 
     return event;
   }
@@ -260,7 +260,7 @@ export async function getEvents(req: Request,  {
   });
 
   const events = paginatedResults.results.map(doc => {
-    return parseEventDoc(doc, null, null);
+    return parseEventDoc(doc, null);
   });
 
   return {

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -449,3 +449,7 @@
 .width-auto {
   width: auto;
 }
+
+.clearfix {
+  @include clearfix;
+}

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -104,6 +104,8 @@ const EventPage = ({ event }: Props) => {
     copyrightHolder: image.copyright && image.copyright.holder,
     copyrightLink: image.copyright && image.copyright.link
   };
+  /* https://github.com/facebook/flow/issues/2405 */
+  /* $FlowFixMe */
   const FeaturedMedia = event.promo && <UiImage tasl={tasl} {...image} />;
   const eventFormat = event.format ? [event.format.title] : [];
   const eventAudiences = event.audiences ? event.audiences.map(a => a.title) : [];

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -70,7 +70,7 @@ function infoBar(event) {
     <Fragment>
       {isDatePast(event.dateRange.lastDate)
         ? <Fragment>{eventStatus('Past', 'marble')}</Fragment>
-        : <PrimaryLink url='#dates' name={`See all dates/times${(!eventbriteId && !bookingEnquiryTeam) ? ' to book' : ''}`} isJumpLink={true} />
+        : <PrimaryLink url='#dates' name={`See all dates/times${(eventbriteId || bookingEnquiryTeam) ? ' to book' : ''}`} isJumpLink={true} />
       }
     </Fragment>
   );
@@ -185,7 +185,7 @@ const EventPage = ({ event }: Props) => {
             }
 
             {event.bookingEnquiryTeam &&
-              <div className={`border-top-width-1 border-color-pumice ${spacing({s: 2}, {padding: ['top', 'bottom']})}`}>
+              <div className={`${spacing({s: 2}, {padding: ['top', 'bottom']})}`}>
                 {event.isCompletelySoldOut ? <Button type='primary' disabled={true} text='Fully booked' />
                   : (
                     <Button

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -79,7 +79,7 @@ function infoBar(event) {
 function topDate(event) {
   // Displays the closest future date, or the first date if _all_
   // dates are in the past
-  const dayAndDate = formatDayDate(event.upcomingDate);
+  const dayAndDate = formatDayDate(event.upcomingDate.startDateTime);
   const startTime = formatTime(event.upcomingDate.startDateTime);
   const endTime = formatTime(event.upcomingDate.endDateTime);
 

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -61,74 +61,11 @@ function InfoBar(cost, eventbriteId, bookingEnquiryTeam) {
   );
 }
 
-function DatesShowHide(event) {
+function topDate(event) {
   return (
-    <div>
+    <Fragment>
       {event.selectedDate ? formatDayDate(event.selectedDate) : event.upcomingDate && formatDayDate(event.upcomingDate)}
-      {event.times && event.times.length > 1 &&
-        <Fragment>
-          <div className='js-show-hide drawer inline'>
-            <a
-              className={[
-                'primary-link',
-                'flex-inline',
-                'flex-v-center',
-                'plain-link',
-                'js-show-hide-trigger',
-                spacing({s: 2}, {margin: ['left']}),
-                font({s: 'HNM4'})].join(' ')} href={'#'}>More dates
-              <Icon name='chevron' extraClasses='icon--green' />
-            </a>
-            <div className={`js-show-hide-drawer drawer__body ${spacing({s: 2}, {padding: ['top']})}`}>
-              {DateInfo(event)}
-            </div>
-          </div>
-          {event.eventbriteId &&
-            <div className={`border-top-width-1 border-color-pumice ${spacing({s: 2}, {padding: ['top', 'bottom']})} ${spacing({s: 2}, {margin: ['top']})}`}>
-              {event.isCompletelySoldOut ? <Button type='primary' disabled={true} text='Fully booked' />
-                : (
-                  <div className='js-eventbrite-ticket-button' data-eventbrite-ticket-id={event.eventbriteId}>
-                    <Button
-                      type='primary'
-                      url={`https://www.eventbrite.com/e/${event.eventbriteId}/`}
-                      eventTracking={JSON.stringify({
-                        category: 'component',
-                        action: 'booking-tickets:click',
-                        label: 'event-page'
-                      })}
-                      icon='ticket'
-                      text='Book free tickets' />
-                    <p className={`font-charcoal ${font({s: 'HNL5'})} ${spacing({s: 1}, {margin: ['top']})} ${spacing({s: 0}, {margin: ['bottom']})}`}>with Eventbrite</p>
-                  </div>
-                )
-              }
-            </div>
-          }
-        </Fragment>
-      }
-
-      {event.bookingEnquiryTeam &&
-        <div className={`border-top-width-1 border-color-pumice ${spacing({s: 2}, {padding: ['top', 'bottom']})}`}>
-          {event.isCompletelySoldOut ? <Button type='primary' disabled={true} text='Fully booked' />
-            : (
-              <Button
-                type='primary'
-                url={`mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`}
-                eventTracking={JSON.stringify({
-                  category: 'component',
-                  action: 'booking-tickets:click',
-                  label: 'event-page (email to book)'
-                })}
-                icon='email'
-                text='Email to book' />
-            )}
-          <SecondaryLink
-            url={`mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`}
-            text={event.bookingEnquiryTeam.email}
-            extraClasses={`block font-charcoal ${spacing({s: 1}, {margin: ['top']})}`} />
-        </div>
-      }
-    </div>
+    </Fragment>
   );
 };
 
@@ -157,7 +94,7 @@ const EventPage = ({ event }: Props) => {
     Background={<WobblyBackground />}
     TagBar={null}
     LabelBar={<Labels labels={(eventFormat.concat(eventAudiences, eventInterpretations))} />}
-    DateInfo={DatesShowHide(event)}
+    DateInfo={topDate(event)}
     InfoBar={InfoBar(event.cost, event.eventbriteId, event.bookingEnquiryTeam)}
     Description={null}
     FeaturedMedia={FeaturedMedia}

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -5,6 +5,7 @@ import BaseHeader from '../BaseHeader/BaseHeader';
 import Body from '../Body/Body';
 import Contributors from '../Contributors/Contributors';
 import WobblyBackground from '../BaseHeader/WobblyBackground';
+import PrimaryLink from '../Links/PrimaryLink/PrimaryLink';
 import EventScheduleItem from '../EventScheduleItem/EventScheduleItem';
 import Labels from '../Labels/Labels';
 import Icon from '../Icon/Icon';
@@ -54,15 +55,15 @@ function infoBar(event) {
   return (
     <Fragment>
       {(eventbriteId || bookingEnquiryTeam) &&
-        <a href='#dates'>See all dates/times to book</a>
+        <PrimaryLink url='#dates' name='See all dates/times to book' isJumpLink={true} />
       }
 
       {(!eventbriteId && !bookingEnquiryTeam) &&
         <Fragment>
-          <div className='clearfix'>
+          <div className={`clearfix ${spacing({s: 2}, {margin: ['bottom']})}`}>
             <Labels labels={['Just turn up']} />
           </div>
-          <a href='#dates'>See all dates/times</a>
+          <PrimaryLink url='#dates' name='See all dates/times' isJumpLink={true} />
         </Fragment>
       }
     </Fragment>

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -48,16 +48,24 @@ function DateInfo(event) {
   );
 }
 
-function InfoBar(cost, eventbriteId, bookingEnquiryTeam) {
+function infoBar(event) {
+  const { eventbriteId, bookingEnquiryTeam } = event;
+
   return (
-    <p className='no-margin'>
-      {cost || 'Free admission'}
-      <span className={`border-left-width-1 border-color-pumice ${spacing({s: 1}, {padding: ['left'], margin: ['left']})}`}>
-        {eventbriteId ? 'Ticketed'
-          : bookingEnquiryTeam ? 'Enquire to book'
-            : 'No ticket required'}
-      </span>
-    </p>
+    <Fragment>
+      {(eventbriteId || bookingEnquiryTeam) &&
+        <a href='#dates'>See all dates/times to book</a>
+      }
+
+      {(!eventbriteId && !bookingEnquiryTeam) &&
+        <Fragment>
+          <div className='clearfix'>
+            <Labels labels={['Just turn up']} />
+          </div>
+          <a href='#dates'>See all dates/times</a>
+        </Fragment>
+      }
+    </Fragment>
   );
 }
 
@@ -95,7 +103,7 @@ const EventPage = ({ event }: Props) => {
     TagBar={null}
     LabelBar={<Labels labels={(eventFormat.concat(eventAudiences, eventInterpretations))} />}
     DateInfo={topDate(event)}
-    InfoBar={InfoBar(event.cost, event.eventbriteId, event.bookingEnquiryTeam)}
+    InfoBar={infoBar(event)}
     Description={null}
     FeaturedMedia={FeaturedMedia}
     isFree={Boolean(!event.cost)}
@@ -131,7 +139,7 @@ const EventPage = ({ event }: Props) => {
         }
 
         <div className={`body-text ${spacing({s: 4}, {padding: ['bottom']})}`}>
-          <h2>Dates</h2>
+          <h2 id='dates'>Dates</h2>
           {DateInfo(event)}
         </div>
 
@@ -178,6 +186,14 @@ const EventPage = ({ event }: Props) => {
               text={event.bookingEnquiryTeam.email}
               extraClasses={`block font-charcoal ${spacing({s: 1}, {margin: ['top']})}`} />
           </div>
+        }
+
+        {(!event.eventbriteId && !event.bookingEnquiryTeam) &&
+          <Fragment>
+            <div className={`clearfix ${spacing({s: 2}, {margin: ['bottom']})}`}>
+              <Labels labels={['Just turn up']} />
+            </div>
+          </Fragment>
         }
 
         <div className={`bg-yellow ${spacing({s: 4}, {padding: ['top', 'right', 'bottom', 'left']})} ${spacing({s: 4}, {margin: ['bottom']})}`}>

--- a/common/views/components/Labels/Labels.js
+++ b/common/views/components/Labels/Labels.js
@@ -11,7 +11,7 @@ const Labels = ({labels}: Props): React.Node[] => {
       line-height-1 bg-yellow
       ${font({s: 'HNM5'})}
       ${spacing({s: 1}, {padding: ['top', 'bottom', 'left', 'right']})}
-    `} style={{display: 'block', float: 'left', marginRight: '1px', marginTop: '1px', whiteSpace: 'nowrap'}}>
+    `} style={{float: 'left', marginRight: '1px', marginTop: '1px', whiteSpace: 'nowrap'}}>
       {text}
     </span>
   ))

--- a/common/views/components/Labels/Labels.js
+++ b/common/views/components/Labels/Labels.js
@@ -1,17 +1,19 @@
 // @flow
 import {font, spacing} from '../../../utils/classnames';
+import {sized} from '../../../utils/style';
 
 type Props = {|
-  labels: string[]
+  labels: string[],
+  isSpaced?: boolean
 |}
 
-const Labels = ({labels}: Props): React.Node[] => {
+const Labels = ({labels, isSpaced = false}: Props): React.Node[] => {
   return (labels.filter(Boolean).map((text, i) => (
     <span key={`text-${i}`} className={`
       line-height-1 bg-yellow
       ${font({s: 'HNM5'})}
       ${spacing({s: 1}, {padding: ['top', 'bottom', 'left', 'right']})}
-    `} style={{float: 'left', marginRight: '1px', marginTop: '1px', whiteSpace: 'nowrap'}}>
+    `} style={{float: 'left', marginRight: isSpaced ? sized(1) : '1px', marginTop: isSpaced ? sized(1) : '1px', whiteSpace: 'nowrap'}}>
       {text}
     </span>
   ))

--- a/common/views/components/Links/PrimaryLink/PrimaryLink.js
+++ b/common/views/components/Links/PrimaryLink/PrimaryLink.js
@@ -8,7 +8,7 @@ type Props = {|
   url: string,
   name: string,
   screenReaderText?: string,
-  isJumpLink: boolean
+  isJumpLink?: boolean
 |}
 
 const PrimaryLink = ({url, name, screenReaderText, isJumpLink = false}: Props) => {

--- a/common/views/components/Links/PrimaryLink/PrimaryLink.js
+++ b/common/views/components/Links/PrimaryLink/PrimaryLink.js
@@ -7,10 +7,11 @@ import trackOutboundLink from '../../../../utils/track-outbound-link';
 type Props = {|
   url: string,
   name: string,
-  screenReaderText?: string
+  screenReaderText?: string,
+  isJumpLink: boolean
 |}
 
-const PrimaryLink = ({url, name, screenReaderText}: Props) => {
+const PrimaryLink = ({url, name, screenReaderText, isJumpLink = false}: Props) => {
   function handleClick(event) {
     trackOutboundLink(event.currentTarget.href);
   }
@@ -24,9 +25,14 @@ const PrimaryLink = ({url, name, screenReaderText}: Props) => {
         'flex-v-center',
         'plain-link',
         font({s: 'HNM4'})].join(' ')} href={url} data-component='PrimaryLink'>
+      {isJumpLink &&
+        <Icon name='arrowSmall' extraClasses='icon--green icon--90' />
+      }
       {name}
       {screenReaderText && <span className='visually-hidden'> {screenReaderText}</span>}
-      <Icon name='arrowSmall' extraClasses='icon--green' />
+      {!isJumpLink &&
+        <Icon name='arrowSmall' extraClasses='icon--green' />
+      }
     </a>
   );
 };

--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -159,8 +159,7 @@ export async function renderExhibitExhibitionLink(ctx, next) {
 
 export async function renderEvent(ctx, next) {
   const event = await getEvent(ctx.request, {
-    id: ctx.params.id,
-    selectedDate: ctx.query.selectedDate
+    id: ctx.params.id
   });
   const tags = [{
     text: 'Events',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,9 +1592,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.76.0.tgz#eb00036991c3abc106743fcbc7ee321f02aa4faa"
+flow-bin@^0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.77.0.tgz#4e5c93929f289a0c28e08fb361a9734944a11297"
 
 flow-typed@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
References #3022.

Adding the relevant date/messaging information to event page headers based on

- whether booking is required
  - if so, if it's email or Eventbrite
- single or multiple dates
- if all events are in the past

__TODO:__
- [ ] Flow

__TODO in another PR:__
- [ ] Add header messaging to Eventbrite events for which booking hasn't yet opened
- [ ] Grey out past events in the date block lower down the page
- [ ] Add 'fully booked' messaging to Eventbrite events when there's no space left
- [ ] ?Add 'Available' messaging to events that can be attended/are available?