### PR TITLE
Add url query parser util

### DIFF
--- a/common/utils/parse-query-string.js
+++ b/common/utils/parse-query-string.js
@@ -1,0 +1,11 @@
+export default (path) => {
+  const queryStart = path.indexOf('?');
+  const queryString = queryStart > -1 && path.slice(queryStart + 1);
+  const queryPairs = queryString && queryString.split('&');
+
+  return queryPairs ? queryPairs.reduce((acc, curr) => {
+    const keyVal = curr.split('=');
+
+    return {...acc, [keyVal[0]]: keyVal[1]};
+  }, {}) : {};
+};

--- a/content/webapp/pages/newsletter.js
+++ b/content/webapp/pages/newsletter.js
@@ -3,13 +3,17 @@ import {Component} from 'react';
 import NewsletterSignup from '@weco/common/views/components/NewsletterSignup/NewsletterSignup';
 import PageWrapper from '@weco/common/views/components/PageWrapper/PageWrapper';
 import {spacing, grid} from '@weco/common/utils/classnames';
+import parseQueryString from '@weco/common/utils/parse-query-string';
 import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
 type Props = {|
   result: ?string
 |}
 export class NewsletterPage extends Component<Props> {
   static getInitialProps = async (context: GetInitialPropsProps) => {
-    const {result} = context.query;
+    const { asPath } = context;
+    const queries = parseQueryString(asPath);
+    const { result } = queries;
+
     return {
       title: 'Newsletter',
       description: 'Sign up for news and information from Wellcome Collection',
@@ -22,7 +26,8 @@ export class NewsletterPage extends Component<Props> {
     };
   }
   render() {
-    const {result} = this.props;
+    const { result } = this.props;
+
     return (
       <div className={spacing({s: 4}, {margin: ['top']})}>
         <div className={`row ${spacing({s: 8}, {padding: ['bottom']})}`}>


### PR DESCRIPTION
Fixes #3666

`context.query` was no longer the object that we wanted to search for the 'error' or 'success' strings since moving to NextJS. Added a util that creates the object we want from a URL path.

![screen shot 2018-11-01 at 16 47 15](https://user-images.githubusercontent.com/1394592/47866276-35da6a80-ddf6-11e8-96f6-94321b7ffce5.png)
