### PR TITLE
dont report on empty page state

### DIFF
--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -62,7 +62,7 @@ export default ({ category, contentType, pageState, featuresCohort }: Props) => 
   if (referringComponentListString) {
     ReactGA.set({'dimension7': referringComponentListString});
   }
-  if (pageState) {
+  if (pageState && Object.keys(pageState) > 0) {
     ReactGA.set({'dimension8': JSON.stringify(pageState)});
   };
 


### PR DESCRIPTION
It cloggs up the results.