### PR TITLE
add contributorProps to BasePage and implement on articles

### DIFF
--- a/common/views/components/BasePage/BasePage.js
+++ b/common/views/components/BasePage/BasePage.js
@@ -1,15 +1,18 @@
 // @flow
 import {Fragment} from 'react';
-import type {Node} from 'react';
+import TextLayout from '../TextLayout/TextLayout';
+import Contributors from '../Contributors/Contributors';
+import {spacing} from '../../../utils/classnames';
+import type {Node, ElementProps} from 'react';
 import type BaseHeader from '../BaseHeader/BaseHeader';
 import type Body from '../Body/Body';
-import TextLayout from '../TextLayout/TextLayout';
 
+// TODO: use Element<typeof Component>
 type Props = {|
   id: string,
   Header: BaseHeader,
   Body: Body,
-
+  contributorProps?: ElementProps<typeof Contributors>,
   children?: ?Node
 |}
 
@@ -17,6 +20,7 @@ const BasePage = ({
   id,
   Header,
   Body,
+  contributorProps,
   children
 }: Props) => {
   return (
@@ -29,6 +33,11 @@ const BasePage = ({
       {children &&
         <TextLayout>
           {children}
+          {contributorProps && contributorProps.contributors.length > 0 &&
+            <div className={`${spacing({s: 4}, {margin: ['bottom']})}`}>
+              <Contributors {...contributorProps} />
+            </div>
+          }
         </TextLayout>
       }
     </article>

--- a/common/views/components/Contributors/Contributors.js
+++ b/common/views/components/Contributors/Contributors.js
@@ -5,7 +5,7 @@ import type {Contributor as ContributorType} from '../../../model/contributors';
 
 type Props = {|
   contributors: ContributorType[],
-  titleOverride: ?string,
+  titleOverride?: ?string,
   titlePrefix?: string,
   excludeTitle?: boolean
 |}

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -151,6 +151,7 @@ export class ArticlePage extends Component<Props, State> {
         id={article.id}
         Header={Header}
         Body={<Body body={article.body} isCreamy={true} />}
+        contributorProps={{contributors: article.contributors}}
       >
         {this.state.listOfSeries.map(({series, articles}) => {
           return <SearchResults


### PR DESCRIPTION
I know we've been passing components about, but that was based on the loose layout and evolutionary phase we've been going through.

This still works for things like the `FeaturedMedia`.

Coming closer to a [refinement on this](https://github.com/wellcometrust/wellcomecollection.org/issues/3327), we know where the contributors go (and a few other things).

How do we feel about this then? Or do we feel it will make things too inflexible, and if so, is it worth it to stop us having to make decisions for all content types and the maintenance overheads on what is going to become an `maintain` part of the project?

__If we're happy for this to go ahead, I'll implement it across the content types in this PR for completeness.__

