### PR TITLE
Gif video layout

### DIFF
--- a/common/styles/components/_captioned_image.scss
+++ b/common/styles/components/_captioned_image.scss
@@ -3,6 +3,7 @@
   margin: 0;
   display: inline-block;
   width: 100%;
+  transition: transform 400ms ease;
 
   .image {
     max-height: 80vh;

--- a/common/styles/components/_captioned_image.scss
+++ b/common/styles/components/_captioned_image.scss
@@ -3,7 +3,6 @@
   margin: 0;
   display: inline-block;
   width: 100%;
-  transition: transform 400ms ease;
 
   .image {
     max-height: 80vh;

--- a/common/styles/components/_gif_video.scss
+++ b/common/styles/components/_gif_video.scss
@@ -1,7 +1,11 @@
-.gif-video__video {
-  width: 100%;
+.gif-video {
+  transition: transform 400ms ease;
 }
 
+.gif-video__video {
+  max-height: 80vh;
+  max-width: 100%;
+}
 .gif-video__play-pause {
   background: transparent;
   border: 0;

--- a/common/styles/components/_gif_video.scss
+++ b/common/styles/components/_gif_video.scss
@@ -1,11 +1,8 @@
-.gif-video {
-  transition: transform 400ms ease;
-}
-
 .gif-video__video {
   max-height: 80vh;
   max-width: 100%;
 }
+
 .gif-video__play-pause {
   background: transparent;
   border: 0;

--- a/common/views/components/GifVideo/GifVideo.js
+++ b/common/views/components/GifVideo/GifVideo.js
@@ -102,7 +102,7 @@ class GifVideo extends Component<Props, State> {
 
     setVideoSize = () => {
       this.setState({
-        computedVideoWidth: this.videoRef.current.clientWidth
+        computedVideoWidth: this.videoRef && this.videoRef.current && this.videoRef.current.clientWidth
       });
     }
 
@@ -139,7 +139,7 @@ class GifVideo extends Component<Props, State> {
       return (
         <figure style={{
           marginLeft: '50%',
-          transform: `translateX(${computedVideoWidth / -2}px)`
+          transform: computedVideoWidth && `translateX(${computedVideoWidth / -2}px)`
         }}
         className='js-gif-video gif-video no-margin' data-playback-rate={playbackRate}>
           <div className='gif-video__inner relative inline-block'>

--- a/common/views/components/GifVideo/GifVideo.js
+++ b/common/views/components/GifVideo/GifVideo.js
@@ -18,14 +18,16 @@ type Props = {|
 type State = {|
   canPlay: boolean,
   isPlaying: boolean,
-  autoPlayDisabled: boolean
+  autoPlayDisabled: boolean,
+  computedVideoWidth: ?number
 |}
 
 class GifVideo extends Component<Props, State> {
   state = {
     canPlay: false,
     isPlaying: false,
-    autoPlayDisabled: false
+    autoPlayDisabled: false,
+    computedVideoWidth: null
   }
 
   videoRef = React.createRef();
@@ -98,8 +100,15 @@ class GifVideo extends Component<Props, State> {
       setTimeout(() => { this.autoControlGif(); }, 0); // TODO - fix properly - canPlay is still false without setTimeout
     };
 
+    setVideoSize = () => {
+      this.setState({
+        computedVideoWidth: this.videoRef.current.clientWidth
+      });
+    }
+
     debounceAutoControl = debounce(this.autoControlGif, 500);
-    throttleAutoControl = throttle(this.autoControlGif, 100)
+    throttleAutoControl = throttle(this.autoControlGif, 100);
+    debouncedSetVidoSize = debounce(this.setVideoSize, 500);
 
     componentDidMount() {
       const video = this.videoRef.current;
@@ -111,23 +120,29 @@ class GifVideo extends Component<Props, State> {
           video.addEventListener('canplaythrough', () => { this.initVideoGif(video); });
         }
       }
+      this.setVideoSize();
       window.addEventListener('resize', this.debounceAutoControl);
       window.addEventListener('scroll', this.throttleAutoControl);
+      window.addEventListener('resize', this.debouncedSetVidoSize);
     }
 
     componentWillUnmount() {
       window.removeEventListener('resize', this.debounceAutoControl);
       window.removeEventListener('scroll', this.throttleAutoControl);
+      window.removeEventListener('resize', this.debouncedSetVidoSize);
     }
-
     // TODO remove 'data-track-label' and 'data-playback-rate' once we're completely moved over to using Nextjs
     // TODO remove 'js-...' classes once we're completely moved over to using Nextjs
     render() {
       const { playbackRate, videoUrl, caption, tasl } = this.props;
-      const { canPlay, isPlaying } = this.state;
+      const { canPlay, isPlaying, computedVideoWidth } = this.state;
       return (
-        <figure className='js-gif-video gif-video no-margin' data-playback-rate={playbackRate}>
-          <div className='gif-video__inner relative'>
+        <figure style={{
+          marginLeft: '50%',
+          transform: `translateX(${computedVideoWidth / -2}px)`
+        }}
+        className='js-gif-video gif-video no-margin' data-playback-rate={playbackRate}>
+          <div className='gif-video__inner relative inline-block'>
             <video ref={this.videoRef} className='gif-video__video block js-gif-video__video'
               preload='metadata'
               muted
@@ -151,7 +166,7 @@ class GifVideo extends Component<Props, State> {
             {(tasl && (tasl.title || tasl.sourceName || tasl.copyrightHolder || tasl.license)) &&
             <Tasl {...tasl} />}
           </div>
-          {caption && <Caption caption={caption} />}
+          {caption && <Caption width={computedVideoWidth} caption={caption} />}
         </figure>
       );
     }


### PR DESCRIPTION
References #3257

Now gif-videos are displayed in the new template, we need to limit their size. This makes them behave the same way as captioned images (limited to 80vh)

Before:
![screen shot 2018-10-09 at 16 23 19](https://user-images.githubusercontent.com/6051896/46680009-0c0b9a80-cbe0-11e8-8314-75f3f92f8771.png)

After: 
![screen shot 2018-10-09 at 16 23 49](https://user-images.githubusercontent.com/6051896/46680019-1037b800-cbe0-11e8-8c4d-a67346c8faec.png)

