### PR TITLE
Correct displayed time for event by Month

### DIFF
--- a/common/utils/dates.js
+++ b/common/utils/dates.js
@@ -1,11 +1,12 @@
 // @flow
 import {london} from './format-date';
 import type {DateRange} from '../model/date-range';
+import type Moment from 'moment';
 
-export function getEarliestFutureDateRange(dateRanges: DateRange[]): ?DateRange {
+export function getEarliestFutureDateRange(dateRanges: DateRange[], fromDate: ?Moment = london()): ?DateRange {
   return dateRanges
     .sort((a, b) => a.start - b.start)
-    .find(range => london(range.start).isSameOrAfter(london(), 'day'));
+    .find(range => london(range.start).isSameOrAfter(fromDate) && london(range.start).isSameOrAfter(london()));
 }
 
 export function isPast(date: Date): boolean {

--- a/common/utils/dates.js
+++ b/common/utils/dates.js
@@ -5,11 +5,11 @@ import type {DateRange} from '../model/date-range';
 export function getEarliestFutureDateRange(dateRanges: DateRange[]): ?DateRange {
   return dateRanges
     .sort((a, b) => a.start - b.start)
-    .find(range => range.start > london().toDate());
+    .find(range => london(range.start).isSameOrAfter(london(), 'day'));
 }
 
 export function isPast(date: Date): boolean {
-  return london(date).isBefore(london());
+  return london(date).isBefore(london(), 'day');
 }
 
 export function getNextWeekendDateRange(date: Date): DateRange {

--- a/common/utils/format-date.js
+++ b/common/utils/format-date.js
@@ -4,7 +4,7 @@ import 'moment-timezone';
 import moment from 'moment';
 import type Moment from 'moment';
 
-export function london(d?: Date | string | Moment) {
+export function london(d?: Date | string | Moment |{M: string}) {
   // $FlowFixMe
   return moment.tz(d, 'Europe/London');
 }

--- a/common/views/components/EventDateRange/EventDateRange.js
+++ b/common/views/components/EventDateRange/EventDateRange.js
@@ -2,17 +2,19 @@
 import {getEarliestFutureDateRange} from '../../../utils/dates';
 import DateRange from '../DateRange/DateRange';
 import type {UiEvent} from '../../../model/events';
+import type Moment from 'moment';
 type Props = {|
   event: UiEvent,
-  splitTime?: boolean
+  splitTime?: boolean,
+  fromDate?: Moment
 |}
 
-const EventDateRange = ({event, splitTime}: Props) => {
+const EventDateRange = ({event, splitTime, fromDate}: Props) => {
   const dateRanges = event.times.map(({range}) => ({
     start: range.startDateTime,
     end: range.endDateTime
   }));
-  const earliestFutureDateRange = getEarliestFutureDateRange(dateRanges);
+  const earliestFutureDateRange = getEarliestFutureDateRange(dateRanges, fromDate);
   const dateRange = earliestFutureDateRange || (dateRanges.length > 0 ? dateRanges[0] : null);
   const DateInfo = dateRange && <DateRange {...dateRange} splitTime={splitTime} />;
 

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -6,19 +6,22 @@ import Icon from '../Icon/Icon';
 import EventDateRange from '../EventDateRange/EventDateRange';
 import {isEventFullyBooked} from '../../../model/events';
 import type {UiEvent} from '../../../model/events';
+import Moment from 'moment';
 
 type Props = {|
   event: UiEvent,
   position?: number,
   dateString?: string,
   timeString?: string,
+  fromDate?: Moment
 |}
 
 const EventPromo = ({
   event,
   position = 0,
   dateString,
-  timeString
+  timeString,
+  fromDate
 }: Props) => {
   const fullyBooked = isEventFullyBooked(event);
   const isPast = event.isPast;
@@ -63,7 +66,7 @@ const EventPromo = ({
 
           {!isPast &&
             <p className={`${font({s: 'HNL4'})} no-padding no-margin`}>
-              <EventDateRange event={event} splitTime={true} />
+              <EventDateRange event={event} splitTime={true} fromDate={fromDate} />
             </p>
           }
 

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -1,5 +1,6 @@
 // @flow
 import {london} from '../../../utils/format-date';
+// import {getEarliestFutureDateRange} from '../../../utils/dates';
 import {classNames, cssGrid, spacing} from '../../../utils/classnames';
 import SegmentedControl from '../SegmentedControl/SegmentedControl';
 import EventPromo from '../EventPromo/EventPromo';
@@ -20,6 +21,20 @@ function getMonthsInDateRange({start, end}, acc = []) {
     return acc;
   }
 }
+const monthsIndex = {
+  'January': 0,
+  'February': 1,
+  'March': 2,
+  'April': 3,
+  'May': 4,
+  'June': 5,
+  'July': 6,
+  'August': 7,
+  'September': 8,
+  'October': 9,
+  'November': 10,
+  'December': 11
+};
 
 const EventsByMonth = ({
   events
@@ -99,6 +114,7 @@ const EventsByMonth = ({
                   <EventPromo
                     event={event}
                     position={i}
+                    fromDate={london({M: monthsIndex[month]})}
                   />
                 </div>
               ))}

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -1,6 +1,6 @@
 // @flow
 import {london} from '../../../utils/format-date';
-// import {getEarliestFutureDateRange} from '../../../utils/dates';
+import {getEarliestFutureDateRange} from '../../../utils/dates';
 import {classNames, cssGrid, spacing} from '../../../utils/classnames';
 import SegmentedControl from '../SegmentedControl/SegmentedControl';
 import EventPromo from '../EventPromo/EventPromo';
@@ -21,6 +21,7 @@ function getMonthsInDateRange({start, end}, acc = []) {
     return acc;
   }
 }
+
 const monthsIndex = {
   'January': 0,
   'February': 1,
@@ -62,6 +63,17 @@ const EventsByMonth = ({
     url: `#${month}`,
     text: month
   }));
+
+  // Need to order the events for each month based on their earliest future date range
+  Object.keys(eventsInMonths).map(month => {
+    eventsInMonths[month].sort((a, b) => {
+      const aTimes = a.times.map(time => ({start: time.range.startDateTime, end: time.range.endDateTime}));
+      const bTimes = b.times.map(time => ({start: time.range.startDateTime, end: time.range.endDateTime}));
+      const aEarliestFuture = getEarliestFutureDateRange(aTimes, london({M: monthsIndex[month]})) || {};
+      const bEarliestFuture = getEarliestFutureDateRange(bTimes, london({M: monthsIndex[month]})) || {};
+      return aEarliestFuture.start - bEarliestFuture.start;
+    });
+  });
 
   return (
     <div className={classNames({

--- a/common/views/components/FindUs/FindUs.js
+++ b/common/views/components/FindUs/FindUs.js
@@ -24,7 +24,7 @@ const FindUs = () => (
         </p>
       </span>
     </a>
-    <p style={{marginLeft: '38px;'}} className={classNames({
+    <p style={{marginLeft: '38px'}} className={classNames({
       [spacing({ s: 3 }, {margin: ['bottom']})]: true,
       'block': true
     })}><abrr title='telephone number'>T</abrr>: <a className='find-us__link' href={`tel:${wellcomeCollection.telephone}`}>+44 (0)20 7611 2222</a></p>


### PR DESCRIPTION
Shows the correct event time for an event promo determined by the month it is displayed in

Fixes #3407 
This solves the second problem raised in the issue above, i.e.:
"Event cards are being displayed in the wrong months. For example, there are 3 November events in 'December'."

The issue wasn't that they were displaying in wrong months. They were events that happen in both November and December. We were correctly showing the event in both months, but the display date was the next upcoming date (which was in November).

This PR changes the display date for the card to the next upcoming date for the month it is in and then orders the events in that month by that date.

For example:

HIV and Aids event displayed under the November tab:
![screen shot 2018-10-10 at 14 47 55](https://user-images.githubusercontent.com/6051896/46740871-b5fc2d00-cc9b-11e8-9477-a261340268d5.png)

HIV and Aids event displayed under the December tab:
![screen shot 2018-10-10 at 14 50 14](https://user-images.githubusercontent.com/6051896/46740941-daf0a000-cc9b-11e8-9166-863ea7935ba3.png)

