### PR TITLE
[spike] make event schedule dates sticky

### DIFF
--- a/common/views/components/EventSchedule/EventSchedule.js
+++ b/common/views/components/EventSchedule/EventSchedule.js
@@ -1,8 +1,7 @@
 // @flow
-import {Fragment} from 'react';
 import EventScheduleItem from '../EventScheduleItem/EventScheduleItem';
 import {groupEventsBy} from '../../../services/prismic/events';
-import {classNames, spacing} from '../../../utils/classnames';
+import {classNames} from '../../../utils/classnames';
 import type {EventSchedule as EventScheduleType} from '../../../model/events';
 
 type Props = {|
@@ -16,20 +15,31 @@ const EventSchedule = ({schedule}: Props) => {
     return isNotLinked ? event.id : null;
   }).filter(Boolean);
 
-  return groupedEvents.map(eventsGroup => (
+  return groupedEvents.map((eventsGroup, i) => (
     eventsGroup.events.length > 0 &&
-      <Fragment key={eventsGroup.label}>
-        {groupedEvents.length > 1 && <h3 className={classNames({
-          'h3': true,
-          [spacing({s: 4}, {margin: ['bottom']})]: true
-        })}>{eventsGroup.label}</h3>}
+      <div key={eventsGroup.label} style={{position: 'relative'}} id={`event-schedule-group-${i}`}>
+        {groupedEvents.length > 1 &&
+          <div
+            className='flex'
+            style={{position: 'sticky', top: 0, background: 'white'}}>
+            <h3 className={classNames({
+              'h3': true,
+              'no-margin': true,
+              'flex-1': true
+            })}>
+              {eventsGroup.label}
+            </h3>
+            <a href={`#event-schedule-group-${i - 1}`} className='h3 margin-right-s1 js-scroll-to-info'>{'<='}</a>
+            <a href={`#event-schedule-group-${i + 1}`} className='h3 js-scroll-to-info'>{'=>'}</a>
+          </div>
+        }
         {eventsGroup.events.map(event =>
           <EventScheduleItem
             key={event.id}
             event={event}
             isNotLinked={isNotLinkedIds.indexOf(event.id) > -1} />
         )}
-      </Fragment>
+      </div>
   ));
 };
 export default EventSchedule;


### PR DESCRIPTION
Just a quick test, seems to be quite nice. Built mostly with what we have... except the nice new `prev/next` `<= =>` arrows.

Preview vid is on iPhone 5, to show what it looks like with not much realestate, thus the dates are thin.

![event_schedule_prototype](https://user-images.githubusercontent.com/31692/45767722-e0c20b00-bc32-11e8-98a6-e92541f8766e.gif)
