### PR TITLE
Fix nav underline for stories content

### DIFF
--- a/server/controllers/content.js
+++ b/server/controllers/content.js
@@ -118,7 +118,7 @@ export const renderArticle = async(ctx, next) => {
         pageConfig: Object.assign({}, createPageConfig({
           path: path,
           title: article.headline,
-          inSection: 'explore',
+          inSection: 'stories',
           category: 'editorial',
           canonicalUri: `${ctx.globals.rootDomain}/articles/${id}`
         }), trackingInfo),
@@ -241,7 +241,7 @@ export async function renderWebcomicSeries(ctx, next) {
       pageConfig: createPageConfig({
         path: path,
         title: series.name,
-        inSection: 'explore',
+        inSection: 'stories',
         category: 'editorial'
       }),
       description: series.description,
@@ -276,7 +276,7 @@ export async function renderSeries(ctx, next) {
       pageConfig: createPageConfig({
         path: path,
         title: series.name,
-        inSection: 'explore',
+        inSection: 'stories',
         category: 'editorial'
       }),
       description: series.description,
@@ -309,7 +309,7 @@ export async function renderArticlesList(ctx, next) {
     pageConfig: createPageConfig({
       path: path,
       title: 'Articles',
-      inSection: 'explore',
+      inSection: 'stories',
       category: 'editorial'
     }),
     list: promoList,

--- a/server/controllers/wordpress.js
+++ b/server/controllers/wordpress.js
@@ -21,7 +21,7 @@ export const article = async(ctx, next) => {
       const pageConfig = createPageConfig(Object.assign({}, {
         path: path,
         title: article.headline,
-        inSection: 'explore',
+        inSection: 'stories',
         category: 'editorial'
       }, editorialAnalyticsInfo));
 
@@ -49,7 +49,7 @@ export const articles = async(ctx, next) => {
     pageConfig: createPageConfig({
       path: path,
       title: 'Articles',
-      inSection: 'explore',
+      inSection: 'stories',
       category: 'editorial'
     }),
     list: promoList,
@@ -70,7 +70,7 @@ export const series = async(ctx, next) => {
       pageConfig: createPageConfig({
         path: path,
         title: series.name,
-        inSection: 'explore',
+        inSection: 'stories',
         category: 'editorial',
         seriesUrl: id
       }),
@@ -97,7 +97,7 @@ export const preview = async(ctx, next) => {
         pageConfig: createPageConfig({
           path: path,
           title: article.headline,
-          inSection: 'explore'
+          inSection: 'stories'
         }),
         article: article
       });


### PR DESCRIPTION
`inSection` in the `pageConfig` needed updating from 'explore' to 'stories' in all places where we'd expect 'Stories' to be underlined in the nav.

![screen shot 2018-09-05 at 12 58 45](https://user-images.githubusercontent.com/1394592/45091796-73c75500-b10b-11e8-8300-4d42bfa31fe0.png)
