### PR TITLE
make sure next asset cache is stronger than HTML cache

### DIFF
--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -73,6 +73,27 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     }
   }
 
+  # Make sure that the next assets always outlive the HTML
+  cache_behavior {
+    target_origin_id       = "origin"
+    path_pattern           = "/_next/*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 86400
+    default_ttl            = 86400
+    max_ttl                = 31536000
+
+    forwarded_values {
+      headers      = ["Host"]
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
   cache_behavior {
     target_origin_id       = "origin"
     path_pattern           = "/events/*"


### PR DESCRIPTION
As per https://spectrum.chat/thread/602ba081-7fea-4c73-9007-a8f0d5a55152
Bumped up the next asset cache times, so they should always outlive the HTML.

Tested this with pages over the weekend, and no errors, but we'll keep an eye out.