### PR TITLE
add crops to article body slices

### DIFF
--- a/prismic-model/js/parts/article-body.js
+++ b/prismic-model/js/parts/article-body.js
@@ -61,53 +61,8 @@ export default {
           }
         }
       },
-      'editorialImage': {
-        'type': 'Slice',
-        'fieldset': 'Editorial image',
-        'non-repeat': {
-          'caption': {
-            'type': 'StructuredText',
-            'config': {
-              'single': 'hyperlink, bold, em',
-              'label': 'Caption'
-            }
-          },
-          'image': {
-            'type': 'Image',
-            'config': {
-              'label': 'Image'
-            }
-          }
-        }
-      },
-      'editorialImageGallery': {
-        'type': 'Slice',
-        'fieldset': 'Editorial image gallery',
-        'non-repeat': {
-          'title': {
-            'type': 'StructuredText',
-            'config': {
-              'label': 'title',
-              'single': 'heading1'
-            }
-          }
-        },
-        'repeat': {
-          'caption': {
-            'type': 'StructuredText',
-            'config': {
-              'label': 'Caption',
-              'single': 'hyperlink, bold, em'
-            }
-          },
-          'image': {
-            'type': 'Image',
-            'config': {
-              'label': 'Image'
-            }
-          }
-        }
-      },
+      'editorialImage': body.config.choices.editorialImage,
+      'editorialImageGallery': body.config.choices.editorialImageGallery,
       'gifVideo': {
         'type': 'Slice',
         'fieldset': 'Gif video',

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -105,47 +105,82 @@
           },
           "editorialImage": {
             "type": "Slice",
-            "fieldset": "Editorial image",
+            "fieldset": "Captioned image",
             "non-repeat": {
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "hyperlink, bold, em",
-                  "label": "Caption"
-                }
-              },
               "image": {
                 "type": "Image",
                 "config": {
-                  "label": "Image"
+                  "label": "Image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
+                }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
                 }
               }
             }
           },
           "editorialImageGallery": {
             "type": "Slice",
-            "fieldset": "Editorial image gallery",
+            "fieldset": "Image gallery",
             "non-repeat": {
               "title": {
                 "type": "StructuredText",
                 "config": {
-                  "label": "title",
-                  "single": "heading1"
+                  "label": "Title",
+                  "single": "heading1",
+                  "useAsTitle": true
                 }
               }
             },
             "repeat": {
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "label": "Caption",
-                  "single": "hyperlink, bold, em"
-                }
-              },
               "image": {
                 "type": "Image",
                 "config": {
-                  "label": "Image"
+                  "label": "Image",
+                  "thumbnails": [
+                    {
+                      "name": "32:15",
+                      "width": 3200,
+                      "height": 1500
+                    },
+                    {
+                      "name": "16:9",
+                      "width": 3200,
+                      "height": 1800
+                    },
+                    {
+                      "name": "square",
+                      "width": 3200,
+                      "height": 3200
+                    }
+                  ]
+                }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
                 }
               }
             }


### PR DESCRIPTION
Annoyingly this means we don't have square crops for most the content.

~I'm not 100% sure if a reimport would do this for us, as, I think, re-saving does.~
Scrap ☝️ - were just going to have to accept we don't have them.