### PR TITLE
Add listeners for content service

### DIFF
--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -161,6 +161,23 @@ module "schools_listener" {
   path = "/schools"
 }
 
+module "opening_times_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "108"
+  path = "/opening-times"
+}
+ module "newsletter_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "109"
+  path = "/newsletter"
+}
+
 module "installations_listener" {
   source = "../../shared-infra/terraform/service_alb_listener"
   alb_listener_https_arn = "${local.alb_listener_https_arn}"
@@ -176,7 +193,7 @@ module "exhibitions_listener" {
   alb_listener_http_arn = "${local.alb_listener_http_arn}"
   target_group_arn = "${module.content.target_group_arn}"
   priority = "111"
-  path = "/exhibitions/*"
+  path = "/exhibitions*"
 }
 
 module "events_listener" {
@@ -208,6 +225,15 @@ module "article_series_listener" {
   # TODO: (wordpress)
   # We're supporting wordpress articles for the time being
   path = "/series/W*"
+}
+
+module "book_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "117"
+  path = "/books/*"
 }
 
 module "preview_listener" {

--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -227,6 +227,17 @@ module "article_series_listener" {
   path = "/series/W*"
 }
 
+module "event_series_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "115"
+  path = "/event-series/*"
+}
+
+# TODO: Books listener
+
 module "book_listener" {
   source = "../../shared-infra/terraform/service_alb_listener"
   alb_listener_https_arn = "${local.alb_listener_https_arn}"


### PR DESCRIPTION
Removed the listeners from all the other PRs, as we'd need to launch all the updated services first.
We can then merge this, and deploy.

Waiting on:
#3547 
#3541 
#3537 