### PR TITLE
Stopped date displaying on permanent exhibitions

### DIFF
--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -113,7 +113,7 @@ export class ExhibitionPage extends Component<Props, State> {
         Background={null}
         ContentTypeInfo={
           <Fragment>
-            {DateInfo}
+            {!exhibition.isPermanent && DateInfo}
             <StatusIndicator start={exhibition.start} end={exhibition.end || new Date()} />
           </Fragment>
         }


### PR DESCRIPTION
Stops the weird dates from being displayed.

Before:
![screen shot 2018-10-03 at 15 06 56](https://user-images.githubusercontent.com/6051896/46415859-21834f00-c71e-11e8-84cd-1105b7a2d480.png)

After:
![screen shot 2018-10-03 at 15 07 17](https://user-images.githubusercontent.com/6051896/46415866-2811c680-c71e-11e8-8160-a95d56c89759.png)

