### PR TITLE
Position background relative to bottom of BaseHeader

### DIFF
--- a/common/views/components/BaseHeader/BaseHeader.js
+++ b/common/views/components/BaseHeader/BaseHeader.js
@@ -72,11 +72,11 @@ const BaseHeader = ({
 
   return (
     <Fragment>
-      {BackgroundComponent}
-      <div className={`row ${spacing({s: 2}, {padding: ['top']})}`} style={{
+      <div className={`row relative ${spacing({s: 2}, {padding: ['top']})}`} style={{
         backgroundImage: BackgroundComponent ? null : `url(${backgroundTexture})`,
         backgroundSize: BackgroundComponent ? null : '150%'
       }}>
+        {BackgroundComponent}
         <div className={`container`}>
           {isFree &&
             <div className={`grid`}>

--- a/common/views/components/BaseHeader/TexturedBackground.js
+++ b/common/views/components/BaseHeader/TexturedBackground.js
@@ -6,17 +6,13 @@ type Props = {|
 const TexturedBackground = ({
   backgroundTexture
 }: Props) => (
-  <div className='row relative'>
-    <div className='absolute overflow-hidden full-width bg-cream' style={{
-      top: 0,
-      height: '40vw',
-      maxHeight: '50vh',
-      minHeight: '200px',
-      zIndex: -1,
-      backgroundImage: `url(${backgroundTexture})`,
-      backgroundSize: '150%'
-    }}>
-    </div>
+  <div className='absolute overflow-hidden full-width bg-cream' style={{
+    top: 0,
+    zIndex: -1,
+    bottom: '100px',
+    backgroundImage: `url(${backgroundTexture})`,
+    backgroundSize: '150%'
+  }}>
   </div>
 );
 

--- a/common/views/components/BaseHeader/WobblyBackground.js
+++ b/common/views/components/BaseHeader/WobblyBackground.js
@@ -1,17 +1,14 @@
 // @flow
 const WobblyBackground = () => (
-  <div className='row relative'>
-    <div className='absolute overflow-hidden full-width bg-cream' style={{
-      top: 0,
-      height: '50vw',
-      maxHeight: '66vh',
-      zIndex: -1
-    }}>
-      <div className='absolute full-width' style={{ bottom: 0 }}>
-        <div className='wobbly-edge wobbly-edge--white js-wobbly-edge'
-          data-is-valley='true'
-          data-max-intensity='100'>
-        </div>
+  <div className='absolute overflow-hidden full-width bg-cream' style={{
+    top: 0,
+    zIndex: -1,
+    bottom: '100px'
+  }}>
+    <div className='absolute full-width' style={{ bottom: 0 }}>
+      <div className='wobbly-edge wobbly-edge--white js-wobbly-edge'
+        data-is-valley='true'
+        data-max-intensity='100'>
       </div>
     </div>
   </div>


### PR DESCRIPTION
References #3143 

Ensures the background always bisects the featured media, regardless of screen size.

![background-height](https://user-images.githubusercontent.com/1394592/44106220-ea13b806-9feb-11e8-95a7-6735f7b65773.gif)
