### PR TITLE
add pa11y to circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,31 +105,36 @@ jobs:
       - run:
           name: Flow
           command: yarn flow
-      - run:
-          name: Pa11y report
-          command: |
-            # TODO: Let's bake this into a container
-            sudo apt-get -y -qq update
-            sudo apt-get -y -qq install python3.4-dev
-            curl -O https://bootstrap.pypa.io/get-pip.py
-            python3.4 get-pip.py --user
-            export PATH=~/.local/bin:$PATH
-            pip install awscli --upgrade --user
-            # Install Chrome deps
-            sudo apt-get update && \
-              sudo apt-get install -yq --no-install-recommends \
-              libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-              libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-              libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
-              libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 \
-              libnss3
-            node pa11y_report.js
-            aws s3 cp --only-show-errors ./pa11y_report.html s3://dash.wellcomecollection.org/pa11y/report.${CIRCLE_SHA1}.html
-            aws s3 cp --only-show-errors ./pa11y_report.html s3://dash.wellcomecollection.org/pa11y/report.latest.html
       - save_cache:
           key: root_modules_circleci_node_8_{{ checksum "package.json" }}
           paths:
             -  node_modules
+  deploy_pa11y:
+    docker:
+      - image: circleci/node:8.11.3
+    working_directory: ~/wellcomecollection.org/pa11y/webapp
+    steps:
+    - add_ssh_keys
+    - restore_cache:
+        key: repo_{{ .Environment.CIRCLE_SHA1 }}
+    - run:
+        name: Install awscli
+        command: sudo apt-get install awscli
+    - run:
+        name: Yarn install
+        command: yarn
+    - run:
+        name: Write pa11y report
+        command: yarn write-report
+    - run:
+        name: Build next app
+        command: |
+            yarn build
+            yarn export
+    - run:
+        name: Deploy
+        command: |
+          aws s3 sync ./out s3://dash.wellcomecollection.org/pa11y --only-show-errors
   install_server_modules:
     docker:
       - image: circleci/node:8.11.3
@@ -415,6 +420,13 @@ workflows:
       - install_common_modules:
           requires:
             - checkout_code
+      - deploy_pa11y:
+          requires:
+            - checkout_code
+          filters:
+            branches:
+              only:
+                - master
       - root_tests:
           requires:
             - checkout_code

--- a/pa11y/webapp/next.config.js
+++ b/pa11y/webapp/next.config.js
@@ -1,0 +1,7 @@
+// We build and deploy from Circle
+// This let's us serve from https://dash.wc.org/pa11y
+const isTest = process.env.NODE_ENV === 'test';
+module.exports = {
+  // You may only need to add assetPrefix in the production.
+  assetPrefix: isTest ? '/pa11y' : ''
+};

--- a/pa11y/webapp/package.json
+++ b/pa11y/webapp/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "export": "next export"
+    "export": "next export",
+    "write-report": "node write-report.js"
   },
   "dependencies": {
     "@babel/preset-flow": "^7.0.0",


### PR DESCRIPTION
Just copies the nicer dash to the same location.

Didn't want to do more work on it, as I wonder if there's something better we could be building i.e.

- Commit
- Build app (content / catalogue)
- In app testing phase: Run report
- Compare to old report
  - Regressions? Error
  - No regressions? Commit new report

We're missing a few things to be able to do this, (having circleci commit for us, which would also be good for linting).
