### PR TITLE
make sure drop cap serialises serialises all text

### DIFF
--- a/common/services/prismic/html-serialisers.js
+++ b/common/services/prismic/html-serialisers.js
@@ -1,8 +1,8 @@
 // @flow
 import PrismicDOM from 'prismic-dom';
 import linkResolver from './link-resolver';
-import {font} from '../../utils/classnames';
-const {Elements} = PrismicDOM.RichText;
+import { font } from '../../utils/classnames';
+const { Elements } = PrismicDOM.RichText;
 
 export type HtmlSeriliser = (
   type: string,
@@ -10,7 +10,7 @@ export type HtmlSeriliser = (
   content: string,
   children: string[],
   i: number
-) => ?string
+) =>?string
 
 export const dropCapSerialiser: HtmlSeriliser = (
   type,
@@ -21,9 +21,12 @@ export const dropCapSerialiser: HtmlSeriliser = (
 ) => {
   if (type === Elements.paragraph && i === 0) {
     const firstLetter = children[0].charAt(0);
-    const restOfLetters = children[0].substr(1);
+    const restOfLetters = [
+      ...children[0].substr(1),
+      ...children.slice(1)
+    ];
 
-    return `<p><span class="drop-cap ${font({s: 'WB3', m: 'WB2'})}">${firstLetter}</span>${restOfLetters}</p>`;
+    return `<p><span class="drop-cap ${font({ s: 'WB3', m: 'WB2' })}">${firstLetter}</span>${restOfLetters.join('')}</p>`;
   }
   return defaultSerializer(type, element, content, children, i);
 };

--- a/router/redirects.conf
+++ b/router/redirects.conf
@@ -50,9 +50,10 @@ rewrite '^/exhibitions/sleeping-dreaming'        /exhibitions/W30vSSkAACIAPowf p
 rewrite '^/exhibitions/heart'                    /exhibitions/W30t8ykAACcAPoc1 permanent;
 
 # Pages
-rewrite '^/pages/WwQHTSAAANBfDYXU$'               /opening-times;
-rewrite '^/visit-us/accessibility'                /access;
-rewrite '^/what-we-do/proposing-online-article'   /pages/Wvl00yAAAB8A3y8p;
+rewrite '^/pages/WwQHTSAAANBfDYXU$'                                   /opening-times;
+rewrite '^/visit-us/accessibility'                                    /access;
+rewrite '^/what-we-do/proposing-online-article'                       /pages/Wvl00yAAAB8A3y8p;
+rewrite '^/press/‘forensics-anatomy-crime’-opens-wellcome-collection' /pages/Wv7RnyAAAPtL9tHr;
 
 # Wordpress articles
 rewrite '^/articles/obsessed-with-buffy-much'         /articles/WsT4Ex8AAHruGfWh;


### PR DESCRIPTION
Makes sure we render all this children.
It was a slight misunderstanding of how the serialisers work.

This case, when there are multiple spans, there will be multiple string children returned.

![screen shot 2018-10-15 at 13 02 14](https://user-images.githubusercontent.com/31692/46949824-9f2e4f80-d07a-11e8-9531-c0c86316d135.png)
---
![screen shot 2018-10-15 at 13 02 21](https://user-images.githubusercontent.com/31692/46949825-9f2e4f80-d07a-11e8-932b-3f065a712255.png)
