### PR TITLE
add composed middleware and add helper route to avoid duplication, and buggy, code

### DIFF
--- a/catalogue/webapp/server.js
+++ b/catalogue/webapp/server.js
@@ -3,8 +3,9 @@ const Router = require('koa-router');
 const next = require('next');
 const Cookies = require('cookies');
 const { initialize, isEnabled } = require('@weco/common/services/unleash/feature-toggles');
-const withGlobalAlert = require('@weco/common/koa-middleware/withGlobalAlert');
-const withOpeningTimes = require('@weco/common/koa-middleware/withOpeningTimes');
+const {
+  middleware, route
+} = require('@weco/common/koa-middleware/withCachedValues');
 
 const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
@@ -79,43 +80,13 @@ app.prepare().then(async () => {
   server.use(getToggles);
 
   // server cached values
-  server.use(withGlobalAlert);
-  server.use(withOpeningTimes);
+  server.use(middleware);
 
   // Next routing
-  router.get('/embed/works/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/embed', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get('/works/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/work', {
-      page: ctx.query.page,
-      query: ctx.query.query,
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get('/works', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/works', {
-      page: ctx.query.page,
-      query: ctx.query.query,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route('/embed/works/:id', '/embed', router, app);
+  route('/works/:id', '/work', router, app);
+  route('/works', '/works', router, app);
+
   router.get('/works/management/healthcheck', async ctx => {
     ctx.status = 200;
     ctx.body = 'ok';

--- a/common/koa-middleware/withCachedValues.js
+++ b/common/koa-middleware/withCachedValues.js
@@ -1,0 +1,30 @@
+
+const compose = require('koa-compose');
+const withGlobalAlert = require('./withGlobalAlert');
+const withOpeningtimes = require('./withOpeningtimes');
+const withToggles = require('./withToggles');
+
+const withCachedValues = compose([
+  withGlobalAlert,
+  withOpeningtimes,
+  withToggles
+]);
+
+async function route(path, page, router, app) {
+  router.get(path, async ctx => {
+    const {toggles, globalAlert, openingTimes} = ctx;
+    const params = ctx.params;
+    await app.render(ctx.req, ctx.res, page, {
+      toggles,
+      globalAlert,
+      openingTimes,
+      ...params
+    });
+    ctx.respond = false;
+  });
+}
+
+module.exports = {
+  middlesware: withCachedValues,
+  route
+};

--- a/common/koa-middleware/withCachedValues.js
+++ b/common/koa-middleware/withCachedValues.js
@@ -14,11 +14,14 @@ async function route(path, page, router, app) {
   router.get(path, async ctx => {
     const {toggles, globalAlert, openingTimes} = ctx;
     const params = ctx.params;
+    const query = ctx.query;
+
     await app.render(ctx.req, ctx.res, page, {
       toggles,
       globalAlert,
       openingTimes,
-      ...params
+      ...params,
+      ...query
     });
     ctx.respond = false;
   });

--- a/common/koa-middleware/withCachedValues.js
+++ b/common/koa-middleware/withCachedValues.js
@@ -10,7 +10,7 @@ const withCachedValues = compose([
   withToggles
 ]);
 
-async function route(path, page, router, app) {
+async function route(path, page, router, app, extraParams = {}) {
   router.get(path, async ctx => {
     const {toggles, globalAlert, openingTimes} = ctx;
     const params = ctx.params;
@@ -21,13 +21,14 @@ async function route(path, page, router, app) {
       globalAlert,
       openingTimes,
       ...params,
-      ...query
+      ...query,
+      ...extraParams
     });
     ctx.respond = false;
   });
 }
 
 module.exports = {
-  middlesware: withCachedValues,
+  middleware: withCachedValues,
   route
 };

--- a/common/package.json
+++ b/common/package.json
@@ -16,6 +16,7 @@
     "immutable": "^3.8.2",
     "isomorphic-unfetch": "^2.1.1",
     "jest": "^22.4.3",
+    "koa-compose": "^4.1.0",
     "lazysizes": "^4.0.1",
     "lodash.debounce": "^4.0.8",
     "lodash.groupby": "^4.6.0",

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -44,6 +44,7 @@ export async function getDocument(
   opts: PrismicQueryOpts
 ): Promise<?PrismicDocument> {
   const api = await getPrismicApi(req);
+  console.info(id);
   const doc = await api.getByID(id, opts);
   return doc;
 }

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -44,7 +44,6 @@ export async function getDocument(
   opts: PrismicQueryOpts
 ): Promise<?PrismicDocument> {
   const api = await getPrismicApi(req);
-  console.info(id);
   const doc = await api.getByID(id, opts);
   return doc;
 }

--- a/common/yarn.lock
+++ b/common/yarn.lock
@@ -4007,6 +4007,11 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
+koa-compose@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/koa-compose/-/koa-compose-4.1.0.tgz#507306b9371901db41121c812e923d0d67d3e877"
+  integrity sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==
+
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -51,66 +51,13 @@ app.prepare().then(async () => {
   route(`/exhibitions/:period(${periodPaths})`, '/exhibitions', router, app);
   route('/exhibitions/:id', '/exhibition', router, app);
 
-  router.get('/events', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/events', {
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get(`/events/:period(${periodPaths})`, async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/events', {
-      period: ctx.params.period,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get('/events/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/event', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route('/events', '/events', router, app);
+  route(`/events/:period(${periodPaths})`, '/events', router, app);
+  route('/events/:id', '/event', router, app);
 
-  router.get('/stories', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/stories', {
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-
-  router.get('/articles', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/articles', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get('/articles/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/article', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route('/stories', '/stories', router, app);
+  route('/articles', '/articles', router, app);
+  route('/articles/:id', '/article', router, app);
 
   router.get('/series/:id', async ctx => {
     const {toggles, globalAlert, openingTimes} = ctx;

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -4,7 +4,7 @@ const next = require('next');
 const Prismic = require('prismic-javascript');
 const linkResolver = require('@weco/common/services/prismic/link-resolver');
 const {
-  middlesware, route
+  middleware, route
 } = require('@weco/common/koa-middleware/withCachedValues');
 
 // FIXME: Find a way to import this.
@@ -25,23 +25,14 @@ const handle = app.getRequestHandler();
 const port = process.argv[2] || 3000;
 
 function pageVanityUrl(router, app, url, pageId) {
-  router.get(url, async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/page', {
-      id: pageId,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route(url, '/page', router, app, {id: pageId});
 }
 
 app.prepare().then(async () => {
   const server = new Koa();
   const router = new Router();
 
-  server.use(middlesware);
+  server.use(middleware);
 
   route('/', '/homepage', router, app);
   route('/whats-on', '/whats-on', router, app);
@@ -50,111 +41,34 @@ app.prepare().then(async () => {
   route('/exhibitions', '/exhibitions', router, app);
   route(`/exhibitions/:period(${periodPaths})`, '/exhibitions', router, app);
   route('/exhibitions/:id', '/exhibition', router, app);
+  route('/installations/:id', '/installation', router, app);
 
   route('/events', '/events', router, app);
   route(`/events/:period(${periodPaths})`, '/events', router, app);
   route('/events/:id', '/event', router, app);
+  route('/event-series/:id', '/event-series', router, app);
 
   route('/stories', '/stories', router, app);
   route('/articles', '/articles', router, app);
   route('/articles/:id', '/article', router, app);
+  route('/series/:id', '/article-series', router, app);
 
-  router.get('/series/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/article-series', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route('/books', '/books', router, app);
+  route('/books/:id', '/book', router, app);
 
-  router.get('/books', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    const {page} = ctx.query;
-    await app.render(ctx.req, ctx.res, '/books', {
-      page,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get('/books/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/book', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route('/places/:id', '/place', router, app);
+  route('/pages/:id', '/page', router, app);
 
-  router.get('/event-series/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/event-series', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route('/opening-times', '/opening-times', router, app);
+  route('/newsletter', '/newsletter', router, app);
 
-  router.get('/places/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/place', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-
-  router.get('/pages/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/page', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-
-  router.get('/installations/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/installation', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-
-  router.get('/opening-times', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/opening-times', {
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-
-  router.get('/newsletter', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/newsletter', {
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  pageVanityUrl(router, app, '/visit-us', 'WwLIBiAAAPMiB_zC');
+  pageVanityUrl(router, app, '/what-we-do', 'WwLGFCAAAPMiB_Ps');
+  pageVanityUrl(router, app, '/press', 'WuxrKCIAAP9h3hmw');
+  pageVanityUrl(router, app, '/venue-hire', 'Wuw2MSIAACtd3SsC');
+  pageVanityUrl(router, app, '/access', 'Wvm2uiAAAIYQ4FHP');
+  pageVanityUrl(router, app, '/youth', 'Wuw2MSIAACtd3Ste');
+  pageVanityUrl(router, app, '/schools', 'Wuw2MSIAACtd3StS');
 
   router.get('/preview', async ctx => {
     // Kill any cookie we had set, as it think it is causing issues.
@@ -175,14 +89,6 @@ app.prepare().then(async () => {
     ctx.status = 200;
     ctx.body = 'ok';
   });
-
-  pageVanityUrl(router, app, '/visit-us', 'WwLIBiAAAPMiB_zC');
-  pageVanityUrl(router, app, '/what-we-do', 'WwLGFCAAAPMiB_Ps');
-  pageVanityUrl(router, app, '/press', 'WuxrKCIAAP9h3hmw');
-  pageVanityUrl(router, app, '/venue-hire', 'Wuw2MSIAACtd3SsC');
-  pageVanityUrl(router, app, '/access', 'Wvm2uiAAAIYQ4FHP');
-  pageVanityUrl(router, app, '/youth', 'Wuw2MSIAACtd3Ste');
-  pageVanityUrl(router, app, '/schools', 'Wuw2MSIAACtd3StS');
 
   router.get('*', async ctx => {
     await handle(ctx.req, ctx.res);

--- a/content/webapp/server.js
+++ b/content/webapp/server.js
@@ -3,9 +3,9 @@ const Router = require('koa-router');
 const next = require('next');
 const Prismic = require('prismic-javascript');
 const linkResolver = require('@weco/common/services/prismic/link-resolver');
-const withGlobalAlert = require('@weco/common/koa-middleware/withGlobalAlert');
-const withOpeningTimes = require('@weco/common/koa-middleware/withOpeningTimes');
-const withToggles = require('@weco/common/koa-middleware/withToggles');
+const {
+  middlesware, route
+} = require('@weco/common/koa-middleware/withCachedValues');
 
 // FIXME: Find a way to import this.
 // We can't because it's not a standard es6 module (import and flowtype)
@@ -41,77 +41,15 @@ app.prepare().then(async () => {
   const server = new Koa();
   const router = new Router();
 
-  // Feature toggles
-  server.use(withToggles);
+  server.use(middlesware);
 
-  // server cached values
-  server.use(withGlobalAlert);
-  server.use(withOpeningTimes);
+  route('/', '/homepage', router, app);
+  route('/whats-on', '/whats-on', router, app);
+  route(`/whats-on/:period(${periodPaths})`, '/whats-on', router, app);
 
-  // Next routing
-  router.get('/', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/homepage', {
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-
-  router.get('/whats-on', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/whats-on', {
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get(`/whats-on/:period(${periodPaths})`, async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/whats-on', {
-      period: ctx.params.period,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-
-  router.get('/exhibitions', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    const {page} = ctx.query;
-    await app.render(ctx.req, ctx.res, '/exhibitions', {
-      page,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get(`/exhibitions/:period(${periodPaths})`, async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    const {page} = ctx.query;
-    await app.render(ctx.req, ctx.res, '/exhibitions', {
-      period: ctx.params.period,
-      page,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
-  router.get('/exhibitions/:id', async ctx => {
-    const {toggles, globalAlert, openingTimes} = ctx;
-    await app.render(ctx.req, ctx.res, '/exhibition', {
-      id: ctx.params.id,
-      toggles,
-      globalAlert,
-      openingTimes
-    });
-    ctx.respond = false;
-  });
+  route('/exhibitions', '/exhibitions', router, app);
+  route(`/exhibitions/:period(${periodPaths})`, '/exhibitions', router, app);
+  route('/exhibitions/:id', '/exhibition', router, app);
 
   router.get('/events', async ctx => {
     const {toggles, globalAlert, openingTimes} = ctx;


### PR DESCRIPTION
A few errors caught us recently by not serving the cached values to our pages.

This helps with that by abstracting it out. I wonder if we should also deal with null cvalues as we've otherwise tightly oupled the templates and external resources.

TODO:
- [x] Add query params
