### PR TITLE
Move spacing (and add demo) to Global section of Cardigan

### DIFF
--- a/cardigan/stories/global/spacing/README.md
+++ b/cardigan/stories/global/spacing/README.md
@@ -22,8 +22,9 @@ Components _within_ these sections are wrapped in a `<SpacingComponent />`. This
 
 We don't apply this top margin to the first `<SpacingComponent />`, since we don't want to add it to the bottom-margin added by a preceding `<SpacingSection />`.
 
-We handle spacing in body copy and `<SpacingComponent />`s in a similar way[^1]. The main difference being that in body copy we use `em` units.
+We handle spacing in body copy and `<SpacingComponent />`s in a similar way*. The main difference being that in body copy we use `em` units.
 
 These are units that are relative to the size of the type, so this enables us to keep the spacing hierarchy consistent when we change the font size (e.g. at different breakpoints) without having to change an absolute pixel value for spacing at the same time.
 
-[^1]: [Axiomatic CSS and Lobotomized Owls](https://alistapart.com/article/axiomatic-css-and-lobotomized-owls)
+*: [Axiomatic CSS and Lobotomized Owls](https://alistapart.com/article/axiomatic-css-and-lobotomized-owls)
+

--- a/cardigan/stories/global/spacing/spacing.js
+++ b/cardigan/stories/global/spacing/spacing.js
@@ -1,0 +1,36 @@
+import { storiesOf } from '@storybook/react';
+import SpacingSection from '../../../../common/views/components/SpacingSection/SpacingSection';
+import SpacingComponent from '../../../../common/views/components/SpacingComponent/SpacingComponent';
+import spacingReadme from './README.md';
+
+const SpacingDemo = () => {
+  return (
+    <div className='bg-cream font-white'>
+      <SpacingSection>
+        <div className='bg-green' style={{minHeight: '200px'}}>Section</div>
+      </SpacingSection>
+      <SpacingSection>
+        <div className='bg-green' style={{minHeight: '200px'}}>
+          Section
+          <SpacingComponent>
+            <div className='bg-teal' style={{minHeight: '100px'}}>Component</div>
+          </SpacingComponent>
+          <SpacingComponent>
+            <div className='bg-teal' style={{minHeight: '100px'}}>Component</div>
+          </SpacingComponent>
+          <SpacingComponent>
+            <div className='bg-teal' style={{minHeight: '100px'}}>Component</div>
+          </SpacingComponent>
+        </div>
+      </SpacingSection>
+      <SpacingSection>
+        <div className='bg-green' style={{minHeight: '200px'}}>Section</div>
+      </SpacingSection>
+    </div>
+  );
+};
+
+const stories = storiesOf('Global', module);
+
+stories
+  .add('Spacing', SpacingDemo, {info: spacingReadme});


### PR DESCRIPTION
Spacing info feels like it belongs in the `Global` section of the docs. Moved it there along with a basic demo of the Section and Component spacings.

Would be good to find a way to fix the (ironically awful) markdown spacing for the documentation.

![screen shot 2018-10-26 at 12 09 25](https://user-images.githubusercontent.com/1394592/47562989-48e1cc00-d918-11e8-979e-5293d8450364.png)
