### PR TITLE
Order upcoming/past event series events

### DIFF
--- a/common/views/components/BasePage/EventSeriesPage.js
+++ b/common/views/components/BasePage/EventSeriesPage.js
@@ -55,9 +55,11 @@ const Page = ({
     const lastStartTime = event.times.length > 0 ? event.times[event.times.length - 1].range.startDateTime : null;
     const inTheFuture = lastStartTime ? new Date(lastStartTime) > new Date() : false;
     return inTheFuture;
-  });
+  }).sort((a, b) => a.dateRange.firstDate - b.dateRange.firstDate);
   const upcomingEventsIds = upcomingEvents.map(event => event.id);
-  const pastEvents = events.filter(event => upcomingEventsIds.indexOf(event.id) === -1).slice(0, 3);
+  const pastEvents = events.filter(event => upcomingEventsIds.indexOf(event.id) === -1)
+    .sort((a, b) => b.dateRange.firstDate - a.dateRange.firstDate)
+    .slice(0, 3);
 
   return (
     <BasePage


### PR DESCRIPTION
@pollecuttn was asking what the ordering logic was for the event series events.

It appears to be just whatever Prismic gives us (unsure exactly what that is – not obvious at a glance).

This PR assumes that we'd want _upcoming_ events to be ordered chronologically and _past_ events to be ordered reverse chronologically.

Don't know that this is the desired behaviour, but leaving this here so we don't forget to address the issue.