### PR TITLE
Future ticket availability

### DIFF
--- a/common/model/events.js
+++ b/common/model/events.js
@@ -91,7 +91,7 @@ export type Event = {|
   ...GenericContentFields,
   format: ?EventFormat,
   isDropIn: boolean,
-  salesStart: ?Date,
+  ticketSalesStart: ?Date,
   times: EventTime[],
   description: ?HTMLString,
   series: EventSeries[],

--- a/common/model/events.js
+++ b/common/model/events.js
@@ -91,6 +91,7 @@ export type Event = {|
   ...GenericContentFields,
   format: ?EventFormat,
   isDropIn: boolean,
+  salesStart: ?DateTimeRange,
   times: EventTime[],
   description: ?HTMLString,
   series: EventSeries[],

--- a/common/model/events.js
+++ b/common/model/events.js
@@ -91,7 +91,7 @@ export type Event = {|
   ...GenericContentFields,
   format: ?EventFormat,
   isDropIn: boolean,
-  salesStart: ?DateTimeRange,
+  salesStart: ?Date,
   times: EventTime[],
   description: ?HTMLString,
   series: EventSeries[],

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -137,6 +137,7 @@ export function parseEventDoc(
     backgroundTexture: document.data.backgroundTexture.data && document.data.backgroundTexture.data.image.url,
     eventbriteId,
     isCompletelySoldOut: data.times && data.times.filter(time => !time.isFullyBooked).length === 0,
+    salesStart: data.salesStart,
     times: data.times && data.times.map(frag => ({
       range: {
         startDateTime: parseTimestamp(frag.startDateTime),

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -137,7 +137,7 @@ export function parseEventDoc(
     backgroundTexture: document.data.backgroundTexture.data && document.data.backgroundTexture.data.image.url,
     eventbriteId,
     isCompletelySoldOut: data.times && data.times.filter(time => !time.isFullyBooked).length === 0,
-    salesStart: data.salesStart,
+    ticketSalesStart: data.ticketSalesStart,
     times: data.times && data.times.map(frag => ({
       range: {
         startDateTime: parseTimestamp(frag.startDateTime),

--- a/common/utils/format-date.js
+++ b/common/utils/format-date.js
@@ -28,6 +28,13 @@ export function formatTime(date: Date): string {
   return london(date).format('HH:mm');
 }
 
+export function isTimePast(date: Date): boolean {
+  const momentNow = london();
+  const momentEnd = london(date);
+
+  return momentEnd.isBefore(momentNow);
+}
+
 export function isDatePast(date: Date): boolean {
   const momentNow = london();
   const momentEnd = london(date);

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -91,7 +91,7 @@ function topDate(event) {
   );
 };
 
-function showSalesStart(dateTime: ?Date): boolean {
+function showSalesStart(dateTime) {
   return dateTime && !isTimePast(dateTime);
 }
 
@@ -188,10 +188,11 @@ const EventPage = ({ event }: Props) => {
           </div>
         </div>
 
-        {showSalesStart(event.salesStart) &&
+        {event.salesStart && showSalesStart(event.salesStart) &&
           <Fragment>
             <div className={`bg-yellow inline-block ${spacing({s: 4}, {padding: ['left', 'right'], margin: ['top', 'bottom']})} ${spacing({s: 2}, {padding: ['top', 'bottom']})} ${font({s: 'HNM4'})}`}>
-              <span>Booking opens {formatDayDate(event.salesStart)} {formatTime(event.salesStart)}</span>
+              {/* TODO: work out why the second method below will fail Flow without a null check */}
+              <span>Booking opens {formatDayDate(event.salesStart)} {event.salesStart && formatTime(event.salesStart)}</span>
             </div>
           </Fragment>
         }

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -221,7 +221,7 @@ const EventPage = ({ event }: Props) => {
               </div>
             }
 
-            {event.bookingEnquiryTeam && !isDatePast(event.dateRange.lastDate) &&
+            {event.bookingEnquiryTeam &&
               <div className={`${spacing({s: 2}, {padding: ['top', 'bottom']})}`}>
                 {event.isCompletelySoldOut ? <Button type='primary' disabled={true} text='Fully booked' />
                   : (
@@ -253,7 +253,7 @@ const EventPage = ({ event }: Props) => {
           </Fragment>
         }
 
-        {event.isCompletelySoldOut &&
+        {event.isCompletelySoldOut && !isDatePast(event.dateRange.lastDate) &&
           <div className={`${spacing({s: 2}, {padding: ['top', 'bottom']})} body-text`}>
             <h3>This event has been fully booked – but there is a waiting list!</h3>
             <p>

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -16,7 +16,15 @@ import {UiImage} from '../Images/Images';
 import type {UiEvent} from '../../../model/events';
 import {spacing, font} from '../../../utils/classnames';
 import camelize from '../../../utils/camelize';
-import {formatAndDedupeOnDate, formatAndDedupeOnTime, joinDateStrings, formatDayDate, isDatePast, isTimePast, formatTime} from '../../../utils/format-date';
+import {
+  formatAndDedupeOnDate,
+  formatAndDedupeOnTime,
+  joinDateStrings,
+  formatDayDate,
+  isDatePast,
+  isTimePast,
+  formatTime
+} from '../../../utils/format-date';
 
 type Props = {|
   event: UiEvent
@@ -91,7 +99,7 @@ function topDate(event) {
   );
 };
 
-function showSalesStart(dateTime) {
+function showTicketSalesStart(dateTime) {
   return dateTime && !isTimePast(dateTime);
 }
 
@@ -188,16 +196,16 @@ const EventPage = ({ event }: Props) => {
           </div>
         </div>
 
-        {event.salesStart && showSalesStart(event.salesStart) &&
+        {event.ticketSalesStart && showTicketSalesStart(event.ticketSalesStart) &&
           <Fragment>
             <div className={`bg-yellow inline-block ${spacing({s: 4}, {padding: ['left', 'right'], margin: ['top', 'bottom']})} ${spacing({s: 2}, {padding: ['top', 'bottom']})} ${font({s: 'HNM4'})}`}>
               {/* TODO: work out why the second method below will fail Flow without a null check */}
-              <span>Booking opens {formatDayDate(event.salesStart)} {event.salesStart && formatTime(event.salesStart)}</span>
+              <span>Booking opens {formatDayDate(event.ticketSalesStart)} {event.ticketSalesStart && formatTime(event.ticketSalesStart)}</span>
             </div>
           </Fragment>
         }
 
-        {!isDatePast(event.dateRange.lastDate) && !showSalesStart(event.salesStart) &&
+        {!isDatePast(event.dateRange.lastDate) && !showTicketSalesStart(event.ticketSalesStart) &&
           <Fragment>
             {/* Booking CTAs */}
             {event.eventbriteId &&

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -16,7 +16,7 @@ import {UiImage} from '../Images/Images';
 import type {UiEvent} from '../../../model/events';
 import {spacing, font} from '../../../utils/classnames';
 import camelize from '../../../utils/camelize';
-import {formatAndDedupeOnDate, formatAndDedupeOnTime, joinDateStrings, formatDayDate, isDatePast, formatTime} from '../../../utils/format-date';
+import {formatAndDedupeOnDate, formatAndDedupeOnTime, joinDateStrings, formatDayDate, isDatePast, isTimePast, formatTime} from '../../../utils/format-date';
 
 type Props = {|
   event: UiEvent
@@ -90,6 +90,10 @@ function topDate(event) {
     </Fragment>
   );
 };
+
+function showSalesStart(dateTime: ?Date): boolean {
+  return dateTime && !isTimePast(dateTime);
+}
 
 const EventPage = ({ event }: Props) => {
   const image = event.promo && event.promo.image;
@@ -184,7 +188,15 @@ const EventPage = ({ event }: Props) => {
           </div>
         </div>
 
-        {!isDatePast(event.dateRange.lastDate) &&
+        {showSalesStart(event.salesStart) &&
+          <Fragment>
+            <div className={`bg-yellow inline-block ${spacing({s: 4}, {padding: ['left', 'right'], margin: ['top', 'bottom']})} ${spacing({s: 2}, {padding: ['top', 'bottom']})} ${font({s: 'HNM4'})}`}>
+              <span>Booking opens {formatDayDate(event.salesStart)} {formatTime(event.salesStart)}</span>
+            </div>
+          </Fragment>
+        }
+
+        {!isDatePast(event.dateRange.lastDate) && !showSalesStart(event.salesStart) &&
           <Fragment>
             {/* Booking CTAs */}
             {event.eventbriteId &&
@@ -209,7 +221,7 @@ const EventPage = ({ event }: Props) => {
               </div>
             }
 
-            {event.bookingEnquiryTeam &&
+            {event.bookingEnquiryTeam && !isDatePast(event.dateRange.lastDate) &&
               <div className={`${spacing({s: 2}, {padding: ['top', 'bottom']})}`}>
                 {event.isCompletelySoldOut ? <Button type='primary' disabled={true} text='Fully booked' />
                   : (

--- a/prismic-model/js/events.js
+++ b/prismic-model/js/events.js
@@ -19,7 +19,7 @@ const Events = {
     series: list('Event series', {
       series: link('Series', 'document', ['event-series'])
     }),
-    salesStart: timestamp('Ticket sales start'),
+    ticketSalesStart: timestamp('Ticket sales start'),
     times: list('Times', {
       startDateTime: timestamp('Start'),
       endDateTime: timestamp('End'),

--- a/prismic-model/js/events.js
+++ b/prismic-model/js/events.js
@@ -19,6 +19,7 @@ const Events = {
     series: list('Event series', {
       series: link('Series', 'document', ['event-series'])
     }),
+    salesStart: timestamp('Ticket sales start'),
     times: list('Times', {
       startDateTime: timestamp('Start'),
       endDateTime: timestamp('End'),

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -47,7 +47,7 @@
         }
       }
     },
-    "salesStart": {
+    "ticketSalesStart": {
       "type": "Timestamp",
       "config": {
         "label": "Ticket sales start"

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -47,6 +47,12 @@
         }
       }
     },
+    "salesStart": {
+      "type": "Timestamp",
+      "config": {
+        "label": "Ticket sales start"
+      }
+    },
     "times": {
       "type": "Group",
       "fieldset": "Times",


### PR DESCRIPTION
Added a date/time field in Prismic to indicate when ticket sales start.

If it's filled in, and the date/time is in the future, the booking button will be swapped out for messaging about when tickets will become available. The date and time formatting are in line with what we currently have (propose to update all of our date formatting at the same time).

![screen shot 2018-08-13 at 15 45 07](https://user-images.githubusercontent.com/1394592/44042558-7d132706-9f18-11e8-8110-960fc45a26f8.png)

__TODO:__
- [ ] clear cache every minute for events?