### PR TITLE
Hide broken 'E' link

### DIFF
--- a/common/styles/components/_buttons.scss
+++ b/common/styles/components/_buttons.scss
@@ -10,10 +10,15 @@
     cursor: pointer;
   }
 
-  &[disabled], &.disabled {
+  &[disabled],
+  &.disabled {
     background: color('pewter');
     border-color: color('pewter');
     cursor: not-allowed;
+  }
+
+  &.disabled {
+    pointer-events: none;
   }
 
   .icon {

--- a/eventbrite/app/controllers.js
+++ b/eventbrite/app/controllers.js
@@ -74,6 +74,6 @@ export async function renderEventbriteButton(ctx, next) {
 export async function renderEventbriteWidget(ctx, next) {
   const id = ctx.params.id;
   const iframeContent = await superagent.get(`https://eventbrite.com/tickets-external?eid=${id}&ref=etckt`);
-  const html = iframeContent.text;
+  const html = iframeContent.text.concat(`<style>.js-powered-by-eb-link {display: none;}</style>`);
   ctx.body = html;
 }


### PR DESCRIPTION
References #3143 

The Eventbrite widget 'E' logo has an absolute linked path, and since we were proxying it, it was linking to a route on wellcomecollection.org that doesn't exist.

The markup is built in JS, so adding a `<style>` block to the end of the iframe made more sense than trying to wait for the markup to be built and replace classes.

Also preventing clicks on `<a>`s with a `disabled` class using `pointer-events: none`. This appears to have the side-effect of preventing the `cursor: not-allowed` styling, but I'd consider this the lesser of two ills.

![screen shot 2018-08-15 at 18 08 13](https://user-images.githubusercontent.com/1394592/44161979-c25a7400-a0b6-11e8-8c26-2a5e9e59abfb.png)
