### PR TITLE
Put tracking back

### DIFF
--- a/common/views/components/BookPromo/BookPromo.js
+++ b/common/views/components/BookPromo/BookPromo.js
@@ -1,5 +1,6 @@
 
 import {spacing, font} from '../../../utils/classnames';
+import {trackGaEvent} from '../../../utils/tracking';
 import UiImage from '../Image/Image';
 import Icon from '../Icon/Icon';
 import type {Image} from '../../../model';
@@ -24,10 +25,13 @@ const BookPromo = ({
   return (
     <PromoTag
       data-component='BookPromo'
-      data-track-event={`${JSON.stringify({category: 'component', action: 'BookPromo:click'})}`}
       href={url}
       className={`book-promo ${spacing({s: 10}, {margin: ['top']})} ${spacing({s: 4, m: 5}, {margin: ['bottom']})} ${spacing({s: 4}, {padding: ['top', 'right', 'bottom', 'left']})} rounded-diagonal`}
-    >
+      onClick={() => trackGaEvent({
+        category: 'component',
+        action: 'BookPromo:click',
+        label: `title : ${title}`
+      })}>
       <div className={`book-promo__image-container ${spacing({s: 4}, {margin: ['right', 'bottom']})}`}>
         {image && image.contentUrl && <UiImage
           contentUrl={image.contentUrl}

--- a/common/views/components/BookPromo/BookPromo.js
+++ b/common/views/components/BookPromo/BookPromo.js
@@ -30,7 +30,7 @@ const BookPromo = ({
       onClick={() => trackGaEvent({
         category: 'component',
         action: 'BookPromo:click',
-        label: `title : ${title}`
+        label: `title:${title}`
       })}>
       <div className={`book-promo__image-container ${spacing({s: 4}, {margin: ['right', 'bottom']})}`}>
         {image && image.contentUrl && <UiImage

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -1,5 +1,6 @@
 // @flow
 import {spacing, font} from '../../../utils/classnames';
+import {trackGaEvent} from '../../../utils/tracking';
 import {UiImage} from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
 import Icon from '../Icon/Icon';
@@ -25,14 +26,17 @@ const EventPromo = ({
 }: Props) => {
   const fullyBooked = isEventFullyBooked(event);
   const isPast = event.isPast;
-
   return (
     <a data-component='EventPromo'
       data-component-state={JSON.stringify({ position: position })}
       data-track-event={JSON.stringify({category: 'component', action: 'EventPromo:click', label: `id : ${event.id}, position : ${position}`})}
-      id={event.id}
       href={event.promo && event.promo.link || `/events/${event.id}`}
-      className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'>
+      className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'
+      onClick={() => trackGaEvent({
+        category: 'component',
+        action: 'EventPromo:click',
+        label: `id : ${event.id}, position : ${position}`
+      })}>
       <div className='relative'>
         {/* FIXME: Image type tidy */}
         {/* $FlowFixMe */}

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -29,13 +29,12 @@ const EventPromo = ({
   return (
     <a data-component='EventPromo'
       data-component-state={JSON.stringify({ position: position })}
-      data-track-event={JSON.stringify({category: 'component', action: 'EventPromo:click', label: `id : ${event.id}, position : ${position}`})}
       href={event.promo && event.promo.link || `/events/${event.id}`}
       className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'
       onClick={() => trackGaEvent({
         category: 'component',
         action: 'EventPromo:click',
-        label: `id : ${event.id}, position : ${position}`
+        label: `id:${event.id}, position:${position}`
       })}>
       <div className='relative'>
         {/* FIXME: Image type tidy */}

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -26,7 +26,7 @@ const ExhibitionPromo = ({
       onClick={() => trackGaEvent({
         category: 'component',
         action: 'ExhibitionPromo:click',
-        label: `id : ${id}, position : ${position}`
+        label: `id:${id}, position:${position}`
       })}>
       <div className='relative'>
         {image && image.contentUrl && <UiImage {...image}

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -1,6 +1,7 @@
 // @flow
 import {Fragment} from 'react';
 import {spacing, font} from '../../../utils/classnames';
+import {trackGaEvent} from '../../../utils/tracking';
 import {formatDate} from '../../../utils/format-date';
 import {UiImage} from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
@@ -19,10 +20,14 @@ const ExhibitionPromo = ({
   return (
     <a data-component='ExhibitionPromo'
       data-component-state={JSON.stringify({ position: position })}
-      data-track-event={JSON.stringify({category: 'component', action: 'ExhibitionPromo:click', label: `id : ${id}, position : ${position}`})}
       id={id}
       href={url}
-      className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'>
+      className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'
+      onClick={() => trackGaEvent({
+        category: 'component',
+        action: 'ExhibitionPromo:click',
+        label: `id : ${id}, position : ${position}`
+      })}>
       <div className='relative'>
         {image && image.contentUrl && <UiImage {...image}
           sizesQueries='(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'

--- a/common/views/components/WorkPromo/WorkPromo.js
+++ b/common/views/components/WorkPromo/WorkPromo.js
@@ -1,6 +1,6 @@
 // @flow
-
 import {font} from '../../../utils/classnames';
+import {trackGaEvent} from '../../../utils/tracking';
 import Image from '../Image/Image';
 import type {Props as ImageProps} from '../Image/Image';
 import NextLink from 'next/link';
@@ -27,8 +27,12 @@ const WorkPromo = ({
       <a
         id={id}
         data-component='WorkPromo'
-        data-track-event={`${JSON.stringify({category: 'component', action: 'WorkPromo:click'})}`}
-        className={`promo promo--work`}>
+        className={`promo promo--work`}
+        onClick={() => trackGaEvent({
+          category: 'component',
+          action: 'WorkPromo:click',
+          label: `id : ${id}`
+        })}>
         <div className={`promo__image-container promo__image-container--constrained`}>
           <Image
             width={image.width}

--- a/common/views/components/WorkPromo/WorkPromo.js
+++ b/common/views/components/WorkPromo/WorkPromo.js
@@ -31,7 +31,7 @@ const WorkPromo = ({
         onClick={() => trackGaEvent({
           category: 'component',
           action: 'WorkPromo:click',
-          label: `id : ${id}`
+          label: `id:${id}`
         })}>
         <div className={`promo__image-container promo__image-container--constrained`}>
           <Image


### PR DESCRIPTION
When we moved to the Next apps the tracking stopped working, because we were relying on the client/app.js which we no longer use.

This puts the tracking into the components
