### PR TITLE
add some spacing to article series

### DIFF
--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -2,7 +2,7 @@
 import Prismic from 'prismic-javascript';
 import {getEvents} from './events';
 import type {EventSeries} from '../../model/event-series';
-import type {PrismicDocument} from './types';
+import type {PrismicDocument, PrismicQueryOpts} from './types';
 import {
   parseGenericFields,
   parseBackgroundTexture,
@@ -23,14 +23,20 @@ export function parseEventSeries(document: PrismicDocument): EventSeries {
   };
 }
 
-type EventSeriesProps = {| id: string |}
-export async function getEventSeries(req: Request, {
-  id
+type EventSeriesProps = {|
+  id: string,
+  ...PrismicQueryOpts
+|}
+
+export async function getEventSeries(req: ?Request, {
+  id,
+  ...opts
 }: EventSeriesProps) {
   const events = await getEvents(req, {
     page: 1,
     predicates: [Prismic.Predicates.at('my.events.series.series', id)],
-    order: 'desc'
+    order: 'desc',
+    ...opts
   });
 
   if (events && events.results.length > 0) {

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -32,7 +32,12 @@ import {isPast} from '../../utils/dates';
 import {getPeriodPredicates} from './utils';
 import type {UiEvent, EventFormat} from '../../model/events';
 import type {Team} from '../../model/team';
-import type {PrismicDocument, PrismicApiSearchResponse, PaginatedResults} from './types';
+import type {
+  PrismicDocument,
+  PrismicApiSearchResponse,
+  PaginatedResults,
+  PrismicQueryOpts
+} from './types';
 import type {Period} from '../../model/periods';
 
 const startField = 'my.events.times.startDateTime';
@@ -189,18 +194,18 @@ export async function getEvent(req: ?Request, {id}: EventQueryProps): Promise<?U
 }
 
 type EventsQueryProps = {|
-  page: number,
   predicates: Prismic.Predicates[],
+  period?: Period,
   order: 'asc' | 'desc',
-  period?: Period
+  ...PrismicQueryOpts
 |}
 
-export async function getEvents(req: Request,  {
-  page = 1,
+export async function getEvents(req: ?Request,  {
   predicates = [],
   order = 'desc',
-  period
-}: EventsQueryProps): Promise<?PaginatedResults<UiEvent>> {
+  period,
+  ...opts
+}: EventsQueryProps): Promise<PaginatedResults<UiEvent>> {
   const graphQuery = `{
     events {
       ...eventsFields
@@ -287,7 +292,7 @@ export async function getEvents(req: Request,  {
     Prismic.Predicates.at('document.type', 'events')
   ].concat(predicates, dateRangePredicates), {
     orderings,
-    page,
+    page: opts.page,
     graphQuery
   });
 

--- a/common/views/components/BasePage/BasePage.js
+++ b/common/views/components/BasePage/BasePage.js
@@ -39,7 +39,7 @@ const BasePage = ({
           <Layout8>
             {children}
             {contributorProps && contributorProps.contributors.length > 0 &&
-              <div className={`${spacing({s: 4}, {margin: ['bottom']})}`}>
+              <div className={`${spacing({s: 6}, {margin: ['top']})}`}>
                 <Contributors {...contributorProps} />
               </div>
             }

--- a/common/views/components/Contributors/Contributors.js
+++ b/common/views/components/Contributors/Contributors.js
@@ -69,7 +69,7 @@ const Contributors = ({
       }
 
       {contributors.map(({contributor, role, description}) => (
-        <div className={spacing({s: 2}, {margin: ['top']})} key={contributor.id}>
+        <div className={spacing({s: 4}, {margin: ['top']})} key={contributor.id}>
           {/*
             we don't show the role if there is only 1 as it will be
             displayed in the title

--- a/common/views/components/SearchResults/SearchResults.js
+++ b/common/views/components/SearchResults/SearchResults.js
@@ -27,7 +27,7 @@ const SearchResults = ({ items, title, summary }: Props) => (
       </div>
     }
     <div className={`
-        ${spacing({s: 11}, {margin: ['top']})}
+        ${spacing({s: 4}, {margin: ['top']})}
       `}>
       {items.map(item => (
         <div className={

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -195,10 +195,15 @@ export class ArticlePage extends Component<Props, State> {
           const dedupedArticles = articles.filter(
             a => a.id !== article.id
           ).slice(0, 2);
-          return <SeriesNavigation
-            key={series.id}
-            series={series}
-            items={dedupedArticles} />;
+          return (
+            <div
+              key={series.id}
+              className={`${spacing({s: 6}, {margin: ['top']})}`}>
+              <SeriesNavigation
+                series={series}
+                items={dedupedArticles} />
+            </div>
+          );
         })}
       </BasePage>
     );

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -24,7 +24,7 @@ import {
 import EventDateRange from '@weco/common/views/components/EventDateRange/EventDateRange';
 import HeaderBackground from '@weco/common/views/components/BaseHeader/HeaderBackground';
 import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
-import { getEvent } from '@weco/common/services/prismic/events';
+import {getEvent} from '@weco/common/services/prismic/events';
 import {convertImageUri} from '@weco/common/utils/convert-image-uri';
 import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
 


### PR DESCRIPTION
I was going to abstract the spacing out, realised that we don't actually put the series on the events pages anyway.

Thinking I would rather get this released and then work on getting the `BasePage` children into some sort of shape... but seems like an over optimisation when there is so much to do.
![space](https://user-images.githubusercontent.com/31692/46027607-27f24500-c0e6-11e8-9f3e-cfa931b6938b.png)
