### PR TITLE
don't show part # on articles that aren't in series

### DIFF
--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -83,17 +83,15 @@ export class ArticlePage extends Component<Props, State> {
         })))
     };
 
-    const inSerial = article.series
-      .map(series => {
-        const titles = series.schedule.map(item => item.title);
-        const index = titles.indexOf(article.title);
-        return {series, position: index + 1};
-      }).find(_ => _);
+    // Check if the article is in a serial, and where
+    const serial = article.series.find(series => series.schedule.length > 0);
+    const titlesInSerial = serial && serial.schedule.map(item => item.title);
+    const positionInSerial = titlesInSerial && titlesInSerial.indexOf(article.title) + 1;
 
     // We can abstract this out as a component if we see it elsewhere.
     // Not too confident it's going to be used like this for long.
-    const TitleTopper = !inSerial ? null
-      : <PartNumberIndicator number={inSerial.position} color={inSerial.series.color} />;
+    const TitleTopper = serial && positionInSerial &&
+      <PartNumberIndicator number={positionInSerial} color={serial.color} />;
 
     const genericFields = {
       id: article.id,
@@ -160,9 +158,9 @@ export class ArticlePage extends Component<Props, State> {
     />;
 
     const Siblings = this.state.listOfSeries.map(({series, articles}) => {
-      if (inSerial) {
-        const nextUp = inSerial.position - 1 === series.schedule.length ? series.items[0]
-          : series.items[inSerial.position] ? series.items[inSerial.position] : null;
+      if (series.schedule.length > 0 && positionInSerial) {
+        const nextUp = positionInSerial - 1 === series.schedule.length ? series.items[0]
+          : series.items[positionInSerial] ? series.items[positionInSerial] : null;
 
         return nextUp && <SeriesNavigation
           key={series.id}


### PR DESCRIPTION
Mistakingly thought it was an index bug, turns out it was a logic bug.
A little bit more self explanatory as to how it all works in the code now.

<img width="1110" alt="screen shot 2018-10-05 at 12 16 01" src="https://user-images.githubusercontent.com/31692/46532430-abefbe00-c898-11e8-9579-c7626628d042.png">
---
<img width="1101" alt="screen shot 2018-10-05 at 12 16 44" src="https://user-images.githubusercontent.com/31692/46532436-b14d0880-c898-11e8-81a0-3c25be62eabe.png">
