### PR TITLE
Image width

### DIFF
--- a/common/styles/base/_responsive-defaults.scss
+++ b/common/styles/base/_responsive-defaults.scss
@@ -1,5 +1,4 @@
 img {
   width: 100%;
-  max-width: 100%;
   height: auto;
 }

--- a/common/styles/base/_responsive-defaults.scss
+++ b/common/styles/base/_responsive-defaults.scss
@@ -1,4 +1,5 @@
 img {
   width: 100%;
+  max-width: 100%;
   height: auto;
 }

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -448,6 +448,7 @@
 
 .width-auto {
   width: auto;
+  max-width: 100%;
 }
 
 .clearfix {


### PR DESCRIPTION
Images with `width: auto` can wind up wider than the viewport and create horizontal scrollbars (e.g. https://wellcomecollection.org/books/WwVK3CAAAHm5ExxN on a phone screen).

Limiting max-width of the `width-auto` class elements to 100% fixes it.