### PR TITLE
Exhibition header update

### DIFF
--- a/cardigan/stories/components/WobblyBottom.js
+++ b/cardigan/stories/components/WobblyBottom.js
@@ -11,7 +11,7 @@ const WobblyBottomExample = () => {
   return (
     <Fragment>
       <h2 className='h2'>An image</h2>
-      <WobblyBottom>
+      <WobblyBottom color='cream'>
         <UiImage {...image()} isFull={true} />
       </WobblyBottom>
 
@@ -21,7 +21,7 @@ const WobblyBottomExample = () => {
       }} />
 
       <h2>A headline</h2>
-      <WobblyBottom>
+      <WobblyBottom color='cream'>
         <h1 className='h1'>Old man yells at cloud</h1>
       </WobblyBottom>
     </Fragment>

--- a/common/data/the-pharmacy-of-colour.js
+++ b/common/data/the-pharmacy-of-colour.js
@@ -74,22 +74,6 @@ const data = ({
       copyrightLink: null
     },
     crops: {}
-  },
-  thinImage: {
-    contentUrl: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/6ee9f05e16a7f7e63ac98064059953457bcce704_ep_000423_001.jpg',
-    width: 3200,
-    height: 1500,
-    alt: 'null',
-    tasl: {
-      title: null,
-      author: null,
-      sourceName: null,
-      sourceLink: null,
-      license: null,
-      copyrightHolder: null,
-      copyrightLink: null
-    },
-    crops: {}
   }
 }: Installation);
 

--- a/common/model/exhibitions.js
+++ b/common/model/exhibitions.js
@@ -49,7 +49,6 @@ export type ExhibitionPromo = {|
   title: string,
   image: ImageType,
   squareImage: ?Picture;
-  thinImage: ?Picture;
   description: string,
   start: Date,
   end: ?Date,

--- a/common/model/generic-content-fields.js
+++ b/common/model/generic-content-fields.js
@@ -19,6 +19,5 @@ export type GenericContentFields = {|
   promoImage: ?Picture,
   image: ?ImageType,
   squareImage: ?ImageType,
-  widescreenImage: ?ImageType,
-  thinImage: ?ImageType
+  widescreenImage: ?ImageType
 |}

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -152,7 +152,6 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
       title,
       image: promoImage.image,
       squareImage: promoSquare && promoSquare.image,
-      thinImage: promoThin && promoThin.image,
       description: (promoThin && promoThin.caption) || '',
       start,
       end,

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -519,12 +519,11 @@ export function parseGenericFields(doc: PrismicFragment): GenericContentFields {
       const originalImage = isImageLink(image) && parseImage(image);
       const squareImage = image.square && isImageLink(image.square) && parseImage(image.square);
       const widescreenImage = image['16:9'] && isImageLink(image['16:9']) && parseImage(image['16:9']);
-      const thinImage = image['32:15'] && isImageLink(image['32:15']) && parseImage(image['32:15']);
 
-      return {image: originalImage, squareImage, widescreenImage, thinImage};
+      return {image: originalImage, squareImage, widescreenImage};
     }).find(_ => _) : {}; // just get the first one;
 
-  const {image, squareImage, widescreenImage, thinImage} = promoImages;
+  const {image, squareImage, widescreenImage} = promoImages;
   return {
     id: doc.id,
     title: parseTitle(data.title),
@@ -536,7 +535,6 @@ export function parseGenericFields(doc: PrismicFragment): GenericContentFields {
     promoImage: promo && promo.image,
     image,
     squareImage,
-    widescreenImage,
-    thinImage
+    widescreenImage
   };
 }

--- a/common/views/components/BaseHeader/BaseHeader.js
+++ b/common/views/components/BaseHeader/BaseHeader.js
@@ -40,7 +40,7 @@ export function getFeaturedMedia(
   isPicture?: boolean
 ): ?FeaturedMedia {
   const image = fields.promo && fields.promo.image;
-  const { squareImage, widescreenImage, thinImage } = fields;
+  const { squareImage, widescreenImage } = fields;
   const {body} = fields;
   const tasl: ?Tasl = image && {
     title: image.title,
@@ -53,9 +53,9 @@ export function getFeaturedMedia(
   };
   const hasFeaturedVideo = body.length > 0 && body[0].type === 'videoEmbed';
   const FeaturedMedia = hasFeaturedVideo
-    ? <VideoEmbed {...body[0].value} /> : isPicture && thinImage && squareImage
+    ? <VideoEmbed {...body[0].value} /> : isPicture && widescreenImage && squareImage
       ? <Picture
-        images={[{...thinImage, minWidth: breakpoints.medium}, {...squareImage, minWidth: null}]}
+        images={[{...widescreenImage, minWidth: breakpoints.medium}, {...squareImage, minWidth: null}]}
         isFull={true} />
       : image && tasl ? <UiImage tasl={tasl} {...widescreenImage} sizesQueries='' /> : null;
 

--- a/common/views/components/BaseHeader/BaseHeader.js
+++ b/common/views/components/BaseHeader/BaseHeader.js
@@ -13,7 +13,7 @@ import type {Link} from '../../../model/link';
 import HeaderText from '../HeaderText/HeaderText';
 import FreeSticker from '../FreeSticker/FreeSticker';
 import Picture from '../Picture/Picture';
-import {BasePageColumn} from '../BasePage/BasePage';
+import TextLayout from '../TextLayout/TextLayout';
 
 export type FeaturedMedia =
   | Element<typeof UiImage>
@@ -88,7 +88,7 @@ const BaseHeader = ({
         backgroundSize: BackgroundComponent ? null : '150%'
       }}>
         {BackgroundComponent}
-        <BasePageColumn>
+        <TextLayout>
           {isFree &&
             <div className='relative'>
               <FreeSticker />
@@ -114,7 +114,7 @@ const BaseHeader = ({
               {LabelBar}
             </div>
           }
-        </BasePageColumn>
+        </TextLayout>
       </div>
     </Fragment>
   );

--- a/common/views/components/BasePage/BasePage.js
+++ b/common/views/components/BasePage/BasePage.js
@@ -1,9 +1,9 @@
 // @flow
 import {Fragment} from 'react';
-import {grid} from '../../../utils/classnames';
 import type {Node} from 'react';
 import type BaseHeader from '../BaseHeader/BaseHeader';
 import type Body from '../Body/Body';
+import TextLayout from '../TextLayout/TextLayout';
 
 type Props = {|
   id: string,
@@ -11,16 +11,6 @@ type Props = {|
   Body: Body,
   children?: ?Node
 |}
-
-export const BasePageColumn = ({children}: {| children: Node |}) => (
-  <div className='container'>
-    <div className='grid'>
-      <div className={`${grid({s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2})}`}>
-        {children}
-      </div>
-    </div>
-  </div>
-);
 
 const BasePage = ({
   id,
@@ -36,9 +26,9 @@ const BasePage = ({
       </div>
 
       {children &&
-        <BasePageColumn>
+        <TextLayout>
           {children}
-        </BasePageColumn>
+        </TextLayout>
       }
     </article>
   );

--- a/common/views/components/BasePage/EventSeriesPage.js
+++ b/common/views/components/BasePage/EventSeriesPage.js
@@ -32,8 +32,7 @@ const Page = ({
     promoText: series.promoText,
     image: series.image,
     squareImage: series.squareImage,
-    widescreenImage: series.widescreenImage,
-    thinImage: series.thinImage
+    widescreenImage: series.widescreenImage
   });
   const TagBar = <Tags tags={[{
     text: 'Event series'

--- a/common/views/components/BasePage/InstallationPage.js
+++ b/common/views/components/BasePage/InstallationPage.js
@@ -30,8 +30,7 @@ const InstallationPage = ({
     promoText: installation.promoText,
     image: installation.image,
     squareImage: installation.squareImage,
-    widescreenImage: installation.widescreenImage,
-    thinImage: installation.thinImage
+    widescreenImage: installation.widescreenImage
   });
   const Header = (<BaseHeader
     title={installation.title}

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -60,7 +60,7 @@ const Body = ({ body, isCreamy = false }: Props) => {
             slice.weight === 'featured' &&
             slice.value.image.crops.square &&
             <FullWidthLayout>
-              <WobblyBottom>
+              <WobblyBottom color='cream'>
                 <PictureFromImages images={{
                   [breakpoints.medium]: slice.value.image.crops['16:9'],
                   'default': slice.value.image.crops.square
@@ -72,7 +72,7 @@ const Body = ({ body, isCreamy = false }: Props) => {
             slice.weight === 'featured' &&
             !slice.value.image.crops.square &&
             <FullWidthLayout>
-              <WobblyBottom>
+              <WobblyBottom color='cream'>
                 <UiImage {...slice.value.image} isFull={true} />
               </WobblyBottom>
             </FullWidthLayout>

--- a/common/views/components/ExhibitionHeader/ExhibitionHeader.js
+++ b/common/views/components/ExhibitionHeader/ExhibitionHeader.js
@@ -2,7 +2,7 @@
 
 import {Fragment} from 'react';
 import HeaderText from '../HeaderText/HeaderText';
-import WobblyEdge from '../WobblyEdge/WobblyEdge';
+import WobblyBottom from '../WobblyBottom/WobblyBottom';
 import FreeSticker from '../FreeSticker/FreeSticker';
 import {BasePageColumn} from '../BasePage/BasePage';
 import {classNames, spacing} from '../../../utils/classnames';
@@ -39,12 +39,11 @@ const ExhibitionHeader = ({
       <div className='relative'>
         <div className={classNames({
           'margin-h-auto': true,
-          [spacing({xl: 4}, {padding: ['left', 'right']})]: true
+          [spacing({s: 2, m: 4}, {padding: ['left', 'right']})]: true
         })} style={{maxWidth: '1450px'}}>
-          {FeaturedMedia}
-        </div>
-        <div style={{position: 'sticky', bottom: 0}}>
-          <WobblyEdge background='white' />
+          <WobblyBottom color='white'>
+            {FeaturedMedia}
+          </WobblyBottom>
         </div>
       </div>
     </Fragment>

--- a/common/views/components/ExhibitionHeader/ExhibitionHeader.js
+++ b/common/views/components/ExhibitionHeader/ExhibitionHeader.js
@@ -24,12 +24,19 @@ const ExhibitionHeader = ({
 }: Props) => {
   return (
     <Fragment>
+      <BasePageColumn>
+        <div className='relative' style={{zIndex: 1}}>
+          <FreeSticker />
+        </div>
+        <HeaderText
+          topLink={{url: '/exhibitions', text: 'Exhibitions'}}
+          Heading={<h1 className='h0 inline-block no-margin'>{title}</h1>}
+          DateInfo={DateInfo}
+          InfoBar={InfoBar}
+          Description={null}
+          TagBar={null} />
+      </BasePageColumn>
       <div className='relative'>
-        <BasePageColumn>
-          <div className='relative' style={{zIndex: 1}}>
-            <FreeSticker />
-          </div>
-        </BasePageColumn>
         <div className={classNames({
           'margin-h-auto': true,
           [spacing({xl: 4}, {padding: ['left', 'right']})]: true
@@ -40,15 +47,6 @@ const ExhibitionHeader = ({
           <WobblyEdge background='white' />
         </div>
       </div>
-      <BasePageColumn>
-        <HeaderText
-          topLink={{url: '/exhibitions', text: 'Exhibitions'}}
-          Heading={<h1 className='h0 inline-block no-margin'>{title}</h1>}
-          DateInfo={DateInfo}
-          InfoBar={InfoBar}
-          Description={null}
-          TagBar={null} />
-      </BasePageColumn>
     </Fragment>
   );
 };

--- a/common/views/components/ExhibitionHeader/ExhibitionHeader.js
+++ b/common/views/components/ExhibitionHeader/ExhibitionHeader.js
@@ -4,7 +4,7 @@ import {Fragment} from 'react';
 import HeaderText from '../HeaderText/HeaderText';
 import WobblyBottom from '../WobblyBottom/WobblyBottom';
 import FreeSticker from '../FreeSticker/FreeSticker';
-import {BasePageColumn} from '../BasePage/BasePage';
+import TextLayout from '../TextLayout/TextLayout';
 import {classNames, spacing} from '../../../utils/classnames';
 import type {Node} from 'react';
 import type {FeaturedMedia as FeaturedMediaType} from '../BaseHeader/BaseHeader';
@@ -24,7 +24,7 @@ const ExhibitionHeader = ({
 }: Props) => {
   return (
     <Fragment>
-      <BasePageColumn>
+      <TextLayout>
         <div className='relative' style={{zIndex: 1}}>
           <FreeSticker />
         </div>
@@ -35,7 +35,7 @@ const ExhibitionHeader = ({
           InfoBar={InfoBar}
           Description={null}
           TagBar={null} />
-      </BasePageColumn>
+      </TextLayout>
       <div className='relative'>
         <div className={classNames({
           'margin-h-auto': true,

--- a/common/views/components/ExhibitionHeader/ExhibitionHeader.js
+++ b/common/views/components/ExhibitionHeader/ExhibitionHeader.js
@@ -25,9 +25,6 @@ const ExhibitionHeader = ({
   return (
     <Fragment>
       <TextLayout>
-        <div className='relative' style={{zIndex: 1}}>
-          <FreeSticker />
-        </div>
         <HeaderText
           topLink={{url: '/exhibitions', text: 'Exhibitions'}}
           Heading={<h1 className='h0 inline-block no-margin'>{title}</h1>}
@@ -36,15 +33,18 @@ const ExhibitionHeader = ({
           Description={null}
           TagBar={null} />
       </TextLayout>
-      <div className='relative'>
-        <div className={classNames({
-          'margin-h-auto': true,
-          [spacing({s: 2, m: 4}, {padding: ['left', 'right']})]: true
-        })} style={{maxWidth: '1450px'}}>
-          <WobblyBottom color='white'>
-            {FeaturedMedia}
-          </WobblyBottom>
+      <TextLayout>
+        <div className='relative' style={{zIndex: 1}}>
+          <FreeSticker />
         </div>
+      </TextLayout>
+      <div className={classNames({
+        'margin-h-auto': true,
+        [spacing({m: 4}, {padding: ['left', 'right']})]: true
+      })} style={{maxWidth: '1450px'}}>
+        <WobblyBottom color='white'>
+          {FeaturedMedia}
+        </WobblyBottom>
       </div>
     </Fragment>
   );

--- a/common/views/components/Header/Header.js
+++ b/common/views/components/Header/Header.js
@@ -15,7 +15,7 @@ type Props = {|
 |}
 
 const Header = withToggler(({ links, siteSection, toggle, isActive }: Props) => (
-  <div className={`header grid js-header-burger js-focus-trap bg-white border-bottom-width-1 border-color-pumice ${isActive ? 'header--is-burger-open' : ''}`}>
+  <div className={`header grid js-header-burger js-focus-trap bg-white border-color-pumice ${isActive ? 'header--is-burger-open' : ''}`}>
     <span className='visually-hidden js-trap-reverse-end'>reset focus</span>
     <div className='header__upper grid__cell'>
       <div className='header__inner container'>

--- a/common/views/components/Index/index.js
+++ b/common/views/components/Index/index.js
@@ -1,6 +1,5 @@
 import BackToTop from '../BackToTop/BackToTop';
 import Body from '../Body/Body';
-import { BasePageColumn } from '../BasePage/BasePage';
 import BookPage from '../BasePage/BookPage';
 import BookPromo from '../BookPromo/BookPromo';
 import Button from '../Buttons/Button/Button';
@@ -68,7 +67,6 @@ import WorkPromo from '../WorkPromo/WorkPromo';
 
 export {
   BackToTop,
-  BasePageColumn,
   Body,
   BookPage,
   BookPromo,

--- a/common/views/components/Layout/Layout.js
+++ b/common/views/components/Layout/Layout.js
@@ -13,11 +13,13 @@ const Layout = ({
   gridSizes,
   children
 }: Props) => (
-  <div className='grid'>
-    <div className={classNames({
-      [grid(gridSizes)]: true
-    })}>
-      {children}
+  <div className='container'>
+    <div className='grid'>
+      <div className={classNames({
+        [grid(gridSizes)]: true
+      })}>
+        {children}
+      </div>
     </div>
   </div>
 );

--- a/common/views/components/WobblyBottom/WobblyBottom.js
+++ b/common/views/components/WobblyBottom/WobblyBottom.js
@@ -4,17 +4,19 @@ import type {Node} from 'react';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 
 type Props = {|
+  color: 'cream' | 'white',
   children: Node
 |}
 
-const ImageWithWobblyBottom = ({
+const WobblyBottom = ({
+  color,
   children
 }: Props) => (
   <div className='relative'>
     <Fragment>
       {children}
-      <WobblyEdge background={'cream'} />
+      <WobblyEdge background={color} />
     </Fragment>
   </div>
 );
-export default ImageWithWobblyBottom;
+export default WobblyBottom;

--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -34,8 +34,7 @@ export const ExhibitionPage = ({
     promoText: exhibition.promoText,
     image: exhibition.image,
     squareImage: exhibition.squareImage,
-    widescreenImage: exhibition.widescreenImage,
-    thinImage: exhibition.thinImage
+    widescreenImage: exhibition.widescreenImage
   }, true);
   const Header = (<ExhibitionHeader
     title={exhibition.title}


### PR DESCRIPTION
Move `HeaderText` above image and use `TextLayout` instead of `BasePageColumn`.

<img width="770" alt="screen shot 2018-09-12 at 16 01 17" src="https://user-images.githubusercontent.com/1394592/45433925-2320a080-b6a5-11e8-8763-0ced5ed4bb7e.png">
