### PR TITLE
Wait a second before making Eventbrite button clickable

### DIFF
--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -269,22 +269,22 @@ const EventPage = ({ event }: Props) => {
                           showWidget.innerHTML = showWidget.innerHTML.replace('${ticketButtonText}', '${ticketButtonLoadingText}');
 
                           iframe.addEventListener('load', function() {
-                            iframe.height = iframe.contentWindow.document.body.scrollHeight + 12;
-                            iframe.style.display = 'none';
-                            iframe.style.visibility = 'visible';
-                            iframe.style.position = 'relative';
-                            iframe.style.minHeight = '400px';
-                            showWidget.classList.remove('disabled');
-
-                            showWidget.addEventListener('click', function(event) {
-                              event.preventDefault();
-                              showWidget.style.display = 'none';
-                              iframe.style.display = 'block';
-                              return false;
-                            });
-                            showWidget.innerHTML = showWidget.innerHTML.replace('${ticketButtonLoadingText}', '${ticketButtonText}');
-                            showWidget.disabled = null;
-                            showWidget.removeEventListener('click', haltClick);
+                            setTimeout(function() {
+                              iframe.height = iframe.contentWindow.document.body.scrollHeight + 12;
+                              iframe.style.display = 'none';
+                              iframe.style.visibility = 'visible';
+                              iframe.style.position = 'relative';
+                              showWidget.classList.remove('disabled');
+                              showWidget.addEventListener('click', function(event) {
+                                event.preventDefault();
+                                showWidget.style.display = 'none';
+                                iframe.style.display = 'block';
+                                return false;
+                              });
+                              showWidget.innerHTML = showWidget.innerHTML.replace('${ticketButtonLoadingText}', '${ticketButtonText}');
+                              showWidget.disabled = null;
+                              showWidget.removeEventListener('click', haltClick);
+                            }, 1000);
                           });
                         })();
                       `}}>

--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -273,6 +273,7 @@ const EventPage = ({ event }: Props) => {
                             iframe.style.display = 'none';
                             iframe.style.visibility = 'visible';
                             iframe.style.position = 'relative';
+                            iframe.style.minHeight = '400px';
                             showWidget.classList.remove('disabled');
 
                             showWidget.addEventListener('click', function(event) {


### PR DESCRIPTION
It's not good enough to wait for the iframe to load to measure the content height, because the iframe's content is built with JS after it loads.

So we wait for a second to let that happen.