### PR TITLE
replace nbsp on wordpress standfirst

### DIFF
--- a/server/utils/body-parser.js
+++ b/server/utils/body-parser.js
@@ -172,7 +172,7 @@ function convertWpStandfirst(node) {
     type: 'standfirst',
     value: [{
       type: 'paragraph',
-      text: striptags(serializeAndCleanNode(unwrapFromEm(node))),
+      text: striptags(serializeAndCleanNode(unwrapFromEm(node))).replace(/&nbsp;/g, ' '),
       spans: []
     }]
   });


### PR DESCRIPTION
💥 from the past:
https://wellcomecollection.org/articles/why-the-world-needs-collectors/