### PR TITLE
do a combo of promo and drupalised promo for pages

### DIFF
--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -34,7 +34,7 @@ export function parsePage(document: PrismicDocument): Page {
   return {
     type: 'pages',
     ...genericFields,
-    promo: promo || drupalisedPromo,
+    promo: promo && promo.image ? promo : drupalisedPromo,
     datePublished: data.datePublished && parseTimestamp(data.datePublished),
     siteSection: siteSection,
     drupalPromoImage: drupalPromoImage,

--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -91,8 +91,8 @@ export const OpenGraph = ({
   <meta key='og:title' property='og:title' content={title} />,
   <meta key='og:description' property='og:description' content={striptags(description)} />,
   // we add itemprop="image" as it's required for WhatsApp
-  <meta key='og:image' property='og:image' content={imageUrl} itemProp='image' />,
-  <meta key='og:image:width' property='og:image:width' content='1200' />,
+  imageUrl ? <meta key='og:image' property='og:image' content={imageUrl} itemProp='image' /> : null,
+  imageUrl ? <meta key='og:image:width' property='og:image:width' content='1200' /> : null,
 
   publishedTime ? <meta key='og:article:published_time' property='og:article:published_time' content={formatDate(publishedTime)} /> : null,
   modifiedTime ? <meta key='og:article:modified_time' property='og:article:modified_time' content={formatDate(modifiedTime)} /> : null,


### PR DESCRIPTION
2 minute investigation showed that we show no drupal image as we have a promo, there's just no image in it.

This way . we use the drupal image, even if we have a promo.

Fixes #3423