### PR TITLE
serve all pages and exhibitions from content app

### DIFF
--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -96,6 +96,14 @@ module "content" {
   alb_priority                       = "700"
 }
 
+module "pages_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "100"
+  path = "/pages/*"
+}
 module "visit_us_listener" {
   source = "../../shared-infra/terraform/service_alb_listener"
   alb_listener_https_arn = "${local.alb_listener_https_arn}"
@@ -103,6 +111,54 @@ module "visit_us_listener" {
   target_group_arn = "${module.content.target_group_arn}"
   priority = "101"
   path = "/visit-us"
+}
+module "what_we_do_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "102"
+  path = "/what-we-do"
+}
+module "press_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "103"
+  path = "/press"
+}
+module "venue_hire_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "104"
+  path = "/venue-hire"
+}
+module "access_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "105"
+  path = "/access"
+}
+module "youth_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "106"
+  path = "/youth"
+}
+module "schools_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "107"
+  path = "/schools"
 }
 
 module "installations_listener" {
@@ -112,4 +168,13 @@ module "installations_listener" {
   target_group_arn = "${module.content.target_group_arn}"
   priority = "110"
   path = "/installations/*"
+}
+
+module "exhibitions_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "111"
+  path = "/exhibitions/*"
 }


### PR DESCRIPTION
Serves all pages and exhibitions from content app (thus the new template).