### PR TITLE
make sure we deserialise the serialised date from getInitialProps

### DIFF
--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -41,7 +41,7 @@ export class Page extends Component<Props> {
 
   render() {
     const {page} = this.props;
-    const DateInfo = page.datePublished && <HTMLDate date={page.datePublished} />;
+    const DateInfo = page.datePublished && <HTMLDate date={new Date(page.datePublished)} />;
 
     const hasFeaturedMedia = page.body.length > 1 &&
     (page.body[0].type === 'picture' || page.body[0].type === 'videoEmbed');


### PR DESCRIPTION
Need to remember that [data from `getInitialProps` is serialised](https://github.com/zeit/next.js#fetching-data-and-component-lifecycle).
 
I wonder if this means that the data models should only ever carry JSON basic types which are then converted when needed in rendering / logic? [That could be particularly annoying with things like events](https://github.com/wellcometrust/wellcomecollection.org/blob/master/content/webapp/pages/event.js#L82), but it doesn't look like it's going to be changed soon.

We could have something like:
* Prismic API
* Our normalised JSON API
* Converted into Dates etc 