### PR TITLE
get page state back into the mix

### DIFF
--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -68,7 +68,6 @@ export default ({
     ReactGA.set({'dimension7': referringComponentListString});
   }
   if (pageState) {
-    console.info(pageState);
     ReactGA.set({'dimension8': pageState});
   };
 

--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -7,7 +7,7 @@ type Props = {|
   category: AnalyticsCategory,
   contentType: ?string,
   pageState: ?Object,
-  featuresCohort: ?string,
+  featuresCohort: ?string
 |}
 
 function testLocalStorage() { // Test localStorage i/o
@@ -25,7 +25,12 @@ function testLocalStorage() { // Test localStorage i/o
 
 const hasWorkingLocalStorage = testLocalStorage();
 
-export default ({ category, contentType, pageState, featuresCohort }: Props) => {
+export default ({
+  category,
+  contentType,
+  pageState,
+  featuresCohort
+}: Props) => {
   const referringComponentListString = hasWorkingLocalStorage && window.localStorage.getItem('wc_referring_component_list');
   window.localStorage.removeItem('wc_referring_component_list');
 
@@ -63,6 +68,7 @@ export default ({ category, contentType, pageState, featuresCohort }: Props) => 
     ReactGA.set({'dimension7': referringComponentListString});
   }
   if (pageState) {
+    console.info(pageState);
     ReactGA.set({'dimension8': pageState});
   };
 

--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -164,13 +164,18 @@ type Props = {|
     upcomingExceptionalOpeningPeriods: {dates: Moment[], type: OverrideType}[]
   },
   globalAlert: GlobalAlert,
-  oEmbedUrl?: string
+  oEmbedUrl?: string,
+  pageState: ?{}
 |}
 
 class DefaultPageLayout extends Component<Props> {
   componentDidMount() {
-    const { analyticsCategory, featuresCohort } = this.props;
-    analytics({analyticsCategory, featuresCohort});
+    const {
+      analyticsCategory,
+      featuresCohort,
+      pageState
+    } = this.props;
+    analytics({analyticsCategory, featuresCohort, pageState});
 
     // $FlowFixMe
     const lazysizes = require('lazysizes');
@@ -269,8 +274,12 @@ class DefaultPageLayout extends Component<Props> {
   }
 
   componentDidUpdate() {
-    const { analyticsCategory, featuresCohort } = this.props;
-    analytics({analyticsCategory, featuresCohort});
+    const {
+      analyticsCategory,
+      featuresCohort,
+      pageState
+    } = this.props;
+    analytics({analyticsCategory, featuresCohort, pageState});
   }
 
   render() {

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -3,7 +3,7 @@ import {Fragment, Component} from 'react';
 import {getArticle} from '@weco/common/services/prismic/articles';
 import {getArticleSeries} from '@weco/common/services/prismic/article-series';
 import {classNames, spacing, font} from '@weco/common/utils/classnames';
-import {default as PageWrapper, pageStore} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import {default as PageWrapper} from '@weco/common/views/components/PageWrapper/PageWrapper';
 import BasePage from '@weco/common/views/components/BasePage/BasePage';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import Body from '@weco/common/views/components/Body/Body';
@@ -18,12 +18,16 @@ import {
 import {convertImageUri} from '@weco/common/utils/convert-image-uri';
 import type {Article} from '@weco/common/model/articles';
 import type {ArticleScheduleItem} from '@weco/common/model/article-schedule-items';
-import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import type {
+  GetInitialPropsProps,
+  ExtraProps
+} from '@weco/common/views/components/PageWrapper/PageWrapper';
 import {articleLd} from '@weco/common/utils/json-ld';
 import {ContentFormatIds} from '@weco/common/model/content-format-id';
 
 type Props = {|
-  article: Article
+  article: Article,
+  showOutro: boolean
 |}
 
 type State = {|
@@ -34,13 +38,22 @@ export class ArticlePage extends Component<Props, State> {
     listOfSeries: []
   }
 
-  static getInitialProps = async (context: GetInitialPropsProps) => {
+  static getInitialProps = async (
+    context: GetInitialPropsProps,
+    { toggles }: ExtraProps
+  ) => {
     const {id} = context.query;
     const article = await getArticle(context.req, id);
 
     if (article) {
+      const showOutro = Boolean(toggles && toggles.outro && (
+        article.outroResearchItem ||
+        article.outroReadItem ||
+        article.outroVisitItem
+      ));
       return {
         article,
+        showOutro,
         title: article.title,
         description: article.promoText,
         type: 'article',
@@ -48,7 +61,8 @@ export class ArticlePage extends Component<Props, State> {
         imageUrl: article.image && convertImageUri(article.image.contentUrl, 800),
         siteSection: 'stories',
         analyticsCategory: 'editorial',
-        pageJsonLd: articleLd(article)
+        pageJsonLd: articleLd(article),
+        pageState: {hasOutro: showOutro}
       };
     } else {
       return {statusCode: 404};
@@ -70,7 +84,10 @@ export class ArticlePage extends Component<Props, State> {
   }
 
   render() {
-    const article = this.props.article;
+    const {
+      article,
+      showOutro
+    } = this.props;
 
     const breadcrumbs = {
       items: [
@@ -193,13 +210,6 @@ export class ArticlePage extends Component<Props, State> {
         );
       }
     }).filter(Boolean);
-
-    const toggles = pageStore('toggles');
-    const showOutro = toggles.outro && (
-      article.outroResearchItem ||
-      article.outroReadItem ||
-      article.outroVisitItem
-    );
 
     return (
       <BasePage

--- a/content/webapp/test/articles.test.js
+++ b/content/webapp/test/articles.test.js
@@ -14,7 +14,7 @@ it('renders <WorkPage /> with an catalogue API work response', async () => {
 
   if (article) {
     const Page = TestRenderer.create(
-      <ArticlePage article={article} />
+      <ArticlePage article={article} showOutro={false} />
     );
     expect(Page).not.toBe(null);
   }


### PR DESCRIPTION
Probably need to rethink the page store, as it isn't much use as it stands.

The values are only set once the `getInitialProps` of `PageWrapper` are run, which is after the child components `getInitialProps` - which means if you try to use it before then (any server rendering) you _might_ get the wrong value.

I still feel a little uneasy with the `PageWrapper` calling `PageComp`, then passing it to `DefaultPageLayout`, but there's a few dependencies now, so it felt safer to work with what's here.