### PR TITLE
Global alert perf

### DIFF
--- a/catalogue/webapp/server.js
+++ b/catalogue/webapp/server.js
@@ -3,6 +3,7 @@ const Router = require('koa-router');
 const next = require('next');
 const Cookies = require('cookies');
 const { initialize, isEnabled } = require('@weco/common/services/unleash/feature-toggles');
+const withGlobalAlert = require('@weco/common/koa-middleware/withGlobalAlert');
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -93,31 +94,37 @@ app.prepare().then(async () => {
   server.use(setUserEnabledToggles);
   server.use(getToggles);
 
+  // server cached values
+  server.use(withGlobalAlert);
+
   // Next routing
   router.get('/embed/works/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/embed', {
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get('/works/:id', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/work', {
       page: ctx.query.page,
       query: ctx.query.query,
       id: ctx.params.id,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });
   router.get('/works', async ctx => {
-    const {toggles} = ctx;
+    const {toggles, globalAlert} = ctx;
     await app.render(ctx.req, ctx.res, '/works', {
       page: ctx.query.page,
       query: ctx.query.query,
-      toggles
+      toggles,
+      globalAlert
     });
     ctx.respond = false;
   });

--- a/common/koa-middleware/withGlobalAlert.js
+++ b/common/koa-middleware/withGlobalAlert.js
@@ -1,14 +1,16 @@
 const Prismic = require('prismic-javascript');
 
-let globalAlert = {isShow: false, text: null};
+let globalAlert = {
+  text: [ { type: 'paragraph',
+    text: null,
+    spans: null } ],
+  isShown: 'hide'
+};
 async function getAndSetGlobalAlert() {
   try {
     const api = await Prismic.getApi('https://wellcomecollection.prismic.io/api/v2');
     const document = await api.getSingle('global-alert');
-    globalAlert = {
-      text: document.data.text,
-      isShown: document.data.isShown && document.data.isShown === 'show'
-    };
+    globalAlert = document.data;
   } catch (e) {
     // TODO: Alert to sentry
   }

--- a/common/views/components/PageWrapper/PageWrapper.js
+++ b/common/views/components/PageWrapper/PageWrapper.js
@@ -1,9 +1,9 @@
 // @flow
 import {Component} from 'react';
+import {asHtml} from '../../../services/prismic/parsers';
 import {getCollectionOpeningTimes} from '../../../services/prismic/opening-times';
 import DefaultPageLayout from '../DefaultPageLayout/DefaultPageLayout';
 import ErrorPage from '../BasePage/ErrorPage';
-import {fetchGlobalAlert} from '../../../services/prismic/global-alert';
 import type Moment from 'moment';
 import type {ComponentType} from 'react';
 import type {OgType, SiteSection, JsonLdObject} from '../DefaultPageLayout/DefaultPageLayout';
@@ -99,6 +99,11 @@ type NextComponent = {
 const PageWrapper = (Comp: NextComponent) => {
   return class Global extends Component<Props> {
     static async getInitialProps(context: GetInitialPropsProps) {
+      const globalAlertData = context.query.globalAlert;
+      const globalAlert = {
+        text: asHtml(globalAlertData.text),
+        isShown: globalAlertData.isShown === 'show'
+      };
       // There's a lot of double checking here, which makes me think we've got
       // the typing wrong.
       const openingTimes = context.req
@@ -109,14 +114,9 @@ const PageWrapper = (Comp: NextComponent) => {
         ? context.query.toggles
         : clientStore && clientStore.get('toggles');
 
-      const globalAlert = context.req
-        ? await fetchGlobalAlert()
-        : clientStore && clientStore.get('globalAlert');
-
       if (serverStore) {
         serverStore.set('openingTimes', openingTimes);
         serverStore.set('toggles', toggles);
-        serverStore.set('globalAlert', globalAlert);
       }
 
       return {
@@ -136,10 +136,6 @@ const PageWrapper = (Comp: NextComponent) => {
 
       if (clientStore && !clientStore.get('toggles')) {
         clientStore.set('toggles', props.toggles);
-      }
-
-      if (clientStore && !clientStore.get('globalAlert')) {
-        clientStore.set('globalAlert', props.globalAlert);
       }
     }
 


### PR DESCRIPTION
Makes use of the work James did here: #3613, so we don't have to wait for the API call to Prismic for the globalAlert
