### PR TITLE
Stop flex child from shrinking if sibling text gets too long

### DIFF
--- a/common/views/components/Contributor/Contributor.js
+++ b/common/views/components/Contributor/Contributor.js
@@ -27,7 +27,7 @@ const Contributor = ({
   return (
     <div className='grid'>
       <div className={`flex ${grid({ s: 12, m: 12, l: 12, xl: 12 })}`}>
-        <div style={{width: '78px'}} className={spacing({ s: 2 }, { margin: ['right'] })}>
+        <div style={{minWidth: '78px'}} className={spacing({ s: 2 }, { margin: ['right'] })}>
           {contributor.type === 'people' && <Avatar imageProps={imageProps} />}
           {contributor.type !== 'people' &&
             <Image {...imageProps} extraClasses={'width-inherit'} />


### PR DESCRIPTION
Fixes #3480

Makes sure the contributor image isn't squashed by the text.