### PR TITLE
route traffic for whats_on and homepage to content app

### DIFF
--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -245,6 +245,24 @@ module "books_listener" {
   path = "/books*"
 }
 
+module "homepage_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "117"
+  path = "/"
+}
+
+module "whats_on_listener" {
+  source = "../../shared-infra/terraform/service_alb_listener"
+  alb_listener_https_arn = "${local.alb_listener_https_arn}"
+  alb_listener_http_arn = "${local.alb_listener_http_arn}"
+  target_group_arn = "${module.content.target_group_arn}"
+  priority = "118"
+  path = "/whats-on*"
+}
+
 module "preview_listener" {
   source = "../../shared-infra/terraform/service_alb_listener"
   alb_listener_https_arn = "${local.alb_listener_https_arn}"


### PR DESCRIPTION
Ref #3540 
~Waiting on: #3573~

Routes traffic for the `/` and `/whats-on` to the new content app.