### PR TITLE
render events page from whats_on service

### DIFF
--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -27,7 +27,8 @@ export async function getEventSeries(req: Request, {
   id
 }: EventSeriesProps) {
   const events = await getEvents(req, {
-    seriesId: id
+    seriesId: id,
+    page: 1
   });
 
   if (events && events.results.length > 0) {

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -187,9 +187,12 @@ export async function getEvent(req: Request, {id}: EventQueryProps): Promise<?Ui
 }
 
 type EventsQueryProps = {|
+  page: number,
   seriesId: string
 |}
+
 export async function getEvents(req: Request,  {
+  page = 1,
   seriesId
 }: EventsQueryProps): Promise<?PaginatedResults<UiEvent>> {
   const graphQuery = `{
@@ -248,7 +251,7 @@ export async function getEvents(req: Request,  {
       }
     }
   }`;
-  const orderings = '[my.events.times.startDateTime]';
+  const orderings = '[my.events.times.startDateTime desc]';
   const predicates = [
     Prismic.Predicates.at('document.type', 'events'),
     seriesId ? Prismic.Predicates.at('my.events.series.series', seriesId) : null
@@ -256,6 +259,7 @@ export async function getEvents(req: Request,  {
 
   const paginatedResults = await getDocuments(req, predicates, {
     orderings,
+    page,
     graphQuery
   });
 

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -39,7 +39,11 @@ const EventPromo = ({
       text: interpretation.interpretationType.title
     };
   });
-  const labels = [(format && {url: null, text: format.title}), (audience && {url: null, text: audience.title}), ...eventInterpretations].filter(Boolean);
+  const labels = [
+    (format && {url: null, text: format.title}),
+    (audience && {url: null, text: audience.title}),
+    ...eventInterpretations
+  ].filter(Boolean);
   return (
     <a data-component='EventPromo'
       data-component-state={JSON.stringify({ position: position })}

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -22,6 +22,8 @@ export function error(beaconError) {
         })
       });
 
+      console.error(err);
+
       if (beaconError && (ctx.status < 400 || ctx.status >= 500)) {
         Raven.config('https://2cfb7b8ceb0a4549a4de2010b219a65d:5b48d985281a47e095a73df871b59149@sentry.io/223943').install();
         Raven.captureException(err, {extra: {url: ctx.request.href, statusCode: ctx.status}});

--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -8,7 +8,10 @@ import {
   getExhibitionExhibits,
   getExhibitExhibition
 } from '@weco/common/services/prismic/exhibitions';
-import {getEvent} from '@weco/common/services/prismic/events';
+import {
+  getEvents,
+  getEvent
+} from '@weco/common/services/prismic/events';
 import {getEventSeries} from '@weco/common/services/prismic/event-series';
 import {getEventbriteEventEmbed} from '@weco/common/services/eventbrite/event-embed';
 import {isPreview as isPrismicPreview} from '@weco/common/services/prismic/api';
@@ -156,6 +159,27 @@ export async function renderExhibitExhibitionLink(ctx, next) {
       React.createElement(Tags, { tags })
     )
   };
+}
+
+export async function renderEvents(ctx, next) {
+  const page = ctx.query.page || 1;
+  const paginatedResults = await getEvents(ctx.request, {
+    page,
+    seriesId: null
+  });
+  if (paginatedResults) {
+    ctx.render('pages/events', {
+      pageConfig: createPageConfig({
+        path: '/events',
+        title: 'Events',
+        inSection: 'whatson',
+        category: 'public-programme',
+        contentType: 'listing',
+        canonicalUri: 'https://wellcomecollection.org/events'
+      }),
+      paginatedResults
+    });
+  }
 }
 
 export async function renderEvent(ctx, next) {

--- a/whats_on/app/routes.js
+++ b/whats_on/app/routes.js
@@ -7,6 +7,7 @@ import {
   renderExhibits,
   renderExhibitExhibitionLink,
   renderEvent,
+  renderEvents,
   renderEventbriteEmbed,
   renderEventSeries
 } from './controllers';
@@ -19,6 +20,7 @@ r.get('/installations/:id', renderInstallation);
 r.get('/exhibitions', renderExhibitions);
 r.get('/exhibitions/:id', renderExhibition);
 r.get('/exhibitions/:id/exhibits', renderExhibits);
+r.get('/events', renderEvents);
 r.get('/events/:id', renderEvent);
 r.get('/eventbrite-event-embed/:id', renderEventbriteEmbed);
 r.get('/event-series/:id', renderEventSeries);

--- a/whats_on/app/views/pages/events.njk
+++ b/whats_on/app/views/pages/events.njk
@@ -1,0 +1,101 @@
+{% extends 'layout/default.njk' %}
+{% set pageDescription = 'Choose from an inspiring range of free talks, tours, discussions and more on at Wellcome Collection in London.' %}
+{% set results = paginatedResults.results %}
+{% set metaContent = {
+  type: 'website',
+  title: 'Exhibitions',
+  image: paginatedResults[0].promoImage.contentUrl,
+  url: pageConfig.canonicalUri,
+  description: pageDescription
+} %}
+
+{% block pageMeta %}
+  {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}
+  {% component 'twitter-card', { pageConfig: pageConfig, metaContent: metaContent } %}
+  <meta name="description" content="{{ pageDescription }}" />
+{% endblock %}
+
+{% block body %}
+   <script type="application/ld+json">
+    [{% for event in results %}
+      {% set featuredImage = {contentUrl: event.image.contentUrl} %}
+      {% set ev = event | objectAssign({safeDescription: event.description | safe | striptags, featuredImage: featuredImage}) %}
+      {{ ev | jsonLd('eventLd') | safe }}{{ ',' if not loop.last }}
+    {% endfor %}]
+  </script>
+
+  {% componentV2 'list-header', {
+    name: 'Events',
+    description: pageDescription,
+    total: paginatedResults.results.length
+  } %}
+
+  {% if paginatedResults.totalPages > 1  %}
+    <div class="css-grid__container">
+      <div class="css-grid">
+        <div class="{{ {s:12, m:12, l:12, xl:12} | cssGridClasses }}">
+          <div class="{{ {s:5, m:5, l:5} | spacingClasses({padding: ['top']}) }}  {{ {s:5, m:5, l:5} | spacingClasses({padding: ['bottom']}) }} flex flex--v-center font-pewter {{ {s:'LR3', m:'LR2'} | fontClasses }}">
+            {{ ((paginatedResults.currentPage - 1) * paginatedResults.results.length + 1) }} - {{ ((paginatedResults.currentPage) * paginatedResults.results.length) }}
+          </div>
+          {% componentV2 'divider', null, {'keyline': true, 'pumice': true} %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="css-grid__container {{ {s:4} | spacingClasses({padding: ['top']}) }} ">
+    <div class="css-grid">
+        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }}">
+          <div class="flex-inline flex--v-center">
+            <span class="{{ {s:'HNM5', m:'HNM4'} | fontClasses }}">Free admission</span>
+          </div>
+        </div>
+        {% for event in paginatedResults.results %}
+          <div class="{{ {s: 12, m: 6, l: 4, xl:4} | cssGridClasses}}">
+            {% componentJsx 'EventPromo', {
+              id: event.id,
+              url: '/events/' + event.id,
+              title: event.title,
+              start: event.times[0].range.startDateTime if event.times.length === 1 else null,
+              end: event.times[0].range.endDateTime if event.times.length === 1 else null,
+              isMultiDate: event.times.length > 1,
+              isFullyBooked: false,
+              hasNotFullyBookedTimes: null,
+              format: event.format,
+              image: event.promoImage,
+              interpretations: event.interpretations,
+              eventbriteId: event.eventbriteId,
+              dateString: null,
+              timeString: null,
+              audience: event.audience,
+              schedule: event.schedule,
+              series: event.series,
+              position: loop.index
+            } %}
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  <div class="css-grid__container  {{ {s:2, m:2, l:2} | spacingClasses({padding: ['top']}) }} {{ {s:3, m:3, l:3} | spacingClasses({padding: ['bottom']}) }} ">
+    <div class="css-grid">
+      {% if paginatedResults.totalPages > 1  %}
+        <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | cssGridClasses }} text-align-right">
+          {% set pageSize = (paginatedResults.totalResults / paginatedResults.pageSize) | round %}
+          {% set currentPage = paginatedResults.currentPage %}
+          {% componentJsx 'Pagination', {
+            prevPage: (currentPage - 1) if currentPage !== 1,
+            currentPage: currentPage,
+            pageCount: pageSize,
+            nextPage: (currentPage + 1) if currentPage < pageSize,
+            nextQueryString: '/events?page=' + (currentPage + 1),
+            prevQueryString: '/events?page=' + (currentPage - 1)
+          } %}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+
+
+{% endblock %}


### PR DESCRIPTION
In prep for removing the old events service, which will then render events from `whats_on`.
![eventlist](https://user-images.githubusercontent.com/31692/44040663-bf847d92-9f13-11e8-92fa-976e7ac1661b.png)
