### PR TITLE
Fixed CompactCard bug

### DIFF
--- a/common/views/components/CompactCard/CompactCard.js
+++ b/common/views/components/CompactCard/CompactCard.js
@@ -47,7 +47,7 @@ const CompactCard = ({
         [spacing({s: 3}, {padding: ['bottom', 'top']})]: true,
         [extraClasses || '']: Boolean(extraClasses)
       })}>
-      {labels.labels.length &&
+      {labels.labels.length !== 0 &&
         <div className={conditionalClassNames({
           [grid({s: 12, m: 12, l: 12, xl: 12})]: true,
           [spacing({s: 1}, {margin: ['bottom']})]: true


### PR DESCRIPTION
Stops weird layout of CompactCards that don't have labels:

<img width="941" alt="screen shot 2018-09-28 at 16 42 21" src="https://user-images.githubusercontent.com/6051896/46218882-ac8ad080-c33d-11e8-98c4-531e865bb3b0.png">

