### PR TITLE
have "no events" mesaging on event series, and cap list to 3 events

### DIFF
--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -24,7 +24,7 @@ export function parseEventSeries(document: PrismicDocument): EventSeries {
 
 type EventSeriesProps = {| id: string |}
 export async function getEventSeries(req: Request, {
-  id
+  id, size
 }: EventSeriesProps) {
   const events = await getEvents(req, {
     seriesId: id,

--- a/common/views/components/BasePage/EventSeriesPage.js
+++ b/common/views/components/BasePage/EventSeriesPage.js
@@ -53,7 +53,7 @@ const Page = ({
     return inTheFuture;
   });
   const upcomingEventsIds = upcomingEvents.map(event => event.id);
-  const pastEvents = events.filter(event => upcomingEventsIds.indexOf(event.id) === -1);
+  const pastEvents = events.filter(event => upcomingEventsIds.indexOf(event.id) === -1).slice(0, 3);
 
   return (
     <BasePage
@@ -69,6 +69,9 @@ const Page = ({
         }
         {upcomingEvents.length > 0 &&
           <SearchResults items={upcomingEvents} title={`What's next`} />
+        }
+        {upcomingEvents.length === 0 &&
+          <h2 className='h2'>No events scheduled at the moment, check back soon…</h2>
         }
 
         {pastEvents.length > 0 &&


### PR DESCRIPTION
Ref #2989 

* Cap past events to 3 events
* Add "No events scheduled at the moment, check back soon…" messaging

<img width="371" alt="screen shot 2018-08-20 at 11 33 15" src="https://user-images.githubusercontent.com/31692/44335657-12498a00-a46d-11e8-9cdc-2c41da46ef0b.png">
