### PR TITLE
Webcomic series parsers

### DIFF
--- a/common/model/articles.js
+++ b/common/model/articles.js
@@ -2,14 +2,12 @@
 import type {ArticleSeries} from './article-series';
 import type {GenericContentFields} from './generic-content-fields';
 import type {LabelField} from './label-field';
-import type {HTMLString} from '../services/prismic/types';
 import type {ColorSelection} from './color-selections';
 
 export type Article = {|
   type: 'articles',
   ...GenericContentFields,
   format: ?LabelField,
-  summary: ?HTMLString,
   datePublished: Date,
   series: ArticleSeries[],
   color?: ?ColorSelection

--- a/common/services/prismic/article-series.js
+++ b/common/services/prismic/article-series.js
@@ -54,9 +54,13 @@ export async function getArticleSeries(req: ?Request, {
   id,
   ...opts
 }: ArticleSeriesProps): Promise<?ArticleSeriesWithArticles> {
+  // GOTCHA: This is for body squabbles where we have the `webcomics` type.
+  // This will have to remain like this until we figure out how to migrate it.
+  const seriesField = id === 'WleP3iQAACUAYEoN'
+    ? 'my.webcomics.series.series' : 'my.articles.series.series';
   const articles = await getArticles(req, {
-    page: 1,
-    predicates: [Prismic.Predicates.at('my.articles.series.series', id)],
+    page: opts.page || 1,
+    predicates: [Prismic.Predicates.at(seriesField, id)],
     ...opts
   });
 

--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -182,7 +182,7 @@ export async function getArticles(req: ?Request, {
 }: ArticleQueryProps): Promise<PaginatedResults<Article>> {
   const orderings = '[my.articles.publishDate, my.webcomics.publishDate, document.first_publication_date desc]';
   const paginatedResults = await getDocuments(req, [
-    Prismic.Predicates.at('document.type', 'articles')
+    Prismic.Predicates.any('document.type', ['articles', 'webcomics'])
   ].concat(predicates), {
     orderings,
     graphQuery,

--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -5,7 +5,8 @@ import {
   parseGenericFields,
   parseSingleLevelGroup,
   parseLabelType,
-  isDocumentLink
+  isDocumentLink,
+  checkAndParseImage
 } from './parsers';
 import {parseArticleSeries} from './article-series';
 import type {Article} from '../../model/articles';
@@ -16,6 +17,22 @@ import type {
 } from './types';
 
 const graphQuery = `{
+  webcomics {
+    ...webcomicsFields
+    series {
+      series {
+        ...seriesFields
+      }
+    }
+    promo {
+      ... on editorialImage {
+        non-repeat {
+          caption
+          image
+        }
+      }
+    }
+  }
   articles {
     ...articlesFields
     format {
@@ -76,14 +93,13 @@ const graphQuery = `{
   }
 }`;
 
-export function parseArticle(document: PrismicDocument): Article {
+function parseArticleDoc(document: PrismicDocument): Article {
   const {data} = document;
   const datePublished = data.publishDate || document.first_publication_date;
   const article = {
     type: 'articles',
     ...parseGenericFields(document),
     format: isDocumentLink(data.format) ? parseLabelType(data.format) : null,
-    summary: data.summary,
     datePublished: new Date(datePublished),
     series: parseSingleLevelGroup(data.series, 'series').map(series => {
       return parseArticleSeries(series);
@@ -100,9 +116,59 @@ export function parseArticle(document: PrismicDocument): Article {
   };
 }
 
+function parseWebcomicDoc(document: PrismicDocument): Article {
+  const {data} = document;
+  const datePublished = data.publishDate || document.first_publication_date;
+  const article = {
+    type: 'articles',
+    ...parseGenericFields(document),
+    format: {
+      id: 'W7d_ghAAALWY3Ujc',
+      title: 'Comic',
+      description: null
+    },
+    datePublished: new Date(datePublished),
+    series: parseSingleLevelGroup(data.series, 'series').map(series => {
+      return parseArticleSeries(series);
+    })
+  };
+  const labels = [
+    article.format ? {url: null, text: article.format.title || ''} : null,
+    article.series.find(series => series.schedule.length > 0) ? {url: null, text: 'Serial'} : null
+  ].filter(Boolean);
+  const body = data.image ? [
+    {
+      type: 'imageGallery',
+      weight: 'standalone',
+      value: {
+        title: null,
+        items: [{
+          image: checkAndParseImage(data.image),
+          caption: null
+        }]
+      }
+    },
+    ...article.body
+  ] : article.body;
+
+  return {
+    ...article,
+    body,
+    labels: labels.length > 0 ? labels : [{url: null, text: 'Story'}]
+  };
+}
+
+export function parseArticle(document: PrismicDocument): Article {
+  if (document.type === 'webcomics') {
+    return parseWebcomicDoc(document);
+  } else {
+    return parseArticleDoc(document);
+  }
+}
+
 export async function getArticle(req: ?Request, id: string): Promise<?Article> {
   const document = await getDocument(req, id, { graphQuery });
-  return document && document.type === 'articles' ? parseArticle(document) : null;
+  return document && (document.type === 'articles' || document.type === 'webcomics') ? parseArticle(document) : null;
 }
 
 type ArticleQueryProps = {|

--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -33,6 +33,7 @@ export function parseMultiContent(documents: PrismicDocument[]): MultiContent[] 
       case 'events':
         return parseEventDoc(document);
       case 'articles':
+      case 'webcomics':
         return parseArticle(document);
       case 'installations':
         return parseInstallationDoc(document);

--- a/common/views/components/ImageGalleryV2/ImageGalleryV2.js
+++ b/common/views/components/ImageGalleryV2/ImageGalleryV2.js
@@ -132,7 +132,7 @@ class ImageGallery extends Component<Props, State> {
                           })}>
                             <span className='visually-hidden'>slide </span>{i + 1} of {items.length}
                           </div>
-                        ) : undefined}>
+                        ) : null}>
                       </CaptionedImage>
                     </div>
                   ))}

--- a/common/views/components/SeriesNavigation/SeriesNavigation.js
+++ b/common/views/components/SeriesNavigation/SeriesNavigation.js
@@ -25,7 +25,7 @@ const SeriesNavigation = ({ series, items }: Props) => {
         showPosition={showPosition} />
       <PrimaryLink
         name={`More from ${series.title}`}
-        url={`/${series.type === 'article-series' ? 'series' : 'event-series'}/${series.id}`}
+        url={`/${series.type === 'article-series' ? 'series' : series.type}/${series.id}`}
       />
     </Fragment>
   );

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -94,6 +94,7 @@ export class ArticlePage extends Component<Props, State> {
     const TitleTopper = serial && positionInSerial &&
       <PartNumberIndicator number={positionInSerial} color={serial.color} />;
 
+    console.info(article.body);
     const genericFields = {
       id: article.id,
       title: article.title,

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -60,7 +60,10 @@ export class ArticlePage extends Component<Props, State> {
     // used a little bit badly, but we don't have capacity to implement a
     // better solution
     const seriesPromises = this.props.article.series.slice(0, 1).map(series =>
-      getArticleSeries(null, { id: series.id, pageSize: 6 })
+      getArticleSeries(null, {
+        id: series.id,
+        pageSize: 6
+      })
     );
     const listOfSeries = await Promise.all(seriesPromises);
     this.setState({ listOfSeries });
@@ -94,7 +97,6 @@ export class ArticlePage extends Component<Props, State> {
     const TitleTopper = serial && positionInSerial &&
       <PartNumberIndicator number={positionInSerial} color={serial.color} />;
 
-    console.info(article.body);
     const genericFields = {
       id: article.id,
       title: article.title,

--- a/prismic-model/js/webcomic-series.js
+++ b/prismic-model/js/webcomic-series.js
@@ -1,7 +1,16 @@
 // @flow
-import ArticleSeries from './series';
 import title from './parts/title';
+import structuredText from './parts/structured-text';
+import promo from './parts/promo';
+import contributorsWithTitle from './parts/contributorsWithTitle';
 
 export default {
-  'Webcomic series': Object.assign({}, ArticleSeries['Article series'], { title })
+  '[Deprecated] Webcomic series': {
+    title: title,
+    description: structuredText('Description')
+  },
+  Contributors: contributorsWithTitle(),
+  Promo: {
+    promo
+  }
 };

--- a/prismic-model/json/webcomic-series.json
+++ b/prismic-model/json/webcomic-series.json
@@ -1,12 +1,5 @@
 {
-  "Webcomic series": {
-    "name": {
-      "type": "Text",
-      "config": {
-        "label": "Title",
-        "useAsTitle": true
-      }
-    },
+  "[Deprecated] Webcomic series": {
     "title": {
       "type": "StructuredText",
       "config": {
@@ -15,79 +8,83 @@
         "useAsTitle": true
       }
     },
-    "color": {
-      "type": "Select",
-      "config": {
-        "label": "Colour",
-        "options": [
-          "turquoise",
-          "red",
-          "orange",
-          "purple"
-        ]
-      }
-    },
     "description": {
       "type": "StructuredText",
       "config": {
         "multi": "paragraph,hyperlink,strong,em",
         "label": "Description"
       }
+    }
+  },
+  "Contributors": {
+    "contributors": {
+      "type": "Group",
+      "fieldset": "Contributors",
+      "config": {
+        "fields": {
+          "role": {
+            "type": "Link",
+            "config": {
+              "label": "Role",
+              "select": "document",
+              "customtypes": [
+                "editorial-contributor-roles"
+              ]
+            }
+          },
+          "contributor": {
+            "type": "Link",
+            "config": {
+              "label": "Contributor",
+              "select": "document",
+              "customtypes": [
+                "people",
+                "organisations"
+              ]
+            }
+          },
+          "description": {
+            "type": "StructuredText",
+            "config": {
+              "multi": "paragraph,hyperlink,strong,em",
+              "label": "Contributor description override"
+            }
+          }
+        }
+      }
     },
-    "body": {
-      "fieldset": "Body content",
+    "contributorsTitle": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Contributors heading override",
+        "single": "heading1"
+      }
+    }
+  },
+  "Promo": {
+    "promo": {
       "type": "Slices",
       "config": {
-        "labels": {
-          "text": [
-            {
-              "name": "featured",
-              "display": "Featured"
-            }
-          ],
-          "editorialImage": [
-            {
-              "name": "supporting",
-              "display": "Supporting"
-            },
-            {
-              "name": "standalone",
-              "display": "Standalone"
-            }
-          ],
-          "quote": [
-            {
-              "name": "pull",
-              "display": "Pull"
-            },
-            {
-              "name": "review",
-              "display": "Review"
-            }
-          ]
-        },
+        "label": "Promo",
         "choices": {
-          "text": {
-            "type": "Slice",
-            "fieldset": "Text",
-            "non-repeat": {
-              "text": {
-                "type": "StructuredText",
-                "config": {
-                  "multi": "paragraph,hyperlink,strong,em,heading2,heading3,list-item",
-                  "label": "Text"
-                }
-              }
-            }
-          },
           "editorialImage": {
             "type": "Slice",
-            "fieldset": "Captioned image",
+            "fieldset": "Editorial image",
+            "config": {
+              "label": "Editorial image"
+            },
             "non-repeat": {
+              "caption": {
+                "type": "StructuredText",
+                "config": {
+                  "label": "Promo text",
+                  "single": "paragraph"
+                }
+              },
               "image": {
                 "type": "Image",
                 "config": {
-                  "label": "Image",
+                  "label": "Promo image",
                   "thumbnails": [
                     {
                       "name": "32:15",
@@ -107,243 +104,10 @@
                   ]
                 }
               },
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "paragraph,hyperlink,strong,em",
-                  "label": "Caption"
-                }
-              }
-            }
-          },
-          "editorialImageGallery": {
-            "type": "Slice",
-            "fieldset": "Image gallery",
-            "non-repeat": {
-              "title": {
-                "type": "StructuredText",
-                "config": {
-                  "label": "Title",
-                  "single": "heading1",
-                  "useAsTitle": true
-                }
-              }
-            },
-            "repeat": {
-              "image": {
-                "type": "Image",
-                "config": {
-                  "label": "Image",
-                  "thumbnails": [
-                    {
-                      "name": "32:15",
-                      "width": 3200,
-                      "height": 1500
-                    },
-                    {
-                      "name": "16:9",
-                      "width": 3200,
-                      "height": 1800
-                    },
-                    {
-                      "name": "square",
-                      "width": 3200,
-                      "height": 3200
-                    }
-                  ]
-                }
-              },
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "paragraph,hyperlink,strong,em",
-                  "label": "Caption"
-                }
-              }
-            }
-          },
-          "gifVideo": {
-            "type": "Slice",
-            "fieldset": "Gif video",
-            "non-repeat": {
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "paragraph,hyperlink,strong,em",
-                  "label": "Caption"
-                }
-              },
-              "tasl": {
+              "link": {
                 "type": "Text",
                 "config": {
-                  "label": "TASL",
-                  "placeholder": "title|author|sourceName|sourceLink|license|copyrightHolder|copyrightLink"
-                }
-              },
-              "video": {
-                "type": "Link",
-                "config": {
-                  "label": "Video",
-                  "select": "media",
-                  "customtypes": [],
-                  "placeholder": "Video"
-                }
-              },
-              "playbackRate": {
-                "type": "Select",
-                "config": {
-                  "label": "Playback rate",
-                  "options": [
-                    "0.1",
-                    "0.25",
-                    "0.5",
-                    "0.75",
-                    "1",
-                    "1.25",
-                    "1.5",
-                    "1.75",
-                    "2"
-                  ]
-                }
-              }
-            }
-          },
-          "iframe": {
-            "type": "Slice",
-            "fieldset": "Iframe",
-            "non-repeat": {
-              "iframeSrc": {
-                "type": "Text",
-                "config": {
-                  "label": "iframe src",
-                  "placeholder": "iframe src"
-                }
-              },
-              "previewImage": {
-                "type": "Image",
-                "config": {
-                  "label": "Preview image"
-                }
-              }
-            }
-          },
-          "quote": {
-            "type": "Slice",
-            "fieldset": "Quote",
-            "non-repeat": {
-              "text": {
-                "type": "StructuredText",
-                "config": {
-                  "multi": "paragraph,hyperlink,strong,em",
-                  "label": "Quote"
-                }
-              },
-              "citation": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "paragraph,hyperlink,strong,em",
-                  "label": "Citation"
-                }
-              }
-            }
-          },
-          "standfirst": {
-            "type": "Slice",
-            "fieldset": "Standfirst",
-            "non-repeat": {
-              "text": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "paragraph,hyperlink,strong,em",
-                  "label": "Standfirst"
-                }
-              }
-            }
-          },
-          "embed": {
-            "type": "Slice",
-            "fieldset": "Embed",
-            "non-repeat": {
-              "embed": {
-                "type": "Embed",
-                "config": {
-                  "label": "Embed (Youtube, Vimeo etc)"
-                }
-              },
-              "caption": {
-                "type": "StructuredText",
-                "config": {
-                  "single": "paragraph,hyperlink,strong,em",
-                  "label": "Caption"
-                }
-              }
-            }
-          },
-          "map": {
-            "type": "Slice",
-            "fieldset": "Map",
-            "non-repeat": {
-              "title": {
-                "type": "StructuredText",
-                "config": {
-                  "label": "Title",
-                  "single": "heading1",
-                  "useAsTitle": true
-                }
-              },
-              "geolocation": {
-                "type": "GeoPoint",
-                "config": {
-                  "label": "Geo point"
-                }
-              }
-            }
-          },
-          "contentList": {
-            "type": "Slice",
-            "fieldset": "(β) Content list",
-            "non-repeat": {
-              "title": {
-                "type": "StructuredText",
-                "config": {
-                  "label": "Title",
-                  "single": "heading1",
-                  "useAsTitle": true
-                }
-              }
-            },
-            "repeat": {
-              "content": {
-                "type": "Link",
-                "config": {
-                  "label": "Content item",
-                  "select": "document",
-                  "customtypes": [
-                    "pages",
-                    "event-series",
-                    "books",
-                    "events"
-                  ]
-                }
-              }
-            }
-          },
-          "searchResults": {
-            "type": "Slice",
-            "fieldset": "(β) Search results",
-            "non-repeat": {
-              "title": {
-                "type": "StructuredText",
-                "config": {
-                  "label": "Title",
-                  "single": "heading1",
-                  "useAsTitle": true
-                }
-              },
-              "query": {
-                "type": "Text",
-                "config": {
-                  "label": "Query"
+                  "label": "Link override"
                 }
               }
             }


### PR DESCRIPTION
Adds webcomics to the mix.

This allows us to maintain the `/articles/{ID}` URL, but it really would be nice to actually bring these into the `articles` fold.

![screenshot-localhost-3000-2018 10 09-15-27-38](https://user-images.githubusercontent.com/31692/46676860-4887c800-cbd9-11e8-8ca0-9764bbcffeaf.png)
