### PR TITLE
Re-align labels

### DIFF
--- a/common/views/components/BasePage/EventPage.js
+++ b/common/views/components/BasePage/EventPage.js
@@ -138,7 +138,8 @@ const EventPage = ({ event }: Props) => {
         <LabelsList labels={(eventFormat.concat(eventAudiences, eventInterpretations))} />
         {event.series.length > 0 && (
           <div className='flex-inline flex--v-center' style={{whiteSpace: 'nowrap'}}>
-            <p className={`${font({s: 'HNL5'})} ${spacing({s: 0}, {margin: ['bottom']})} ${spacing({s: 1}, {margin: ['right', 'top']})} inline-block no-padding`}>{'Part of '}</p>
+            <p className={`${font({s: 'HNL5'})} ${spacing({s: 0}, {margin: ['bottom']})} ${spacing({s: 1}, {margin: ['right']})} inline-block no-padding`}
+              style={{marginTop: '3px'}}>{'Part of '}</p> {/* TODO: revisit 3px as part of spacing system */}
             {event.series.length > 0 && <LabelsList labels={event.series.map((series) => {
               return {
                 url: `/event-series/${series.id}`,


### PR DESCRIPTION
Fixes #3226

When the vertical spacing between labels changed from 6px to 3px in #3219, it had the knock-on effect of mis-aligning the linked labels.

This PR fixes the alignment with an inline style, but as 3px is looking like a necessary spacing unit for at least a few things, we should consider how we're going to incorporate it into our spacing strategy.

![screen shot 2018-08-24 at 12 47 51](https://user-images.githubusercontent.com/1394592/44583140-f0694380-a79b-11e8-90c4-ce65096b775d.png)