### PR TITLE
Allow Prismic preview on the event-series page

### DIFF
--- a/events/app/controllers.js
+++ b/events/app/controllers.js
@@ -1,5 +1,6 @@
 import {model, prismic} from 'common';
 import {getEventSeries} from '@weco/common/services/prismic/events';
+import {isPreview as isPrismicPreview} from '@weco/common/services/prismic/api';
 const {createPageConfig} = model;
 const {
   getPaginatedEventPromos,
@@ -76,6 +77,7 @@ function convertEventToEventPromos(events) {
 
 export async function renderEventSeries(ctx, next) {
   const {id} = ctx.params;
+  const isPreview = isPrismicPreview(ctx.request);
   const {events, series} = await getEventSeries(ctx.request, { id });
 
   if (events.length > 0) {
@@ -104,7 +106,8 @@ export async function renderEventSeries(ctx, next) {
       htmlDescription: asHtml(series.description),
       paginatedEvents: upcomingEvents,
       pastEvents: pastEvents,
-      backgroundTexture: series.backgroundTexture
+      backgroundTexture: series.backgroundTexture,
+      isPreview
     });
   }
 

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -396,7 +396,9 @@ const linkResolver = (doc) => {
 };
 
 export function asText(maybeContent: any) {
-  return maybeContent && Array.isArray(maybeContent) && RichText.asText(maybeContent).trim();
+  if (!Array.isArray(maybeContent)) return '';
+
+  return maybeContent && RichText.asText(maybeContent).trim();
 }
 
 export function asHtml(maybeContent: any) {

--- a/server/services/prismic-parsers.js
+++ b/server/services/prismic-parsers.js
@@ -387,6 +387,7 @@ const linkResolver = (doc) => {
     case 'webcomics'     : return `/articles/${doc.id}`;
     case 'exhibitions'   : return `/exhibitions/${doc.id}`;
     case 'events'        : return `/events/${doc.id}`;
+    case 'event-series'  : return `/event-series/${doc.id}`;
     case 'series'        : return `/series/${doc.id}`;
     case 'installations' : return `/installations/${doc.id}`;
     case 'pages'         : return `/pages/${doc.id}`;
@@ -395,7 +396,7 @@ const linkResolver = (doc) => {
 };
 
 export function asText(maybeContent: any) {
-  return maybeContent && RichText.asText(maybeContent, linkResolver).trim();
+  return maybeContent && Array.isArray(maybeContent) && RichText.asText(maybeContent).trim();
 }
 
 export function asHtml(maybeContent: any) {


### PR DESCRIPTION
Allowing the `event-series` route to be viewed with the Prismic preview API.

