### PR TITLE
Exhibition drupal redirect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_circleci_node_8_{{ checksum "../../server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "../../server/package.json" }}
       - restore_cache:
           keys:
             - common_modules_circleci_node_8_{{ checksum "package.json" }}
@@ -202,7 +202,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_circleci_node_8_{{ checksum "../../server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "../../server/package.json" }}
       - restore_cache:
           keys:
             - common_modules_circleci_node_8_{{ checksum "package.json" }}
@@ -250,7 +250,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_circleci_node_8_{{ checksum "server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "server/package.json" }}
       - restore_cache:
           keys:
             - common_modules_circleci_node_8_{{ checksum "package.json" }}
@@ -282,7 +282,7 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
-          key: server_modules_circleci_node_8_{{ checksum "server/yarn.lock" }}
+          key: server_modules_circleci_node_8_{{ checksum "server/package.json" }}
       - restore_cache:
           keys:
             - common_modules_circleci_node_8_{{ checksum "package.json" }}

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -307,3 +307,17 @@ export async function getExhibitExhibition(req: Request, exhibitId: string): Pro
     return parseExhibitionDoc(apiResponse.results[0]);
   }
 }
+
+export async function getExhibitionFromDrupalPath(req: Request, path: string): Promise<?UiExhibition> {
+  const exhibitions = await getDocuments(req, [Prismic.Predicates.at('my.exhibitions.drupalPath', path)], {
+    fetchLinks: peopleFields.concat(
+      contributorsFields,
+      placesFields,
+      installationFields
+    )
+  });
+
+  if (exhibitions.results.length > 0) {
+    return parseExhibitionDoc(exhibitions.results[0]);
+  }
+}

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -429,7 +429,7 @@ export async function searchForDrupalRedirect(ctx, next) {
   if (page) {
     superagent.post(gaPath)
       .type('form')
-      .send(Object.assign({}, baseGaPayload, {el: `from:${path} to: /pages/${page.id}`}));
+      .send(Object.assign({}, baseGaPayload, {el: path}));
 
     ctx.status = 301;
     ctx.redirect(`/pages/${page.id}`);
@@ -439,7 +439,7 @@ export async function searchForDrupalRedirect(ctx, next) {
     if (exhibition) {
       superagent.post(gaPath)
         .type('form')
-        .send(Object.assign({}, baseGaPayload, {el: `from:${path} to: /exhibitions/${exhibition.id}`}));
+        .send(Object.assign({}, baseGaPayload, {el: path}));
 
       ctx.status = 301;
       // TODO: this _should_ work, but seems like micro-proxy doesn't honour

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -20,8 +20,8 @@ import {search} from '../../common/services/prismic/search';
 import {getCollectionOpeningTimes} from '../../common/services/prismic/opening-times';
 import {isPreview as getIsPreview} from '../../common/services/prismic/api';
 import superagent from 'superagent';
-
 import {dailyTourPromo} from '../../server/data/facility-promos';
+import uuidv4 from 'uuid/v4';
 
 export const renderOpeningTimes = async(ctx, next) => {
   const path = ctx.request.url;
@@ -419,7 +419,7 @@ export async function searchForDrupalRedirect(ctx, next) {
   const baseGaPayload = {
     v: 1,
     tid: 'UA-55614-6',
-    cid: 555,
+    cid: uuidv4(),
     t: 'event',
     ec: 'Server',
     ea: 'Redirect'

--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -13,6 +13,7 @@ import {london} from '../filters/format-date';
 import {PromoListFactory} from '../model/promo-list';
 import {PaginationFactory} from '../model/pagination';
 import {getPage, getPageFromDrupalPath} from '../../common/services/prismic/pages';
+import {getExhibitionFromDrupalPath} from '../../common/services/prismic/exhibitions';
 import {getBook} from '../../common/services/prismic/books';
 import {getPlace} from '../../common/services/prismic/places';
 import {search} from '../../common/services/prismic/search';
@@ -418,6 +419,13 @@ export async function searchForDrupalRedirect(ctx, next) {
   if (page) {
     ctx.status = 301;
     ctx.redirect(`/pages/${page.id}`);
+  } else  {
+    const exhibition = await getExhibitionFromDrupalPath(ctx.request, `/${path}`);
+
+    if (exhibition) {
+      ctx.status = 301;
+      ctx.redirect(`/exhibitions/${exhibition.id}`);
+    }
   }
 
   return next();

--- a/server/package.json
+++ b/server/package.json
@@ -52,6 +52,7 @@
     "rimraf": "^2.6.1",
     "superagent": "^3.6.0",
     "supertest": "^3.0.0",
+    "uuid": "^3.3.2",
     "webpack": "^3.8.1"
   },
   "devDependencies": {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -6053,6 +6053,10 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 v8-compile-cache@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-1.1.2.tgz#8d32e4f16974654657e676e0e467a348e89b0dc4"


### PR DESCRIPTION
Catching old exhibitions that we have back-filled and redirecting to them on the V2 site rather than going to Drupal. Also, adding analytics to report that this has happened (saying where we redirected from and to).

A couple of things to note
1. I've not managed to see this working locally (using `micro-proxy`) but can't see why it wouldn't work in prod (not ideal)
2. I've not seen any evidence of the GA events showing up in GA – not sure if this is because we filter out events from localhost, or if I've not configured it correctly.

Lots of eyes and suggestions welcome.

Not got any reason to believe that this (a) wouldn't work or (b) would break anything even if it didn't work, but probably safest not to merge until after the bank holiday.