### PR TITLE
[spike] only group exhibitions at the edge of rendering on whats on

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -235,7 +235,6 @@ export async function getExhibitions(
   );
 
   const uiExhibitions: UiExhibition[] = paginatedResults.results.map(parseExhibitionDoc);
-  const exhibitionsWithPermAfterCurrent = putPermanentAfterCurrentExhibitions(uiExhibitions);
 
   // { ...paginatedResults, results: uiExhibitions } should work, but Flow still
   // battles with spreading.
@@ -244,11 +243,11 @@ export async function getExhibitions(
     pageSize: paginatedResults.pageSize,
     totalResults: paginatedResults.totalResults,
     totalPages: paginatedResults.totalPages,
-    results: exhibitionsWithPermAfterCurrent
+    results: uiExhibitions
   };
 }
 
-function putPermanentAfterCurrentExhibitions(exhibitions: UiExhibition[]): UiExhibition[] {
+export function putPermanentAfterCurrentExhibitions(exhibitions: UiExhibition[]): UiExhibition[] {
   // We order the list this way as, from a user's perspective, seeing the
   // temporary exhibitions is more urgent, so they're at the front of the list,
   // but there's no good way to express that ordering through Prismic's ordering

--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -7,7 +7,8 @@ import {
   getExhibitions,
   getExhibition,
   getExhibitionExhibits,
-  getExhibitExhibition
+  getExhibitExhibition,
+  putPermanentAfterCurrentExhibitions
 } from '@weco/common/services/prismic/exhibitions';
 import {
   getEvents,
@@ -45,6 +46,10 @@ export async function renderWhatsOn(ctx, next) {
     exhibitionsPromise, eventsPromise
   ]);
   const dateRange = getMomentsForPeriod(period);
+  const reorderedExhibitions = Object.assign({},
+    exhibitions,
+    {results: putPermanentAfterCurrentExhibitions(exhibitions.results)}
+  );
 
   ctx.render('pages/whats-on', {
     pageConfig: createPageConfig({
@@ -59,7 +64,7 @@ export async function renderWhatsOn(ctx, next) {
       }
     }),
     events,
-    exhibitions,
+    exhibitions: reorderedExhibitions,
     pharmacyOfColourData,
     dateRange,
     listHeader: getListHeader(ctx.intervalCache.get('collectionOpeningTimes')),


### PR DESCRIPTION
Walking home realisation: We could just move the ordered grouping of exhibitions to the whats on page.

i.e.
__Current setup:__
All exhibitions:
* Order by `endDate desc`.
* Group by `permanent`, `current`, and `upcoming`
* order groupings as `current`, `permanent`, `upcoming`.

__Suggested in this spike:__
Keep this setup ☝️ on What's on.
Order by `isPermanent`, `endDate desc` on lists.

`desc` = new to old

# example of /exhibitions after (no change to WO)
![exhibitions](https://user-images.githubusercontent.com/31692/46373356-b71ed000-c685-11e8-8411-cf6e5d1f0690.png)
