### PR TITLE
add healthchecks to nextjs apps

### DIFF
--- a/catalogue/terraform/terraform.tf
+++ b/catalogue/terraform/terraform.tf
@@ -92,7 +92,7 @@ module "catalogue" {
   primary_container_port             = "80"
   secondary_container_port           = "3000"
   path_pattern                       = "/works*"
-  healthcheck_path                   = "/management/healthcheck"
+  healthcheck_path                   = "/works/management/healthcheck"
   alb_priority                       = "200"
 }
 

--- a/catalogue/webapp/server.js
+++ b/catalogue/webapp/server.js
@@ -105,7 +105,6 @@ app.prepare().then(async () => {
     });
     ctx.respond = false;
   });
-
   router.get('/works/:id', async ctx => {
     const {toggles} = ctx;
     await app.render(ctx.req, ctx.res, '/work', {
@@ -116,7 +115,6 @@ app.prepare().then(async () => {
     });
     ctx.respond = false;
   });
-
   router.get('/works', async ctx => {
     const {toggles} = ctx;
     await app.render(ctx.req, ctx.res, '/works', {
@@ -125,6 +123,10 @@ app.prepare().then(async () => {
       toggles
     });
     ctx.respond = false;
+  });
+  router.get('/works/management/healthcheck', async ctx => {
+    ctx.status = 200;
+    ctx.body = 'ok';
   });
 
   router.get('*', async ctx => {

--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -209,3 +209,12 @@ module "preview_listener" {
   priority = "120"
   path = "/preview"
 }
+
+module "management_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "120"
+  path = "/content/management*"
+}

--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -92,7 +92,7 @@ module "content" {
   primary_container_port             = "80"
   secondary_container_port           = "3000"
   host_name                          = "content.wellcomecollection.org"
-  healthcheck_path                   = "/management/healthcheck"
+  healthcheck_path                   = "/content/management/healthcheck"
   alb_priority                       = "700"
 }
 

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -204,7 +204,6 @@ app.prepare().then(async () => {
     });
     ctx.respond = false;
   });
-
   router.get('/preview', async ctx => {
     // Kill any cookie we had set, as it think it is causing issues.
     ctx.cookies.set(Prismic.previewCookie);
@@ -218,6 +217,10 @@ app.prepare().then(async () => {
       httpOnly: false
     });
     ctx.redirect(url);
+  });
+  router.get('/content/management/healthcheck', async ctx => {
+    ctx.status = 200;
+    ctx.body = 'ok';
   });
 
   pageVanityUrl(router, app, '/visit-us', 'WwLIBiAAAPMiB_zC');


### PR DESCRIPTION
Noticed some 500s on the `nextjs` JS. 

This time not content that couldn't be served because the cache had cleared, but rather content that wasn't available yet as the healthcheck was passing, but the next app hadn't actually started.

The reason for this is the healthcheck `/management/healthcheck` is serving from the nginx server, and in this case, the nginx `server` of the server app.

So now we have the healthcheck render from the app itself meaning we will only start passing content to it once the app is up.