### PR TITLE
Remove JS enhanced EB iframe (just use link)

### DIFF
--- a/common/views/components/EventbriteButton/EventbriteButton.js
+++ b/common/views/components/EventbriteButton/EventbriteButton.js
@@ -11,6 +11,7 @@ type Props = {
 const ticketButtonText = 'Check for tickets';
 const ticketButtonLoadingText = 'Loading…';
 
+// FIXME: add back to button extraClasses={`js-eventbrite-show-widget-${event.eventbriteId || ''}`}
 const EventbriteButton = ({event}: Props) => {
   return (
     <div className={spacing({s: 4}, {margin: ['bottom']})}>
@@ -19,7 +20,6 @@ const EventbriteButton = ({event}: Props) => {
           <Fragment>
             <Button
               type='primary'
-              extraClasses={`js-eventbrite-show-widget-${event.eventbriteId || ''}`}
               url={`https://www.eventbrite.com/e/${event.eventbriteId || ''}/`}
               trackingEvent={{
                 category: 'component',
@@ -30,7 +30,7 @@ const EventbriteButton = ({event}: Props) => {
               text={ticketButtonText} />
             <iframe
               className={`js-eventbrite-widget-${event.eventbriteId || ''}`}
-              src={`/eventbrite/widget/${event.eventbriteId || ''}`}
+              src={`https://eventbrite.com/tickets-external?eid=${event.eventbriteId || ''}&ref=etckt`}
               frameBorder='0'
               width='100%'
               vspace='0'

--- a/common/views/components/EventbriteButton/EventbriteButton.js
+++ b/common/views/components/EventbriteButton/EventbriteButton.js
@@ -30,7 +30,7 @@ const EventbriteButton = ({event}: Props) => {
               text={ticketButtonText} />
             <iframe
               className={`js-eventbrite-widget-${event.eventbriteId || ''}`}
-              src={`https://eventbrite.com/tickets-external?eid=${event.eventbriteId || ''}&ref=etckt`}
+              src={`/eventbrite/widget/${event.eventbriteId || ''}`}
               frameBorder='0'
               width='100%'
               vspace='0'


### PR DESCRIPTION
Short-term fix for Eventbrite – removing the iframe and linking the button through to the eventbrite page.