### PR TITLE
Events ordering

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -238,7 +238,7 @@ type EventsQueryProps = {|
 
 export async function getEvents(req: ?Request,  {
   predicates = [],
-  order = 'desc',
+  order = 'asc',
   period,
   ...opts
 }: EventsQueryProps): Promise<PaginatedResults<UiEvent>> {
@@ -329,6 +329,7 @@ export async function getEvents(req: ?Request,  {
   ].concat(predicates, dateRangePredicates), {
     orderings,
     page: opts.page,
+    pageSize: opts.pageSize,
     graphQuery
   });
 
@@ -340,12 +341,19 @@ export async function getEvents(req: ?Request,  {
     return a.displayStart - b.displayStart;
   });
 
+  // Prismic uses the first date in times to determine past events,
+  // so we need to remove the ones that still have more dates in the future
+  const eventsWithoutIncorrectPast = events.filter(event => {
+    const hasFutureDates = event.times.find(time => london(time.range.startDateTime).isSameOrAfter(london(), 'day'));
+    return !hasFutureDates;
+  });
+
   return {
     currentPage: paginatedResults.currentPage,
     pageSize: paginatedResults.pageSize,
     totalResults: paginatedResults.totalResults,
     totalPages: paginatedResults.totalPages,
-    results: eventsOrderedByDisplayDate
+    results: order === 'desc' ? eventsWithoutIncorrectPast : eventsOrderedByDisplayDate
   };
 }
 

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -77,7 +77,7 @@ function determineDateRange(times) {
 
 function determineDisplayTime(times: EventTime[]): EventTime {
   const upcomingDates = times.filter(t => {
-    return london(t.range.startDateTime).isSameOrAfter(london());
+    return london(t.range.startDateTime).isSameOrAfter(london(), 'day');
   });
   return upcomingDates.length > 0 ? upcomingDates[0] : times[0];
 }

--- a/common/utils/dates.js
+++ b/common/utils/dates.js
@@ -6,7 +6,7 @@ import type Moment from 'moment';
 export function getEarliestFutureDateRange(dateRanges: DateRange[], fromDate: ?Moment = london()): ?DateRange {
   return dateRanges
     .sort((a, b) => a.start - b.start)
-    .find(range => london(range.start).isSameOrAfter(fromDate) && london(range.start).isSameOrAfter(london()));
+    .find(range => london(range.start).isSameOrAfter(fromDate, 'day') && london(range.start).isSameOrAfter(london(), 'day'));
 }
 
 export function isPast(date: Date): boolean {

--- a/whats_on/app/controllers.js
+++ b/whats_on/app/controllers.js
@@ -37,6 +37,7 @@ export async function renderWhatsOn(ctx, next) {
     order: 'asc'
   });
   const eventsPromise = getEvents(ctx.request, {
+    pageSize: 100,
     period,
     order: 'asc'
   });
@@ -188,11 +189,13 @@ export async function renderExhibitExhibitionLink(ctx, next) {
 
 export async function renderEvents(ctx, next) {
   const {page = 1} = ctx.query;
-  const {period} = ctx.params;
+  const {period = 'current-and-coming-up'} = ctx.params;
   const paginatedResults = await getEvents(ctx.request, {
     page,
+    pageSize: 100,
     seriesId: null,
-    period
+    period: period,
+    order: period === 'past' ? 'desc' : 'asc'
   });
   if (paginatedResults) {
     ctx.render('pages/events', {

--- a/whats_on/app/views/pages/events.njk
+++ b/whats_on/app/views/pages/events.njk
@@ -3,7 +3,7 @@
 {% set results = paginatedResults.results %}
 {% set metaContent = {
   type: 'website',
-  title: 'Exhibitions',
+  title: pageConfig.title,
   image: paginatedResults[0].promoImage.contentUrl,
   url: pageConfig.canonicalUri,
   description: pageDescription
@@ -25,7 +25,7 @@
   </script>
 
   {% componentV2 'list-header', {
-    name: 'Events',
+    name: pageConfig.title,
     description: pageDescription,
     total: paginatedResults.results.length
   } %}


### PR DESCRIPTION
Finishing up the events ordering stuff
As discussed with @Heesoomoon 
/events shows current and upcoming in ascending order (with the next available date displayed)
/past shows past in descending order

N.B. @Heesoomoon was keen to remove past events from /events and it was also necessary technically, so as not to get into weird ordering issues with pagination. We probably need to add a link to past events, from events?

There's quite a lot going on here in terms of the difficulties that arise between how we can query from prismic and how we want to display things. I want to write it all down, so it's clear to myself and others, but haven't managed to yet - will do this ASAP.
