### PR TITLE
use labels property instead of component on cards

### DIFF
--- a/common/views/components/CompactCard/CompactCard.js
+++ b/common/views/components/CompactCard/CompactCard.js
@@ -1,19 +1,19 @@
 // @flow
-import type {Element} from 'react';
+import type {Element, ElementProps} from 'react';
 import {grid, font, spacing, conditionalClassNames} from '../../../utils/classnames';
 import DateRange from '../DateRange/DateRange';
-import LabelsList from '../LabelsList/LabelsList';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
+import LabelsList from '../LabelsList/LabelsList';
 import {default as ImageType} from '../Image/Image';
 
 type Props = {|
   url: string,
   title: string,
   promoType: string,
+  labels: ElementProps<typeof LabelsList>,
   description: ?string,
   urlOverride: ?string,
   extraClasses?: string,
-  Tags: ?Element<typeof LabelsList>,
   Image: ?Element<typeof ImageType>,
   DateInfo: ?Element<typeof DateRange>,
   StatusIndicator: ?Element<typeof StatusIndicator>
@@ -23,10 +23,10 @@ const CompactCard = ({
   url,
   title,
   promoType,
+  labels,
   description,
   urlOverride,
   extraClasses,
-  Tags,
   Image,
   DateInfo,
   StatusIndicator
@@ -47,12 +47,12 @@ const CompactCard = ({
         [spacing({s: 3}, {padding: ['bottom', 'top']})]: true,
         [extraClasses || '']: Boolean(extraClasses)
       })}>
-      {Tags &&
+      {labels.labels.length &&
         <div className={conditionalClassNames({
           [grid({s: 12, m: 12, l: 12, xl: 12})]: true,
           [spacing({s: 1}, {margin: ['bottom']})]: true
         })}>
-          {Tags}
+          <LabelsList {...labels} />
         </div>
       }
       {Image &&

--- a/common/views/components/EventCard/EventCard.js
+++ b/common/views/components/EventCard/EventCard.js
@@ -1,5 +1,4 @@
 // @flow
-import LabelsList from '../LabelsList/LabelsList';
 import CompactCard from '../CompactCard/CompactCard';
 import Image from '../Image/Image';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
@@ -28,7 +27,7 @@ const EventCard = ({ event }: Props) => {
     ...audienceLabels,
     ...interpretationLabels
   ].filter(Boolean);
-  const LabelsComponent = <LabelsList labels={labels} />;
+
   const DateRangeComponent = EventDateRange({event});
   const ImageComponent = event.promo && event.promo.image && <Image {...event.promo.image} />;
 
@@ -41,9 +40,9 @@ const EventCard = ({ event }: Props) => {
     url={`/events/${event.id}`}
     title={event.title}
     promoType={'EventPromo'}
+    labels={{labels}}
     description={null}
     urlOverride={event.promo && event.promo.link}
-    Tags={LabelsComponent}
     Image={ImageComponent}
     DateInfo={DateRangeComponent}
     StatusIndicator={StatusIndicatorComponent}

--- a/common/views/components/SearchResults/SearchResults.js
+++ b/common/views/components/SearchResults/SearchResults.js
@@ -4,7 +4,6 @@ import {spacing, grid, classNames} from '../../../utils/classnames';
 import Image from '../Image/Image';
 import CompactCard from '../CompactCard/CompactCard';
 import EventCard from '../EventCard/EventCard';
-import LabelsList from '../LabelsList/LabelsList';
 import type {MultiContent} from '../../../model/multi-content';
 
 type Props = {|
@@ -39,10 +38,10 @@ const SearchResults = ({ items, title, summary }: Props) => (
               promoType='PagePromo'
               url={`/pages/${item.id}`}
               title={item.title || ''}
+              labels={{labels: []}}
               description={item.promo && item.promo.caption}
               urlOverride={item.promo && item.promo.link}
               Image={item.promo && item.promo.image && <Image {...item.promo.image} />}
-              Tags={null}
               DateInfo={null}
               StatusIndicator={null}
             />
@@ -53,10 +52,10 @@ const SearchResults = ({ items, title, summary }: Props) => (
               promoType='EventSeriesPromo'
               url={`/event-series/${item.id}`}
               title={item.title || ''}
+              labels={{labels: [{url: null, text: 'Event series'}]}}
               description={item.promo && item.promo.caption}
               urlOverride={item.promo && item.promo.link}
               Image={item.promo && item.promo.image && <Image {...item.promo.image} />}
-              Tags={null}
               DateInfo={null}
               StatusIndicator={null}
             />
@@ -67,10 +66,10 @@ const SearchResults = ({ items, title, summary }: Props) => (
               promoType='BooksPromo'
               url={`/books/${item.id}`}
               title={item.title || ''}
+              labels={{labels: [{url: null, text: 'Book'}]}}
               description={item.promo && item.promo.caption}
               urlOverride={item.promo && item.promo.link}
               Image={item.promo && item.promo.image && <Image {...item.promo.image} />}
-              Tags={<LabelsList labels={[{url: null, text: 'Book'}]} />}
               DateInfo={null}
               StatusIndicator={null}
             />
@@ -81,10 +80,10 @@ const SearchResults = ({ items, title, summary }: Props) => (
               promoType='ArticlePromo'
               url={`/articles/${item.id}`}
               title={item.title || ''}
+              labels={{labels: [{url: null, text: 'Article'}]}}
               description={item.promoText}
               urlOverride={item.promo && item.promo.link}
               Image={item.promo && item.promo.image && <Image {...item.promo.image} />}
-              Tags={<LabelsList labels={[{url: null, text: 'Article'}]} />}
               DateInfo={null}
               StatusIndicator={null}
             />
@@ -99,10 +98,10 @@ const SearchResults = ({ items, title, summary }: Props) => (
               promoType='InstallationPromo'
               url={`/installations/${item.id}`}
               title={item.title || ''}
+              labels={{labels: [{url: null, text: 'Installation'}]}}
               description={item.promoText}
               urlOverride={item.promo && item.promo.link}
               Image={item.promo && item.promo.image && <Image {...item.promo.image} />}
-              Tags={<LabelsList labels={[{url: null, text: 'Installation'}]} />}
               DateInfo={null}
               StatusIndicator={null}
             />


### PR DESCRIPTION
Might then abstract this further into genericContentFields, as nearly everything should have labels, and we want to make sure they're the same across the different places we display them i.e. page header, cards etc.