### PR TITLE
make sure you can only interact with the check tickets button once th…

### DIFF
--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -250,18 +250,29 @@ const EventPage = ({ event }: Props) => {
                         marginHeight='5'
                         marginWidth='5'
                         scrolling='auto'
-                        height='1'>
+                        height='1'
+                        style={{
+                          visibility: 'hidden',
+                          position: 'absolute'
+                        }}>
                       </iframe>
                       <script dangerouslySetInnerHTML={{ __html: `
                         (function() {
                           var iframe = document.getElementById('eventbrite-widget-${event.eventbriteId || ''}');
                           var showWidget = document.getElementById('eventbrite-show-widget-${event.eventbriteId || ''}');
+                          var haltClick = function(event) {
+                            event.preventDefault();
+                            return false;
+                          }
+                          showWidget.addEventListener('click', haltClick)
                           showWidget.classList.add('disabled');
                           showWidget.innerHTML = showWidget.innerHTML.replace('${ticketButtonText}', '${ticketButtonLoadingText}');
 
                           iframe.addEventListener('load', function() {
-                            iframe.height = iframe.contentWindow.document.body.scrollHeight;
+                            iframe.height = iframe.contentWindow.document.body.scrollHeight + 12;
                             iframe.style.display = 'none';
+                            iframe.style.visibility = 'visible';
+                            iframe.style.position = 'relative';
                             showWidget.classList.remove('disabled');
 
                             showWidget.addEventListener('click', function(event) {
@@ -272,6 +283,7 @@ const EventPage = ({ event }: Props) => {
                             });
                             showWidget.innerHTML = showWidget.innerHTML.replace('${ticketButtonLoadingText}', '${ticketButtonText}');
                             showWidget.disabled = null;
+                            showWidget.removeEventListener('click', haltClick);
                           });
                         })();
                       `}}>

--- a/server/middleware/error.js
+++ b/server/middleware/error.js
@@ -23,7 +23,7 @@ export function error(beaconError) {
         })
       });
 
-      console.error(err);
+      console.error(ctx.request.url, err);
 
       if (beaconError && (ctx.status < 400 || ctx.status >= 500)) {
         Raven.config('https://2cfb7b8ceb0a4549a4de2010b219a65d:5b48d985281a47e095a73df871b59149@sentry.io/223943').install();


### PR DESCRIPTION
…e eb widget has loaded

fixes #3184 

Forces further the inability to interact with the button until the widget has loaded.
Also uses `position: absolute` to get the page to stop jumping.

![screencast-github com-2018 08 17-09-07-29](https://user-images.githubusercontent.com/31692/44255160-0192dd00-a1fd-11e8-8550-317fe4677e3d.gif)
