### PR TITLE
parse contribution description better

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -341,13 +341,15 @@ export function parseBoolean(fragment: PrismicFragment): boolean {
   return Boolean(fragment);
 }
 
-function parseStructuredText(maybeFragment: ?PrismicFragment): ?HTMLString {
-  return maybeFragment && isStructuredText(maybeFragment.description) ? maybeFragment.description : null;
+function parseStructuredText(maybeFragment: ?any): ?HTMLString {
+  return maybeFragment &&
+    isStructuredText((maybeFragment: HTMLString))
+    ? (maybeFragment: HTMLString) : null;
 }
 
 // Prismic return `[ { type: 'paragraph', text: '', spans: [] } ]` when you have
 // inserted text, then removed it, so we need to do this check.
-export function isStructuredText(structuredTextObject: ?HTMLString): boolean {
+export function isStructuredText(structuredTextObject: HTMLString): boolean {
   const text = asText(structuredTextObject);
   return Boolean(structuredTextObject) && (text || '').trim() !== '';
 }


### PR DESCRIPTION
Spotted by Alice.
The contribution description wasn't overriding the contributor description.
![screenshot-localhost-3003-2018 08 16-14-50-18](https://user-images.githubusercontent.com/31692/44212643-cc867c00-a163-11e8-8a70-0dc70c72fdd4.png)
