### PR TITLE
Exhibition resources

### DIFF
--- a/prismic-model/js/exhibition-resources.js
+++ b/prismic-model/js/exhibition-resources.js
@@ -3,11 +3,11 @@ import select from './parts/select';
 
 const typeLabel = 'Exhibition resource';
 const labelObject = label(typeLabel);
-const labelObjectWithIcon = {
+const exhibitionResources = {
   [typeLabel]: {
     ...labelObject[typeLabel],
     icon: select('Icon type', ['information', 'family'])
   }
 };
 
-export default labelObjectWithIcon;
+export default exhibitionResources;

--- a/prismic-model/js/exhibition-resources.js
+++ b/prismic-model/js/exhibition-resources.js
@@ -1,0 +1,13 @@
+import label from './types/label';
+import select from './parts/select';
+
+const typeLabel = 'Exhibition resource';
+const labelObject = label(typeLabel);
+const labelObjectWithIcon = {
+  [typeLabel]: {
+    ...labelObject[typeLabel],
+    icon: select('Icon type', ['information', 'family'])
+  }
+};
+
+export default labelObjectWithIcon;

--- a/prismic-model/js/exhibitions.js
+++ b/prismic-model/js/exhibitions.js
@@ -86,6 +86,11 @@ const Exhibitions = {
       }
     }
   },
+  Resources: {
+    resources: list('Resources', {
+      resource: link('Resource', 'document', ['exhibition-resources'])
+    })
+  },
   Migration: {
     drupalPromoImage: link('Drupal promo image', 'web'),
     drupalNid: text('Drupal node ID'),

--- a/prismic-model/json/exhibition-resources.json
+++ b/prismic-model/json/exhibition-resources.json
@@ -1,0 +1,29 @@
+{
+  "Exhibition resource": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Title",
+        "single": "heading1",
+        "useAsTitle": true
+      }
+    },
+    "description": {
+      "type": "StructuredText",
+      "config": {
+        "multi": "paragraph,hyperlink,strong,em",
+        "label": "Description"
+      }
+    },
+    "icon": {
+      "type": "Select",
+      "config": {
+        "label": "Icon type",
+        "options": [
+          "information",
+          "family"
+        ]
+      }
+    }
+  }
+}

--- a/prismic-model/json/exhibitions.json
+++ b/prismic-model/json/exhibitions.json
@@ -461,6 +461,26 @@
       }
     }
   },
+  "Resources": {
+    "resources": {
+      "type": "Group",
+      "fieldset": "Resources",
+      "config": {
+        "fields": {
+          "resource": {
+            "type": "Link",
+            "config": {
+              "label": "Resource",
+              "select": "document",
+              "customtypes": [
+                "exhibition-resources"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
   "Migration": {
     "drupalPromoImage": {
       "type": "Link",


### PR DESCRIPTION
References #3009

Adds a Prismic model for exhibition-resources and updates the exhibitions model to allow for linking to them
