### PR TITLE
add one classname function to rule them all

### DIFF
--- a/common/utils/classnames.js
+++ b/common/utils/classnames.js
@@ -44,8 +44,13 @@ export function font(sizes: FontMap): string {
   }).join(' ');
 }
 
-export function classNames(classNames: string[]): string {
-  return classNames.join(' ');
+type ClassNames = string[] | { [string]: boolean }
+export function classNames(classNames: ClassNames): string {
+  if (Array.isArray(classNames)) {
+    return classNames.join(' ');
+  } else {
+    return conditionalClassNames(classNames);
+  }
 }
 
 export function conditionalClassNames(obj: { [string]: boolean }): string {


### PR DESCRIPTION
> There should be one-- and preferably only one --obvious way to do it.

We can then use this everywhere with an array or object?

@wellcometrust/experience-dev ❓ 