### PR TITLE
get global alert on server

### DIFF
--- a/common/koa-middleware/withGlobalAlert.js
+++ b/common/koa-middleware/withGlobalAlert.js
@@ -9,7 +9,6 @@ async function getAndSetGlobalAlert() {
       text: document.data.text,
       isShown: document.data.isShown && document.data.isShown === 'show'
     };
-    throw new Error('Kapow');
   } catch (e) {
     // TODO: Alert to sentry
   }

--- a/common/koa-middleware/withGlobalAlert.js
+++ b/common/koa-middleware/withGlobalAlert.js
@@ -1,0 +1,21 @@
+const Prismic = require('prismic-javascript');
+
+let globalAlert = {isShow: false, text: null};
+async function getAndSetGlobalAlert() {
+  try {
+    const api = await Prismic.getApi('https://wellcomecollection.prismic.io/api/v2');
+    const document = await api.getSingle('global-alert');
+    globalAlert = {
+      text: document.data.text,
+      isShown: document.data.isShown && document.data.isShown === 'show'
+    };
+    throw new Error('Kapow');
+  } catch (e) {
+    // TODO: Alert to sentry
+  }
+}
+setInterval(getAndSetGlobalAlert, 6000);
+module.exports = function withGlobalAlert(ctx, next) {
+  ctx.globalAlert = globalAlert;
+  return next();
+};

--- a/common/services/prismic/opening-times.js
+++ b/common/services/prismic/opening-times.js
@@ -3,7 +3,17 @@ import Prismic from 'prismic-javascript';
 import {getDocuments} from './api';
 import {isDatePast, london} from '../../utils/format-date';
 import groupBy from 'lodash.groupby';
-import type {Day, OverrideType, ExceptionalPeriod, OverrideDate, ExceptionalVenueHours, PlacesOpeningHours, ExceptionalOpeningHoursDay, Venue, periodModifiedHours} from '../../model/opening-hours';
+import type {
+  Day,
+  OverrideType,
+  ExceptionalPeriod,
+  OverrideDate,
+  ExceptionalVenueHours,
+  PlacesOpeningHours,
+  ExceptionalOpeningHoursDay,
+  Venue,
+  periodModifiedHours
+} from '../../model/opening-hours';
 import type {PrismicFragment} from '../../services/prismic/types';
 import type Moment from 'moment';
 

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -123,11 +123,6 @@ app.prepare().then(async () => {
 
   // server cached values
   server.use(withGlobalAlert);
-  router.get('/alert', async ctx => {
-    const {globalAlert} = ctx;
-    ctx.status = 200;
-    ctx.body = globalAlert;
-  });
 
   // Next routing
   router.get('/', async ctx => {

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -83,20 +83,41 @@ function setCohortCookie(ctx, next) {
 
 function pageVanityUrl(router, app, url, pageId) {
   router.get(url, async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/page', {
       id: pageId,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
+}
+
+let globalAlert = {isShow: false, text: null};
+async function getAndSetGlobalAlert() {
+  try {
+    const api = await Prismic.getApi('https://wellcomecollection.prismic.io/api/v2');
+    const document = await api.getSingle('global-alert');
+    globalAlert = {
+      text: document.data.text,
+      isShown: document.data.isShown && document.data.isShown === 'show'
+    };
+    throw new Error('Kapow');
+  } catch (e) {
+    // TODO: Alert to sentry
+  }
+}
+setInterval(getAndSetGlobalAlert, 60000);
+function setGobalAlert(ctx, next) {
+  ctx.globalAlert = globalAlert;
+  return next();
 }
 
 app.prepare().then(async () => {
   const server = new Koa();
   const router = new Router();
   const instance = initialize({
-    appName: 'works'
+    appName: 'content'
   });
 
   try {
@@ -119,163 +140,202 @@ app.prepare().then(async () => {
   server.use(setUserEnabledToggles);
   server.use(getToggles);
 
+  // server cached values
+  server.use(setGobalAlert);
+
   // Next routing
   router.get('/', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/homepage', {
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/whats-on', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/whats-on', {
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get(`/whats-on/:period(${periodPaths})`, async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/whats-on', {
       period: ctx.params.period,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/exhibitions', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     const {page} = ctx.query;
     await app.render(ctx.req, ctx.res, '/exhibitions', {
+      page,
       toggles,
-      page
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get(`/exhibitions/:period(${periodPaths})`, async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     const {page} = ctx.query;
     await app.render(ctx.req, ctx.res, '/exhibitions', {
       period: ctx.params.period,
+      page,
       toggles,
-      page
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get('/exhibitions/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/exhibition', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/events', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/events', {
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get(`/events/:period(${periodPaths})`, async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/events', {
       period: ctx.params.period,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get('/events/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/event', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/articles', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/articles', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get('/articles/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/article', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/series/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/article-series', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/books', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     const {page} = ctx.query;
     await app.render(ctx.req, ctx.res, '/books', {
-      id: ctx.params.id,
+      page,
       toggles,
-      page
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get('/books/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/book', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/event-series/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/event-series', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/places/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/place', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/pages/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/page', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
 
   router.get('/installations/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/installation', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
+
+  router.get('/opening-times', async ctx => {
+    const {toggles, globalAlert} = ctx;
+    await app.render(ctx.req, ctx.res, '/opening-times', {
+      toggles,
+      globalAlert
+    });
+    ctx.respond = false;
+  });
+
+  router.get('/newsletter', async ctx => {
+    const {toggles, globalAlert} = ctx;
+    await app.render(ctx.req, ctx.res, '/newsletter', {
+      toggles,
+      globalAlert
+    });
+    ctx.respond = false;
+  });
+
   router.get('/preview', async ctx => {
     // Kill any cookie we had set, as it think it is causing issues.
     ctx.cookies.set(Prismic.previewCookie);
@@ -290,24 +350,12 @@ app.prepare().then(async () => {
     });
     ctx.redirect(url);
   });
+
   router.get('/content/management/healthcheck', async ctx => {
     ctx.status = 200;
     ctx.body = 'ok';
   });
-  router.get('/opening-times', async ctx => {
-    const {toggles} = ctx;
-    await app.render(ctx.req, ctx.res, '/opening-times', {
-      toggles
-    });
-    ctx.respond = false;
-  });
-  router.get('/newsletter', async ctx => {
-    const {toggles} = ctx;
-    await app.render(ctx.req, ctx.res, '/newsletter', {
-      toggles
-    });
-    ctx.respond = false;
-  });
+
   pageVanityUrl(router, app, '/visit-us', 'WwLIBiAAAPMiB_zC');
   pageVanityUrl(router, app, '/what-we-do', 'WwLGFCAAAPMiB_Ps');
   pageVanityUrl(router, app, '/press', 'WuxrKCIAAP9h3hmw');


### PR DESCRIPTION
Ref #3632 

Realising the initial page load at the moment is getting very heavy.

Looking at the stats, it's the initial page load that taking a while which would make sense, as for every page load we are making 2 synchronous calls to Prismic, and then whatever other API calls we need to make for data, so the latency is going to be large - and this is before anyone even sees the page.

Looking at the averages, I think we're mitigating this by:

- On content pages, CloudFront cache
- On Works, having the initial page load and then the rest of the interface being asynchronous

In the future though, it feels as though relying on cache for highly user centred requests (search), or letting people wait ages for the initial app to load seems unfair.

We have also coupled the whole site with Prismic with the current setup, which makes me feel uneasy. If Prismic goes down here, we lose the catalogue app too, which defeats the point of the initial decoupling.

I reckon we could probably get this for the opening hours, understandably the parsing of the data is more complicated and can benefit Babel, but maybe we just fetch the data here, and pass it to the app to parse.