### PR TITLE
add DeprecatedImageList component

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -508,6 +508,22 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
             }
           };
         }
+        break;
+
+      // Deprecated
+      case 'imageList':
+        return {
+          type: 'deprecatedImageList',
+          weight: getWeight(slice.slice_label),
+          value: {
+            items: slice.items.map(item => ({
+              title: parseTitle(item.title),
+              subtitle: parseTitle(item.subtitle),
+              image: parseCaptionedImage(item),
+              description: parseStructuredText(item.description)
+            }))
+          }
+        };
     }
   }).filter(Boolean);
 }

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -9,6 +9,7 @@ import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import FeaturedText from '../FeaturedText/FeaturedText';
 import VideoEmbed from '../VideoEmbed/VideoEmbed';
 import Map from '../Map/Map';
+import DeprecatedImageList from '../DeprecatedImageList/DeprecatedImageList';
 import Layout8 from '../Layout8/Layout8';
 import Layout10 from '../Layout10/Layout10';
 import Layout12 from '../Layout12/Layout12';
@@ -112,6 +113,13 @@ const Body = ({ body }: Props) => {
             {slice.type === 'map' &&
               <Layout8>
                 <Map {...slice.value} />
+              </Layout8>
+            }
+
+            {/* deprecated */}
+            {slice.type === 'deprecatedImageList' &&
+              <Layout8>
+                <DeprecatedImageList {...slice.value} />
               </Layout8>
             }
           </div>

--- a/common/views/components/DeprecatedImageList/DeprecatedImageList.js
+++ b/common/views/components/DeprecatedImageList/DeprecatedImageList.js
@@ -1,0 +1,29 @@
+// @flow
+import {CaptionedImage} from '../Images/Images';
+import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
+import type {CaptionedImage as CaptionedImageType} from '../../model/captioned-image';
+import type {HTMLString} from '../../service/prismic/types';
+
+type Props = {|
+  items: {|
+    title: string,
+    subtitle: string,
+    image: CaptionedImageType,
+    description: HTMLString
+  |}
+|}
+const DeprecatedImageList = ({
+  items
+}: Props) => {
+  return (
+    items.map((item, i) => (
+      <div className='body-text' key={i}>
+        <h2>{item.title}</h2>
+        <CaptionedImage {...item.image} />
+        <PrismicHtmlBlock html={item.description} />
+      </div>
+    ))
+  );
+};
+
+export default DeprecatedImageList;

--- a/common/views/components/DeprecatedImageList/DeprecatedImageList.js
+++ b/common/views/components/DeprecatedImageList/DeprecatedImageList.js
@@ -1,8 +1,8 @@
 // @flow
 import {CaptionedImage} from '../Images/Images';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
-import type {CaptionedImage as CaptionedImageType} from '../../model/captioned-image';
-import type {HTMLString} from '../../service/prismic/types';
+import type {CaptionedImage as CaptionedImageType} from '../../../model/captioned-image';
+import type {HTMLString} from '../../../services/prismic/types';
 
 type Props = {|
   items: {|
@@ -10,16 +10,22 @@ type Props = {|
     subtitle: string,
     image: CaptionedImageType,
     description: HTMLString
-  |}
+  |}[]
 |}
 const DeprecatedImageList = ({
   items
 }: Props) => {
   return (
+    // Missing type annotation for U.
+    // Not sure why I am getting the above, don't really care as this is deprecated.
+    // $FlowFixMe
     items.map((item, i) => (
       <div className='body-text' key={i}>
         <h2>{item.title}</h2>
-        <CaptionedImage {...item.image} />
+        <CaptionedImage
+          {...item.image}
+          sizesQueries='(min-width: 1540px) 1402px, (min-width: 600px) 92.39vw, 100vw'
+        />
         <PrismicHtmlBlock html={item.description} />
       </div>
     ))

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -6,7 +6,7 @@ import {imageSizes} from '../../../utils/image-sizes';
 import Tasl from '../Tasl/Tasl';
 import type {Node as ReactNode} from 'react';
 import type {ImageType} from '../../../model/image';
-import type {CaptionedImage as CaptionedImageProps} from '../../../model/captioned-image';
+import type {CaptionedImage as CaptionedImageType} from '../../../model/captioned-image';
 import Caption from '../Caption/Caption';
 import debounce from 'lodash.debounce';
 
@@ -123,7 +123,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
 }
 
 export type UiCaptionedImageProps = {|
-  ...CaptionedImageProps,
+  ...CaptionedImageType,
   sizesQueries: string,
   extraClasses?: string,
   preCaptionNode?: ReactNode,


### PR DESCRIPTION
Add the image list as an `h2`, `image` and `paragraph`.
Works until we decide what to do with them.

Is we added title to the new image list, we would be able to migrate them.

See #3257 for articles with them in.