### PR TITLE
Re-add underline under what's on for exhibitions

### DIFF
--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -54,6 +54,7 @@ export class ExhibitionPage extends Component<Props, State> {
         description: exhibition.promoText,
         canonicalUrl: `https://wellcomecollection.org/exhibitions/${exhibition.id}`,
         pageJsonLd: exhibitionLd(exhibition),
+        siteSection: 'whatson',
         exhibition
       };
     } else {


### PR DESCRIPTION
Underlining 'What's on' in the nav when you're on an individual exhibition.

<img width="803" alt="screen shot 2018-10-25 at 17 38 20" src="https://user-images.githubusercontent.com/1394592/47516247-ee476200-d87c-11e8-84e8-435552bfcd9d.png">
