### PR TITLE
Use 16:9 crop for promo image if available

### DIFF
--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -4,6 +4,12 @@ import {convertImageUri} from '../../../utils/convert-image-uri';
 import {imageSizes} from '../../../utils/image-sizes';
 import {Fragment} from 'react';
 
+type ImageCrops = {|
+  '16:9': {contentUrl: string},
+  '32:15': {contentUrl: string},
+  'square': {contentUrl: string}
+|}
+
 export type Props = {|
   contentUrl: string,
   width: number,
@@ -18,6 +24,7 @@ export type Props = {|
   clickHandler?: () => void,
   zoomable?: boolean,
   extraClasses?: string,
+  crops?: ImageCrops,
   style?: { [string]: any } // TODO: find flowtype for this
 |}
 

--- a/common/views/components/Promo/Promo.js
+++ b/common/views/components/Promo/Promo.js
@@ -72,8 +72,7 @@ const Promo = ({
   const seriesTitle =  series && getSeriesTitle(series);
   const commissionedSeries = series && series.find(item => item.commissionedLength);
   const iconName = getIconForContentType(contentType);
-  const sixteenNineCrop = image.crops && image.crops['16:9'];
-  const bestImageCropUrl = sixteenNineCrop ? sixteenNineCrop.contentUrl : image.contentUrl;
+  const sixteenNineCrop = image && image.crops && image.crops['16:9'];
 
   return (
     <PromoTag id={id}
@@ -88,7 +87,7 @@ const Promo = ({
         {image
           ? <Image
             width={image.width}
-            contentUrl={bestImageCropUrl}
+            contentUrl={sixteenNineCrop ? sixteenNineCrop.contentUrl : image.contentUrl}
             lazyload={true}
             sizesQueries={sizes}
             clipPathClass={series && commissionedSeries && positionInSeries && url ? 'promo__clip-path--chapters-third' : ''}

--- a/common/views/components/Promo/Promo.js
+++ b/common/views/components/Promo/Promo.js
@@ -72,6 +72,8 @@ const Promo = ({
   const seriesTitle =  series && getSeriesTitle(series);
   const commissionedSeries = series && series.find(item => item.commissionedLength);
   const iconName = getIconForContentType(contentType);
+  const sixteenNineCrop = image.crops && image.crops['16:9'];
+  const bestImageCropUrl = sixteenNineCrop ? sixteenNineCrop.contentUrl : image.contentUrl;
 
   return (
     <PromoTag id={id}
@@ -86,7 +88,7 @@ const Promo = ({
         {image
           ? <Image
             width={image.width}
-            contentUrl={image.contentUrl}
+            contentUrl={bestImageCropUrl}
             lazyload={true}
             sizesQueries={sizes}
             clipPathClass={series && commissionedSeries && positionInSeries && url ? 'promo__clip-path--chapters-third' : ''}


### PR DESCRIPTION
We want `Promo` images to be 16:9 everywhere, so we should use the 16:9 Prismic crop that we auto-generate for this.
