### PR TITLE
No js image display

### DIFF
--- a/common/styles/components/_captioned_image.scss
+++ b/common/styles/components/_captioned_image.scss
@@ -7,6 +7,11 @@
   .image {
     max-height: 80vh;
     max-width: 100%;
+
+  }
+
+  noscript .image {
+    max-height: none;
   }
 }
 

--- a/common/styles/components/_lazyload.scss
+++ b/common/styles/components/_lazyload.scss
@@ -2,6 +2,8 @@
   opacity: 0.6;
   transition: opacity $transition-properties;
 
+  display: none;
+
   .enhanced & {
     display: block;
   }

--- a/common/styles/components/_work_media.scss
+++ b/common/styles/components/_work_media.scss
@@ -14,8 +14,10 @@
     width: auto;
     align-self: center;
     margin: 0 auto;
+    display: none;
 
     .enhanced & {
+      display: block;
       padding: 0;
       cursor: zoom-in;
     }

--- a/common/styles/components/_work_media.scss
+++ b/common/styles/components/_work_media.scss
@@ -29,6 +29,9 @@
 
   .image--noscript {
     display: block;
+    margin: auto;
+    width: auto;
+    height: auto;
   }
 }
 

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -485,9 +485,3 @@
 .spacing-section {
   padding-bottom: $spacing-unit * 13;
 }
-
-  // We use noscript to show images in non js environments
-  // If they are showing then we don't want to show the lazyload image - which would display thte alt text
-  noscript + .image {
-    display: none;
-  }

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -485,3 +485,9 @@
 .spacing-section {
   padding-bottom: $spacing-unit * 13;
 }
+
+  // We use noscript to show images in non js environments
+  // If they are showing then we don't want to show the lazyload image - which would display thte alt text
+  noscript + .image {
+    display: none;
+  }

--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -26,7 +26,7 @@ const Image = (props: Props) => (
     <noscript dangerouslySetInnerHTML={{__html: `
       <img width='${props.width}'
         height='${props.height || ''}'
-        className='image image--noscript'
+        class='image image--noscript'
         src='${convertImageUri(props.contentUrl, 640, false)}'
         alt='${props.alt || ''}' />`}} />
 

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -85,8 +85,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
           <img width='${width}'
             height='${height || ''}'
             class='image image--noscript'
-            style='width: auto;'
-            src=''
+            src=${convertImageUri(contentUrl, 640, false)}
             alt='${alt || ''}' />`}} />
 
         <img width={width}


### PR DESCRIPTION
Without js enabled the images were displaying weirdly on the site: duplicated/ blurry with alt text showing/ covering the whole page on works:

![localhost_3000_stories](https://user-images.githubusercontent.com/6051896/47580575-21eebe80-d947-11e8-9d9b-81415ff10a9d.gif)
![promos](https://user-images.githubusercontent.com/6051896/47580578-23b88200-d947-11e8-90da-6f7da6ee99e2.gif)
![localhost_3002_works_etk3phgd_query sun page 1](https://user-images.githubusercontent.com/6051896/47580583-25824580-d947-11e8-8014-371874b4c1fa.gif)


This fixes that
