### PR TITLE
Add infra for ab_testing lambda@edge

### DIFF
--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -3,17 +3,6 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
-  ### A/B test
-  split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
-    50%     "testA";
-    50%     "testB";
-  }
-  map $cookie_WC_featuresCohort $cohort {
-    ""      $cohort_split_test;
-    default $cookie_WC_featuresCohort;
-  }
-  ###
-
   server {
     listen 80;
     listen 443;

--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -2,17 +2,6 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
-  ### A/B test
-  split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
-    50%     "testA";
-    50%     "testB";
-  }
-  map $cookie_WC_featuresCohort $cohort {
-    ""      $cohort_split_test;
-    default $cookie_WC_featuresCohort;
-  }
-  ###
-
   server {
     listen           80;
     listen           443 ssl;

--- a/nginx_webapp/nginx.conf
+++ b/nginx_webapp/nginx.conf
@@ -3,17 +3,6 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
-  ### A/B test
-  split_clients "${remote_addr}${date_gmt}" $cohort_split_test {
-    50%     "testA";
-    50%     "testB";
-  }
-  map $cookie_WC_featuresCohort $cohort {
-    ""      $cohort_split_test;
-    default $cookie_WC_featuresCohort;
-  }
-  ###
-
   server {
     listen 80;
     listen 443;

--- a/router/terraform/ab_testing.tf
+++ b/router/terraform/ab_testing.tf
@@ -1,0 +1,45 @@
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "Service"
+      identifiers = [
+        "lambda.amazonaws.com",
+        "edgelambda.amazonaws.com"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "ab_testing_lambda_role" {
+  name_prefix = "ab_testing"
+  assume_role_policy = "${data.aws_iam_policy_document.lambda.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "basic_labda_execution" {
+  role = "${aws_iam_role.ab_testing_lambda_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "archive_file" "ab_testing_zip" {
+  type = "zip"
+  output_path = "${path.module}/.dist/ab_tesing.zip"
+
+  source {
+    filename = "index.js"
+    content = "${file("${path.module}/../webapp/index.js")}"
+  }
+}
+
+resource "aws_lambda_function" "ab_testing_lambda" {
+  provider = "aws.us-east-1"
+  function_name = "ab_testing"
+  filename = "${data.archive_file.ab_testing_zip.output_path}"
+  source_code_hash = "${data.archive_file.ab_testing_zip.output_base64sha256}"
+  role = "${aws_iam_role.ab_testing_lambda_role.arn}"
+  runtime = "nodejs8.10"
+  handler = "index.handler"
+  memory_size = 128
+  timeout = 3
+  publish = true
+}

--- a/router/terraform/ab_testing.tf
+++ b/router/terraform/ab_testing.tf
@@ -27,7 +27,7 @@ data "archive_file" "ab_testing_zip" {
 
   source {
     filename = "index.js"
-    content = "${file("${path.module}/../webapp/index.js")}"
+    content = "${file("${path.module}/../webapp/ab_testing.js")}"
   }
 }
 

--- a/router/terraform/ab_testing.tf
+++ b/router/terraform/ab_testing.tf
@@ -31,15 +31,24 @@ data "archive_file" "ab_testing_zip" {
   }
 }
 
-resource "aws_lambda_function" "ab_testing_lambda" {
+resource "aws_lambda_function" "ab_testing_request_lambda" {
   provider = "aws.us-east-1"
-  function_name = "ab_testing"
+  function_name = "ab_testing_request"
   filename = "${data.archive_file.ab_testing_zip.output_path}"
   source_code_hash = "${data.archive_file.ab_testing_zip.output_base64sha256}"
   role = "${aws_iam_role.ab_testing_lambda_role.arn}"
   runtime = "nodejs8.10"
-  handler = "index.handler"
-  memory_size = 128
-  timeout = 3
+  handler = "index.request"
+  publish = true
+}
+
+resource "aws_lambda_function" "ab_testing_response_lambda" {
+  provider = "aws.us-east-1"
+  function_name = "ab_testing_response"
+  filename = "${data.archive_file.ab_testing_zip.output_path}"
+  source_code_hash = "${data.archive_file.ab_testing_zip.output_base64sha256}"
+  role = "${aws_iam_role.ab_testing_lambda_role.arn}"
+  runtime = "nodejs8.10"
+  handler = "index.response"
   publish = true
 }

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -182,7 +182,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
   ordered_cache_behavior {
     target_origin_id       = "origin"
-    path_pattern           = "/articles/*"
+    path_pattern           = "/ab_testing"
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
@@ -191,8 +191,13 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     max_ttl                = 86400
 
     lambda_function_association {
+      event_type = "origin-request"
+      lambda_arn = "${aws_lambda_function.ab_testing_request_lambda.qualified_arn}"
+    }
+
+    lambda_function_association {
       event_type = "origin-response"
-      lambda_arn = "${aws_lambda_function.ab_testing_lambda.qualified_arn}"
+      lambda_arn = "${aws_lambda_function.ab_testing_response_lambda.qualified_arn}"
     }
 
     forwarded_values {

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -182,7 +182,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
   ordered_cache_behavior {
     target_origin_id       = "origin"
-    path_pattern           = "/ab_testing*"
+    path_pattern           = "/articles/*"
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
@@ -191,7 +191,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     max_ttl                = 86400
 
     lambda_function_association {
-      event_type = "origin-request"
+      event_type = "origin-response"
       lambda_arn = "${aws_lambda_function.ab_testing_lambda.qualified_arn}"
     }
 
@@ -200,7 +200,11 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
       headers      = ["Host"]
 
       cookies {
-        forward = "none"
+        forward = "whitelist"
+
+        whitelisted_names = [
+          "toggles",           # feature toggles
+        ]
       }
     }
   }

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -182,7 +182,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
   ordered_cache_behavior {
     target_origin_id       = "origin"
-    path_pattern           = "/ab_testing"
+    path_pattern           = "/articles/*"
     allowed_methods        = ["HEAD", "GET"]
     cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -209,6 +209,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
         whitelisted_names = [
           "toggles",           # feature toggles
+          "toggle_*",           # feature toggles
         ]
       }
     }

--- a/router/terraform/cloudfront.tf
+++ b/router/terraform/cloudfront.tf
@@ -66,15 +66,13 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
         whitelisted_names = [
           "toggles",           # feature toggles
-          "WC_featuresCohort", # feature toggles
-          "*SESS*",            # Drupal
         ]
       }
     }
   }
 
   # Make sure that the next assets always outlive the HTML
-  cache_behavior {
+  ordered_cache_behavior {
     target_origin_id       = "origin"
     path_pattern           = "/_next/*"
     allowed_methods        = ["HEAD", "GET"]
@@ -94,7 +92,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     }
   }
 
-  cache_behavior {
+  ordered_cache_behavior {
     target_origin_id       = "origin"
     path_pattern           = "/events/*"
     allowed_methods        = ["HEAD", "GET"]
@@ -117,13 +115,12 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
 
         whitelisted_names = [
           "toggles",           # feature toggles
-          "WC_featuresCohort", # feature toggles
         ]
       }
     }
   }
 
-  cache_behavior {
+  ordered_cache_behavior {
     target_origin_id       = "origin"
     path_pattern           = "/eventbrite/*"
     allowed_methods        = ["HEAD", "GET"]
@@ -143,48 +140,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     }
   }
 
-  # TODO: Deprecate
-  cache_behavior {
-    target_origin_id       = "origin"
-    path_pattern           = "/articles/preview/*"
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = true
-      headers      = ["*"]
-
-      cookies {
-        forward = "all"
-      }
-    }
-  }
-
-  cache_behavior {
-    target_origin_id       = "origin"
-    path_pattern           = "/preview/*"
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = true
-      headers      = ["*"]
-
-      cookies {
-        forward = "all"
-      }
-    }
-  }
-
-  cache_behavior {
+  ordered_cache_behavior {
     target_origin_id       = "origin"
     path_pattern           = "/preview"
     allowed_methods        = ["HEAD", "GET"]
@@ -204,27 +160,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     }
   }
 
-  cache_behavior {
-    target_origin_id       = "origin"
-    path_pattern           = "/flags"
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = true
-      headers      = ["*"]
-
-      cookies {
-        forward = "all"
-      }
-    }
-  }
-
-  cache_behavior {
+  ordered_cache_behavior {
     target_origin_id       = "origin"
     path_pattern           = "/management/*"
     allowed_methods        = ["HEAD", "GET"]
@@ -244,88 +180,30 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     }
   }
 
-  # This is all for Drupal...
-  cache_behavior {
+  ordered_cache_behavior {
     target_origin_id       = "origin"
-    path_pattern           = "/system/ajax"
-    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    path_pattern           = "/ab_testing*"
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
     default_ttl            = 3600
     max_ttl                = 86400
 
+    lambda_function_association {
+      event_type = "origin-request"
+      lambda_arn = "${aws_lambda_function.ab_testing_lambda.qualified_arn}"
+    }
+
     forwarded_values {
-      query_string = true
-      headers      = ["*"]
+      query_string = false
+      headers      = ["Host"]
 
       cookies {
-        forward = "all"
+        forward = "none"
       }
     }
   }
-
-  cache_behavior {
-    target_origin_id       = "origin"
-    path_pattern           = "/admin/*"
-    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-    cached_methods         = ["HEAD", "GET", "OPTIONS"]
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = true
-      headers      = ["*"]
-
-      cookies {
-        forward = "all"
-      }
-    }
-  }
-
-  cache_behavior {
-    target_origin_id       = "origin"
-    path_pattern           = "/user"
-    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-    cached_methods         = ["HEAD", "GET", "OPTIONS"]
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = true
-      headers      = ["*"]
-
-      cookies {
-        forward = "all"
-      }
-    }
-  }
-
-  cache_behavior {
-    target_origin_id       = "origin"
-    path_pattern           = "/node/*"
-    allowed_methods        = ["HEAD", "GET", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
-    cached_methods         = ["HEAD", "GET", "OPTIONS"]
-    viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
-
-    forwarded_values {
-      query_string = true
-      headers      = ["*"]
-
-      cookies {
-        forward = "all"
-      }
-    }
-  }
-
-  # End Drupal...
 
   viewer_certificate {
     acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"

--- a/router/terraform/terraform.tf
+++ b/router/terraform/terraform.tf
@@ -20,12 +20,12 @@ data "terraform_remote_state" "wellcomecollection" {
 }
 
 provider "aws" {
-  version = "~> 0.1"
+  version = "~> 1.29.0"
   region  = "eu-west-1"
 }
 
 provider "aws" {
-  version = "~> 0.1"
+  version = "~> 1.29.0"
   region  = "us-east-1"
   alias   = "us-east-1"
 }

--- a/router/webapp/ab_testing.js
+++ b/router/webapp/ab_testing.js
@@ -39,6 +39,7 @@ exports.request = (event, context, callback) => {
   // Run outro test
   // Should run, and isn't already set
   if (request.uri.match(/^\/articles\/*/) && !('outro' in prevToggles)) {
+    console.log('Request: Setting outro toggle');
     // Flip the dice
     if (Math.random() < 0.5) {
       newToggles.outro = true;
@@ -49,6 +50,7 @@ exports.request = (event, context, callback) => {
   // End bespoke tests
 
   if (Object.keys(newToggles).length > 0) {
+    console.log('Request: Setting toggled header and cookies');
     const toggles = Object.assign({}, prevToggles, newToggles);
     const togglesCookie = `toggles=${JSON.stringify(toggles)}; Path=/;`;
     // TODO: This doens't take into account any other cookie
@@ -65,8 +67,7 @@ exports.request = (event, context, callback) => {
     }];
   }
 
-  console.log(JSON.stringify(request.headers));
-  request.uri = '/';
+  console.log('Request: goodbye');
   callback(null, request);
 };
 
@@ -75,6 +76,7 @@ exports.response = (event, context, callback) => {
   const response = event.Records[0].cf.response;
 
   if (request.headers['x-toggled']) {
+    console.log('Response: trying to set set-cookie header');
     const cookieHeader = request.headers.cookie || [];
     const cookies = parseCookies(cookieHeader);
     let toggles = {};
@@ -83,9 +85,11 @@ exports.response = (event, context, callback) => {
     } catch (e) {}
 
     if (Object.keys(toggles).length > 0) {
+      console.log('Response: setting set-cookie header');
       response.headers['set-cookie'] = [{ key: 'Set-Cookie', value: `toggles=${JSON.stringify(toggles)}; Path=/;` }];
     }
   }
 
+  console.log('Response: goodbye');
   callback(null, response);
 };

--- a/router/webapp/ab_testing.js
+++ b/router/webapp/ab_testing.js
@@ -1,0 +1,58 @@
+'use strict';
+
+// Potential format for a test
+// const outroTest = {
+//   segments: {
+//     a: [0, 0.5],
+//     b: [0.5, 1]
+//   },
+//   canRun: function(request, headers) {
+//     return request.uri.match(/^\/articles\/*/);
+//   }
+// };
+
+// Taken from https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-examples.html#lambda-examples-redirect-to-signin-page
+function parseCookies(headers) {
+  const parsedCookie = {};
+  if (headers.cookie) {
+    headers.cookie[0].value.split(';').forEach((cookie) => {
+      if (cookie) {
+        const parts = cookie.split('=');
+        parsedCookie[parts[0].trim()] = parts[1].trim();
+      }
+    });
+  }
+  return parsedCookie;
+}
+
+exports.handler = (event, context, callback) => {
+  const request = event.Records[0].cf.request;
+  const response = event.Records[0].cf.response;
+  const headers = request.headers;
+  const cookies = parseCookies(headers);
+
+  let prevToggles = {};
+  let newToggles = {};
+  try {
+    prevToggles = JSON.parse(cookies.toggles);
+  } catch (e) {}
+
+  // Run outro test
+  // Should run, and isn't already set
+  if (request.uri.match(/^\/articles\/*/) && !('outro' in prevToggles)) {
+    // Flip the dice
+    if (Math.random() < 0.5) {
+      newToggles.outro = true;
+    } else {
+      newToggles.outro = false;
+    }
+  }
+  // End bespoke tests
+
+  if (Object.keys(newToggles).length > 0) {
+    const toggles = Object.assign({}, prevToggles, newToggles);
+    response.headers['set-cookie'] = [{ key: 'Set-Cookie', value: `toggles=${JSON.stringify(toggles)}; Path=/;` }];
+  }
+
+  callback(null, response);
+};

--- a/router/webapp/index.js
+++ b/router/webapp/index.js
@@ -1,9 +1,0 @@
-'use strict';
-
-exports.handler = (event, context, callback) => {
-  const request = event.Records[0].cf.request;
-  const headers = request.headers;
-  console.log(`Request: "${request}"`);
-  console.log(`Headers: "${headers}"`);
-  callback(null, request);
-};

--- a/router/webapp/index.js
+++ b/router/webapp/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.handler = (event, context, callback) => {
+  const request = event.Records[0].cf.request;
+  const headers = request.headers;
+  console.log(`Request: "${request}"`);
+  console.log(`Headers: "${headers}"`);
+  callback(null, request);
+};

--- a/router/webapp/test_event_request.json
+++ b/router/webapp/test_event_request.json
@@ -1,0 +1,38 @@
+{
+  "Records": [
+    {
+      "cf": {
+        "config": {
+          "distributionId": "EXAMPLE"
+        },
+        "request": {
+          "uri": "/articles/things",
+          "method": "GET",
+          "clientIp": "2001:cdba::3257:9652",
+          "headers": {
+            "user-agent": [
+              {
+                "key": "User-Agent",
+                "value": "Test Agent"
+              }
+            ],
+            "host": [
+              {
+                "key": "Host",
+                "value": "d123.cf.net"
+              }
+            ],
+            "cookie": [
+              {
+                "key": "Cookie",
+                "value": "toggles={\"nooutro\":true}; Path=/;"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}
+
+

--- a/router/webapp/test_event_request.json
+++ b/router/webapp/test_event_request.json
@@ -25,7 +25,7 @@
             "cookie": [
               {
                 "key": "Cookie",
-                "value": "toggles={\"nooutro\":true}; Path=/;"
+                "value": "toggle_noutro=false; nothingtodowiththis=10"
               }
             ]
           }

--- a/router/webapp/test_event_response.json
+++ b/router/webapp/test_event_response.json
@@ -1,0 +1,50 @@
+{
+  "Records": [
+    {
+      "cf": {
+        "config": {
+          "distributionId": "EXAMPLE"
+        },
+        "request": {
+          "uri": "/",
+          "method": "GET",
+          "clientIp": "2001:cdba::3257:9652",
+          "headers": {
+            "user-agent": [
+              {
+                "key": "User-Agent",
+                "value": "Test Agent"
+              }
+            ],
+            "host": [
+              {
+                "key": "Host",
+                "value": "d123.cf.net"
+              }
+            ],
+            "cookie": [
+              {
+                "key": "Cookie",
+                "value": "toggles={\"nooutro\":true,\"outro\":false}; Path=/;"
+              }
+            ],
+            "x-toggled": [
+              {
+                "key": "X-toggled",
+                "value": "true"
+              }
+            ]
+          }
+        },
+        "response": {
+          "uri": "/articles/things",
+          "method": "GET",
+          "clientIp": "2001:cdba::3257:9652",
+          "headers": {}
+        }
+      }
+    }
+  ]
+}
+
+

--- a/router/webapp/test_event_response.json
+++ b/router/webapp/test_event_response.json
@@ -25,13 +25,13 @@
             "cookie": [
               {
                 "key": "Cookie",
-                "value": "toggles={\"nooutro\":true,\"outro\":false}; Path=/;"
+                "value": "toggle_outro=true; toggle_noutro=false;"
               }
             ],
             "x-toggled": [
               {
                 "key": "X-toggled",
-                "value": "true"
+                "value": "toggle_outro=true;"
               }
             ]
           }


### PR DESCRIPTION
Ref #3631 

After hassling around with the cache for ages, I thought, surely we could use a lmabda for this.
Turns out it's a pretty standard way as you can have lambdas @ edge (before the cache).

It feels like this would be a way more sustainable solution to A/B testing, and breaks from using subsiderary services (unleash).

[It also seems to be quite common](https://www.google.com/search?q=lambda+A%2FB+testing).

Here's a flow of cookies / headers: https://docs.google.com/drawings/d/1053dECKDOsVwIAUqtq-Q5N6DEJJ7TmYIW-mu3_TtpgI/edit?usp=sharing

__Edit__

Moved to a multi cookie setup where we have `toggle_*`.

This will allow us much more control over what we allow, and don't allow, and will also allow us to more finally tune a users experience. e.g.

Vimbai visits the site, we see there are no toggles set, we're running a test on the outro, so stick them into bucket A.

In the same session, Vimbai looks through our catalogue, notices an opt-in for the Alpha-Beta search, and opts in.

We might want to drop Vimbai out of the outro test, as that was just for the session, but we definitely want to leave them in the search, so this cookie can have a much longer `max-age`.