### PR TITLE
route all events to content app

### DIFF
--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -202,7 +202,7 @@ module "events_listener" {
   alb_listener_http_arn = "${local.alb_listener_http_arn}"
   target_group_arn = "${module.content.target_group_arn}"
   priority = "112"
-  path = "/events/*"
+  path = "/events*"
 }
 
 module "articles_listener" {


### PR DESCRIPTION
Waiting on #3593 

Routes all event traffic through to content app. Currently `/events/{id}` already is, this is just for the listings.