### PR TITLE
Specify scrolling as an interaction (to keep data consistent)

### DIFF
--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -120,7 +120,7 @@ export default ({ category, contentType, pageState, featuresCohort }: Props) => 
             action: 'Percentage',
             label: mark,
             value: 1,
-            nonInteraction: true
+            nonInteraction: false
           });
 
           ReactGA.timing({


### PR DESCRIPTION
Previously, we treated scrolling as an interaction in GA, so it affected bounce rate. When we switched to use `ReactGA` we stopped doing this. This PR reinstates scrolling as an interaction so that @hthair gets consistent data to analyse.