### PR TITLE
Embeds

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -498,6 +498,18 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
       case 'embed':
         const embed = slice.primary.embed;
 
+        if (embed.provider_name === 'Vimeo') {
+          const embedUrl = slice.primary.embed.html.match(/src="([-a-zA-Z0-9://.?=_]+)?/)[1];
+          return {
+            type: 'videoEmbed',
+            weight: getWeight(slice.slice_label),
+            value: {
+              embedUrl: `${embedUrl}?rel=0`,
+              caption: slice.primary.caption
+            }
+          };
+        }
+
         if (embed.provider_name === 'SoundCloud') {
           const apiUrl = embed.html.match(/url=([^&]*)&/);
           const secretToken = embed.html.match(/secret_token=([^"]*)"/);

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -498,6 +498,18 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
       case 'embed':
         const embed = slice.primary.embed;
 
+        if (embed.provider_name === 'SoundCloud') {
+          const apiUrl = embed.html.match(/url=([^&]*)&/);
+          const secretToken = embed.html.match(/secret_token=([^"]*)"/);
+
+          return {
+            type: 'soundcloudEmbed',
+            value: {
+              embedUrl: `https://w.soundcloud.com/player/?url=${apiUrl[1]}%3Fsecret_token%3D${secretToken[1]}&color=%23ff5500&inverse=false&auto_play=false&show_user=true`
+            }
+          };
+        }
+
         if (embed.provider_name === 'YouTube') {
           const embedUrl = slice.primary.embed.html.match(/src="([-a-zA-Z0-9://.?=_]+)?/)[1];
           return {

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -504,8 +504,10 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
 
           return {
             type: 'soundcloudEmbed',
+            weight: getWeight(slice.slice_label),
             value: {
-              embedUrl: `https://w.soundcloud.com/player/?url=${apiUrl[1]}%3Fsecret_token%3D${secretToken[1]}&color=%23ff5500&inverse=false&auto_play=false&show_user=true`
+              embedUrl: `https://w.soundcloud.com/player/?url=${apiUrl[1]}%3Fsecret_token%3D${secretToken[1]}&color=%23ff5500&inverse=false&auto_play=false&show_user=true`,
+              caption: slice.primary.caption
             }
           };
         }
@@ -516,7 +518,8 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
             type: 'videoEmbed',
             weight: getWeight(slice.slice_label),
             value: {
-              embedUrl: `${embedUrl}?rel=0`
+              embedUrl: `${embedUrl}?rel=0`,
+              caption: slice.primary.caption
             }
           };
         }

--- a/common/styles/content.scss
+++ b/common/styles/content.scss
@@ -44,6 +44,7 @@ $is-next: true;
 @import 'components/footer_social';
 @import 'components/header';
 @import 'components/highlighted_heading';
+@import 'components/iframe_container';
 @import 'components/image_gallery_v2';
 @import 'components/image_viewer';
 @import 'components/input';

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -106,9 +106,19 @@ const Body = ({ body }: Props) => {
             }
             {slice.type === 'videoEmbed' &&
               <Layout8>
-                <VideoEmbed {...slice.value} />
+                <div className={classNames({
+                  [spacing({s: 6}, {margin: ['bottom']})]: true
+                })}>
+                  <VideoEmbed {...slice.value} />
+                </div>
               </Layout8>
             }
+            {slice.type === 'soundcloudEmbed' &&
+              <Layout8>
+                <iframe width='100%' height='20' frameBorder='none' src={slice.value.embedUrl} />
+              </Layout8>
+            }
+
             {slice.type === 'map' &&
               <Layout8>
                 <Map {...slice.value} />

--- a/prismic-model/js/parts/article-body.js
+++ b/prismic-model/js/parts/article-body.js
@@ -181,6 +181,14 @@ export default {
           'embed': {
             'type': 'Embed',
             'fieldset': 'Embed'
+          },
+          'caption': {
+            'type': 'StructuredText',
+            'config': {
+              'label': 'Caption',
+              'single': 'hyperlink, bold, em',
+              'placeholder': 'Caption'
+            }
           }
         }
       },
@@ -192,24 +200,6 @@ export default {
             'type': 'Text',
             'config': {
               'label': 'iframe src'
-            }
-          }
-        }
-      },
-      'youtubeVideoEmbed': {
-        'type': 'Slice',
-        'fieldset': 'YouTube video',
-        'non-repeat': {
-          'embed': {
-            'type': 'Embed',
-            'fieldset': 'YouTube embed'
-          },
-          'caption': {
-            'type': 'StructuredText',
-            'config': {
-              'label': 'Caption',
-              'single': 'hyperlink, bold, em',
-              'placeholder': 'Caption'
             }
           }
         }
@@ -241,6 +231,24 @@ export default {
           'embed': {
             'type': 'Embed',
             'fieldset': 'Twitter embed'
+          }
+        }
+      },
+      'youtubeVideoEmbed': {
+        'type': 'Slice',
+        'fieldset': '[Deprecated] YouTube video (please use embed)',
+        'non-repeat': {
+          'embed': {
+            'type': 'Embed',
+            'fieldset': 'YouTube embed'
+          },
+          'caption': {
+            'type': 'StructuredText',
+            'config': {
+              'label': 'Caption',
+              'single': 'hyperlink, bold, em',
+              'placeholder': 'Caption'
+            }
           }
         }
       },

--- a/prismic-model/js/parts/body.js
+++ b/prismic-model/js/parts/body.js
@@ -81,7 +81,8 @@ export default {
       }),
       embed: slice('Embed', {
         nonRepeat: {
-          embed: embed('Embed (Youtube, Vimeo etc)')
+          embed: embed('Embed (Youtube, Vimeo etc)'),
+          caption: structuredText('Caption', 'single')
         }
       }),
       map: slice('Map', {

--- a/prismic-model/json/articles.json
+++ b/prismic-model/json/articles.json
@@ -330,6 +330,14 @@
               "embed": {
                 "type": "Embed",
                 "fieldset": "Embed"
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Caption",
+                  "single": "hyperlink, bold, em",
+                  "placeholder": "Caption"
+                }
               }
             }
           },
@@ -341,24 +349,6 @@
                 "type": "Text",
                 "config": {
                   "label": "iframe src"
-                }
-              }
-            }
-          },
-          "youtubeVideoEmbed": {
-            "type": "Slice",
-            "fieldset": "YouTube video",
-            "non-repeat": {
-              "embed": {
-                "type": "Embed",
-                "fieldset": "YouTube embed"
-              },
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "label": "Caption",
-                  "single": "hyperlink, bold, em",
-                  "placeholder": "Caption"
                 }
               }
             }
@@ -390,6 +380,24 @@
               "embed": {
                 "type": "Embed",
                 "fieldset": "Twitter embed"
+              }
+            }
+          },
+          "youtubeVideoEmbed": {
+            "type": "Slice",
+            "fieldset": "[Deprecated] YouTube video (please use embed)",
+            "non-repeat": {
+              "embed": {
+                "type": "Embed",
+                "fieldset": "YouTube embed"
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Caption",
+                  "single": "hyperlink, bold, em",
+                  "placeholder": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/books.json
+++ b/prismic-model/json/books.json
@@ -185,6 +185,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/event-series.json
+++ b/prismic-model/json/event-series.json
@@ -188,6 +188,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -246,6 +246,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/exhibitions.json
+++ b/prismic-model/json/exhibitions.json
@@ -188,6 +188,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/installations.json
+++ b/prismic-model/json/installations.json
@@ -201,6 +201,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/pages.json
+++ b/prismic-model/json/pages.json
@@ -184,6 +184,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/places.json
+++ b/prismic-model/json/places.json
@@ -203,6 +203,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/prismic-model/json/series.json
+++ b/prismic-model/json/series.json
@@ -202,6 +202,13 @@
                 "config": {
                   "label": "Embed (Youtube, Vimeo etc)"
                 }
+              },
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "single": "paragraph,hyperlink,strong,em",
+                  "label": "Caption"
+                }
               }
             }
           },

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -151,6 +151,14 @@ function parseBodyPart(slice) {
         }
       };
 
+    case 'embed':
+      return {
+        type: 'embed',
+        value: {
+          embed: slice.primary.embed
+        }
+      };
+
     default:
       break;
   }

--- a/server/services/prismic-body-parser.js
+++ b/server/services/prismic-body-parser.js
@@ -107,15 +107,35 @@ function parseBodyPart(slice) {
         }
       };
 
-    case 'soundcloudEmbed':
-      return {
-        type: 'soundcloudEmbed',
-        value: {
-          iframeSrc: slice.primary.iframeSrc
-        }
-      };
+    case 'embed':
+      const embed = slice.primary.embed;
 
-    case 'youtubeVideoEmbed':
+      if (embed.provider_name === 'SoundCloud') {
+        const apiUrl = embed.html.match(/url=([^&]*)&/);
+        const secretToken = embed.html.match(/secret_token=([^"]*)"/);
+
+        return {
+          type: 'soundcloudEmbed',
+          weight: slice.slice_label,
+          value: {
+            iframeSrc: `https://w.soundcloud.com/player/?url=${apiUrl[1]}%3Fsecret_token%3D${secretToken[1]}&color=%23ff5500&inverse=false&auto_play=false&show_user=true`
+          }
+        };
+      }
+
+      if (embed.provider_name === 'YouTube') {
+        const embedUrl = slice.primary.embed.html.match(/src="([-a-zA-Z0-9://.?=_]+)?/)[1];
+        return {
+          type: 'video-embed',
+          weight: slice.slice_label,
+          value: {
+            embedUrl: `${embedUrl}?rel=0`,
+            caption: slice.primary.caption
+          }
+        };
+      }
+      break;
+
     case 'vimeoVideoEmbed':
       // TODO: Not this ;﹏;
       const embedUrl = slice.primary.embed.html.match(/src="([-a-zA-Z0-9://.?=_]+)?/)[1];
@@ -148,14 +168,6 @@ function parseBodyPart(slice) {
           videoUrl: slice.primary.video && slice.primary.video.url,
           playbackRate: slice.primary.playbackRate || 1,
           tasl: parseTaslFromString(slice.primary.tasl)
-        }
-      };
-
-    case 'embed':
-      return {
-        type: 'embed',
-        value: {
-          embed: slice.primary.embed
         }
       };
 


### PR DESCRIPTION
ref #3257 

Deprecates the old `?Embed`s, and uses a single `embed`.

It's safe to replace the old prismic parser with the new one, as the data has been duplicated in prismic i.e. there is both the `youtubeEmbed` and `embed` where necessary. This halfway house will be removed once the slice is removed.

This has been tested on old and new articles.

![screen shot 2018-10-04 at 07 53 41](https://user-images.githubusercontent.com/31692/46457582-c2b7e700-c7aa-11e8-846e-a346fc4fa5c1.png)

This creates a more universal and simpler editing experience, as well as tidier code.

