### PR TITLE
add ALB listener rule to serve pages from content app

### DIFF
--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -95,3 +95,12 @@ module "content" {
   healthcheck_path                   = "/management/healthcheck"
   alb_priority                       = "700"
 }
+
+module "pages_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "100"
+  path = "/pages/*"
+}

--- a/shared-infra/terraform/service_alb_listener/alb_listener.tf
+++ b/shared-infra/terraform/service_alb_listener/alb_listener.tf
@@ -1,0 +1,36 @@
+variable "alb_listener_https_arn" {}
+variable "alb_listener_http_arn" {}
+variable "target_group_arn" {}
+variable "priority" {}
+variable "path" {}
+
+
+resource "aws_alb_listener_rule" "https" {
+  listener_arn = "${var.alb_listener_https_arn}"
+  priority     = "${var.priority}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${var.target_group_arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${var.path}"]
+  }
+}
+
+resource "aws_alb_listener_rule" "http" {
+  listener_arn = "${var.alb_listener_http_arn}"
+  priority     = "${var.priority}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${var.target_group_arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["${var.path}"]
+  }
+}


### PR DESCRIPTION
Let's start with pages as a test for GA etc before moving onto the articles and exhibitions.