### PR TITLE
add NewsletterPromo to DefaultPageLayout

### DIFF
--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -3,6 +3,7 @@ import {Component} from 'react';
 import Head from 'next/head';
 import NastyJs from '../Header/NastyJs';
 import Header from '../Header/Header';
+import NewsletterPromo from '../NewsletterPromo/NewsletterPromo';
 import InfoBanner from '../InfoBanner/InfoBanner2';
 import {striptags} from '../../../utils/striptags';
 import {formatDate} from '../../../utils/format-date';
@@ -288,6 +289,7 @@ class DefaultPageLayout extends Component<Props> {
           <div id='main' className='main' role='main'>
             {children}
           </div>
+          <NewsletterPromo />
           {openingTimes &&
             <Footer
               openingHoursId='footer'


### PR DESCRIPTION
Fixes #3461


Nice on white pages:
![screen shot 2018-10-04 at 17 50 11](https://user-images.githubusercontent.com/31692/46489688-fa9c4a00-c7fd-11e8-965d-8fba889d1218.png)

Strange on articles:
![screen shot 2018-10-04 at 17 48 39](https://user-images.githubusercontent.com/31692/46489704-025bee80-c7fe-11e8-9b68-795ed1283d2e.png)

Let's get this in then we can deal with the latter.
