### PR TITLE
use priorities properly

### DIFF
--- a/router/terraform/services.tf
+++ b/router/terraform/services.tf
@@ -9,7 +9,7 @@ module "router" {
   listener_https_arn = "${module.router_alb.listener_https_arn}"
   listener_http_arn  = "${module.router_alb.listener_http_arn}"
   is_config_managed  = false
-  alb_priority       = "100"
+  alb_priority       = "1000"
 
   desired_count = 2
 


### PR DESCRIPTION
@gestchild this was the effect of making the priority lower.

Priorities are from low => high.
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#listener-rule-priority

This makes the default check the last thing.
