### PR TITLE
[SPIKE] Use tag content with other pieces of content

### DIFF
--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -30,11 +30,12 @@ export async function getMultiContent(
   req: Request,
   structuredSearchQuery: StructuredSearchQuery
 ): Promise<PaginatedResults<MultiContent>> {
-  const {types, type, id, ids, tags, tag, pageSize, orderings} = structuredSearchQuery;
+  const {types, type, id, ids, tags, tag, partOf, pageSize, orderings} = structuredSearchQuery;
   const idsPredicate = ids.length > 0 ? Prismic.Predicates.at('document.id', ids) : null;
   const idPredicate = id.length > 0 ? Prismic.Predicates.in('document.id', id) : null;
   const tagsPredicate = tags.length > 0 ? Prismic.Predicates.at('document.tags', tags) : null;
   const tagPredicate = tag.length > 0 ? Prismic.Predicates.any('document.tags', tag) : null;
+  const partOfPredicate = partOf.length > 0 ? Prismic.Predicates.any('my.pages.tags.tag', partOf) : null;
   const typesPredicate = types.length > 0 ? Prismic.Predicates.in('document.type', types) : null;
   const typePredicate = type.length > 0 ? Prismic.Predicates.any('document.type', type) : null;
   const predicates = [
@@ -42,6 +43,7 @@ export async function getMultiContent(
     idPredicate,
     tagsPredicate,
     tagPredicate,
+    partOfPredicate,
     typesPredicate,
     typePredicate
   ].filter(Boolean);

--- a/common/services/prismic/search.js
+++ b/common/services/prismic/search.js
@@ -10,6 +10,7 @@ export type StructuredSearchQuery = {|
   id: string[],
   tags: string[],
   tag: string[],
+  partOf: string[],
   pageSize: number,
   orderings: string[]
 |}
@@ -27,7 +28,7 @@ export function parseQuery(query: string): StructuredSearchQuery {
     keywords: [
       'types', 'type',
       'ids', 'id',
-      'tags', 'tag',
+      'tags', 'tag', 'partOf', // if we implememnt partOf, we can remove tags.
       'pageSize', 'orderings'
     ]
   });
@@ -48,6 +49,7 @@ export function parseQuery(query: string): StructuredSearchQuery {
     id: arrayedStructuredQuery.id || [],
     tags: arrayedStructuredQuery.tags || [],
     tag: arrayedStructuredQuery.tag || [],
+    partOf: arrayedStructuredQuery.partOf || [],
     orderings: arrayedStructuredQuery.orderings || [],
     pageSize: arrayedStructuredQuery.pageSize
   };


### PR DESCRIPTION
# Problem
Creating new relationships between content seems not to be as easy as it should be. We are creating new relationships between different type of content internally, but the system isn't flexible enough to allow this.

Tagging systems can often solve this, but it felt like that might not express relationships as well as we might want.

e.g. We might have a tag of "What we do". "About Wellcome Collection", "Youth", "Schools", "Families" would all have this tag and be part of that. If an event was part of an exhibition though, we would need to create another tag, probably after the exhibition, and add the exhibition and event to it. 

# Proposal
I am using "tag" and "Part of" interchangeably here.

One phrase that has stuck around for a while and is quite a good abstract concept for a lot of relationships is "Part of".

Using that as a starting point, if we allow editors to "tag" content with content, this would cover all the cases we currently have, and probably allow for more interesting relationships to be made. 

i.e.
* An `event` is part of an `event-series`
* A `page` is part of a `page` e.g.  "About Wellcome Collection" is part of "What we do"
* An `installation` is part of an `exhibition`
* An `event` is part of an `exhibition`
* An `event` is part of an `event`
* An article is part of an `editorial-series`
* An `event-series` is part of a `page` e.g. Saturday Studio is part of `Schools`

# Technical limitations
Prismic's querying system. It does not allow for `OR` querying. (This is why I haven't explored this too far in the past).

This means if a content type can have multiple content types related to it, we would have to add this to the "Things that are part of this" query.

e.g.
If an event-series has events part of it
```JS
const query = api.query([Predicates.at('my.events.tags.tag', eventSeriesId)]);
```

If a page had pages, and events-series as part of it:
```JS
const pagesQuery = api.query([Predicates.at('my.pages.tags.tag', pageId)]);
const eventSeriesQuery = api.query([Predicates.at('my.event-series.tags.tag', pageId)]);
```

We can see how this is already breaking the line in the sand of 1 query per response, and could become really unwieldy with something like an `exhibition`, which might have `articles`, `events`, `installations` and more tagged with it.

I have put a proposal forward to allow for multiple field search, something similar to the `any` predicate, but for fields.

e.g.
```
const pagesAndEventSeriesQuery = api.query([Predicates.at([
  'my.pages.tags.tag',
  'my.event-series.tags.tag'
], pageId)]);
```

# Workaround to technical limitations

## Limit number of content type relationships
As we could make the list generation of "Things that are tagged / part of" this, we could limit it to 2 content types per content type. e.g. `installations` and `events` can be tagged with `exhibitions`. `pages` can have `pages` and `event-series` attached.
  
The down side to this, is it limits the content team in what relationships could be made.

## Static site building
If we statically built the site, we could flatten the relationships into the content. This feels like it might be an interim step to 👇  

# Longer term solution
We can create another index that we push Prismic into with greater query functionality.
This would benefit us for many other reasons (finding article with certain works in them etc).

This would be similar to the platform infrastructure in the sense of we would have Prismic as the  source of truth, and an index to serve and query the content from that source.

@jennpb @Heesoomoon ☝️ 