### PR TITLE
use isPreview cookie and stop relying on Prismic's preview implementation

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -11,7 +11,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-env": "^1.6.1",
     "cookie-cutter": "^0.2.0",
-    "cookies": "^0.7.1",
+    "cookies": "^0.7.2",
     "fontfaceobserver": "^2.0.13",
     "immutable": "^3.8.2",
     "isomorphic-unfetch": "^2.1.1",

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -7,7 +7,8 @@ import type {
   PaginatedResults,
   DocumentType
 } from './types';
-const dev = process.env.NODE_ENV !== 'production';
+import Cookies from 'cookies';
+
 const oneMinute = 1000 * 60;
 const apiUri = 'https://wellcomecollection.prismic.io/api/v2';
 
@@ -20,12 +21,9 @@ function periodicallyUpdatePrismic() {
 }
 periodicallyUpdatePrismic();
 
-export function isPreview(req: Request): boolean {
-  // TODO: (flow) turns out we're not using the right request object here, which has
-  // the host property
-  // $FlowFixMe
-  const isPreview = Boolean(req.host) && Boolean(req.host.match('preview.wellcomecollection.org')) || dev;
-  return isPreview;
+export function isPreview(req: ?Request): boolean {
+  const cookies = req && new Cookies(req);
+  return cookies ? Boolean(cookies.get('isPreview')) : false;
 }
 
 export async function getPrismicApi(req: ?Request) {

--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -110,7 +110,7 @@ const graphQuery = `{
 
 function parseArticleDoc(document: PrismicDocument): Article {
   const {data} = document;
-  const datePublished = data.publishDate || document.first_publication_date;
+  const datePublished = data.publishDate || document.first_publication_date || undefined;
   const article = {
     type: 'articles',
     ...parseGenericFields(document),

--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -203,7 +203,7 @@ class DefaultPageLayout extends Component<Props> {
     }).install();
 
     // Prismic preview and validation warnings
-    if (window.location.host === 'preview.wellcomecollection.org') {
+    if (document.cookie.match('isPreview=true;')) {
       window.prismic = {
         endpoint: 'https://wellcomecollection.prismic.io/api/v2'
       };

--- a/common/yarn.lock
+++ b/common/yarn.lock
@@ -1692,12 +1692,12 @@ cookiejar@^2.1.0:
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
 
-cookies@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.1.tgz#7c8a615f5481c61ab9f16c833731bcb8f663b99b"
-  integrity sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=
+cookies@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookies/-/cookies-0.7.2.tgz#52736976126658af7713d7f858f7d21f99dab486"
+  integrity sha512-J2JjH9T3PUNKPHknprxgCrCaZshIfxW2j49gq1E1CP5Micj1LppWAR2y9EHSQAzEiX84zOsScWNwUZ0b/ChlMw==
   dependencies:
-    depd "~1.1.1"
+    depd "~1.1.2"
     keygrip "~1.0.2"
 
 copy-concurrently@^1.0.0:

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -223,6 +223,9 @@ app.prepare().then(async () => {
         case 'books'            : return `/books/${doc.id}`;
       }
     }, '/');
+    ctx.cookies.set('isPreview', 'true', {
+      httpOnly: false
+    });
     ctx.redirect(url);
   });
 


### PR DESCRIPTION
Use our own implementation of when to serve preview content as Prismic's is likely to change, and their advice is use preview everywhere 😿 .