### PR TITLE
add period routes to content app

### DIFF
--- a/common/model/periods.js
+++ b/common/model/periods.js
@@ -1,4 +1,5 @@
 // @flow
+// We use this in routing, so we use standard JS
 export const Periods = {
   Today: 'today',
   ThisWeekend: 'this-weekend',

--- a/common/model/periods.js
+++ b/common/model/periods.js
@@ -1,5 +1,4 @@
 // @flow
-// We use this in routing, so we use standard JS
 export const Periods = {
   Today: 'today',
   ThisWeekend: 'this-weekend',

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -199,16 +199,16 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
 
 type Order = 'desc' | 'asc';
 type GetExhibitionsProps = {|
-  predicates: Prismic.Predicates[],
-  order: Order,
+  predicates?: Prismic.Predicates[],
+  order?: Order,
   period?: Period,
   page?: number
 |}
 export async function getExhibitions(
-  req: Request,
+  req: ?Request,
   {
     predicates = [],
-    order = 'asc',
+    order = 'desc',
     period,
     page = 1
   }: GetExhibitionsProps = {}

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -10,7 +10,7 @@ import type {Installation} from '../../../model/installations';
 
 type EvExIn = UiEvent | UiExhibition | Installation; // TODO: This should be MultiContent
 type Props = {|
-  items: EvExIn[]
+  items: $ReadOnlyArray<EvExIn>
 |}
 
 const CardGrid = ({

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -1,0 +1,112 @@
+// @flow
+import {Fragment} from 'react';
+import CardGrid from '../CardGrid/CardGrid';
+import Layout12 from '../Layout12/Layout12';
+import Divider from '../Divider/Divider';
+import Pagination from '../Pagination/Pagination';
+import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
+import {classNames, spacing, font, grid} from '../../../utils/classnames';
+import type {Period} from '../../../model/periods';
+import type {UiExhibition} from '../../../model/exhibitions';
+import type {PaginatedResults, HTMLString} from '../../../services/prismic/types';
+
+type Props = {|
+  title: string,
+  description: ?HTMLString,
+  paginatedResults: PaginatedResults<UiExhibition>,
+  period?: Period
+|}
+
+const LayoutPaginatedResults = ({
+  title,
+  description,
+  paginatedResults,
+  period
+}: Props) => (
+  <Fragment>
+    <div className={classNames({
+      'row': true,
+      'bg-cream': true,
+      'plain-text': true,
+      [spacing({s: 3, m: 5, l: 5}, {padding: ['top', 'bottom']})]: true
+
+    })}>
+      <div className='container'>
+        <div className='grid'>
+          <div className={classNames({
+            [grid({s: 12, m: 12, l: 8, xl: 8})]: true
+          })}>
+            <h1 className={classNames({
+              'no-margin': true,
+              [font({s: 'WB6', m: 'WB5', l: 'WB4'})]: true
+            })}>{title}</h1>
+
+            {description &&
+              <div className={classNames({
+                'first-para-no-margin': true,
+                [spacing({s: 2}, {margin: ['top']})]: true
+              })}>
+                <PrismicHtmlBlock html={description} />
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {paginatedResults.totalPages > 1  &&
+      <Layout12>
+        <div className={classNames({
+          'flex': true,
+          'flex--v-center': true,
+          'font-pewter': true,
+          [spacing({s: 5, m: 5, l: 5}, {padding: ['top', 'bottom']})]: true,
+          [font({s: 'LR3', m: 'LR2'})]: true
+        })}>
+          {(paginatedResults.pageSize * paginatedResults.currentPage) - (paginatedResults.pageSize - 1)}
+              -
+          {paginatedResults.currentPage < paginatedResults.totalPages ? paginatedResults.pageSize * paginatedResults.currentPage : null}
+          {paginatedResults.currentPage === paginatedResults.totalPages ? paginatedResults.totalResults : null}
+        </div>
+        <Divider extraClasses={'divider--keyline divider--pumice'} />
+      </Layout12>
+    }
+
+    <div className={classNames({
+      [spacing({s: 4}, {margin: ['top']})]: true
+    })}>
+      <Layout12>
+        <div className='flex-inline flex--v-center'>
+          <span className={classNames({
+            [font({s: 'HNM5', m: 'HNM4'})]: true,
+            [spacing({s: 4}, {margin: ['bottom']})]: true
+          })}>Free admission</span>
+        </div>
+      </Layout12>
+      <CardGrid items={paginatedResults.results} />
+    </div>
+
+    {paginatedResults.totalPages > 1 &&
+      <div className={classNames({
+        [spacing({s: 2, m: 2, l: 2}, {padding: ['top']})]: true,
+        [spacing({s: 3, m: 3, l: 3}, {padding: ['bottom']})]: true
+      })}>
+        <Layout12>
+          <div className='text-align-right'>
+            <Pagination
+              currentPage={paginatedResults.currentPage}
+              pageCount={paginatedResults.totalPages}
+              prevPage={paginatedResults.currentPage > 1 ? paginatedResults.currentPage - 1 : 0}
+              nextPage={paginatedResults.currentPage < paginatedResults.totalPages ? paginatedResults.currentPage + 1 : 0}
+              prevQueryString={'/exhibitions' + (period ? `/${period}` : '') + (paginatedResults.currentPage > 1 ? `?page=${paginatedResults.currentPage - 1}` : '')}
+              nextQueryString={'/exhibitions' + (period ? `/${period}` : '') + (paginatedResults.currentPage < paginatedResults.totalPages ? `?page=${paginatedResults.currentPage + 1}` : '')}
+            />
+          </div>
+        </Layout12>
+      </div>
+    }
+
+  </Fragment>
+);
+
+export default LayoutPaginatedResults;

--- a/common/views/components/Pagination/Pagination.js
+++ b/common/views/components/Pagination/Pagination.js
@@ -4,10 +4,10 @@ import {font, spacing} from '../../../utils/classnames';
 import Control from '../Buttons/Control/Control';
 
 export type Props = {|
-  prevPage?: number,
+  prevPage?: ?number,
   currentPage: number,
   pageCount: number,
-  nextPage?: number,
+  nextPage?: ?number,
   nextQueryString?: string,
   prevQueryString?: string,
   range?: {beginning: number, end: number}

--- a/content/webapp/pages/exhibitions.js
+++ b/content/webapp/pages/exhibitions.js
@@ -1,0 +1,53 @@
+// @flow
+import {Component} from 'react';
+import {getExhibitions} from '@weco/common/services/prismic/exhibitions';
+import PageWrapper from '@weco/common/views/components/PageWrapper/PageWrapper';
+import LayoutPaginatedResults from '@weco/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults';
+import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import type {UiExhibition} from '@weco/common/model/exhibitions';
+import type {PaginatedResults} from '@weco/common/services/prismic/types';
+
+type Props = {|
+  exhibitions: PaginatedResults<UiExhibition>
+|}
+
+const pageDescription = 'Explore the connections between science, medicine, life and art through our permanent and temporary exhibitions. Admission is always free.';
+export class ArticleSeriesPage extends Component<Props> {
+  static getInitialProps = async (context: GetInitialPropsProps) => {
+    const {page = 1} = context.query;
+    const {period} = context.query;
+    const exhibitions = await getExhibitions(context.req, {page, period});
+    if (exhibitions) {
+      return {
+        exhibitions,
+        title: 'Exhibitions',
+        description: pageDescription,
+        type: 'website',
+        canonicalUrl: `https://wellcomecollection.org/exhibitions`,
+        imageUrl: null,
+        siteSection: 'whatson',
+        analyticsCategory: 'public-programme'
+      };
+    } else {
+      return {statusCode: 404};
+    }
+  }
+
+  render() {
+    const {exhibitions} = this.props;
+
+    return (
+      <LayoutPaginatedResults
+        title={'Exhibitions'}
+        description={[{
+          type: 'paragraph',
+          text: pageDescription,
+          spans: []
+        }]}
+        paginatedResults={exhibitions}
+      />
+    );
+  }
+};
+
+export default PageWrapper(ArticleSeriesPage);

--- a/whats_on/app/views/pages/exhibitions.njk
+++ b/whats_on/app/views/pages/exhibitions.njk
@@ -72,7 +72,6 @@
           } %}
         </div>
       {% endif %}
-
     </div>
   </div>
 


### PR DESCRIPTION
Move exhibitions rendering completely over to nextJS.
NEXTIBITIONS!

I'll change the route listener once I've tested this with `/exhibitions/past`.

There will be quite a lot of deprecation and deletion after this.