### PR TITLE
allow no promo on exhibitions

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -144,8 +144,9 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
   const start = parseTimestamp(data.start);
   const end = data.end && parseTimestamp(data.end);
   const statusOverride = asText(data.statusOverride);
-
-  const promoImage = drupalPromoImage || (promo && parsePromoToCaptionedImage(data.promo));
+  const promoImage = drupalPromoImage || (
+    promo && promo.length > 0 && parsePromoToCaptionedImage(data.promo)
+  );
   // As we store the intro as an H2 in the model, incorrectly, we then convert
   // it here to a paragraph
   const intro = data.intro && data.intro[0] && [Object.assign({}, data.intro[0], {type: 'paragraph'})];

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -145,7 +145,7 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
   const end = data.end && parseTimestamp(data.end);
   const statusOverride = asText(data.statusOverride);
   const promoImage = drupalPromoImage || (
-    promo && promo.length > 0 && parsePromoToCaptionedImage(data.promo)
+    promo && promo.length > 0 ? parsePromoToCaptionedImage(data.promo) : null
   );
   // As we store the intro as an H2 in the model, incorrectly, we then convert
   // it here to a paragraph
@@ -165,12 +165,12 @@ function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
     statusOverride: statusOverride,
     place: isDocumentLink(data.place) ? parsePlace(data.place) : null,
     exhibits: data.exhibits ? parseExhibits(data.exhibits) : [],
-    promo: {
+    promo: promoImage && {
       id,
       format,
       url,
       title,
-      image: promoImage.image,
+      image: promoImage && promoImage.image,
       squareImage: promoSquare && promoSquare.image,
       description: (promoThin && promoThin.caption) || '',
       start,


### PR DESCRIPTION
Annoyingly promos can be `null`, `[]`, or `[{ promoContent }]` - so we need to double check.

Tried to think of a more scalable solution, but think that would be migrating the promo to not be slices, but root properties - which will be hard.