### PR TITLE
encode query for works

### DIFF
--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -39,7 +39,7 @@ export async function getWorks({ query, page, version = 1 }: GetWorksProps): Obj
   const url = `${rootUri}/v${version}/works?includes=${includeString}&include=${includeString}`;
   const res = await fetch(
     `${url}&pageSize=100` +
-    (query ? `&query=${query}` : '') +
+    (query ? `&query=${encodeURIComponent(query)}` : '') +
     (page ? `&page=${page}` : '')
   );
   const json = await res.json();


### PR DESCRIPTION
Not sure why we weren't  doing this?
Any idea?

Noticed it from the erroring:
https://wellcomecollection.org/works?query=creators%3A%22Petros%20M%C3%85%C2%8Drait%C3%84%E2%80%9Cs%22