### PR TITLE
use promoImage and promoText over a seperate promo property

### DIFF
--- a/common/model/generic-content-fields.js
+++ b/common/model/generic-content-fields.js
@@ -1,6 +1,7 @@
 // @flow
 import type {Contributor} from './contributors';
 import type {ImagePromo} from './image-promo';
+import type {Picture} from './picture';
 
 export type Body = any[];
 
@@ -12,5 +13,7 @@ export type GenericContentFields = {|
   contributorsTitle: ?string,
   contributors: Contributor[],
   promo: ?ImagePromo,
-  body: any[]
+  body: any[],
+  promoText: ?string,
+  promoImage: ?Picture
 |}

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -482,12 +482,15 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
 
 export function parseGenericFields(doc: PrismicFragment): GenericContentFields {
   const {data} = doc;
+  const promo = data.promo && parseImagePromo(data.promo);
   return {
     id: doc.id,
     title: parseTitle(data.title),
     contributorsTitle: asText(data.contributorsTitle),
     contributors: data.contributors ? parseContributors(data.contributors) : [],
-    promo: data.promo && parseImagePromo(data.promo),
-    body: data.body ? parseBody(data.body) : []
+    body: data.body ? parseBody(data.body) : [],
+    promo: promo,
+    promoText: promo && promo.caption,
+    promoImage: promo && promo.image
   };
 }

--- a/common/views/components/BasePage/EventSeriesPage.js
+++ b/common/views/components/BasePage/EventSeriesPage.js
@@ -25,7 +25,9 @@ const Page = ({
     contributors: series.contributors,
     contributorsTitle: series.contributorsTitle,
     promo: series.promo,
-    body: series.body
+    body: series.body,
+    promoImage: series.promoImage,
+    promoText: series.promoText
   });
   const Header = (<BaseHeader
     title={series.title}

--- a/common/views/components/BasePage/InstallationPage.js
+++ b/common/views/components/BasePage/InstallationPage.js
@@ -25,7 +25,9 @@ const InstallationPage = ({
     contributors: installation.contributors,
     contributorsTitle: installation.contributorsTitle,
     promo: installation.promo,
-    body: installation.body
+    body: installation.body,
+    promoImage: installation.promoImage,
+    promoText: installation.promoText
   });
   const Header = (<BaseHeader
     title={installation.title}

--- a/server/views/layout/default.njk
+++ b/server/views/layout/default.njk
@@ -52,6 +52,7 @@
           validationBar.style.background = '#ffce3c';
           validationBar.style.bottom = '75px';
           validationBar.style.fontSize = '12px';
+          validationBar.style.zIndex = 2147483000;
 
           window.addEventListener('load', function() {
             var validationFails = [];

--- a/whats_on/app/views/pages/event-series.njk
+++ b/whats_on/app/views/pages/event-series.njk
@@ -4,9 +4,9 @@
   {% set metaContent = {
     type: 'website',
     title: 'Events',
-    image: paginatedEvents.results[0].image.contentUrl,
+    image: series.promoImage.contentUrl,
     url: pageConfig.canonicalUri,
-    description: 'Choose from an inspiring range of free talks, tours, discussions and more on at Wellcome Collection in London.'
+    description: series.promoText
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
@@ -15,7 +15,7 @@
 
 {% block body %}
   <script type="application/ld+json">
-    [{% for event in paginatedEvents.results %}
+    [{% for event in events %}
       {{ event | jsonLd('eventPromoLd') | safe }}
       {{ ',' if not loop.last }}
     {% endfor %}]

--- a/whats_on/app/views/pages/installation.njk
+++ b/whats_on/app/views/pages/installation.njk
@@ -1,17 +1,16 @@
 {% extends 'layout/default.njk' %}
 
-{% set description = installation.promo.caption | safe | striptags %}
 {% block pageMeta %}
   {% set metaContent = {
     type: 'website',
     title: installation.title,
-    description: description,
-    image: installation.promo.image.contentUrl,
+    description: installation.promoText,
+    image: installation.promoImage.contentUrl,
     url: pageConfig.canonicalUri
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
   {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
-  <meta name="description" content="{{ description }}" />
+  <meta name="description" content="{{ installation.promoText }}" />
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
Introduces `promoText` and `promoImage` - I'll get on deprecating using `promo`.
This helps with not having to null check the whole time.

Couple of bug fixes in the event series page too.