### PR TITLE
Ab outro

### DIFF
--- a/catalogue/webapp/server.js
+++ b/catalogue/webapp/server.js
@@ -13,15 +13,18 @@ function setUserEnabledToggles(ctx, next) {
   const togglesRequest = ctx.query.toggles;
 
   if (togglesRequest) {
+    const cookies = new Cookies(ctx.req, ctx.res);
     const toggles = togglesRequest.split(',').reduce((acc, toggle) => {
       const toggleParts = toggle.split(':');
-      return Object.assign({}, acc, {
-        [toggleParts[0]]: Boolean(toggleParts[1])
-      });
+      const key = toggleParts[0];
+      delete acc[key];
+
+      return toggleParts[1] === 'true' ? Object.assign({}, acc, {
+        [key]: true
+      }) : acc;
     }, {});
 
     if (Object.keys(toggles).length > 0) {
-      const cookies = new Cookies(ctx.req, ctx.res);
       const togglesCookie = cookies.get('toggles');
       let previousToggles = {};
       try {
@@ -29,6 +32,8 @@ function setUserEnabledToggles(ctx, next) {
       } catch (e) {}
       const mergedToggles = Object.assign({}, previousToggles, toggles);
       cookies.set('toggles', JSON.stringify(mergedToggles));
+    } else {
+      cookies.set('toggles');
     }
   }
   return next();

--- a/common/koa-middleware/withUserEnabledToggles.js
+++ b/common/koa-middleware/withUserEnabledToggles.js
@@ -1,0 +1,58 @@
+const Cookies = require('cookies');
+
+function withUserEnabledCookies(ctx, next) {
+  const togglesQuery = ctx.query.toggles;
+  const cookies = new Cookies(ctx.req, ctx.res);
+
+  // Kill all of your toggles
+  if (togglesQuery === 'null') {
+    cookies.set('toggles');
+    ctx.userEnabledToggles = {};
+    return next();
+  }
+
+  const togglesCookie = cookies.get('toggles');
+  let toggles = {};
+  try {
+    toggles = JSON.parse(togglesCookie);
+  } catch (e) {}
+
+  if (togglesQuery) {
+    const togglesRequest = togglesQuery.split(',').reduce((acc, toggle) => {
+      const toggleParts = toggle.split(':');
+      const key = toggleParts[0];
+      const val = toggleParts[1];
+
+      return Object.assign({}, acc, {
+        [key]: val === 'true'
+      });
+    }, {});
+
+    Object.keys(togglesRequest).map(key => {
+      const val = togglesRequest[key];
+      if (val === true) {
+        toggles[key] = true;
+      } else {
+        delete toggles[key];
+      }
+    });
+
+    if (Object.keys(toggles).length > 0) {
+      cookies.set('toggles', JSON.stringify(toggles), {
+        overwrite: true,
+        maxAge: 365 * 24 * 60 * 60 * 1000,
+        sameSite: 'strict'
+      });
+      ctx.userEnabledToggles = toggles;
+    } else {
+      cookies.set('toggles');
+      ctx.userEnabledToggles = {};
+    }
+  } else {
+    ctx.userEnabledToggles = toggles;
+  }
+
+  return next();
+}
+
+module.exports = withUserEnabledCookies;

--- a/common/services/unleash/feature-toggles.js
+++ b/common/services/unleash/feature-toggles.js
@@ -56,6 +56,5 @@ function init(options) {
 
 module.exports = {
   initialize: init,
-  ActiveForUserInCohort,
   isEnabled
 };

--- a/common/services/unleash/feature-toggles.js
+++ b/common/services/unleash/feature-toggles.js
@@ -17,9 +17,13 @@ class ABTest extends Strategy {
     super('ABTest');
   }
 
-  isEnabled({ percentage }) {
+  isEnabled({ percentage }, { isUserEnabled }) {
     // Unleash support numbers not booleans...
     // And sends them as strings....
+    if (isUserEnabled === true) {
+      return true;
+    }
+
     const chance = percentage / 100;
     const coinToss = Math.random() < chance;
     return coinToss;

--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -68,7 +68,6 @@ export default ({
     ReactGA.set({'dimension7': referringComponentListString});
   }
   if (pageState) {
-    console.info(pageState);
     ReactGA.set({'dimension8': pageState});
   };
 

--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -7,7 +7,7 @@ type Props = {|
   category: AnalyticsCategory,
   contentType: ?string,
   pageState: ?Object,
-  featuresCohort: ?string,
+  featuresCohort: ?string
 |}
 
 function testLocalStorage() { // Test localStorage i/o
@@ -25,7 +25,12 @@ function testLocalStorage() { // Test localStorage i/o
 
 const hasWorkingLocalStorage = testLocalStorage();
 
-export default ({ category, contentType, pageState, featuresCohort }: Props) => {
+export default ({
+  category,
+  contentType,
+  pageState,
+  featuresCohort
+}: Props) => {
   const referringComponentListString = hasWorkingLocalStorage && window.localStorage.getItem('wc_referring_component_list');
   window.localStorage.removeItem('wc_referring_component_list');
 
@@ -63,6 +68,7 @@ export default ({ category, contentType, pageState, featuresCohort }: Props) => 
     ReactGA.set({'dimension7': referringComponentListString});
   }
   if (pageState) {
+    console.info(pageState);
     ReactGA.set({'dimension8': pageState});
   };
 

--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -7,7 +7,7 @@ type Props = {|
   category: AnalyticsCategory,
   contentType: ?string,
   pageState: ?Object,
-  featuresCohort: ?string
+  featuresCohort: ?string,
 |}
 
 function testLocalStorage() { // Test localStorage i/o
@@ -25,12 +25,7 @@ function testLocalStorage() { // Test localStorage i/o
 
 const hasWorkingLocalStorage = testLocalStorage();
 
-export default ({
-  category,
-  contentType,
-  pageState,
-  featuresCohort
-}: Props) => {
+export default ({ category, contentType, pageState, featuresCohort }: Props) => {
   const referringComponentListString = hasWorkingLocalStorage && window.localStorage.getItem('wc_referring_component_list');
   window.localStorage.removeItem('wc_referring_component_list');
 
@@ -53,7 +48,7 @@ export default ({
 
     window.GA_INITIALIZED = true;
   }
-
+  console.info(pageState);
   ReactGA.set({'dimension1': '2'});
   if (category) {
     ReactGA.set({'dimension2': category});

--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.js
@@ -164,13 +164,18 @@ type Props = {|
     upcomingExceptionalOpeningPeriods: {dates: Moment[], type: OverrideType}[]
   },
   globalAlert: GlobalAlert,
-  oEmbedUrl?: string
+  oEmbedUrl?: string,
+  pageState: ?{}
 |}
 
 class DefaultPageLayout extends Component<Props> {
   componentDidMount() {
-    const { analyticsCategory, featuresCohort } = this.props;
-    analytics({analyticsCategory, featuresCohort});
+    const {
+      analyticsCategory,
+      featuresCohort,
+      pageState
+    } = this.props;
+    analytics({analyticsCategory, featuresCohort, pageState});
 
     // $FlowFixMe
     const lazysizes = require('lazysizes');
@@ -269,8 +274,12 @@ class DefaultPageLayout extends Component<Props> {
   }
 
   componentDidUpdate() {
-    const { analyticsCategory, featuresCohort } = this.props;
-    analytics({analyticsCategory, featuresCohort});
+    const {
+      analyticsCategory,
+      featuresCohort,
+      pageState
+    } = this.props;
+    analytics({analyticsCategory, featuresCohort, pageState});
   }
 
   render() {

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -171,7 +171,7 @@ const PageWrapper = (Comp: NextComponent) => {
         globalAlert,
         oEmbedUrl,
         pageState,
-        toggles,
+        toggles = {},
         ...props
       } = this.props;
 

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -171,6 +171,7 @@ const PageWrapper = (Comp: NextComponent) => {
         globalAlert,
         oEmbedUrl,
         pageState,
+        toggles,
         ...props
       } = this.props;
 
@@ -191,9 +192,19 @@ const PageWrapper = (Comp: NextComponent) => {
         </DefaultPageLayout>;
       }
 
+      // We flatten the toggles to make the page state easier to grep in GA
+      // and "Flat is better than nested."
+      const flattenedToggles = Object.keys(toggles).reduce((acc, key) => {
+        const val = toggles[key];
+        return {
+          ...acc,
+          [`toggle:${key}`]: val
+        };
+      }, {});
+
       const pageStateWithToggles = {
         ...pageState,
-        ...(this.props.toggles ? {toggles: this.props.toggles} : {})
+        ...(Object.keys(flattenedToggles).length > 0 ? {toggles: this.props.toggles} : {})
       };
 
       return (

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -204,7 +204,7 @@ const PageWrapper = (Comp: NextComponent) => {
 
       const pageStateWithToggles = {
         ...pageState,
-        ...(Object.keys(flattenedToggles).length > 0 ? {toggles: this.props.toggles} : {})
+        ...(Object.keys(flattenedToggles).length > 0 ? flattenedToggles : {})
       };
 
       return (

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -191,6 +191,11 @@ const PageWrapper = (Comp: NextComponent) => {
         </DefaultPageLayout>;
       }
 
+      const pageStateWithToggles = {
+        ...pageState,
+        ...(this.props.toggles ? {toggles: this.props.toggles} : {})
+      };
+
       return (
         <DefaultPageLayout
           title={title}
@@ -204,7 +209,7 @@ const PageWrapper = (Comp: NextComponent) => {
           openingTimes={openingTimes}
           globalAlert={globalAlert}
           oEmbedUrl={oEmbedUrl}
-          pageState={pageState}>
+          pageState={pageStateWithToggles}>
           <Comp {...props} />
         </DefaultPageLayout>
       );

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -40,7 +40,7 @@ export class ArticlePage extends Component<Props, State> {
 
   static getInitialProps = async (
     context: GetInitialPropsProps,
-    { toggles }: ExtraProps
+    { toggles = {} }: ExtraProps
   ) => {
     const {id} = context.query;
     const article = await getArticle(context.req, id);
@@ -51,7 +51,9 @@ export class ArticlePage extends Component<Props, State> {
         article.outroReadItem ||
         article.outroVisitItem);
 
-      const showOutro = hasOutro && Boolean(toggles && toggles.outro);
+      // We're using the user enabled, and A/B test here for editors
+      // TODO: Think about sticky A/B
+      const showOutro = hasOutro && (Boolean(toggles.outroAB) || Boolean(toggles.outro));
 
       return {
         article,

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -53,7 +53,7 @@ export class ArticlePage extends Component<Props, State> {
 
       // We're using the user enabled, and A/B test here for editors
       // TODO: Think about sticky A/B
-      const showOutro = hasOutro && (Boolean(toggles.outroAB) || Boolean(toggles.outro));
+      const showOutro = hasOutro && (Boolean(toggles.outro));
 
       return {
         article,

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -3,7 +3,7 @@ import {Fragment, Component} from 'react';
 import {getArticle} from '@weco/common/services/prismic/articles';
 import {getArticleSeries} from '@weco/common/services/prismic/article-series';
 import {classNames, spacing, font} from '@weco/common/utils/classnames';
-import {default as PageWrapper, pageStore} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import {default as PageWrapper} from '@weco/common/views/components/PageWrapper/PageWrapper';
 import BasePage from '@weco/common/views/components/BasePage/BasePage';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
 import Body from '@weco/common/views/components/Body/Body';
@@ -18,12 +18,16 @@ import {
 import {convertImageUri} from '@weco/common/utils/convert-image-uri';
 import type {Article} from '@weco/common/model/articles';
 import type {ArticleScheduleItem} from '@weco/common/model/article-schedule-items';
-import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import type {
+  GetInitialPropsProps,
+  ExtraProps
+} from '@weco/common/views/components/PageWrapper/PageWrapper';
 import {articleLd} from '@weco/common/utils/json-ld';
 import {ContentFormatIds} from '@weco/common/model/content-format-id';
 
 type Props = {|
-  article: Article
+  article: Article,
+  showOutro: boolean
 |}
 
 type State = {|
@@ -34,13 +38,22 @@ export class ArticlePage extends Component<Props, State> {
     listOfSeries: []
   }
 
-  static getInitialProps = async (context: GetInitialPropsProps) => {
+  static getInitialProps = async (
+    context: GetInitialPropsProps,
+    { toggles }: ExtraProps
+  ) => {
     const {id} = context.query;
     const article = await getArticle(context.req, id);
 
     if (article) {
+      const showOutro = Boolean(toggles && toggles.outro && (
+        article.outroResearchItem ||
+        article.outroReadItem ||
+        article.outroVisitItem
+      ));
       return {
         article,
+        showOutro,
         title: article.title,
         description: article.promoText,
         type: 'article',
@@ -48,7 +61,8 @@ export class ArticlePage extends Component<Props, State> {
         imageUrl: article.image && convertImageUri(article.image.contentUrl, 800),
         siteSection: 'stories',
         analyticsCategory: 'editorial',
-        pageJsonLd: articleLd(article)
+        pageJsonLd: articleLd(article),
+        pageState: {hasOutro: showOutro}
       };
     } else {
       return {statusCode: 404};
@@ -70,7 +84,10 @@ export class ArticlePage extends Component<Props, State> {
   }
 
   render() {
-    const article = this.props.article;
+    const {
+      article,
+      showOutro
+    } = this.props;
 
     const breadcrumbs = {
       items: [
@@ -193,13 +210,6 @@ export class ArticlePage extends Component<Props, State> {
         );
       }
     }).filter(Boolean);
-
-    const toggles = pageStore('toggles');
-    const showOutro = toggles.outro && (
-      article.outroResearchItem ||
-      article.outroReadItem ||
-      article.outroVisitItem
-    );
 
     return (
       <BasePage

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -46,11 +46,13 @@ export class ArticlePage extends Component<Props, State> {
     const article = await getArticle(context.req, id);
 
     if (article) {
-      const showOutro = Boolean(toggles && toggles.outro && (
+      const hasOutro = Boolean(
         article.outroResearchItem ||
         article.outroReadItem ||
-        article.outroVisitItem
-      ));
+        article.outroVisitItem);
+
+      const showOutro = hasOutro && Boolean(toggles && toggles.outro);
+
       return {
         article,
         showOutro,
@@ -62,7 +64,7 @@ export class ArticlePage extends Component<Props, State> {
         siteSection: 'stories',
         analyticsCategory: 'editorial',
         pageJsonLd: articleLd(article),
-        pageState: {hasOutro: showOutro}
+        pageState: {hasOutro}
       };
     } else {
       return {statusCode: 404};

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -25,7 +25,9 @@ const handle = app.getRequestHandler();
 const port = process.argv[2] || 3000;
 
 function withToggles(ctx, next) {
-  const {userEnabledToggles} = ctx;
+  const {
+    userEnabledToggles = {}
+  } = ctx;
 
   ctx.toggles = {
     outro: isEnabled('outro', {

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -165,10 +165,18 @@ app.prepare().then(async () => {
     ctx.respond = false;
   });
 
+  router.get('/stories', async ctx => {
+    const {toggles, globalAlert} = ctx;
+    await app.render(ctx.req, ctx.res, '/stories', {
+      toggles,
+      globalAlert
+    });
+    ctx.respond = false;
+  });
+
   router.get('/articles', async ctx => {
     const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/articles', {
-      id: ctx.params.id,
       toggles,
       globalAlert
     });

--- a/content/webapp/test/articles.test.js
+++ b/content/webapp/test/articles.test.js
@@ -14,7 +14,7 @@ it('renders <WorkPage /> with an catalogue API work response', async () => {
 
   if (article) {
     const Page = TestRenderer.create(
-      <ArticlePage article={article} />
+      <ArticlePage article={article} showOutro={false} />
     );
     expect(Page).not.toBe(null);
   }

--- a/toggles/README.md
+++ b/toggles/README.md
@@ -9,6 +9,26 @@ easier to deploy from Heroku.
 
 The API is currently hosted under https://weco-feature-flags.herokuapp.com.
 
+# A/B Testing
+To create an A/B test, follow these steps:
+
+* Create a toggle in Unleash
+* Add the ABTest Strategy to the toggle
+* Set the amount you want to the control / test. If you set the amount to 80,
+  there will be an 80% chance they're in the test
+* Add the code to your server app:
+  ```JS
+    [switchName]: isEnabled(switchName, {
+      isUserEnabled: userEnabledToggles[switchName] === true
+    })
+  ```
+* Deploy
+
+If you'd like to force yourself into a tests, we have the
+`toggle={switchName}:true` querystring parameter. To un-force yourself from the
+test, use `toggle={switchName}:false`. This won't exclude you, but will make
+sure you're rolling dice as to whether you're getting the feature or not again.
+
 # TODO
 - [ ] Move code over to this repo
 - [ ] Move service over to AWS


### PR DESCRIPTION
Forked from #3607 

- This is not a sticky switch, it is either on or off.
- These requests are being cached, so most users should see the same thing, but that might change the next day.
- outro is now an ABTest which has also inherited the ability to manually set via the cookie. i.e. `enabled = cookie set OR random`. This means we can get rid of the UserEnabled strategy, but we're using it for the catalogue for now.
- `pageState` is extended with `{ toggles }` to make this more scalable (it might help with auto reporting later if we decide to do it).

I'd like to release like this to see what analytics we get back before optimising.