### PR TITLE
add v2 pages to catalogue app

### DIFF
--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -1,0 +1,250 @@
+// @flow
+import {Fragment, Component} from 'react';
+import Router from 'next/router';
+import {font, grid, spacing, classNames} from '@weco/common/utils/classnames';
+import PageDescription from '@weco/common/views/components/PageDescription/PageDescription';
+import PageWrapper from '@weco/common/views/components/PageWrapper/PageWrapper';
+import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner2';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import SearchBox from '@weco/common/views/components/SearchBox/SearchBox';
+import StaticWorksContent from '@weco/common/views/components/StaticWorksContent/StaticWorksContent';
+import WorkPromo from '@weco/common/views/components/WorkPromo/WorkPromo';
+import Pagination, {PaginationFactory} from '@weco/common/views/components/Pagination/Pagination';
+import type {Props as PaginationProps} from '@weco/common/views/components/Pagination/Pagination';
+import type {EventWithInputValue} from '@weco/common/views/components/HTMLInput/HTMLInput';
+import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
+import {getWorks} from '../services/catalogue/worksv2';
+
+// TODO: Setting the event parameter to type 'Event' leads to
+// an 'Indexable signature not found in EventTarget' Flow
+// error. We're setting the properties we expect here until
+// we find a better solution.
+type PageProps = {|
+  query: ?string,
+  page: ?number,
+  works: {| results: [], totalResults: number |},
+  pagination: ?PaginationProps,
+  version: ?number
+|}
+
+type ComponentProps = {|
+  ...PageProps,
+  handleSubmit: (EventWithInputValue) => void
+|}
+
+export const Works = ({
+  query,
+  page,
+  works,
+  pagination,
+  handleSubmit,
+  version
+}: ComponentProps) => (
+  <Fragment>
+    <PageDescription title='Search our images' extraClasses='page-description--hidden' />
+    <InfoBanner text={`Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`} cookieName='WC_wellcomeImagesRedirect' />
+
+    <div className={classNames([
+      'row bg-cream',
+      spacing({s: 3, m: 5}, {padding: ['top']}),
+      spacing({s: 3, m: 4, l: 6}, {padding: ['bottom']})
+    ])}>
+      <div className='container'>
+        <div className='grid'>
+          <div className={grid({s: 12, m: 12, l: 12, xl: 12})}>
+            <div className={classNames([
+              'flex flex--h-space-between flex--v-center flex--wrap',
+              spacing({s: 2}, {margin: ['bottom']})
+            ])}>
+              <h2 className={classNames([
+                font({s: 'WB6', m: 'WB4'}),
+                spacing({s: 2}, {margin: ['bottom']}),
+                spacing({s: 4}, {margin: ['right']}),
+                spacing({s: 0}, {margin: ['top']})
+              ])}>Search our images</h2>
+              <div className='plain-text flex flex--v-center'>
+                <Icon name='underConstruction' extraClasses='margin-right-s2' />
+                <p className='no-margin'>We’re improving how search works. <a href='/progress'>Find out more</a>.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className='grid'>
+          <div className={grid({s: 12, m: 10, l: 8, xl: 8})}>
+            <SearchBox
+              action=''
+              id='search-works'
+              name='query'
+              query={query || ''}
+              autofocus={true}
+              onSubmit={handleSubmit} />
+
+            {!query
+              ? <p className={classNames([
+                spacing({s: 4}, {margin: ['top']}),
+                font({s: 'HNL4', m: 'HNL3'})
+              ])}>Find thousands of Creative Commons licensed images from historical library materials and museum objects to contemporary digital photographs.</p>
+              : <p className={classNames([
+                spacing({s: 2}, {margin: ['top', 'bottom']}),
+                font({s: 'LR3', m: 'LR2'})
+              ])}>{works.totalResults !== 0 ? works.totalResults : 'No'} results for &apos;{query}&apos;
+              </p>
+            }
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {!query &&
+      <StaticWorksContent />
+    }
+
+    {query &&
+      <Fragment>
+        {pagination && pagination.range &&
+          <div className={`row ${spacing({s: 3, m: 5}, {padding: ['top']})}`}>
+            <div className='container'>
+              <div className='grid'>
+                <div className='grid__cell'>
+                  <div className='flex flex--h-space-between flex--v-center'>
+
+                    <Fragment>
+                      <div className={`flex flex--v-center font-pewter ${font({s: 'LR3', m: 'LR2'})}`}>
+                          Showing {pagination.range.beginning} - {pagination.range.end}
+                      </div>
+                      <Pagination
+                        prevPage={pagination.prevPage}
+                        currentPage={pagination.currentPage}
+                        pageCount={pagination.pageCount}
+                        nextPage={pagination.nextPage}
+                        nextQueryString={pagination.nextQueryString}
+                        prevQueryString={pagination.prevQueryString} />
+                    </Fragment>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        }
+
+        <div className={`row ${spacing({s: 4}, {padding: ['top']})}`}>
+          <div className='container'>
+            <div className='grid'>
+              {works.results.map(result => (
+                <div key={result.id} className={grid({s: 6, m: 4, l: 3, xl: 2})}>
+                  <WorkPromo
+                    id={result.id}
+                    image={{
+                      contentUrl: result.thumbnail ? result.thumbnail.url : 'https://via.placeholder.com/1600x900?text=%20',
+                      width: 300,
+                      height: 300,
+                      alt: ''
+                    }}
+                    datePublished={result.createdDate && result.createdDate.label}
+                    title={result.title}
+                    url={`/worksv2/${result.id}${getQueryParamsForWork(query, page)}`} />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {pagination && pagination.range &&
+          <div className={`row ${spacing({s: 10}, {padding: ['top', 'bottom']})}`}>
+            <div className='container'>
+              <div className='grid'>
+                <div className='grid__cell'>
+                  <div className='flex flex--h-space-between flex--v-center'>
+
+                    <Fragment>
+                      <div className={`flex flex--v-center font-pewter ${font({s: 'LR3', m: 'LR2'})}`}>
+                        Showing {pagination.range.beginning} - {pagination.range.end}
+                      </div>
+                      <Pagination
+                        prevPage={pagination.prevPage}
+                        currentPage={pagination.currentPage}
+                        pageCount={pagination.pageCount}
+                        nextPage={pagination.nextPage}
+                        nextQueryString={pagination.nextQueryString}
+                        prevQueryString={pagination.prevQueryString} />
+                    </Fragment>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        }
+      </Fragment>
+    }
+  </Fragment>
+);
+
+export class WorksPage extends Component<PageProps> {
+  static getInitialProps = async (context: GetInitialPropsProps) => {
+    const query = context.query.query;
+    const page = context.query.page ? parseInt(context.query.page, 10) : 1;
+    const works = await getWorks({ query, page });
+
+    if (works.type === 'Error') {
+      return { statusCode: works.httpStatus };
+    }
+
+    const pagination = PaginationFactory.fromList(
+      works.results,
+      Number(works.totalResults) || 1,
+      Number(page) || 1,
+      works.pageSize || 1,
+      {query: query || ''}
+    );
+
+    return {
+      works,
+      query,
+      page,
+      pagination: pagination,
+      title: `Image catalogue search${query ? `: ${query}` : ''}`,
+      description: 'Search through the Wellcome Collection image catalogue',
+      analyticsCategory: 'collections',
+      siteSection: 'images',
+      canonicalUrl: `https://wellcomecollection.org/works${query && `?query=${query}`}`
+    };
+  };
+
+  handleSubmit = (event: EventWithInputValue) => {
+    event.preventDefault();
+    const queryString = event.target[0].value;
+
+    // Update the URL, which in turn will update props
+    Router.push({
+      pathname: '/worksv2',
+      query: {
+        query: queryString,
+        page: '1'
+      }
+    });
+  }
+
+  render() {
+    return (
+      <Works
+        version={this.props.version}
+        page={this.props.page}
+        query={this.props.query}
+        works={this.props.works}
+        pagination={this.props.pagination}
+        handleSubmit={this.handleSubmit}
+      />
+    );
+  }
+}
+
+function getQueryParamsForWork(query: ?string, page: ?number) {
+  const params = {query, page};
+  return Object.keys({query, page})
+    .filter(key => params[key])
+    .reduce((acc, key, index) => {
+      return `${acc}${index > 0 ? '&' : ''}${key}=${params[key] || ''}`;
+    }, '?');
+}
+
+export default PageWrapper(WorksPage);

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -1,0 +1,430 @@
+// @flow
+import {Fragment} from 'react';
+import ReactGA from 'react-ga';
+import NextLink from 'next/link';
+import {font, spacing, grid, classNames} from '@weco/common/utils/classnames';
+import {iiifImageTemplate, convertImageUri} from '@weco/common/utils/convert-image-uri';
+import PageDescription from '@weco/common/views/components/PageDescription/PageDescription';
+import PageWrapper from '@weco/common/views/components/PageWrapper/PageWrapper';
+import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import PrimaryLink from '@weco/common/views/components/Links/PrimaryLink/PrimaryLink';
+import License from '@weco/common/views/components/License/License';
+import Divider from '@weco/common/views/components/Divider/Divider';
+import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
+import SecondaryLink from '@weco/common/views/components/Links/SecondaryLink/SecondaryLink';
+import Button from '@weco/common/views/components/Buttons/Button/Button';
+import {workLd} from '@weco/common/utils/json-ld';
+import WorkMedia from '../components/WorkMedia/WorkMedia';
+import {getWork} from '../services/catalogue/worksv2';
+
+export type Link = {|
+  text: string;
+  url: string;
+|};
+
+// Not sure we want to type this not dynamically
+// as the API is subject to change?
+type Work = Object;
+type Props = {|
+  work: Work,
+  previousQueryString: ?string,
+  page: ?number
+|}
+
+export const WorkPage = ({
+  work,
+  previousQueryString
+}: Props) => {
+  const [iiifImageLocation] = work.items.map(
+    item => item.locations.find(
+      location => location.locationType.id === 'iiif-image'
+    )
+  );
+  const iiifInfoUrl = iiifImageLocation && iiifImageLocation.url;
+
+  const sierraId = (work.identifiers.find(identifier =>
+    identifier.identifierType.id === 'sierra-system-number'
+  ) || {}).value;
+  // We strip the last character as that's what Wellcome Library expect
+  const encoreLink = sierraId && `http://search.wellcomelibrary.org/iii/encore/record/C__R${sierraId.substr(0, sierraId.length - 1)}`;
+  const credit = work.items[0].locations[0].credit;
+  const workImageUrl = work.items[0].locations[0].url;
+
+  return (
+    <Fragment>
+      <PageDescription title='Search our images' extraClasses='page-description--hidden' />
+      <InfoBanner text={`Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`} cookieName='WC_wellcomeImagesRedirect' />
+
+      {previousQueryString &&
+        <div className='row'>
+          <div className='container'>
+            <div className='grid'>
+              <div className={grid({s: 12})}>
+                <SecondaryLink
+                  url={`/works${previousQueryString || ''}#${work.id}`}
+                  text='Search results'
+                  trackingEvent={{
+                    category: 'component',
+                    action: 'return-to-results:click',
+                    label: `id:${work.id}, query:${previousQueryString || ''}, title:${work.title}`
+                  }} />
+              </div>
+            </div>
+          </div>
+        </div>
+      }
+
+      <Fragment>
+        {iiifInfoUrl && <WorkMedia
+          id={work.id}
+          iiifUrl={iiifInfoUrl}
+          title={work.title} />}
+
+        <div className={`row ${spacing({s: 6}, {padding: ['top', 'bottom']})}`}>
+          <div className='container'>
+            <div className='grid'>
+              <div className={classNames([
+                grid({s: 12, m: 10, shiftM: 1, l: 7, xl: 7}),
+                spacing({s: 4}, {margin: ['bottom']})
+              ])}>
+                <div className={spacing({s: 5}, {margin: ['bottom']})}>
+                  <h1 id='work-info'
+                    className={classNames([
+                      font({s: 'HNM3', m: 'HNM2', l: 'HNM1'}),
+                      spacing({s: 0}, {margin: ['top']})
+                    ])}>{work.title}</h1>
+
+                  <div className={classNames([
+                    spacing({s: 2}, {padding: ['top', 'bottom']}),
+                    spacing({s: 4}, {padding: ['left', 'right']}),
+                    spacing({s: 4}, {margin: ['bottom']}),
+                    'bg-cream rounded-diagonal flex flex--v-center'
+                  ])}>
+                    <Icon name='underConstruction' extraClasses='margin-right-s2' />
+                    <p className={`${font({s: 'HNL5', m: 'HNL4'})} no-margin`}>
+                      We’re improving the information on this page. <a href='/progress'>Find out more</a>.
+                    </p>
+                  </div>
+
+                  {work.description &&
+                    <div>
+                      <h2 className='h3'>Description</h2>
+                      <p>{work.description}</p>
+                    </div>
+
+                  }
+
+                  {work.physicalDescription &&
+                    <div>
+                      <h2 className='h3'>Physical description</h2>
+                      <p>{work.physicalDescription}</p>
+                    </div>
+                  }
+
+                  {work.workType &&
+                    <div>
+                      <h2 className='h3'>Work type</h2>
+                      <p>
+                        <NextLink href={`/worksv2?query=workType:"${work.workType.label}"`}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.workType.label}</a>
+                        </NextLink>
+                      </p>
+                    </div>
+                  }
+
+                  {work.extent &&
+                    <div>
+                      <h2 className='h3'>Extent</h2>
+                      <p>{work.extent}</p>
+                    </div>
+                  }
+
+                  {work.lettering &&
+                    <div>
+                      <h2 className='h3'>Lettering</h2>
+                      <p>{work.lettering}</p>
+                    </div>
+                  }
+
+                  {work.createdDate &&
+                    <div>
+                      <h2 className='h3'>Created date</h2>
+                      <p>{work.createdDate.label}</p>
+                    </div>
+                  }
+
+                  {work.contributors.length > 0 &&
+                    <div>
+                      <h2 className='h3'>Contributors</h2>
+                      <ul className='plain-list no-margin no-padding'>
+                        {work.contributors.map(contributor => {
+                          return (
+                            <li
+                              className='inline'
+                              key={contributor.agent.label}>
+                              <NextLink href={`/worksv2?query=contributors:"${contributor.agent.label}"`}>
+                                <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{contributor.agent.label}</a>
+                              </NextLink>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  }
+
+                  {work.subjects.length > 0 &&
+                    <div>
+                      <h2 className='h3'>Subjects</h2>
+                      <ul className='plain-list no-margin no-padding'>
+                        {work.subjects.map(subject => {
+                          return (
+                            <li
+                              className='inline'
+                              key={subject.label}>
+                              <NextLink href={`/worksv2?query=subjects:"${subject.label}"`}>
+                                <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{subject.label}</a>
+                              </NextLink>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  }
+
+                  {work.genres.length > 0 &&
+                    <div>
+                      <h2 className='h3'>Genres</h2>
+                      <ul className='plain-list no-margin no-padding'>
+                        {work.genres.map(genre => {
+                          return (
+                            <li
+                              className='inline'
+                              key={genre.label}>
+                              <NextLink href={`/worksv2?query=genres:"${genre.label}"`}>
+                                <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{genre.label}</a>
+                              </NextLink>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  }
+
+                  {work.production.length > 0 &&
+                    <div>
+                      <h2 className='h3'>Production</h2>
+                      {work.production.map(production => {
+                        return (
+                          <div key={production.function}>
+                            {production.places.length > 0 &&
+                              <div>
+                                <h3>Places</h3>
+                                <ul>
+                                  {production.places.map(place => {
+                                    return (
+                                      <li key={place.label}>{place.label}</li>
+                                    );
+                                  })}
+                                </ul>
+                              </div>
+                            }
+                            {production.agents.length > 0 &&
+                            <div>
+                              <h3>Agents</h3>
+                              <ul>
+                                {production.agents.map(agent => {
+                                  return (
+                                    <li key={agent.label}>{agent.label}</li>
+                                  );
+                                })}
+                              </ul>
+                            </div>
+                            }
+                            {production.dates.length > 0 &&
+                            <div>
+                              <h3>Dates</h3>
+                              <ul>
+                                {production.dates.map(dates => {
+                                  return (
+                                    <li key={dates.label}>{dates.label}</li>
+                                  );
+                                })}
+                              </ul>
+                            </div>
+                            }
+                          </div>
+                        );
+                      })}
+                    </div>
+                  }
+
+                  {work.language &&
+                    <div>
+                      <h2 className='h3'>Language</h2>
+                      <p>
+                        <NextLink href={`/worksv2?query=language:"${work.language.label}"`}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.language.label}</a>
+                        </NextLink>
+                      </p>
+                    </div>
+                  }
+
+                  {work.dimensions &&
+                    <div>
+                      <h2 className='h3'>Dimensions</h2>
+                      <p>
+                        <NextLink href={`/worksv2?query=dimensions:"${work.dimensions}"`}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.dimensions}</a>
+                        </NextLink>
+                      </p>
+                    </div>
+                  }
+
+                  {work.type &&
+                    <div>
+                      <h2 className='h3'>Type</h2>
+                      <p>
+                        <NextLink href={`/worksv2?query=type:"${work.type}"`}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>
+                            {work.type}
+                          </a>
+                        </NextLink>
+                      </p>
+                    </div>
+                  }
+
+                  {encoreLink &&
+                    <div className={spacing({s: 2}, {margin: ['top']})}>
+                      <PrimaryLink name='View Wellcome Library catalogue record' url={encoreLink} />
+                    </div>
+                  }
+                </div>
+              </div>
+
+              <div className={classNames([
+                grid({s: 12, m: 10, shiftM: 1, l: 5, xl: 5}),
+                spacing({s: 1}, {margin: ['top']})
+              ])}>
+                <h2 className={classNames([
+                  font({s: 'HNM4', m: 'HNM3'}),
+                  spacing({s: 0}, {margin: ['top']}),
+                  spacing({s: 2}, {margin: ['bottom']})
+                ])}>
+                  Download
+                </h2>
+
+                {workImageUrl && <div className={spacing({s: 2}, {margin: ['bottom']})}>
+                  <Button
+                    type='tertiary'
+                    url={convertImageUri(workImageUrl, 'full')}
+                    target='_blank'
+                    download={`${work.id}.jpg`}
+                    rel='noopener noreferrer'
+                    trackingEvent={{
+                      category: 'component',
+                      action: 'download-button:click',
+                      label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
+                    }}
+                    clickHandler={() => {
+                      ReactGA.event({
+                        category: 'component',
+                        action: 'download-button:click',
+                        label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
+                      });
+                    }}
+                    icon='download'
+                    text='Download full size' />
+                </div>}
+
+                {workImageUrl && <div className={spacing({s: 3}, {margin: ['bottom']})}>
+                  <Button
+                    type='tertiary'
+                    url={convertImageUri(workImageUrl, 760)}
+                    target='_blank'
+                    download={`${work.id}.jpg`}
+                    rel='noopener noreferrer'
+                    trackingEvent={{
+                      category: 'component',
+                      action: 'download-button:click',
+                      label: `id: work.id , size:760, title:${work.title.substring(50)}`
+                    }}
+                    clickHandler={() => {
+                      ReactGA.event({
+                        category: 'component',
+                        action: 'download-button:click',
+                        label: `id: work.id , size:760, title:${work.title.substring(50)}`
+                      });
+                    }}
+                    icon='download'
+                    text='Download small (760px)' />
+                </div>}
+
+                {work.thumbnail && work.thumbnail.license && <div className={spacing({s: 4}, {margin: ['bottom']})}>
+                  <p className={classNames([
+                    font({s: 'HNL5', m: 'HNL4'}),
+                    spacing({s: 1}, {margin: ['bottom']})
+                  ])}>Credit: {credit}</p>
+
+                  {/* TODO: the download links once this is in
+                  https://github.com/wellcometrust/wellcomecollection.org/pull/2164/files#diff-f9d8c53a2dbf55f0c9190e6fbd99e45cR21 */}
+                  {/* the small one is 760 */}
+                  <License subject={''} licenseType={work.thumbnail.license.licenseType} />
+                </div>}
+
+                <div className={spacing({s: 2}, {margin: ['top']})}>
+                  <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
+                  <h2 className={classNames([
+                    font({s: 'HNM4', m: 'HNM3'}),
+                    spacing({s: 2}, {margin: ['top']}),
+                    spacing({s: 1}, {margin: ['bottom']})
+                  ])}>
+                    Share
+                  </h2>
+                  <CopyUrl id={work.id} url={`https://wellcomecollection.org/works/${work.id}`} />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Fragment>
+    </Fragment>
+  );
+};
+
+WorkPage.getInitialProps = async (context) => {
+  const {id} = context.query;
+  const {asPath} = context;
+  const queryStart = asPath.indexOf('?');
+  const previousQueryString = queryStart > -1 && asPath.slice(queryStart);
+  const work = await getWork({ id });
+
+  if (work.type === 'Error') {
+    return { statusCode: work.httpStatus };
+  }
+
+  const [iiifImageLocation] = work.items.map(
+    item => item.locations.find(
+      location => location.locationType === 'iiif-image'
+    )
+  );
+
+  const iiifInfoUrl = iiifImageLocation && iiifImageLocation.url;
+  const iiifImage = iiifInfoUrl && iiifImageTemplate(iiifInfoUrl);
+
+  return {
+    title: work.title || work.description,
+    description: work.description || '',
+    type: 'website',
+    canonicalUrl: `https://wellcomecollection.org/works/${work.id}`,
+    imageUrl: iiifImage ? iiifImage({size: '800,'}) : null,
+    analyticsCategory: 'collections',
+    siteSection: 'images',
+    previousQueryString,
+    work: (work: Work),
+    oEmbedUrl: `https://wellcomecollection.org/oembed/works/${work.id}`,
+    pageJsonLd: workLd(work)
+  };
+};
+
+export default PageWrapper(WorkPage);

--- a/catalogue/webapp/server.js
+++ b/catalogue/webapp/server.js
@@ -86,6 +86,8 @@ app.prepare().then(async () => {
   route('/embed/works/:id', '/embed', router, app);
   route('/works/:id', '/work', router, app);
   route('/works', '/works', router, app);
+  route('/worksv2/:id', '/workv2', router, app);
+  route('/worksv2', '/worksv2', router, app);
 
   router.get('/works/management/healthcheck', async ctx => {
     ctx.status = 200;

--- a/catalogue/webapp/services/catalogue/worksv2.js
+++ b/catalogue/webapp/services/catalogue/worksv2.js
@@ -1,0 +1,35 @@
+// @flow
+import fetch from 'isomorphic-unfetch';
+
+type GetWorksProps = {|
+  query: string,
+  page: number
+|}
+
+type GetWorkProps = {|
+  id: string
+|}
+
+const rootUri = 'https://api.wellcomecollection.org/catalogue';
+const includes = ['identifiers', 'items', 'contributors', 'subjects', 'genres', 'production'];
+
+export async function getWorks({ query, page }: GetWorksProps): Object {
+  const url = `${rootUri}/v2/works?include=${includes.join(',')}` +
+    `&pageSize=100` +
+    '&workType=q,k' +
+    '&items.locations.locationType=iiif-image,iiif-presentation' +
+    (query ? `&query=${encodeURIComponent(query)}` : '') +
+    (page ? `&page=${page}` : '');
+
+  const res = await fetch(url);
+  const json = await res.json();
+
+  return json;
+}
+
+export async function getWork({ id }: GetWorkProps): Object {
+  const url = `${rootUri}/v2/works/${id}?include=${includes.join(',')}`;
+  const res = await fetch(url);
+  const json = await res.json();
+  return json;
+}


### PR DESCRIPTION
Use V2 for the works.

Seems the best way to go ahead, just create some new routes, we can then start testing them later, or allowing people to swap to them.

Does not look pretty on purpose so we can start defining what components we need:
![screenshot_2018-11-07 a fruiting tree branch and enlarged single pod watercolour wellcome collection](https://user-images.githubusercontent.com/31692/48131231-4754c400-e287-11e8-8e1a-a2d655bfe209.png)

