### PR TITLE
parse date range as date on events from getInitialProps

### DIFF
--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -83,6 +83,11 @@ function showTicketSalesStart(dateTime) {
 // Convert dates back to Date types because it's serialised through
 // `getInitialProps`
 export function convertJsonToDates(jsonEvent: UiEvent): UiEvent {
+  const dateRange = {
+    ...jsonEvent.dateRange,
+    firstDate: new Date(jsonEvent.dateRange.firstDate),
+    lastDate: new Date(jsonEvent.dateRange.lastDate)
+  };
   const times = jsonEvent.times.map(time => {
     return {
       ...time,
@@ -98,7 +103,12 @@ export function convertJsonToDates(jsonEvent: UiEvent): UiEvent {
     event: convertJsonToDates(item.event)
   }));
 
-  return {...jsonEvent, times, schedule};
+  return {
+    ...jsonEvent,
+    times,
+    schedule,
+    dateRange
+  };
 }
 
 class EventPage extends Component<Props, State> {


### PR DESCRIPTION
The `getInitialProps` issue again, serialising `Date`s down to strings.

Then the comparison is on strings, which then puts everything out of whack when reordering the events.