### PR TITLE
include fields that are lists in catalogue app

### DIFF
--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -20,7 +20,7 @@ const rootUri = 'https://api.wellcomecollection.org/catalogue';
 const include = [
   [],
   ['identifiers', 'thumbnail', 'items'],
-  ['identifiers', 'items']
+  ['identifiers', 'items', 'contributors', 'subjects', 'genres', 'production']
 ];
 
 export async function getWork({ id, version = 1 }: GetWorkProps): Work {


### PR DESCRIPTION
The new API rule is, if it's a list, you need to include it.
This does that.