### PR TITLE
apply drop cap to first instance of text slice in body

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -474,6 +474,7 @@
   padding-right: $spacing-unit;
 
   @include respond-to('medium') {
-    line-height: $spacing-unit * 10;
+    line-height: $spacing-unit * 11;
+    margin-bottom: -$spacing-unit;
   }
 }

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -35,15 +35,18 @@ const Body = ({
   body,
   isDropCapped
 }: Props) => {
+  const filteredBody = body
+    .filter(slice => !(slice.type === 'picture' && slice.weight === 'featured'))
+    // The standfirst is now put into the header
+    // and used exclusively by articles / article series
+    .filter(slice => slice.type !== 'standfirst');
+
+  const firstTextSliceIndex = filteredBody.map(slice => slice.type).indexOf('text');
   return (
     <div className={classNames({
       'basic-body': true
     })}>
-      {body
-        .filter(slice => !(slice.type === 'picture' && slice.weight === 'featured'))
-        // The standfirst is now put into the header
-        // and used exclusively by articles / article series
-        .filter(slice => slice.type !== 'standfirst')
+      {filteredBody
         .map((slice, i) =>
           <div className={classNames({
             'body-part': true,
@@ -55,7 +58,7 @@ const Body = ({
                 <div className='body-text'>
                   {slice.weight === 'featured' && <FeaturedText html={slice.value} />}
                   {slice.weight !== 'featured' &&
-                    i === 0 && isDropCapped
+                    firstTextSliceIndex === i && isDropCapped
                     ? <PrismicHtmlBlock html={slice.value} htmlSerialiser={dropCapSerialiser} />
                     : <PrismicHtmlBlock html={slice.value} />
                   }


### PR DESCRIPTION
Applies the drop cap to the first text slice in the body, rather than the first slice - which might be an image etc.

![screen shot 2018-10-15 at 08 37 56](https://user-images.githubusercontent.com/31692/46936253-b7d83e80-d055-11e8-851d-b848b7e427f4.png)
