### PR TITLE
Force size on contributor org image

### DIFF
--- a/common/views/components/Contributor/Contributor.js
+++ b/common/views/components/Contributor/Contributor.js
@@ -30,7 +30,9 @@ const Contributor = ({
         <div style={{minWidth: '78px'}} className={spacing({ s: 2 }, { margin: ['right'] })}>
           {contributor.type === 'people' && <Avatar imageProps={imageProps} />}
           {contributor.type !== 'people' &&
-            <Image {...imageProps} extraClasses={'width-inherit'} />
+            <div style={{width: '72px'}}>
+              <Image {...imageProps} extraClasses={'width-inherit'} />
+            </div>
           }
         </div>
         <div>


### PR DESCRIPTION
Not sure when this started happening - might be time to look at how we're setting the width etc of our images.

Broken
![screen shot 2018-10-23 at 15 59 10](https://user-images.githubusercontent.com/31692/47369936-9bcf3f80-d6dc-11e8-8904-0cd56b5af08f.png)

Fixed
![screen shot 2018-10-23 at 15 59 03](https://user-images.githubusercontent.com/31692/47369947-a093f380-d6dc-11e8-8da0-92af1571ab9d.png)
