### PR TITLE
Image weights

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -393,12 +393,15 @@ export function isWebLink(fragment: ?PrismicFragment): boolean {
   return Boolean(fragment && fragment.url);
 }
 
-export type Weight = 'default' | 'featured';
+export type Weight = 'default' | 'featured' | 'standalone' | 'supporting';
 function getWeight(weight: ?string): ?Weight {
   switch (weight) {
     case 'featured':
       return weight;
-
+    case 'standalone':
+      return weight;
+    case 'supporting':
+      return weight;
     default:
       return 'default';
   }

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -416,6 +416,12 @@
   width: inherit;
 }
 
+.image-max-height-restricted {
+  max-height: 90vh;
+  width: auto;
+  margin: 0 auto;
+}
+
 // This is for when we receive content from a CMS,
 // making it easier to style the first node
 .first-para-bold p:first-of-type {

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -418,7 +418,7 @@
 
 .image-max-height-restricted {
   max-height: 90vh;
-  width: auto;
+  max-width: 100%;
   margin: 0 auto;
 }
 

--- a/common/views/components/BaseHeader/BaseHeader.js
+++ b/common/views/components/BaseHeader/BaseHeader.js
@@ -9,7 +9,7 @@ import HighlightedHeading from '../HighlightedHeading/HighlightedHeading';
 import HeaderText from '../HeaderText/HeaderText';
 import FreeSticker from '../FreeSticker/FreeSticker';
 import Picture from '../Picture/Picture';
-import TextLayout from '../TextLayout/TextLayout';
+import Layout8 from '../Layout8/Layout8';
 import Breadcrumb from '../Breadcrumb/Breadcrumb';
 import type {Node, Element} from 'react';
 import type {GenericContentFields} from '../../../model/generic-content-fields';
@@ -86,7 +86,7 @@ const BaseHeader = ({
         backgroundSize: BackgroundComponent ? null : '150%'
       }}>
         {BackgroundComponent}
-        <TextLayout>
+        <Layout8>
           {isFree &&
             <div className='relative'>
               <FreeSticker />
@@ -111,7 +111,7 @@ const BaseHeader = ({
               {LabelBar}
             </div>
           }
-        </TextLayout>
+        </Layout8>
       </div>
     </Fragment>
   );

--- a/common/views/components/BasePage/BasePage.js
+++ b/common/views/components/BasePage/BasePage.js
@@ -3,7 +3,7 @@ import {Fragment} from 'react';
 import type {Node} from 'react';
 import type BaseHeader from '../BaseHeader/BaseHeader';
 import type Body from '../Body/Body';
-import TextLayout from '../TextLayout/TextLayout';
+import Layout8 from '../Layout8/Layout8';
 
 type Props = {|
   id: string,
@@ -27,9 +27,9 @@ const BasePage = ({
       </div>
 
       {children &&
-        <TextLayout>
+        <Layout8>
           {children}
-        </TextLayout>
+        </Layout8>
       }
     </article>
   );

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -9,8 +9,9 @@ import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import FeaturedText from '../FeaturedText/FeaturedText';
 import VideoEmbed from '../VideoEmbed/VideoEmbed';
 import Map from '../Map/Map';
-import TextLayout from '../TextLayout/TextLayout';
+import Layout8 from '../Layout8/Layout8';
 import Layout10 from '../Layout10/Layout10';
+import Layout12 from '../Layout12/Layout12';
 import type {Weight} from '../../../services/prismic/parsers';
 
 type BodySlice = {|
@@ -38,55 +39,66 @@ const Body = ({ body, isCreamy = false }: Props) => {
         .map((slice, i) =>
           <div className={`body-part ${spacing({s: 6}, {padding: ['top']})}`} key={`slice${i}`}>
             {slice.type === 'standfirst' &&
-              <TextLayout>
+              <Layout8>
                 <div className='body-text'>
                   <FeaturedText html={slice.value} />
                 </div>
-              </TextLayout>
+              </Layout8>
             }
             {slice.type === 'text' &&
-              <TextLayout>
+              <Layout8>
                 <div className='body-text'>
                   {slice.weight === 'featured' && <FeaturedText html={slice.value} />}
                   {slice.weight !== 'featured' && <PrismicHtmlBlock html={slice.value} />}
                 </div>
-              </TextLayout>
+              </Layout8>
             }
 
-            {slice.type === 'picture' && slice.weight !== 'featured' &&
+            {slice.type === 'picture' && slice.weight === 'default' &&
               <Layout10>
-                <CaptionedImage {...slice.value} sizesQueries={''} />
+                <CaptionedImage {...slice.value} sizesQueries={''} maxHeightRestricted={true} />
               </Layout10>
             }
+            {slice.type === 'picture' && slice.weight === 'standalone' &&
+              <Layout12>
+                <CaptionedImage {...slice.value} sizesQueries={''} maxHeightRestricted={true} />
+              </Layout12>
+            }
+            {slice.type === 'picture' && slice.weight === 'supporting' &&
+              <Layout8>
+                <CaptionedImage {...slice.value} sizesQueries={''} maxHeightRestricted={true} />
+              </Layout8>
+            }
+
             {slice.type === 'imageGallery' && <ImageGallery {...slice.value} />}
             {slice.type === 'quote' &&
-              <TextLayout>
+              <Layout8>
                 <Quote {...slice.value} />
-              </TextLayout>
+              </Layout8>
             }
 
             {slice.type === 'contentList' &&
-              <TextLayout>
+              <Layout8>
                 <AsyncSearchResults
                   title={slice.value.title}
                   query={slice.value.items.map(({id}) => `id:${id}`).join(' ')}
                 />
-              </TextLayout>
+              </Layout8>
             }
             {slice.type === 'searchResults' &&
-              <TextLayout>
+              <Layout8>
                 <AsyncSearchResults {...slice.value} />
-              </TextLayout>
+              </Layout8>
             }
             {slice.type === 'videoEmbed' &&
-              <TextLayout>
+              <Layout8>
                 <VideoEmbed {...slice.value} />
-              </TextLayout>
+              </Layout8>
             }
             {slice.type === 'map' &&
-              <TextLayout>
+              <Layout8>
                 <Map {...slice.value} />
-              </TextLayout>
+              </Layout8>
             }
           </div>
         )}

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -1,6 +1,7 @@
 // @flow
 import {Fragment} from 'react';
 import {convertImageUri} from '../../../utils/convert-image-uri';
+import {classNames} from '../../../utils/classnames';
 import {imageSizes} from '../../../utils/image-sizes';
 import Tasl from '../Tasl/Tasl';
 import type {Node} from 'react';
@@ -16,7 +17,8 @@ export type UiImageProps = {|
   sizesQueries: string,
   extraClasses?: string,
   isFull?: boolean,
-  showTasl?: boolean
+  showTasl?: boolean,
+  maxHeightRestricted?: boolean
 |}
 
 export const UiImage = ({
@@ -28,7 +30,8 @@ export const UiImage = ({
   sizesQueries,
   extraClasses = '',
   isFull = false,
-  showTasl = true
+  showTasl = true,
+  maxHeightRestricted = false
 }: UiImageProps) => {
   return (
     <Fragment>
@@ -41,7 +44,13 @@ export const UiImage = ({
 
       <img width={width}
         height={height}
-        className={`image lazy-image lazyload ${extraClasses}`}
+        className={classNames({
+          'image': true,
+          'lazy-image': true,
+          'lazyload': true,
+          [extraClasses || '']: true,
+          'image-max-height-restricted': maxHeightRestricted
+        })}
         src={convertImageUri(contentUrl, 30, false)}
         data-srcset={imageSizes(width).map(size => {
           return `${convertImageUri(contentUrl, size, false)} ${size}w`;
@@ -57,7 +66,8 @@ export type UiCaptionedImageProps = {|
   ...CaptionedImageProps,
   sizesQueries: string,
   extraClasses?: string,
-  preCaptionNode?: Node
+  preCaptionNode?: Node,
+  maxHeightRestricted?: boolean
 |}
 
 export const CaptionedImage = ({
@@ -65,9 +75,10 @@ export const CaptionedImage = ({
   caption,
   sizesQueries,
   extraClasses = '',
-  preCaptionNode
+  preCaptionNode,
+  maxHeightRestricted = false
 }: UiCaptionedImageProps) => {
-  const uiImageProps = {...image, sizesQueries};
+  const uiImageProps = {...image, sizesQueries, maxHeightRestricted};
   return (
     <figure className={`captioned-image ${extraClasses}`}>
       <div className='captioned-image__image-container'>

--- a/common/views/components/Layout12/Layout12.js
+++ b/common/views/components/Layout12/Layout12.js
@@ -6,10 +6,10 @@ type Props = {|
   children: Node
 |}
 
-const FullWidthLayout = ({children}: Props) => (
+const Layout12 = ({children}: Props) => (
   <Layout gridSizes={{s: 12, m: 12, l: 12, xl: 12}}>
     {children}
   </Layout>
 );
 
-export default FullWidthLayout;
+export default Layout12;

--- a/common/views/components/Layout8/Layout8.js
+++ b/common/views/components/Layout8/Layout8.js
@@ -5,10 +5,10 @@ type Props = {|
   children: Node
 |}
 
-const TextLayout = ({children}: Props) => (
+const Layout8 = ({children}: Props) => (
   <Layout gridSizes={{s: 12, m: 10, shiftM: 1, l: 8, shiftL: 2, xl: 8, shiftXL: 2}}>
     {children}
   </Layout>
 );
 
-export default TextLayout;
+export default Layout8;


### PR DESCRIPTION
Ref #3297 

Add image weights and image restrictions:
* Images in body are restricted to `100% width`, or `90vh, which ever they hit first
* 100% = 
  * supporting: 8 cols (same as text)
  * default: 10cols
  * standalone: 12cols

On medium / small breakpoints :point_up: doesn't make a difference, same as on mobile now.

Where this falls apart a little is when we have a portrait supporting image, as it reaches it's mx height before filling the column width.

But I wonder if this solves for the fact that they were using the supporting to get the portrait images into the right rail as they look terrible on desktop as it stands [e.g.](https://wellcomecollection.org/articles/W4z18x4AACIAmwSs) 

# Portrait @ 90vh
![screen shot 2018-09-20 at 18 31 14](https://user-images.githubusercontent.com/31692/45836395-ac1e8400-bd04-11e8-9185-ce7bd1209d56.png)

# Supporting @ 8 cols
![screen shot 2018-09-20 at 18 31 08](https://user-images.githubusercontent.com/31692/45836394-ac1e8400-bd04-11e8-9f00-4a65f6c018dd.png)

# Standalone @ 12 cols
![screen shot 2018-09-20 at 18 31 22](https://user-images.githubusercontent.com/31692/45836397-acb71a80-bd04-11e8-8b72-605db1a1135a.png)

