### PR TITLE
Remove BasePageColumn bottom padding

### DIFF
--- a/common/views/components/BasePage/BasePage.js
+++ b/common/views/components/BasePage/BasePage.js
@@ -1,6 +1,6 @@
 // @flow
 import {Fragment} from 'react';
-import {spacing, grid} from '../../../utils/classnames';
+import {grid} from '../../../utils/classnames';
 import type {Node} from 'react';
 import type BaseHeader from '../BaseHeader/BaseHeader';
 import type Body from '../Body/Body';
@@ -13,12 +13,10 @@ type Props = {|
 |}
 
 export const BasePageColumn = ({children}: {| children: Node |}) => (
-  <div className={`row ${spacing({s: 8}, {padding: ['bottom']})}`}>
-    <div className='container'>
-      <div className='grid'>
-        <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
-          {children}
-        </div>
+  <div className='container'>
+    <div className='grid'>
+      <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
+        {children}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Getting rid of slightly arbitrary space at the bottom of the `BasePageColumn` so any spacing decisions we make start from a level playing field.
