### PR TITLE
move polyfill io into default page layout

### DIFF
--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -295,12 +295,20 @@ class DefaultPageLayout extends Component<Props> {
     const title = this.props.title
       ? `${this.props.title} | Wellcome Collection`
       : 'Wellcome Collection | The free museum and library for the incurably curious';
+
+    const polyfillFeatures = [
+      'default',
+      'Array.prototype.find',
+      'Array.prototype.includes',
+      'WeakMap'
+    ];
     return (
       <div>
         <Head>
           <meta charSet='utf-8' />
           <meta httpEquiv='X-UA-Compatible' content='IE=edge,chrome=1' />
           <title>{title}</title>
+          <script src={`https://cdn.polyfill.io/v2/polyfill.js?features=${polyfillFeatures.join(',')}`}></script>
           <meta name='viewport' content='width=device-width, initial-scale=1' />
           <meta name='theme-color' content='#000000'/>
 

--- a/common/views/pages/_document.js
+++ b/common/views/pages/_document.js
@@ -12,17 +12,9 @@ export default function WeDoc(css: string) {
     }
 
     render() {
-      const polyfillFeatures = [
-        'default',
-        'Array.prototype.find',
-        'Array.prototype.includes',
-        'WeakMap'
-      ];
       return (
         <html id='top' lang='en'>
           <Head>
-            <script src={`https://cdn.polyfill.io/v2/polyfill.js?features=${polyfillFeatures.join(',')}`}></script>
-            <script dangerouslySetInnerHTML={{ __html: `` }}></script>
             <style dangerouslySetInnerHTML={{ __html: css }} />
           </Head>
           <body>


### PR DESCRIPTION
Moves the polyfill service into DPL.

Oddly, I noticed that the script was being injected quite far down the head, where we had already run some of the JSON LD JS, which includes `Object.assign`.

Adding it here seems to add it to the top of the `<head>`. Not much time to figure out why, just needed to know that it did.

Seems the org logos also look good in IE.
![screen shot 2018-10-23 at 16 34 44](https://user-images.githubusercontent.com/31692/47372698-2d8d7b80-d6e2-11e8-918f-283a76ce597a.png)
