### PR TITLE
remove content slider from stories page

### DIFF
--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -5,6 +5,7 @@ import EventPromo from '../EventPromo/EventPromo';
 import InstallationPromo from '../InstallationPromo/InstallationPromo';
 import DailyTourPromo from '../DailyTourPromo/DailyTourPromo';
 import BookPromo from '../BookPromo/BookPromo';
+import StoryPromo from '../StoryPromo/StoryPromo';
 import type {UiExhibition} from '../../../model/exhibitions';
 import type {UiEvent} from '../../../model/events';
 import type {Installation} from '../../../model/installations';
@@ -66,6 +67,14 @@ const CardGrid = ({
                 event={item}
                 position={i} />
             }
+            {item.type === 'articles' &&
+              // TODO: (remove Picture type)
+              // $FlowFixMe
+              <StoryPromo
+                item={item}
+                position={i}
+                showPosition={true} />
+            }
             {item.type === 'books' &&
               <BookPromo
                 url={`/books/${item.id}`}
@@ -74,7 +83,16 @@ const CardGrid = ({
                 description={item.promoText}
                 image={item.cover} />
             }
-
+            {item.type === 'installations' &&
+              <InstallationPromo
+                id={item.id}
+                description={item.promoText}
+                start={item.start}
+                end={item.end}
+                image={item.promoImage}
+                title={item.title}
+              />
+            }
           </div>
         ))}
       </div>

--- a/common/views/components/StoryPromo/StoryPromo.js
+++ b/common/views/components/StoryPromo/StoryPromo.js
@@ -1,0 +1,77 @@
+// @flow
+import {spacing, font} from '../../../utils/classnames';
+import {UiImage} from '../Images/Images';
+import LabelsList from '../LabelsList/LabelsList';
+import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
+import type {Article} from '../../../model/articles';
+
+type Props = {|
+  item: Article,
+  position: number,
+  showPosition?: boolean
+|}
+
+const EventPromo = ({
+  item,
+  position,
+  showPosition = false
+}: Props) => {
+  return (
+    <a data-component='StoryPromo'
+      data-component-state={JSON.stringify({ position: position })}
+      data-track-event={JSON.stringify({
+        category: 'component',
+        action: 'StoryPromo:click',
+        label: `id : ${item.id}, position : ${position}`}
+      )}
+      id={item.id}
+      href={item.promo && item.promo.link || `/items/${item.id}`}
+      className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'>
+      <div className='relative'>
+        {/* FIXME: Image type tidy */}
+        {/* $FlowFixMe */}
+        {item.promoImage && <UiImage {...item.promoImage}
+          sizesQueries='(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'
+          showTasl={false} />}
+
+        {item.labels.length > 0 &&
+          <div style={{position: 'absolute', bottom: 0}}>
+            <LabelsList labels={item.labels} />
+          </div>
+        }
+      </div>
+
+      <div className={`
+          flex flex--column flex-1 flex--h-space-between
+          ${spacing({s: 2}, {padding: ['top']})}
+          ${spacing({s: 2}, {padding: ['left', 'right']})}
+          ${spacing({s: 4}, {padding: ['bottom']})}
+        `}>
+
+        <div>
+          {showPosition && <PartNumberIndicator number={position + 1} />}
+          <h2 className={`
+            promo-link__title
+            ${font({s: 'WB5'})}
+            ${spacing({s: 0}, {margin: ['top']})}
+            ${spacing({s: 1}, {margin: ['bottom']})}
+          `}>
+            {item.title}
+          </h2>
+        </div>
+
+        {item.series.length > 0 &&
+          <div className={spacing({s: 4}, {margin: ['top']})}>
+            {item.series.map((series) => (
+              <p key={series.title} className={`${font({s: 'HNM5'})} no-margin`}>
+                <span className={font({s: 'HNL5'})}>Part of</span>{' '}{series.title}
+              </p>
+            ))}
+          </div>
+        }
+      </div>
+    </a>
+  );
+};
+
+export default EventPromo;

--- a/server/views/pages/curated-lists.njk
+++ b/server/views/pages/curated-lists.njk
@@ -68,35 +68,8 @@
 
   {% for section in curatedList.data.section %}
     {% if section.slice_type === 'series' %}
-      {% if section.value.data.wordpressSlug %}
-        {# Deprecated: Digital stories (Wordpress) #}
-        <div class="row {{ {s:2} | spacingClasses({padding:['top']}) }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }} relative">
-          <div class="container container--scroll-xl">
-            <div class="grid grid--no-gutters">
-              <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | gridClasses }}">
-                {% set asyncContentEndpoint = '/series-transporter/' + section.value.data.wordpressSlug %}
-                {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-explore": true}' } %}
-              </div>
-            </div>
-          </div>
-          <div class="{{ {s:4} | spacingClasses({margin:['top']}) }}">
-            <div class="container container--no-collapse">
-              {% componentV2 'divider', null, {'thick': true, 'black': true} %}
-            </div>
-          </div>
-        </div>
-      {% else %}
-        <div class="row {{ {s:2} | spacingClasses({padding:['top']}) }} {{ {s:4} | spacingClasses({margin: ['bottom']}) }} relative">
-          <div class="container container--scroll-xl">
-            <div class="grid grid--no-gutters">
-              <div class="{{ {s: 12, m: 12, l: 12, xl: 12} | gridClasses }}">
-                {% set asyncContentEndpoint = '/series-transporter/' + section.value.id %}
-                {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-explore": true}' } %}
-              </div>
-            </div>
-          </div>
-        </div>
-      {% endif %}
+      {% set asyncContentEndpoint = '/series-transporter/' + section.value.id %}
+      {% component 'async', { endpoint: asyncContentEndpoint, component: 'series-transporter', modifiers: '{"in-explore": true}' } %}
     {% endif %}
   {% endfor %}
 


### PR DESCRIPTION
Ref #3540 

In an attempt to remove the content slider from our UI and code, I've added used a standard promo list to the `/stories` page for the list of serials (digital story).

![screenshot-localhost-3003-2018 10 18-17-08-11](https://user-images.githubusercontent.com/31692/47168529-0822fb00-d2f9-11e8-85e2-a9dc7f5ad047.png)

We could release this (with tweaks and QA) and monitor the CTR on stories to see we haven't completely broken it. If it works, it would be good to get this page running from our new app infrastructure.

Thoughts?