### PR TITLE
Remove height limit from current article page images

### DIFF
--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -101,7 +101,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
           onLoad={this.getImageSize}
           ref={this.setImgRef}
           style={{
-            width: isWidthAuto && 'auto'
+            width: isWidthAuto ? 'auto' : undefined
           }}
           className={classNames({
             'lazy-image': true,
@@ -127,7 +127,8 @@ export type UiCaptionedImageProps = {|
   sizesQueries: string,
   extraClasses?: string,
   preCaptionNode?: ReactNode,
-  setTitleStyle?: (value: number) => void
+  setTitleStyle?: (value: number) => void,
+  shameNoMaxHeight?: boolean // FIXME: remove once we're totally React
 |}
 
 type UiCaptionedImageState = {|
@@ -158,20 +159,33 @@ export class CaptionedImage extends Component<UiCaptionedImageProps, UiCaptioned
   }
 
   render() {
-    const { caption, preCaptionNode, extraClasses, image, sizesQueries } = this.props;
-    const { isActive, computedImageWidth, isWidthAuto } = this.state;
+    const {
+      caption,
+      preCaptionNode,
+      extraClasses,
+      image,
+      sizesQueries,
+      shameNoMaxHeight
+    } = this.props;
+    const {
+      isActive,
+      computedImageWidth,
+      isWidthAuto
+    } = this.state;
     const uiImageProps = {...image, sizesQueries};
 
     return (
       <figure
         style={{
-          marginLeft: isActive && isWidthAuto && '50%',
-          transform: isActive && isWidthAuto && computedImageWidth && `translateX(${computedImageWidth / -2}px)`
+          marginLeft: (isActive && isWidthAuto) ? '50%' : undefined,
+          transform: (isActive && isWidthAuto && computedImageWidth)
+            ? `translateX(${computedImageWidth / -2}px)`
+            : undefined
         }}
         className={`captioned-image ${extraClasses || ''}`}>
         <div
           style={{
-            display: isWidthAuto && 'inline-block'
+            display: isWidthAuto ? 'inline-block' : undefined
           }}
           className='captioned-image__image-container relative'>
           {/* https://github.com/facebook/flow/issues/2405 */}
@@ -180,7 +194,8 @@ export class CaptionedImage extends Component<UiCaptionedImageProps, UiCaptioned
             {...uiImageProps}
             setIsWidthAuto={this.setIsWidthAuto}
             isWidthAuto={isWidthAuto}
-            setComputedImageWidth={this.setComputedImageWidth}  />
+            setComputedImageWidth={this.setComputedImageWidth}
+            extraClasses={shameNoMaxHeight ? 'shame-no-max-height' : ''}  />
         </div>
         <Caption
           width={computedImageWidth}

--- a/server/views/components/article-body/article-body.njk
+++ b/server/views/components/article-body/article-body.njk
@@ -35,9 +35,9 @@
               <div class="{{ {s: 1} | spacingClasses({margin: ['bottom']}) }}">
                 {% set caption = bodyPart.value.caption | prismicAsText %}
                 {% if bodyPart.value.caption and caption !== '' %}
-                  {% componentJsx 'CaptionedImage', bodyPart.value | objectAssign({ sizesQueries: sizes }) %}
+                  {% componentJsx 'CaptionedImage', bodyPart.value | objectAssign({ sizesQueries: sizes, shameNoMaxHeight: true }) %}
                 {% else %}
-                  {% componentJsx 'UiImage', bodyPart.value.image | objectAssign({ sizesQueries: sizes }) %}
+                  {% componentJsx 'UiImage', bodyPart.value.image | objectAssign({ sizesQueries: sizes, extraClasses: 'shame-no-max-height' }) %}
                 {% endif %}
               </div>
             </div>


### PR DESCRIPTION
Prevents images in the current article page getting distorted if they're larger than 80% of the viewport.
