### PR TITLE
fix preview links

### DIFF
--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -1,6 +1,5 @@
 // @flow
 import Prismic from 'prismic-javascript';
-import Cookies from 'cookies';
 import type {
   PrismicDocument,
   PrismicQueryOpts,
@@ -8,7 +7,7 @@ import type {
   PaginatedResults,
   DocumentType
 } from './types';
-
+const dev = process.env.NODE_ENV !== 'production';
 const oneMinute = 1000 * 60;
 const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
 
@@ -22,7 +21,8 @@ function periodicallyUpdatePrismic() {
 periodicallyUpdatePrismic();
 
 export function isPreview(req: Request) {
-  return Boolean(new Cookies(req).get(Prismic.previewCookie));
+  const isPreview = dev || Boolean(req.url.match('preview.wellcomecollection.org'));
+  return isPreview;
 }
 
 export async function getPrismicApi(req: ?Request) {

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -1,12 +1,9 @@
 import Raven from 'raven';
 import {createPageConfig} from '../model/page-config';
+import {isPreview} from '../../common/services/prismic/api';
 
 export function error(beaconError) {
   return async (ctx, next) => {
-    const isPreview = true ||
-      Boolean(ctx.request.url.match('/preview')) ||
-      Boolean(ctx.request.host.match('preview.wellcomecollection.org'));
-
     try {
       await next();
       if (404 === ctx.response.status && !ctx.response.body) {
@@ -18,7 +15,7 @@ export function error(beaconError) {
       const url = ctx.request.href;
       ctx.status = err.statusCode || err.status || 500;
       ctx.render('pages/error', {
-        isPreview,
+        isPreview: isPreview(ctx.response),
         errorStatus: ctx.status,
         pageConfig: createPageConfig({
           title: `${ctx.status} error`


### PR DESCRIPTION
We are in preview mode if we are on `preview.` or not prod.

This was because the preview links functionality doesn't actually set a cookie on the site, but rather on `prismic.io`, which it then pings, which we should not be passing on to users who aren't expecting that.