### PR TITLE
add simpler toggles

### DIFF
--- a/common/koa-middleware/withToggles.js
+++ b/common/koa-middleware/withToggles.js
@@ -1,0 +1,29 @@
+const Cookies = require('cookies');
+
+function withToggles(ctx, next) {
+  // Any cookies set from anywhere
+  // But normally from the lambdas@edge
+  const cookies = new Cookies(ctx.req, ctx.res);
+  const togglesCookie = cookies.get('toggles');
+  let toggles = {};
+  try {
+    toggles = JSON.parse(togglesCookie);
+  } catch (e) {}
+
+  // Have we set any via the URL?
+  const togglesQuery = ctx.query.toggles;
+  const urlToggles = togglesQuery ? togglesQuery.split(',').reduce((acc, toggle) => {
+    const toggleParts = toggle.split(':');
+    const key = toggleParts[0];
+    const val = toggleParts[1];
+    return Object.assign({}, acc, {
+      [key]: val === 'true'
+    });
+  }, {}) : {};
+
+  ctx.toggles = Object.assign({}, toggles, urlToggles);
+
+  return next();
+}
+
+module.exports = withToggles;

--- a/common/koa-middleware/withToggles.js
+++ b/common/koa-middleware/withToggles.js
@@ -1,6 +1,11 @@
 const parseCookies = function(req) {
-  return (req.headers.cookie || '').split(';').map(cookieString => {
+  if (!req.headers.cookie) {
+    return [];
+  }
+
+  return (req.headers.cookie).split(';').map(cookieString => {
     const keyVal = cookieString.split('=');
+    console.info(keyVal, cookieString);
     const key = keyVal[0].trim();
     const value = keyVal[1].trim();
 

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -1,11 +1,10 @@
 const Koa = require('koa');
 const Router = require('koa-router');
 const next = require('next');
-const Cookies = require('cookies');
 const Prismic = require('prismic-javascript');
 const linkResolver = require('@weco/common/services/prismic/link-resolver');
-const { initialize, isEnabled } = require('@weco/common/services/unleash/feature-toggles');
 const withGlobalAlert = require('@weco/common/koa-middleware/withGlobalAlert');
+const withToggles = require('@weco/common/koa-middleware/withToggles');
 
 // FIXME: Find a way to import this.
 // We can't because it's not a standard es6 module (import and flowtype)
@@ -24,64 +23,6 @@ const app = next({ dev });
 const handle = app.getRequestHandler();
 const port = process.argv[2] || 3000;
 
-function setUserEnabledToggles(ctx, next) {
-  const togglesRequest = ctx.query.toggles;
-
-  if (togglesRequest) {
-    const toggles = togglesRequest.split(',').reduce((acc, toggle) => {
-      const toggleParts = toggle.split(':');
-      return Object.assign({}, acc, {
-        [toggleParts[0]]: Boolean(toggleParts[1])
-      });
-    }, {});
-
-    if (Object.keys(toggles).length > 0) {
-      const cookies = new Cookies(ctx.req, ctx.res);
-      const togglesCookie = cookies.get('toggles');
-      let previousToggles = {};
-      try {
-        previousToggles = JSON.parse(togglesCookie);
-      } catch (e) {}
-      const mergedToggles = Object.assign({}, previousToggles, toggles);
-      cookies.set('toggles', JSON.stringify(mergedToggles));
-    }
-  }
-  return next();
-}
-
-function getToggles(ctx, next) {
-  const cookies = new Cookies(ctx.req, ctx.res);
-  // Leaving this here as we might need it for `ActiveForUserInCohort`
-  // const cohort = cookies.get('WC_featuresCohort');
-  let userEnabledToggles = {};
-  try {
-    userEnabledToggles = JSON.parse(cookies.get('toggles'));
-  } catch (e) {}
-
-  ctx.toggles = {
-    outro: isEnabled('outro', {
-      isUserEnabled: userEnabledToggles.outro === true
-    }),
-    outroAB: isEnabled('outroAB')
-  };
-
-  return next();
-}
-
-function setCohortCookie(ctx, next) {
-  const cohort = ctx.query.cohort;
-  if (cohort) {
-    const cookies = new Cookies(ctx.req, ctx.res);
-    cookies.set('WC_featuresCohort', cohort, {
-      maxAge: 365 * 24 * 60 * 60 * 1000,
-      overwrite: true,
-      path: '/',
-      domain: dev ? null : 'wellcomecollection.org'
-    });
-  }
-  return next();
-}
-
 function pageVanityUrl(router, app, url, pageId) {
   router.get(url, async ctx => {
     const {toggles, globalAlert} = ctx;
@@ -97,29 +38,9 @@ function pageVanityUrl(router, app, url, pageId) {
 app.prepare().then(async () => {
   const server = new Koa();
   const router = new Router();
-  const instance = initialize({
-    appName: 'content'
-  });
-
-  try {
-    await new Promise((resolve, reject) => {
-      instance.on('ready', async () => {
-        resolve(true);
-      });
-      instance.on('error', async () => {
-        reject(new Error('unleash: unable to initialize unleash'));
-      });
-    });
-  } catch (e) {
-    // TODO: We don't want to not start the app here
-    // but we should report to sentry.
-    console.error(e);
-  }
 
   // Feature toggles
-  server.use(setCohortCookie);
-  server.use(setUserEnabledToggles);
-  server.use(getToggles);
+  server.use(withToggles);
 
   // server cached values
   server.use(withGlobalAlert);


### PR DESCRIPTION
Adds a simple way of setting toggles thanks to #3638.

A user toggle now needs to stay in the URL, which might not be ideal, but that's relatively easy to fix, I'd rather wait for it to come up as a requirement though.

The stickyness would be dealt with in the lambdas, this abdocates all cookie writing to the lambda, which makes way more sense.