### PR TITLE
get not featured text rendering logic right

### DIFF
--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -58,9 +58,9 @@ const Body = ({
                 <div className='body-text'>
                   {slice.weight === 'featured' && <FeaturedText html={slice.value} />}
                   {slice.weight !== 'featured' &&
-                    firstTextSliceIndex === i && isDropCapped
-                    ? <PrismicHtmlBlock html={slice.value} htmlSerialiser={dropCapSerialiser} />
-                    : <PrismicHtmlBlock html={slice.value} />
+                    (firstTextSliceIndex === i && isDropCapped
+                      ? <PrismicHtmlBlock html={slice.value} htmlSerialiser={dropCapSerialiser} />
+                      : <PrismicHtmlBlock html={slice.value} />)
                   }
                 </div>
               </Layout8>


### PR DESCRIPTION
Brackets make all the difference.

Before
<img width="1136" alt="screen shot 2018-10-16 at 10 46 41" src="https://user-images.githubusercontent.com/31692/47007736-d19a8400-d130-11e8-99fb-0b41ee1372d9.png">

After
<img width="1119" alt="screen shot 2018-10-16 at 10 47 41" src="https://user-images.githubusercontent.com/31692/47007969-45d52780-d131-11e8-906f-6d16908b35da.png">
