### PR TITLE
Accessibility fixes

### DIFF
--- a/catalogue/webapp/components/WorkMedia/WorkMedia.js
+++ b/catalogue/webapp/components/WorkMedia/WorkMedia.js
@@ -21,7 +21,7 @@ const WorkMedia = ({
   const imageContentUrl = iiifImageTemplate(iiifUrl)({ size: `${width},` });
   return (
     <div>
-      <div id={`work-media-${id}`} className='row bg-black work-media js-work-media'>
+      <div id={`work-media-${id}`} className='row bg-black font-white work-media js-work-media'>
         <Control
           type='dark'
           extraClasses='scroll-to-info js-scroll-to-info js-work-media-control flush-container-right'

--- a/common/styles/components/_image_gallery_v2.scss
+++ b/common/styles/components/_image_gallery_v2.scss
@@ -25,6 +25,7 @@ $image-gallery-v2-transition-properties: 400ms ease;
     }
 
     .captioned-image__image-container {
+      background: color('charcoal');
       &:hover:before {
         opacity: 0;
       }

--- a/common/views/components/ChapterIndicator/ChapterIndicator.js
+++ b/common/views/components/ChapterIndicator/ChapterIndicator.js
@@ -26,7 +26,7 @@ function buildMarkup(showSingle, commissionedLength, position, showTotal, color)
       : `data:image/gif;base64,R0lGODlhAQAEAIAAA${colorDataUris['white']}`;
 
     return (
-      <img key={index} className={`chapter-indicator__bar ${(index < position) || showTotal ? 'chapter-indicator__bar--filled' : ''}`}
+      <img key={index} alt='' className={`chapter-indicator__bar ${(index < position) || showTotal ? 'chapter-indicator__bar--filled' : ''}`}
         src={srcUrl} />
     );
   });

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -30,7 +30,6 @@ const EventPromo = ({
     <a data-component='EventPromo'
       data-component-state={JSON.stringify({ position: position })}
       data-track-event={JSON.stringify({category: 'component', action: 'EventPromo:click', label: `id : ${event.id}, position : ${position}`})}
-      id={event.id}
       href={event.promo && event.promo.link || `/events/${event.id}`}
       className='plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column'>
       <div className='relative'>

--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -24,11 +24,11 @@ export type Props = {|
 const Image = (props: Props) => (
   <Fragment>
     <noscript dangerouslySetInnerHTML={{__html: `
-      <img width=${props.width}
-        height=${props.height || ''}
+      <img width='${props.width}'
+        height='${props.height || ''}'
         className='image image--noscript'
-        src=${convertImageUri(props.contentUrl, 640, false)}
-        alt=${props.alt || ''} />`}} />
+        src='${convertImageUri(props.contentUrl, 640, false)}'
+        alt='${props.alt || ''}' />`}} />
 
     {props.clipPathClass ? (
       <Fragment>

--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -28,7 +28,7 @@ const Image = (props: Props) => (
         height=${props.height || ''}
         className='image image--noscript'
         src=${convertImageUri(props.contentUrl, 640, false)}
-        alt=${props.alt} />`}} />
+        alt=${props.alt || ''} />`}} />
 
     {props.clipPathClass ? (
       <Fragment>
@@ -73,7 +73,7 @@ const Img = ({
       sizes={sizesQueries}
       data-copyright={copyright}
       onClick={clickHandler}
-      alt={alt}
+      alt={alt || ''}
       style={style} />
   );
 };

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -85,9 +85,9 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
           <img width=${width}
             height=${height || ''}
             class='image image--noscript'
-            style="width: auto;"
-            src=${convertImageUri(contentUrl, 640, false)}
-            alt=${alt} />`}} />
+            style='width: auto;'
+            src=''
+            alt=${alt || ''} />`}} />
 
         <img width={width}
           height={height}
@@ -107,7 +107,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
             return `${convertImageUri(contentUrl, size, false)} ${size}w`;
           })}
           sizes={sizesQueries}
-          alt={alt} />
+          alt={alt || ''} />
 
         {showTasl && <Tasl {...tasl} isFull={isFull} />}
       </Fragment>

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -82,12 +82,12 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
     return (
       <Fragment>
         <noscript dangerouslySetInnerHTML={{__html: `
-          <img width=${width}
-            height=${height || ''}
+          <img width='${width}'
+            height='${height || ''}'
             class='image image--noscript'
             style='width: auto;'
             src=''
-            alt=${alt || ''} />`}} />
+            alt='${alt || ''}' />`}} />
 
         <img width={width}
           height={height}

--- a/common/views/components/Picture/Picture.js
+++ b/common/views/components/Picture/Picture.js
@@ -37,7 +37,7 @@ const Picture = ({ images, extraClasses, isFull = false }: Props) => {
         {lastImage && lastImage.contentUrl && lastImage.width && <img
           className='image block'
           src={convertImageUri(lastImage.contentUrl, lastImage.width, false)}
-          alt={lastImage.alt} />}
+          alt={lastImage.alt || ''} />}
       </picture>
       {tasl && <Tasl {...tasl} isFull={isFull} />}
     </figure>
@@ -84,7 +84,7 @@ export const PictureFromImages = ({
           width={lastImage.width}
           className='image lazy-image lazyload'
           data-src={convertImageUri(lastImage.contentUrl, lastImage.width, false)}
-          alt={lastImage.alt} />}
+          alt={lastImage.alt || ''} />}
       </picture>
       {lastImage && <Tasl {...lastImage.tasl} isFull={isFull} />}
     </figure>

--- a/common/views/components/SearchResults/AsyncSearchResults.js
+++ b/common/views/components/SearchResults/AsyncSearchResults.js
@@ -26,7 +26,7 @@ class AsyncSearchResults extends Component<Props, State> {
       <Fragment>
         <div className='grid'>
           <div className={grid({s: 12})}>
-            <h2 className='h2'>{this.props.title}</h2>
+            {this.props.title && <h2 className='h2'>{this.props.title}</h2>}
           </div>
         </div>
 

--- a/pa11y/webapp/write-report.js
+++ b/pa11y/webapp/write-report.js
@@ -7,9 +7,15 @@ const writeFile = promisify(fs.writeFile);
 console.info('Pa11y: Starting report');
 const urls = [
   'https://wellcomecollection.org',
-  'https://wellcomecollection.org/stories',
+  'https://wellcomecollection.org/visit-us',
   'https://wellcomecollection.org/whats-on',
-  'https://wellcomecollection.org/works'
+  'https://wellcomecollection.org/stories',
+  'https://wellcomecollection.org/articles/WyjHUicAACvGnmJI',
+  'https://wellcomecollection.org/articles/W8ivQRAAAJFijw1h',
+  'https://wellcomecollection.org/works',
+  'https://wellcomecollection.org/works?query=health',
+  'https://wellcomecollection.org/works/cjwep3ze?query=health&page=1',
+  'https://wellcomecollection.org/what-we-do'
 ];
 
 const promises = urls.map(url => pa11y(url));


### PR DESCRIPTION
Adds more pages to run accessibility checks against and fixes issues:
![localhost_3000_](https://user-images.githubusercontent.com/6051896/47435557-c385dc80-d79c-11e8-90d3-8f695d874141.png)

@Heesoomoon @GarethOrmerod One outstanding issue is the colour contrast of a primary link on the cream background:
![screen shot 2018-10-24 at 14 52 27](https://user-images.githubusercontent.com/6051896/47435631-e44e3200-d79c-11e8-9024-cb3e96e39e9e.png)

This uses green(#088574) on cream(#F0EDE3), which has a contrast ratio of 3.88:1, not the required 4.5:1
