### PR TITLE
only return series if there is a series

### DIFF
--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -33,7 +33,8 @@ export async function getEventSeries(req: Request, {
 
   if (events && events.results.length > 0) {
     const series = events.results[0].series.find(series => series.id === id);
-    return {
+
+    return series && {
       series,
       events: events.results
     };


### PR DESCRIPTION
Turns out you can still query for things that are linked to broken / archived documents.
In this instance Library Tours.

Spotted in explosions.