### PR TITLE
Move toggles readme over to repo

### DIFF
--- a/toggles/README.md
+++ b/toggles/README.md
@@ -1,0 +1,15 @@
+# Weco Toggles
+
+We currently use [Unlesash](https://github.com/Unleash/unleash) to manage our
+feature toggles.
+
+The code is currently in
+[another repo](https://github.com/wellcometrust/feature-flags) to make it
+easier to deploy from Heroku.
+
+The API is currently hosted under https://weco-feature-flags.herokuapp.com.
+
+# TODO
+- [ ] Move code over to this repo
+- [ ] Move service over to AWS
+- [ ] Serve from toggles.wellcomecollection.org


### PR DESCRIPTION
Gives us a checklist, but also a place to start for toggles.
Might work on the purpose / process of how we might use them once I've got through the checklist.