### PR TITLE
Add image to open-graph meta

### DIFF
--- a/server/views/pages/page.njk
+++ b/server/views/pages/page.njk
@@ -6,6 +6,7 @@
     type: 'article',
     title: page.title,
     url: pageConfig.canonicalUri,
+    image: page.promo.image.contentUrl,
     description: description
   } %}
   {% component 'open-graph', { pageConfig: pageConfig, metaContent: metaContent } %}


### PR DESCRIPTION
Adding open-graph/twitter-card image to pages. This fixes the issue of Prismic preview warning that there isn't an image when there is one. More importantly, makes that image appear on the socials.