### PR TITLE
Use square image for default contributor fallback

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -165,7 +165,7 @@ export function parsePromoToCaptionedImage(frag: PrismicFragment, crop: ?Crop = 
 export const defaultContributorImage = {
   width: 64,
   height: 64,
-  contentUrl: 'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F3ed09488-1992-4f8a-9f0c-de2d296109f9_group+21.png',
+  contentUrl: 'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F021d6105-3308-4210-8f65-d207e04c2cb2_contributor_default%402x.png',
   tasl: {
     sourceName: 'Unknown',
     title: null,


### PR DESCRIPTION
References #3143

Fixes the not-quite-rounded-off corners weirdness

![screen shot 2018-08-14 at 12 57 44](https://user-images.githubusercontent.com/1394592/44090325-bf527aaa-9fc1-11e8-9565-27259a588a5e.png)
