### PR TITLE
use polyfill with next app

### DIFF
--- a/common/views/pages/_document.js
+++ b/common/views/pages/_document.js
@@ -1,5 +1,4 @@
 // @flow
-import {Fragment} from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 
 export default function WeDoc(css: string) {
@@ -13,17 +12,17 @@ export default function WeDoc(css: string) {
     }
 
     render() {
+      const polyfillFeatures = [
+        'default',
+        'Array.prototype.find',
+        'Array.prototype.includes'
+      ];
       return (
         <html id='top' lang='en'>
           <Head>
-            {this.props.usePolyfill &&
-              <Fragment>
-                <script src='https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.23.0/polyfill.min.js' />
-                <script src='https://cdn.polyfill.io/v2/polyfill.min.js'></script>
-              </Fragment>
-            }
+            <script src={`https://cdn.polyfill.io/v2/polyfill.js?features=${polyfillFeatures.join(',')}`}></script>
+            <script dangerouslySetInnerHTML={{ __html: `` }}></script>
             <style dangerouslySetInnerHTML={{ __html: css }} />
-
           </Head>
           <body>
             <Main />


### PR DESCRIPTION
Turns out we were using the `user-agent` header to work out whether to server polyfill.
We don't send that header through due to our cache control, and rightfully so.

So now we serve up polyfill to all, which for chrome looks like this:
![screen shot 2018-08-29 at 14 35 31](https://user-images.githubusercontent.com/31692/44791222-0ceced80-ab99-11e8-8f97-a29042bc06a5.png)

It feels like being able to move onto the new platform and start optimising from there over rules the 50ms.

Fixes #3240 