### PR TITLE
Remove unused london variable

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -9,7 +9,6 @@ import {
   getArticle, getSeriesAndArticles, getArticleList, getCuratedList,
   defaultPageSize, getExhibitionAndEventPromos
 } from '../services/prismic';
-import {london} from '../filters/format-date';
 import {PromoListFactory} from '../model/promo-list';
 import {PaginationFactory} from '../model/pagination';
 import {getPage, getPageFromDrupalPath} from '../../common/services/prismic/pages';
@@ -62,9 +61,7 @@ export const renderOpeningTimes = async(ctx, next) => {
 
 export async function renderHomepage(ctx, next) {
   const path = ctx.request.url;
-  const todaysDate = london();
-  const todaysDatePlusSix = todaysDate.clone().add(6, 'days');
-  const exhibitionAndEventPromos = await getExhibitionAndEventPromos({startDate: todaysDate.format('YYYY-MM-DD'), endDate: todaysDatePlusSix.format('YYYY-MM-DD')}, ctx.intervalCache.get('collectionOpeningTimes'));
+  const exhibitionAndEventPromos = await getExhibitionAndEventPromos('this-week', ctx.intervalCache.get('collectionOpeningTimes'));
   const contentList = await getArticleList();
   const storiesPromos = contentList.results.map(PromoFactory.fromArticleStub).slice(0, 4);
 

--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -486,14 +486,22 @@ function getListHeader(dates, collectionOpeningTimes) {
   };
 }
 
+function getMomentsForPeriod(period) {
+  const todaysDate = london();
+  const todaysDatePlusSix = todaysDate.clone().add(6, 'days');
+
+  switch (period) {
+    case 'today': return [todaysDate.startOf('day'), todaysDate.endOf('day')];
+    case 'this-weekend': return [getWeekendFromDate(todaysDate), getWeekendToDate(todaysDate)];
+    // FIXME: this isn't really 'this week', but the 'next seven days' (needs UX/content rethink?)
+    case 'this-week': return [todaysDate.startOf('day'), todaysDatePlusSix.endOf('day')];
+    default: return [todaysDate.startOf('day'), undefined];
+  }
+}
+
 export async function getExhibitionAndEventPromos(dateRange, collectionOpeningTimes) {
   const todaysDate = london();
-
-  const [fromDateMoment, toDateMoment] =
-    dateRange === 'today' ? [todaysDate.startOf('day'), todaysDate.endOf('day')]
-      : dateRange === 'this-weekend' ? [getWeekendFromDate(todaysDate), getWeekendToDate(todaysDate)]
-        : [todaysDate.startOf('day'), undefined];
-
+  const [fromDateMoment, toDateMoment] = getMomentsForPeriod(dateRange);
   const fromDate = fromDateMoment.format('YYYY-MM-DD');
   const toDate  = toDateMoment ? toDateMoment.format('YYYY-MM-DD') : undefined;
 


### PR DESCRIPTION
Only show next seven days event/exhibition cards on homepage.

The call to `getExhibitionAndEventPromos` on the homepage didn't get updated [here](https://github.com/wellcometrust/wellcomecollection.org/commit/829648f339f26fde5738b84b0c1df5db9c4303d9).