### PR TITLE
groupd and order exhibitions by current, permanent, comingUp, past

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -262,6 +262,8 @@ function putPermanentAfterCurrentExhibitions(exhibitions: UiExhibition[]): UiExh
       acc.permanent.push(result);
     } else if (london(result.start).isAfter(london())) {
       acc.comingUp.push(result);
+    } else if (london(result.end).isBefore(london())) {
+      acc.past.push(result);
     } else {
       acc.current.push(result);
     }
@@ -270,12 +272,16 @@ function putPermanentAfterCurrentExhibitions(exhibitions: UiExhibition[]): UiExh
   }, {
     current: [],
     permanent: [],
-    comingUp: []
+    comingUp: [],
+    past: []
   });
 
-  return groupedResults.current
-    .concat(groupedResults.permanent)
-    .concat(groupedResults.comingUp);
+  return [
+    ...groupedResults.current,
+    ...groupedResults.permanent,
+    ...groupedResults.comingUp,
+    ...groupedResults.past
+  ];
 }
 
 export async function getExhibition(req: ?Request, id: string): Promise<?UiExhibition> {


### PR DESCRIPTION
Exhibitions are:
* ordered new - old
* grouped then ordered by `current`, `permanent`, `comingUp`, `past`

Adds past to heading of past exhibitions.

__To discuss__ - do we need a separator of sorts for past exhibitions?

![screen shot 2018-10-09 at 18 38 17](https://user-images.githubusercontent.com/31692/46687318-8a713800-cbf2-11e8-92a3-b5cc4769d770.png)

![screen shot 2018-10-09 at 18 43 06](https://user-images.githubusercontent.com/31692/46687645-403c8680-cbf3-11e8-8d6d-99e92d50bf2d.png)

