### PR TITLE
Render homepage from content app

### DIFF
--- a/common/data/our-voice-our-way.js
+++ b/common/data/our-voice-our-way.js
@@ -1,6 +1,7 @@
 // @flow
 import type {Installation} from '../model/installations';
 const data = ({
+  'type': 'installations',
   'id': 'W5Y-NyYAACMALAdp',
   'title': 'Our Voice, Our Way',
   'contributorsTitle': '',
@@ -98,7 +99,6 @@ const data = ({
     'url': null,
     'text': 'Installation'
   }],
-  'type': 'installations',
   'start': new Date('2018-10-24T09:00:00.000Z'),
   'end': new Date('2018-10-28T18:00:00.000Z'),
   'place': null

--- a/common/model/periods.js
+++ b/common/model/periods.js
@@ -5,7 +5,8 @@ export const Periods = {
   CurrentAndComingUp: 'current-and-coming-up',
   Past: 'past',
   ComingUp: 'coming-up',
-  ThisWeek: 'this-week'
+  ThisWeek: 'this-week',
+  NextSevenDays: 'next-seven-days'
 };
 
 export type Period = $Values<typeof Periods>;

--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -208,7 +208,7 @@ export async function getArticle(req: ?Request, id: string): Promise<?Article> {
 }
 
 type ArticleQueryProps = {|
-  predicates: Prismic.Predicates[],
+  predicates?: Prismic.Predicates[],
   ...PrismicQueryOpts
 |}
 

--- a/common/services/prismic/utils.js
+++ b/common/services/prismic/utils.js
@@ -14,7 +14,6 @@ export function getPeriodPredicates(
   const startOfDay = moment().startOf('day');
   const endOfDay = moment().endOf('day');
   const weekendDateRange = getNextWeekendDateRange(now);
-
   const predicates =
     period === 'coming-up' ? [
       Predicates.dateAfter(startField, endOfDay.toDate())
@@ -29,8 +28,8 @@ export function getPeriodPredicates(
       Predicates.dateBefore(startField, weekendDateRange.end),
       Predicates.dateAfter(endField, weekendDateRange.start)
     ] : period === 'this-week' ? [
-      Predicates.dateBefore(startField, now.endOf('week')),
-      Predicates.dateAfter(startField, now.startOf('week'))
+      Predicates.dateBefore(startField, now.endOf('week').toDate()),
+      Predicates.dateAfter(startField, now.startOf('week').toDate())
     ] : period === 'next-seven-days' ? [
       Predicates.dateBefore(startField, now.add(6, 'days').endOf('day').toDate()),
       Predicates.dateAfter(endField, startOfDay.toDate())

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -83,16 +83,6 @@ const CardGrid = ({
                 description={item.promoText}
                 image={item.cover} />
             }
-            {item.type === 'installations' &&
-              <InstallationPromo
-                id={item.id}
-                description={item.promoText}
-                start={item.start}
-                end={item.end}
-                image={item.promoImage}
-                title={item.title}
-              />
-            }
           </div>
         ))}
       </div>

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -1,0 +1,150 @@
+// @flow
+import {Component, Fragment} from 'react';
+import {classNames, font, spacing, cssGrid} from '@weco/common/utils/classnames';
+import {getExhibitions} from '@weco/common/services/prismic/exhibitions';
+import {getEvents} from '@weco/common/services/prismic/events';
+import {getArticles} from '@weco/common/services/prismic/articles';
+import {convertJsonToDates} from './event';
+import pharmacyOfColourData from '@weco/common/data/the-pharmacy-of-colour';
+import ourVoiceOurWayData from '@weco/common/data/our-voice-our-way';
+import {
+  exhibitionLd,
+  eventLd,
+  articleLd
+} from '@weco/common/utils/json-ld';
+import {default as PageWrapper} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import Promo from '@weco/common/views/components/Promo/Promo';
+import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
+import ExhibitionsAndEvents from '@weco/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents';
+import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import type {UiExhibition} from '@weco/common/model/exhibitions';
+import type {UiEvent} from '@weco/common/model/events';
+import type {Article} from '@weco/common/model/articles';
+import type {PaginatedResults} from '@weco/common/services/prismic/types';
+
+type Props = {|
+  exhibitions: PaginatedResults<UiExhibition>,
+  events: PaginatedResults<UiEvent>,
+  articles: PaginatedResults<Article>,
+  tryTheseTooPromos: any[],
+  eatShopPromos: any[]
+|}
+
+const pageDescription = 'Visit our free museum and library in central London connecting science, medicine, life and art. Explore our exhibitions, live events, gallery tours, restaurant, cafe, bookshop, and cafe. Fully accessible. Open late on Thursday evenings.';
+const pageImage = 'https://iiif.wellcomecollection.org/image/prismic:fc1e68b0528abbab8429d95afb5cfa4c74d40d52_tf_180516_2060224.jpg/full/800,/0/default.jpg';
+export class HomePage extends Component<Props> {
+  static getInitialProps = async (context: GetInitialPropsProps) => {
+    const exhibitionsPromise = getExhibitions(context.req, {
+      period: 'next-seven-days',
+      order: 'asc'
+    });
+    const eventsPromise = getEvents(context.req, {
+      period: 'next-seven-days',
+      order: 'asc'
+    });
+    const articlesPromise = getArticles(context.req, {pageSize: 4});
+    const [exhibitions, events, articles] = await Promise.all([
+      exhibitionsPromise, eventsPromise, articlesPromise
+    ]);
+
+    console.info(exhibitions.results.length);
+
+    if (events && exhibitions && articles) {
+      return {
+        exhibitions,
+        events,
+        articles,
+        title: 'The free museum and library for the incurably curious',
+        description: pageDescription,
+        type: 'website',
+        canonicalUrl: `https://wellcomecollection.org/whats-on`,
+        imageUrl: pageImage,
+        siteSection: 'whatson',
+        analyticsCategory: 'public-programme',
+        pageJsonLd: [
+          ...exhibitions.results.map(exhibitionLd),
+          ...events.results.map(eventLd),
+          ...articles.results.map(articleLd)
+        ]
+      };
+    } else {
+      return {statusCode: 404};
+    }
+  }
+
+  render() {
+    const events = this.props.events.results.map(convertJsonToDates);
+    const exhibitions = this.props.exhibitions.results.map(exhibition => {
+      return {
+        start: exhibition.start && new Date(exhibition.start),
+        end: exhibition.end && new Date(exhibition.end),
+        ...exhibition
+      };
+    });
+    const articles = this.props.articles;
+    return (
+      <Fragment>
+        <div className='css-grid__container'>
+          <div className='css-grid'>
+            <div className={classNames({
+              [cssGrid({s: 12, m: 12, l: 10, xl: 9})]: true
+            })}>
+              <h1 className={classNames({
+                [font({s: 'WB4', m: 'WB3'})]: true,
+                [spacing({s: 3}, {margin: ['top', 'bottom']})]: true
+              })}>
+                The free museum and library for the incurably curious
+              </h1>
+            </div>
+          </div>
+        </div>
+
+        <SectionHeader
+          title='This week at Wellcome Collection'
+          linkText='All exhibitions and events'
+          linkUrl='/whats-on'
+        />
+        <ExhibitionsAndEvents
+          exhibitions={exhibitions}
+          events={events}
+          extras={[ourVoiceOurWayData, pharmacyOfColourData]}
+        />
+
+        <SectionHeader
+          title='Latest articles, comics and more'
+          linkText='All stories'
+          linkUrl='/stories'
+        />
+
+        <div className='css-grid__container'>
+          <div className='css-grid'>
+            {articles.results.map(article => {
+              const isSerial = article.series.find(series => series.schedule.length > 0);
+              return (
+                <div
+                  key={article.id}
+                  className={classNames({
+                    [cssGrid({s: 12, m: 6, l: 3, xl: 3})]: true
+                  })}>
+                  {/* $FlowFixMe */}
+                  <Promo
+                    sizes={'(min-width: 1420px) 282px, (min-width: 960px) calc(21.36vw - 17px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'}
+                    url={`/articles/${article.id}`}
+                    contentType={article.format && article.format.title || (isSerial ? 'Serial' : 'Story')}
+                    image={article.image}
+                    title={article.title}
+                    weight={'default'}
+                    description={article.promoText}
+                    series={article.series}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
+};
+
+export default PageWrapper(HomePage);

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -47,8 +47,6 @@ export class HomePage extends Component<Props> {
       exhibitionsPromise, eventsPromise, articlesPromise
     ]);
 
-    console.info(exhibitions.results.length);
-
     if (events && exhibitions && articles) {
       return {
         exhibitions,

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -119,8 +119,13 @@ app.prepare().then(async () => {
   server.use(getToggles);
 
   // Next routing
-  // TODO: As we have this pattern all over the shop we might want to abstract
-  // it out for ease... although copy / paste is not bad
+  router.get('/', async ctx => {
+    const {toggles} = ctx;
+    await app.render(ctx.req, ctx.res, '/homepage', {
+      toggles
+    });
+    ctx.respond = false;
+  });
   router.get('/whats-on', async ctx => {
     const {toggles} = ctx;
     await app.render(ctx.req, ctx.res, '/whats-on', {


### PR DESCRIPTION
Ref #3540 
Forked from #3570 

Renders the homepage from the `content` app.

It won't serve traffic until we setup the listeners, so this is pretty safe and will be able to be tested on `content.`.

