### PR TITLE
parse JSON event dates in event series

### DIFF
--- a/content/webapp/pages/event-series.js
+++ b/content/webapp/pages/event-series.js
@@ -13,6 +13,7 @@ import {
 import {convertImageUri} from '@weco/common/utils/convert-image-uri';
 import {spacing} from '@weco/common/utils/classnames';
 import {eventLd} from '@weco/common/utils/json-ld';
+import {convertJsonToDates} from './event';
 import type {EventSeries} from '@weco/common/model/event-series';
 import type {UiEvent} from '@weco/common/model/events';
 import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
@@ -50,7 +51,10 @@ export class EventSeriesPage extends Component<Props> {
   }
 
   render() {
-    const {series, events} = this.props;
+    const {series} = this.props;
+    const jsonEvents = this.props.events;
+    const events = jsonEvents.map(convertJsonToDates);
+
     const breadcrumbs = {
       items: [
         {

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -82,7 +82,7 @@ function showTicketSalesStart(dateTime) {
 
 // Convert dates back to Date types because it's serialised through
 // `getInitialProps`
-function convertJsonToDates(jsonEvent: UiEvent): UiEvent {
+export function convertJsonToDates(jsonEvent: UiEvent): UiEvent {
   const times = jsonEvent.times.map(time => {
     return {
       ...time,


### PR DESCRIPTION
Had a load of explosions alerting us to the fact that we're not parsing the JSON dates.
It'd be good to have a think about how we might do this more scalably?
