### PR TITLE
Responsive hero-image-bg

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -479,9 +479,29 @@
 }
 
 .spacing-component + .spacing-component {
-  margin-top: $spacing-unit * 8;
+  margin-top: $spacing-unit * 6;
+
+  @include respond-to('medium') {
+    margin-top: $spacing-unit * 8;
+  }
 }
 
 .spacing-section {
-  padding-bottom: $spacing-unit * 13;
+  padding-bottom: $spacing-unit * 9;
+
+  @include respond-to('medium') {
+    padding-bottom: $spacing-unit * 13;
+  }
+}
+
+// TODO: move this back into PageHeader if/when we
+// use e.g. styled JSX with media query support
+.hero-picture-bg {
+  height: 50%;
+  width: 100%;
+  bottom: $spacing-unit * -9;
+
+  @include respond-to('medium') {
+    bottom: $spacing-unit * -13;
+  }
 }

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -14,7 +14,6 @@ import WobblyBottom from '../WobblyBottom/WobblyBottom';
 import {breakpoints} from '../../../utils/breakpoints';
 import type {Node, Element, ElementProps} from 'react';
 import type {GenericContentFields} from '../../../model/generic-content-fields';
-import {sized} from '../../../utils/style';
 
 export type FeaturedMedia =
   | Element<typeof UiImage>
@@ -162,14 +161,9 @@ const PageHeader = ({
           [spacing({s: 3, m: 4}, {padding: ['top']})]: true
         })} style={{height: '100%'}}>
           <div
-            style={{
-              height: '50%',
-              width: '100%',
-              bottom: `-${sized(13)}`
-            }}
             className={classNames({
               [`bg-${heroImageBgColor}`]: true,
-              'absolute': true
+              'hero-picture-bg absolute': true
             })}></div>
           <div
             style={{maxWidth: '1450px'}}


### PR DESCRIPTION
Fixes #3661 

The absolutely positioned cream background that has to go behind part of the hero image _and_ cover the white gap that would appear between sections as a result of the section spacing now has to be responsive (since the section spacing is larger on desktop than mobile).
