### PR TITLE
add basic exhibition groupings to exhibitions service

### DIFF
--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -4,6 +4,9 @@ import searchQuery from 'search-query-parser';
 import {getInstallation} from '@weco/common/services/prismic/installations';
 import {
   getExhibitions,
+  getExhibitionsComingUp,
+  getExhibitionsCurrent,
+  getExhibitionsPast,
   getExhibition,
   getExhibitionExhibits,
   getExhibitExhibition
@@ -83,7 +86,7 @@ export async function renderInstallation(ctx, next) {
 }
 
 export async function renderExhibitions(ctx, next) {
-  const paginatedResults = await getExhibitions(ctx.request, ctx.params.id);
+  const paginatedResults = await getExhibitions(ctx.request);
   if (paginatedResults) {
     ctx.render('pages/exhibitions', {
       pageConfig: createPageConfig({
@@ -93,6 +96,57 @@ export async function renderExhibitions(ctx, next) {
         category: 'public-programme',
         contentType: 'listing',
         canonicalUri: 'https://wellcomecollection.org/exhibitions'
+      }),
+      paginatedResults
+    });
+  }
+}
+
+export async function renderExhibitionsComingUp(ctx, next) {
+  const paginatedResults = await getExhibitionsComingUp(ctx.request);
+  if (paginatedResults) {
+    ctx.render('pages/exhibitions', {
+      pageConfig: createPageConfig({
+        path: '/exhibitions/coming-up',
+        title: 'Coming up exhibitions',
+        inSection: 'whatson',
+        category: 'public-programme',
+        contentType: 'listing',
+        canonicalUri: 'https://wellcomecollection.org/exhibitions/coming-up'
+      }),
+      paginatedResults
+    });
+  }
+}
+
+export async function renderExhibitionsCurrent(ctx, next) {
+  const paginatedResults = await getExhibitionsCurrent(ctx.request);
+  if (paginatedResults) {
+    ctx.render('pages/exhibitions', {
+      pageConfig: createPageConfig({
+        path: '/exhibitions/current',
+        title: 'Current exhibitions',
+        inSection: 'whatson',
+        category: 'public-programme',
+        contentType: 'listing',
+        canonicalUri: 'https://wellcomecollection.org/exhibitions/current'
+      }),
+      paginatedResults
+    });
+  }
+}
+
+export async function renderExhibitionsPast(ctx, next) {
+  const paginatedResults = await getExhibitionsPast(ctx.request);
+  if (paginatedResults) {
+    ctx.render('pages/exhibitions', {
+      pageConfig: createPageConfig({
+        path: '/exhibitions/past',
+        title: 'Past exhibitions',
+        inSection: 'whatson',
+        category: 'public-programme',
+        contentType: 'listing',
+        canonicalUri: 'https://wellcomecollection.org/exhibitions/past'
       }),
       paginatedResults
     });

--- a/whats_on/app/routes.js
+++ b/whats_on/app/routes.js
@@ -3,6 +3,9 @@ import {
   renderWhatsOn,
   renderInstallation,
   renderExhibitions,
+  renderExhibitionsComingUp,
+  renderExhibitionsCurrent,
+  renderExhibitionsPast,
   renderExhibition,
   renderExhibits,
   renderExhibitExhibitionLink,
@@ -15,11 +18,17 @@ import {
 const r = new Router({ sensitive: true });
 
 r.get('/whats-on', renderWhatsOn);
+
 r.get('/installations/:id/exhibition', renderExhibitExhibitionLink);
 r.get('/installations/:id', renderInstallation);
+
 r.get('/exhibitions', renderExhibitions);
+r.get('/exhibitions/coming-up', renderExhibitionsComingUp);
+r.get('/exhibitions/current', renderExhibitionsCurrent);
+r.get('/exhibitions/past', renderExhibitionsPast);
 r.get('/exhibitions/:id', renderExhibition);
 r.get('/exhibitions/:id/exhibits', renderExhibits);
+
 r.get('/events', renderEvents);
 r.get('/events/:id', renderEvent);
 r.get('/eventbrite-event-embed/:id', renderEventbriteEmbed);

--- a/whats_on/app/views/pages/exhibitions.njk
+++ b/whats_on/app/views/pages/exhibitions.njk
@@ -24,7 +24,7 @@
     {% endfor %}]
   </script>
 
-  {% componentV2 'list-header', {name: 'Exhibitions', description: pageDescription, total: paginatedResults.results.length} %}
+  {% componentV2 'list-header', {name: pageConfig.title, description: pageDescription, total: paginatedResults.results.length} %}
 
   {% if paginatedExhibitions.pagination.pageCount > 1  %}
     <div class="css-grid__container">


### PR DESCRIPTION
Trying to work out groupings and how we might query exhibitions efficiently and correctly.
Also trying to put some logic as to why we order by the way we order.

* Coming up (chronological)
* Current (reverse chronological)
* Past (reverse chronological)

The logic of the ordering so far stands that: if you stand on a point, let's call it now, and are using the start date of an exhibition as to what you are looking at:
* When looking backwards into the past, you would see things from newest -> oldest. This covers current and past.
* Turn around and look forward, you see things from old to new.

e.g.
<pre>
    12 Jul            01 Aug        10 Aug  <== 👀 ==>     20 Aug             01 Nov     31 Dec
<---|-----------------|-------------|------------|---------|------------------|----------|--------->
</pre>

We are still left with trying to figure out how permanent exhibitions make it into this mix, but starting at the beginning seems like a good start.

[URLs taken from here](https://github.com/wellcometrust/platform/blob/66fc791c53a7fce9732e99e1a5567b0b94676790/ontologies/WIP/wellcome%20urls.csv)

Ping @Heesoomoon @jennpb 