### PR TITLE
exclude articles with wordpress tag

### DIFF
--- a/server/services/prismic.js
+++ b/server/services/prismic.js
@@ -130,7 +130,7 @@ export async function getArticleList(page = 1, {pageSize = 10, predicates = []} 
   const prismic = await prismicApi();
   const articlesList = await prismic.query([
     Prismic.Predicates.any('document.type', ['articles', 'webcomics']),
-    Prismic.Predicates.not('document.tags', ['delist'])
+    Prismic.Predicates.not('document.tags', ['delist', 'wordpress'])
   ].concat(predicates), {fetchLinks, page, pageSize, orderings});
 
   const articlesAsArticles = articlesList.results.map(result => {


### PR DESCRIPTION
Plan

* exclude `wordpress` tagged content
* reindex the content with the time in the proper format

