### PR TITLE
Align bulleted lists better

### DIFF
--- a/common/styles/components/_body_text.scss
+++ b/common/styles/components/_body_text.scss
@@ -22,6 +22,7 @@
 
     li {
       margin-bottom: $spacing-unit;
+      padding-left: $spacing-unit * 2;
 
       &:before {
         content: '';
@@ -32,6 +33,7 @@
         border-radius: 0.1em;
         background: color('currentColor');
         margin-right: $spacing-unit;
+        margin-left: $spacing-unit * -2;
       }
 
       &:last-child {


### PR DESCRIPTION
Fixes #3223.

Indenting all list item lines the same amount.

![screen shot 2018-08-24 at 17 22 18](https://user-images.githubusercontent.com/1394592/44595912-6aacbe80-a7c2-11e8-81c3-613e9c0aaacb.png)
