### PR TITLE
use package.json checksum for circle cache as greenkeeper doesn't upd…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
               aws s3 sync --only-show-errors . s3://dash.wellcomecollection.org/bundles
             popd
       - save_cache:
-          key: catalogue_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+          key: catalogue_modules_circleci_node_8_{{ checksum "package.json" }}
           paths:
             -  node_modules
   root_tests:
@@ -62,7 +62,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: root_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+          key: root_modules_circleci_node_8_{{ checksum "package.json" }}
       - run:
           name: Install root modules
           command: yarn install
@@ -91,7 +91,7 @@ jobs:
             aws s3 cp --only-show-errors ./pa11y_report.html s3://dash.wellcomecollection.org/pa11y/report.${CIRCLE_SHA1}.html
             aws s3 cp --only-show-errors ./pa11y_report.html s3://dash.wellcomecollection.org/pa11y/report.latest.html
       - save_cache:
-          key: root_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+          key: root_modules_circleci_node_8_{{ checksum "package.json" }}
           paths:
             -  node_modules
   install_server_modules:
@@ -105,7 +105,7 @@ jobs:
           name: Install server modules
           command: yarn install --production
       - save_cache:
-          key: server_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "package.json" }}
           paths:
             -  node_modules
   install_common_modules:
@@ -119,7 +119,7 @@ jobs:
           name: Install common modules
           command: yarn install
       - save_cache:
-          key: common_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+          key: common_modules_circleci_node_8_{{ checksum "package.json" }}
           paths:
             -  node_modules
   build_client:
@@ -136,7 +136,7 @@ jobs:
           name: Build client assets
           command: yarn compile
       - save_cache:
-          key: client_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+          key: client_modules_circleci_node_8_{{ checksum "package.json" }}
           paths:
             -  node_modules
       - save_cache:
@@ -157,7 +157,7 @@ jobs:
           key: server_modules_circleci_node_8_{{ checksum "../../server/yarn.lock" }}
       - restore_cache:
           keys:
-            - common_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+            - common_modules_circleci_node_8_{{ checksum "package.json" }}
             - common_modules_circleci_node_8_
       - restore_cache:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
@@ -205,7 +205,7 @@ jobs:
           key: server_modules_circleci_node_8_{{ checksum "../../server/yarn.lock" }}
       - restore_cache:
           keys:
-            - common_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+            - common_modules_circleci_node_8_{{ checksum "package.json" }}
             - common_modules_circleci_node_8_
       - restore_cache:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
@@ -253,7 +253,7 @@ jobs:
           key: server_modules_circleci_node_8_{{ checksum "server/yarn.lock" }}
       - restore_cache:
           keys:
-            - common_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+            - common_modules_circleci_node_8_{{ checksum "package.json" }}
             - common_modules_circleci_node_8_
       - restore_cache:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
@@ -285,7 +285,7 @@ jobs:
           key: server_modules_circleci_node_8_{{ checksum "server/yarn.lock" }}
       - restore_cache:
           keys:
-            - common_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+            - common_modules_circleci_node_8_{{ checksum "package.json" }}
             - common_modules_circleci_node_8_
       - restore_cache:
           key: built_server_{{ .Environment.CIRCLE_SHA1 }}
@@ -346,7 +346,7 @@ jobs:
           key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
-            - common_modules_circleci_node_8_{{ checksum "yarn.lock" }}
+            - common_modules_circleci_node_8_{{ checksum "package.json" }}
             - common_modules_circleci_node_8_
       - add_ssh_keys
       - run:


### PR DESCRIPTION
…ate yarn.lock

Hopefully this will make us deployable again.
May be worth looking into: https://github.com/greenkeeperio/greenkeeper-lockfile