### PR TITLE
allow userenabled switches to be set to public via app

### DIFF
--- a/catalogue/webapp/server.js
+++ b/catalogue/webapp/server.js
@@ -45,10 +45,7 @@ function getToggles(ctx, next) {
 
   ctx.toggles = {
     apiV2: isEnabled('apiV2', {
-      enabled: userEnabledToggles.apiV2 === true
-    }),
-    catalogueApiStaging: isEnabled('catalogueApiStaging', {
-      enabled: userEnabledToggles.catalogueApiStaging === true
+      isUserEnabled: userEnabledToggles.apiV2 === true
     })
   };
 

--- a/common/services/unleash/feature-toggles.js
+++ b/common/services/unleash/feature-toggles.js
@@ -17,8 +17,10 @@ class UserEnabled extends Strategy {
     super('UserEnabled');
   }
 
-  isEnabled(_, { enabled }) {
-    return enabled;
+  isEnabled({ isPublic }, { isUserEnabled }) {
+    // Unleash support numbers not booleans...
+    // And sends them as strings....
+    return isUserEnabled || parseInt(isPublic, 10) === 1;
   }
 }
 

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -59,7 +59,7 @@ function getToggles(ctx, next) {
 
   ctx.toggles = {
     outro: isEnabled('outro', {
-      enabled: userEnabledToggles.outro === true
+      isUserEnabled: userEnabledToggles.outro === true
     })
   };
 


### PR DESCRIPTION
## Requirement

Allow us to develop a feature, behind a switch (available on prod) - and to turn that switch on and off for the public. 

## How
This means `isUserEnabled` is set via the URL and cookie.
There is also not a field in Unleash which is `isPublic` that will turn this on for everyone.

The alternative, I suppose, would be, when we would like to switch, we could change the strategy to `default` and just turn it on off.

I think I prefer a three phase switch:
- Off
- Off for public, switchable for us
- On for all