### PR TITLE
Event series

### DIFF
--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -37,7 +37,7 @@ export async function getEventSeries(req: ?Request, {
   const events = await getEvents(req, {
     page: 1,
     predicates: [Prismic.Predicates.at('my.events.series.series', id)],
-    order: 'desc',
+    order: 'asc',
     ...opts
   });
 

--- a/common/services/prismic/event-series.js
+++ b/common/services/prismic/event-series.js
@@ -41,7 +41,7 @@ export async function getEventSeries(req: ?Request, {
     ...opts
   });
 
-  if (events && events.results.length > 0) {
+  if (events && events.results && events.results.length > 0) {
     const series = events.results[0].series.find(series => series.id === id);
 
     return series && {
@@ -49,7 +49,7 @@ export async function getEventSeries(req: ?Request, {
       events: events.results
     };
   } else {
-    // TODO: (perf) we shoulnd't really be doing two calls here, but it's for
+    // TODO: (perf) we shouldn't really be doing two calls here, but it's for
     // when a series has no events attached.
     const document = await getDocument(req, id, {});
     return document && { series: parseEventSeries(document), events: [] };

--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -210,15 +210,6 @@ module "article_series_listener" {
   path = "/series/W*"
 }
 
-module "event_series_listener" {
-  source = "../../shared-infra/terraform/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "115"
-  path = "/event-series/*"
-}
-
 module "preview_listener" {
   source = "../../shared-infra/terraform/service_alb_listener"
   alb_listener_https_arn = "${local.alb_listener_https_arn}"

--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -210,6 +210,15 @@ module "article_series_listener" {
   path = "/series/W*"
 }
 
+module "event_series_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "112"
+  path = "/event-series/*"
+}
+
 module "preview_listener" {
   source = "../../shared-infra/terraform/service_alb_listener"
   alb_listener_https_arn = "${local.alb_listener_https_arn}"

--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -215,7 +215,7 @@ module "event_series_listener" {
   alb_listener_https_arn = "${local.alb_listener_https_arn}"
   alb_listener_http_arn = "${local.alb_listener_http_arn}"
   target_group_arn = "${module.content.target_group_arn}"
-  priority = "112"
+  priority = "115"
   path = "/event-series/*"
 }
 

--- a/content/webapp/pages/event-series.js
+++ b/content/webapp/pages/event-series.js
@@ -1,0 +1,130 @@
+// @flow
+import {Component} from 'react';
+import {getEventSeries} from '@weco/common/services/prismic/event-series';
+import PageWrapper from '@weco/common/views/components/PageWrapper/PageWrapper';
+import BasePage from '@weco/common/views/components/BasePage/BasePage';
+import Body from '@weco/common/views/components/Body/Body';
+import SearchResults from '@weco/common/views/components/SearchResults/SearchResults';
+import HeaderBackground from '@weco/common/views/components/BaseHeader/HeaderBackground';
+import {
+  default as PageHeader,
+  getFeaturedMedia
+} from '@weco/common/views/components/PageHeader/PageHeader';
+import {convertImageUri} from '@weco/common/utils/convert-image-uri';
+import {spacing} from '@weco/common/utils/classnames';
+import {eventLd} from '@weco/common/utils/json-ld';
+import type {EventSeries} from '@weco/common/model/event-series';
+import type {UiEvent} from '@weco/common/model/events';
+import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
+
+type Props = {|
+  series: EventSeries,
+  events: UiEvent[]
+|}
+
+export class EventSeriesPage extends Component<Props> {
+  static getInitialProps = async (context: GetInitialPropsProps) => {
+    const {id} = context.query;
+    const seriesAndEvents = await getEventSeries(context.req, {
+      id,
+      pageSize: 100,
+      order: 'asc'
+    });
+
+    if (seriesAndEvents) {
+      const {series, events} = seriesAndEvents;
+      return {
+        series,
+        events,
+        title: series.title,
+        description: series.promoText,
+        type: 'webpage',
+        canonicalUrl: `https://wellcomecollection.org/events-series/${series.id}`,
+        imageUrl: series.image && convertImageUri(series.image.contentUrl, 800),
+        siteSection: 'whatson',
+        analyticsCategory: 'public-programme',
+        jsonPageLd: events.map(eventLd)
+      };
+    } else {
+      return {statusCode: 404};
+    }
+  }
+
+  render() {
+    const {series, events} = this.props;
+    const breadcrumbs = {
+      items: [
+        {
+          url: '/events',
+          text: 'Events'
+        },
+        {
+          url: `/events-series/${series.id}`,
+          text: series.title,
+          isHidden: true
+        }
+      ]
+    };
+
+    const genericFields = {
+      id: series.id,
+      title: series.title,
+      contributors: series.contributors,
+      contributorsTitle: series.contributorsTitle,
+      promo: series.promo,
+      body: series.body,
+      standfirst: series.standfirst,
+      promoImage: series.promoImage,
+      promoText: series.promoText,
+      image: series.image,
+      squareImage: series.squareImage,
+      widescreenImage: series.widescreenImage,
+      labels: series.labels
+    };
+
+    const FeaturedMedia = getFeaturedMedia(genericFields);
+    const Header = <PageHeader
+      breadcrumbs={breadcrumbs}
+      labels={{labels: series.labels}}
+      title={series.title}
+      ContentTypeInfo={null}
+      Background={<HeaderBackground hasWobblyEdge={true} />}
+      FeaturedMedia={FeaturedMedia}
+      HeroPicture={null}
+    />;
+
+    const upcomingEvents = events.filter(event => {
+      const lastStartTime = event.times.length > 0 ? event.times[event.times.length - 1].range.startDateTime : null;
+      const inTheFuture = lastStartTime ? new Date(lastStartTime) > new Date() : false;
+      return inTheFuture;
+    }).sort((a, b) => a.dateRange.firstDate - b.dateRange.firstDate);
+    const upcomingEventsIds = upcomingEvents.map(event => event.id);
+    const pastEvents = events.filter(event => upcomingEventsIds.indexOf(event.id) === -1)
+      .sort((a, b) => b.dateRange.firstDate - a.dateRange.firstDate)
+      .slice(0, 3);
+
+    return (
+      <BasePage
+        id={series.id}
+        Header={Header}
+        Body={<Body body={series.body} />}
+        contributorProps={{ contributors: series.contributors }}
+      >
+        {upcomingEvents.length > 0 &&
+          <SearchResults items={upcomingEvents} title={`What's next`} />
+        }
+        {upcomingEvents.length === 0 &&
+          <h2 className='h2'>No events scheduled at the moment, check back soon…</h2>
+        }
+
+        {pastEvents.length > 0 &&
+        <div className={spacing({s: 8}, {margin: ['top']})}>
+          <SearchResults items={pastEvents} title={`What we've done before`} />
+        </div>
+        }
+      </BasePage>
+    );
+  }
+};
+
+export default PageWrapper(EventSeriesPage);

--- a/content/webapp/pages/event-series.js
+++ b/content/webapp/pages/event-series.js
@@ -27,8 +27,7 @@ export class EventSeriesPage extends Component<Props> {
     const {id} = context.query;
     const seriesAndEvents = await getEventSeries(context.req, {
       id,
-      pageSize: 100,
-      order: 'asc'
+      pageSize: 100
     });
 
     if (seriesAndEvents) {
@@ -37,7 +36,7 @@ export class EventSeriesPage extends Component<Props> {
         series,
         events,
         title: series.title,
-        description: series.promoText,
+        description: series.promoText || '',
         type: 'webpage',
         canonicalUrl: `https://wellcomecollection.org/events-series/${series.id}`,
         imageUrl: series.image && convertImageUri(series.image.contentUrl, 800),

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -172,6 +172,14 @@ app.prepare().then(async () => {
     });
     ctx.respond = false;
   });
+  router.get('/event-series/:id', async ctx => {
+    const {toggles} = ctx;
+    await app.render(ctx.req, ctx.res, '/event-series', {
+      id: ctx.params.id,
+      toggles
+    });
+    ctx.respond = false;
+  });
   router.get('/books/:id', async ctx => {
     const {toggles} = ctx;
     await app.render(ctx.req, ctx.res, '/book', {


### PR DESCRIPTION
Fixes #3538
Ref #3540 

Regressed because when creating the new logic around event ordering, we filter a list if it is ordered `desc`. So now we order `asc`.