### PR TITLE
add ab strategy to unleash

### DIFF
--- a/common/services/unleash/feature-toggles.js
+++ b/common/services/unleash/feature-toggles.js
@@ -12,6 +12,20 @@ class ActiveForUserInCohort extends Strategy {
   }
 }
 
+class ABTest extends Strategy {
+  constructor() {
+    super('ABTest');
+  }
+
+  isEnabled({ percentage }) {
+    // Unleash support numbers not booleans...
+    // And sends them as strings....
+    const chance = percentage / 100;
+    const coinToss = Math.random() < chance;
+    return coinToss;
+  }
+}
+
 class UserEnabled extends Strategy {
   constructor() {
     super('UserEnabled');
@@ -28,7 +42,11 @@ function init(options) {
   return initialize(Object.assign(options, {
     url: 'https://weco-feature-flags.herokuapp.com/api/',
     refreshInterval: 60 * 1000,
-    strategies: [new ActiveForUserInCohort(), new UserEnabled()]
+    strategies: [
+      new ActiveForUserInCohort(),
+      new UserEnabled(),
+      new ABTest()
+    ]
   }));
 }
 

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -60,7 +60,8 @@ function getToggles(ctx, next) {
   ctx.toggles = {
     outro: isEnabled('outro', {
       isUserEnabled: userEnabledToggles.outro === true
-    })
+    }),
+    outroAB: isEnabled('outroAB')
   };
 
   return next();


### PR DESCRIPTION
If we're good with this and #3607 - I'd like to send an event off to GA, just to get confidence that we are splitting by what we say we're splitting __with cache__. 

It worked for the NGINX bit, so we might be good.