### PR TITLE
Filter out irrelevant event times from schedule

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -363,10 +363,16 @@ export function groupEventsBy(events: UiEvent[], groupBy: GroupDatesBy): EventsG
         return (time.range.startDateTime >= start && time.range.endDateTime <= end);
       });
 
-      return Object.assign({}, event, {times: timesInRange});
+      return {
+        ...event,
+        times: timesInRange
+      };
     });
 
-    return Object.assign({}, range, {events});
+    return {
+      ...range,
+      events
+    };
   });
 
   return rangesWithFilteredTimes;

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -307,6 +307,7 @@ type EventsGroup = {|
   end: Date,
   events: UiEvent[]
 |}
+
 export function groupEventsBy(events: UiEvent[], groupBy: GroupDatesBy): EventsGroup[] {
   // Get the full range of all the events
   const range = events.map(({times}) => times.map(time => ({
@@ -353,7 +354,22 @@ export function groupEventsBy(events: UiEvent[], groupBy: GroupDatesBy): EventsG
     });
   }, {});
 
-  return ranges;
+  // Remove times from event that fall outside the range of the current event group it is in
+  const rangesWithFilteredTimes = ranges.map((range) => {
+    const start = range.start;
+    const end = range.end;
+    const events = range.events.map((event) => {
+      const timesInRange = event.times.filter((time) => {
+        return (time.range.startDateTime >= start && time.range.endDateTime <= end);
+      });
+
+      return Object.assign({}, event, {times: timesInRange});
+    });
+
+    return Object.assign({}, range, {events});
+  });
+
+  return rangesWithFilteredTimes;
 }
 
 // TODO: maybe use a Map?


### PR DESCRIPTION
On the event schedule, multi date events are listed separately for each day on which they occur.
However, for each day, they are displaying the times for all of the days on which they occur:

![screen-shot-2018-09-11-at-17 03 16](https://user-images.githubusercontent.com/6051896/45372494-07ee5c00-b5e5-11e8-94be-92f8e56586f8.gif)

This fixes that so only the times of the relevant day are displayed:

<img width="879" alt="screen shot 2018-09-11 at 16 52 48" src="https://user-images.githubusercontent.com/6051896/45372366-b34ae100-b5e4-11e8-9109-df09e65bb6dc.png">



