### PR TITLE
delete troublesome prismic cookie

### DIFF
--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -203,7 +203,8 @@ class DefaultPageLayout extends Component<Props> {
     }).install();
 
     // Prismic preview and validation warnings
-    if (document.cookie.match('isPreview=true;')) {
+    const isPreview = document.cookie.match('isPreview=true');
+    if (isPreview) {
       window.prismic = {
         endpoint: 'https://wellcomecollection.prismic.io/api/v2'
       };

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -206,6 +206,9 @@ app.prepare().then(async () => {
   });
 
   router.get('/preview', async ctx => {
+    // Kill any cookie we had set, as it think it is causing issues.
+    ctx.cookies.set(Prismic.previewCookie);
+
     const token = ctx.request.query.token;
     const api = await Prismic.getApi('https://wellcomecollection.prismic.io/api/v2', {
       req: ctx.request


### PR DESCRIPTION
deletes the preview cookie before setting another.
Seems to help, I'd like to understand more why, but that can wait.
Also accounts for the cookie being the last cookie and thus not having the `;`.