### PR TITLE
Use appropriate responsive image sizes

### DIFF
--- a/common/views/components/ImageGalleryV2/ImageGalleryV2.js
+++ b/common/views/components/ImageGalleryV2/ImageGalleryV2.js
@@ -9,6 +9,7 @@ import Layout12 from '../Layout12/Layout12';
 import type {CaptionedImage as CaptionedImageProps} from '../../../model/captioned-image';
 import {PageBackgroundContext} from '../BasePage/BasePage';
 import {repeatingLsBlack} from '../../../utils/backgrounds';
+import {breakpoints} from '../../../utils/breakpoints';
 
 type Props = {|
   id: string,
@@ -124,7 +125,10 @@ class ImageGallery extends Component<Props, State> {
                         image={captionedImage.image}
                         caption={captionedImage.caption}
                         setTitleStyle={i === 0 ? this.setTitleStyle : undefined}
-                        sizesQueries={'(max-width: 600px) 100vw, ' + (captionedImage.image.width / captionedImage.image.height) * 640 + 'px'}
+                        sizesQueries={`
+                          (min-width: ${breakpoints.xlarge}) calc(${breakpoints.xlarge} - 120px),
+                          calc(100vw - 84px)
+                        `}
                         preCaptionNode={items.length > 1 ? (
                           <div className={classNames({
                             [font({s: 'HNM5', m: 'HNM4'})]: true,


### PR DESCRIPTION
Refs #3543.

Because we rely on width auto in combination with a `max-height` determined in `vh`, the responsive images we serve need to be at least as wide as they could be were they allowed to get to 100% of their container. For the image gallery this is always all 12 columns.

![screen shot 2018-10-16 at 15 54 15](https://user-images.githubusercontent.com/1394592/47025644-c6a91900-d15b-11e8-9a38-610ef5d2b368.png)
