### PR TITLE
Exhibition meta

### DIFF
--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -13,6 +13,7 @@ import Body from '@weco/common/views/components/Body/Body';
 import InfoBox from '@weco/common/views/components/InfoBox/InfoBox';
 import type {UiExhibition} from '@weco/common/model/exhibitions';
 import {font} from '@weco/common/utils/classnames';
+import {convertImageUri} from '@weco/common/utils/convert-image-uri';
 
 type Props = {|
   exhibition: UiExhibition
@@ -136,7 +137,7 @@ ExhibitionPage.getInitialProps = async ({req, query}) => {
       return {
         type: 'website',
         title: exhibition.title,
-        imageUrl: exhibition.promoImage && exhibition.promoImage.contentUrl,
+        imageUrl: exhibition.promoImage && convertImageUri(exhibition.promoImage.contentUrl, 800),
         description: exhibition.promoText,
         canonicalUrl: `https://wellcomecollection.org/exhibitions/${exhibition.id}`,
         exhibition

--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -134,7 +134,11 @@ ExhibitionPage.getInitialProps = async ({req, query}) => {
 
     if (exhibition) {
       return {
+        type: 'website',
         title: exhibition.title,
+        imageUrl: exhibition.promoImage && exhibition.promoImage.contentUrl,
+        description: exhibition.promoText,
+        canonicalUrl: `https://wellcomecollection.org/exhibitions/${exhibition.id}`,
         exhibition
       };
     }


### PR DESCRIPTION
References #3009

## Who is this for?
People who want to share/browse our content on social media platforms

## What is it doing for them?
Allowing Twitter et al. to display content snippets when wellcomecollection.org links are shared on their platforms

![screen shot 2018-09-11 at 14 24 51](https://user-images.githubusercontent.com/6051896/45363681-09615980-b5d0-11e8-9684-9eab81006c48.png)
