### PR TITLE
add work links to catalogue app

### DIFF
--- a/cardigan/.cache/325c8f456729b912b0d2134054eb7448-dfeeb2271cc2857eb0a45a5003c8bbee
+++ b/cardigan/.cache/325c8f456729b912b0d2134054eb7448-dfeeb2271cc2857eb0a45a5003c8bbee
@@ -1,0 +1,1 @@
+{"value":{"success":true,"data":{"latest":{"version":"4.0.0","info":{"plain":"- upgrade webpack & babel to latest\n- new addParameters and third argument to .add to pass data to addons\n- added the ability to theme storybook\n- improved ui for mobile devices\n- improved performance of addon-knobs"}}},"time":1541690580855},"type":"Object"}

--- a/cardigan/stories/components/Promos.js
+++ b/cardigan/stories/components/Promos.js
@@ -11,6 +11,7 @@ import ExhibitionPromoReadme from '../../../common/views/components/ExhibitionPr
 import ExhibitionPromo from '../../../common/views/components/ExhibitionPromo/ExhibitionPromo';
 import WorkPromoReadme from '../../../common/views/components/WorkPromo/README.md';
 import WorkPromo from '../../../common/views/components/WorkPromo/WorkPromo';
+import {workLink} from '../../../catalogue/webapp/services/catalogue/links';
 
 const sizes = '(min-width: 1340px) calc(15vw + 120px), (min-width: 960px) calc(40vw - 84px), (min-width: 600px) calc(60vw - 83px), calc(75vw - 72px)';
 const datePublished = '1685';
@@ -199,7 +200,7 @@ const WorkPromoExample = () => {
   const title = text('Title', 'Diogenes, sitting in front of his barrel and being offered whatever he wants by Alexander the Great, asks Alexander to step aside so that he can see the sun. Etching by S. Rosa.');
   return (
     <WorkPromo
-      url={url}
+      link={workLink({ id: '123' })}
       id={id}
       image={image('https://iiif.wellcomecollection.org/image/V0049964ER.jpg/full/full/0/default.jpg', 800, 1309)}
       title={title}

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -15,6 +15,7 @@ import type {Props as PaginationProps} from '@weco/common/views/components/Pagin
 import type {EventWithInputValue} from '@weco/common/views/components/HTMLInput/HTMLInput';
 import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
 import {getWorks} from '../services/catalogue/works';
+import {workLink, worksLink} from '../services/catalogue/links';
 
 // TODO: Setting the event parameter to type 'Event' leads to
 // an 'Indexable signature not found in EventTarget' Flow
@@ -158,7 +159,7 @@ export const Works = ({
                       }}
                       datePublished={result.createdDate && result.createdDate.label}
                       title={result.title}
-                      url={`/works/${result.id}${getQueryParamsForWork(query, page)}`} />
+                      link={workLink({ id: result.id, query, page })} />
                   </div>
                 ))}
               </div>
@@ -233,13 +234,7 @@ export class WorksPage extends Component<PageProps> {
     const queryString = event.target[0].value;
 
     // Update the URL, which in turn will update props
-    Router.push({
-      pathname: '/works',
-      query: {
-        query: queryString,
-        page: '1'
-      }
-    });
+    Router.push(worksLink({ query: queryString, page: 1 }).href);
   }
 
   render() {
@@ -254,15 +249,6 @@ export class WorksPage extends Component<PageProps> {
       />
     );
   }
-}
-
-function getQueryParamsForWork(query: ?string, page: ?number) {
-  const params = {query, page};
-  return Object.keys({query, page})
-    .filter(key => params[key])
-    .reduce((acc, key, index) => {
-      return `${acc}${index > 0 ? '&' : ''}${key}=${params[key] || ''}`;
-    }, '?');
 }
 
 export default PageWrapper(WorksPage);

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -14,6 +14,7 @@ import type {Props as PaginationProps} from '@weco/common/views/components/Pagin
 import type {EventWithInputValue} from '@weco/common/views/components/HTMLInput/HTMLInput';
 import type {GetInitialPropsProps} from '@weco/common/views/components/PageWrapper/PageWrapper';
 import {getWorks} from '../services/catalogue/worksv2';
+import {workV2Link, worksV2Link} from '../services/catalogue/links';
 
 // TODO: Setting the event parameter to type 'Event' leads to
 // an 'Indexable signature not found in EventTarget' Flow
@@ -142,7 +143,7 @@ export const Works = ({
                     }}
                     datePublished={result.createdDate && result.createdDate.label}
                     title={result.title}
-                    url={`/worksv2/${result.id}${getQueryParamsForWork(query, page)}`} />
+                    link={workV2Link({ id: result.id, query, page })} />
                 </div>
               ))}
             </div>
@@ -215,13 +216,7 @@ export class WorksPage extends Component<PageProps> {
     const queryString = event.target[0].value;
 
     // Update the URL, which in turn will update props
-    Router.push({
-      pathname: '/worksv2',
-      query: {
-        query: queryString,
-        page: '1'
-      }
-    });
+    Router.push(worksV2Link({ query: queryString, page: 1 }).href);
   }
 
   render() {
@@ -236,15 +231,6 @@ export class WorksPage extends Component<PageProps> {
       />
     );
   }
-}
-
-function getQueryParamsForWork(query: ?string, page: ?number) {
-  const params = {query, page};
-  return Object.keys({query, page})
-    .filter(key => params[key])
-    .reduce((acc, key, index) => {
-      return `${acc}${index > 0 ? '&' : ''}${key}=${params[key] || ''}`;
-    }, '?');
 }
 
 export default PageWrapper(WorksPage);

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -17,6 +17,7 @@ import Button from '@weco/common/views/components/Buttons/Button/Button';
 import {workLd} from '@weco/common/utils/json-ld';
 import WorkMedia from '../components/WorkMedia/WorkMedia';
 import {getWork} from '../services/catalogue/worksv2';
+import {worksV2Link} from '../services/catalogue/links';
 
 export type Link = {|
   text: string;
@@ -48,8 +49,7 @@ export const WorkPage = ({
   ) || {}).value;
   // We strip the last character as that's what Wellcome Library expect
   const encoreLink = sierraId && `http://search.wellcomelibrary.org/iii/encore/record/C__R${sierraId.substr(0, sierraId.length - 1)}`;
-  const credit = work.items[0].locations[0].credit;
-  const workImageUrl = work.items[0].locations[0].url;
+  const workImageUrl = work.items.length > 0 && work.items[0].locations.length > 0 && work.items[0].locations[0].url;
 
   return (
     <Fragment>
@@ -126,7 +126,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Work type</h2>
                       <p>
-                        <NextLink href={`/worksv2?query=workType:"${work.workType.label}"`}>
+                        <NextLink {...worksV2Link({ query: `workType:"${work.workType.label}"` })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.workType.label}</a>
                         </NextLink>
                       </p>
@@ -163,7 +163,7 @@ export const WorkPage = ({
                             <li
                               className='inline'
                               key={contributor.agent.label}>
-                              <NextLink href={`/worksv2?query=contributors:"${contributor.agent.label}"`}>
+                              <NextLink {...worksV2Link({ query: `contributors:"${contributor.agent.label}"` })}>
                                 <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{contributor.agent.label}</a>
                               </NextLink>
                             </li>
@@ -182,7 +182,7 @@ export const WorkPage = ({
                             <li
                               className='inline'
                               key={subject.label}>
-                              <NextLink href={`/worksv2?query=subjects:"${subject.label}"`}>
+                              <NextLink  {...worksV2Link({ query: `subjects:"${subject.label}"` })}>
                                 <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{subject.label}</a>
                               </NextLink>
                             </li>
@@ -201,7 +201,7 @@ export const WorkPage = ({
                             <li
                               className='inline'
                               key={genre.label}>
-                              <NextLink href={`/worksv2?query=genres:"${genre.label}"`}>
+                              <NextLink {...worksV2Link({ query: `genres:"${genre.label}"` })}>
                                 <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{genre.label}</a>
                               </NextLink>
                             </li>
@@ -263,7 +263,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Language</h2>
                       <p>
-                        <NextLink href={`/worksv2?query=language:"${work.language.label}"`}>
+                        <NextLink {...worksV2Link({ query: `language:"${work.language.label}"` })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.language.label}</a>
                         </NextLink>
                       </p>
@@ -274,7 +274,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Dimensions</h2>
                       <p>
-                        <NextLink href={`/worksv2?query=dimensions:"${work.dimensions}"`}>
+                        <NextLink {...worksV2Link({ query: `dimensions:"${work.dimensions}"` })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.dimensions}</a>
                         </NextLink>
                       </p>
@@ -285,7 +285,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Type</h2>
                       <p>
-                        <NextLink href={`/worksv2?query=type:"${work.type}"`}>
+                        <NextLink {...worksV2Link({ query: `query=type:"${work.type}"` })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>
                             {work.type}
                           </a>
@@ -361,10 +361,12 @@ export const WorkPage = ({
                 </div>}
 
                 {work.thumbnail && work.thumbnail.license && <div className={spacing({s: 4}, {margin: ['bottom']})}>
-                  <p className={classNames([
-                    font({s: 'HNL5', m: 'HNL4'}),
-                    spacing({s: 1}, {margin: ['bottom']})
-                  ])}>Credit: {credit}</p>
+                  {work.items.length > 0 && work.items[0].locations.length > 0 &&
+                    <p className={classNames([
+                      font({s: 'HNL5', m: 'HNL4'}),
+                      spacing({s: 1}, {margin: ['bottom']})
+                    ])}>Credit: {work.items[0].locations[0].credit}</p>
+                  }
 
                   {/* TODO: the download links once this is in
                   https://github.com/wellcometrust/wellcomecollection.org/pull/2164/files#diff-f9d8c53a2dbf55f0c9190e6fbd99e45cR21 */}

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -126,7 +126,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Work type</h2>
                       <p>
-                        <NextLink {...worksV2Link({ query: `workType:"${work.workType.label}"` })}>
+                        <NextLink {...worksV2Link({ query: `workType:"${work.workType.label}"`, page: undefined })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.workType.label}</a>
                         </NextLink>
                       </p>
@@ -163,7 +163,7 @@ export const WorkPage = ({
                             <li
                               className='inline'
                               key={contributor.agent.label}>
-                              <NextLink {...worksV2Link({ query: `contributors:"${contributor.agent.label}"` })}>
+                              <NextLink {...worksV2Link({ query: `contributors:"${contributor.agent.label}"`, page: undefined })}>
                                 <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{contributor.agent.label}</a>
                               </NextLink>
                             </li>
@@ -182,7 +182,7 @@ export const WorkPage = ({
                             <li
                               className='inline'
                               key={subject.label}>
-                              <NextLink  {...worksV2Link({ query: `subjects:"${subject.label}"` })}>
+                              <NextLink  {...worksV2Link({ query: `subjects:"${subject.label}"`, page: undefined })}>
                                 <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{subject.label}</a>
                               </NextLink>
                             </li>
@@ -201,7 +201,7 @@ export const WorkPage = ({
                             <li
                               className='inline'
                               key={genre.label}>
-                              <NextLink {...worksV2Link({ query: `genres:"${genre.label}"` })}>
+                              <NextLink {...worksV2Link({ query: `genres:"${genre.label}"`, page: undefined })}>
                                 <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{genre.label}</a>
                               </NextLink>
                             </li>
@@ -263,7 +263,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Language</h2>
                       <p>
-                        <NextLink {...worksV2Link({ query: `language:"${work.language.label}"` })}>
+                        <NextLink {...worksV2Link({ query: `language:"${work.language.label}"`, page: undefined })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.language.label}</a>
                         </NextLink>
                       </p>
@@ -274,7 +274,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Dimensions</h2>
                       <p>
-                        <NextLink {...worksV2Link({ query: `dimensions:"${work.dimensions}"` })}>
+                        <NextLink {...worksV2Link({ query: `dimensions:"${work.dimensions}"`, page: undefined })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.dimensions}</a>
                         </NextLink>
                       </p>
@@ -285,7 +285,7 @@ export const WorkPage = ({
                     <div>
                       <h2 className='h3'>Type</h2>
                       <p>
-                        <NextLink {...worksV2Link({ query: `query=type:"${work.type}"` })}>
+                        <NextLink {...worksV2Link({ query: `query=type:"${work.type}"`, page: undefined })}>
                           <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>
                             {work.type}
                           </a>

--- a/catalogue/webapp/services/catalogue/links.js
+++ b/catalogue/webapp/services/catalogue/links.js
@@ -20,6 +20,10 @@ type LinkProps = {|
   as: Link
 |}
 
+function removeEmpty(obj: Object): Object {
+  return JSON.parse(JSON.stringify(obj));
+}
+
 export function workLink({ id, query, page }: WorkLinkProps): LinkProps {
   return {
     href: {
@@ -28,7 +32,7 @@ export function workLink({ id, query, page }: WorkLinkProps): LinkProps {
     },
     as: {
       pathname: `/works/${id}`,
-      query: { query, page }
+      query: removeEmpty({ query, page })
     }
   };
 }
@@ -41,7 +45,7 @@ export function worksLink({ query, page }: WorksLinkProps): LinkProps {
     },
     as: {
       pathname: `/works`,
-      query: { query, page }
+      query: removeEmpty({ query, page })
     }
   };
 }
@@ -54,7 +58,7 @@ export function workV2Link({ id, query, page }: WorkLinkProps): LinkProps {
     },
     as: {
       pathname: `/worksv2/${id}`,
-      query: { query, page }
+      query: removeEmpty({ query, page })
     }
   };
 }
@@ -67,7 +71,7 @@ export function worksV2Link({ query, page }: WorksLinkProps): LinkProps {
     },
     as: {
       pathname: `/worksv2`,
-      query: { query, page }
+      query: removeEmpty({ query, page })
     }
   };
 }

--- a/catalogue/webapp/services/catalogue/links.js
+++ b/catalogue/webapp/services/catalogue/links.js
@@ -1,0 +1,73 @@
+// @flow
+type WorkLinkProps = {|
+  id: string,
+  query: ?string,
+  page: ?number
+|}
+
+type WorksLinkProps = {|
+  query: ?string,
+  page: ?number
+|}
+
+type Link = {|
+  pathname: string,
+  query: Object
+|}
+
+type LinkProps = {|
+  href: Link,
+  as: Link
+|}
+
+export function workLink({ id, query, page }: WorkLinkProps): LinkProps {
+  return {
+    href: {
+      pathname: `/work`,
+      query: { id, query, page }
+    },
+    as: {
+      pathname: `/works/${id}`,
+      query: { query, page }
+    }
+  };
+}
+
+export function worksLink({ query, page }: WorksLinkProps): LinkProps {
+  return {
+    href: {
+      pathname: `/works`,
+      query: { query, page }
+    },
+    as: {
+      pathname: `/works`,
+      query: { query, page }
+    }
+  };
+}
+
+export function workV2Link({ id, query, page }: WorkLinkProps): LinkProps {
+  return {
+    href: {
+      pathname: `/workv2`,
+      query: { id, query, page }
+    },
+    as: {
+      pathname: `/worksv2/${id}`,
+      query: { query, page }
+    }
+  };
+}
+
+export function worksV2Link({ query, page }: WorksLinkProps): LinkProps {
+  return {
+    href: {
+      pathname: `/worksv2`,
+      query: { query, page }
+    },
+    as: {
+      pathname: `/worksv2`,
+      query: { query, page }
+    }
+  };
+}

--- a/catalogue/webapp/services/catalogue/worksv2.js
+++ b/catalogue/webapp/services/catalogue/worksv2.js
@@ -16,8 +16,8 @@ const includes = ['identifiers', 'items', 'contributors', 'subjects', 'genres', 
 export async function getWorks({ query, page }: GetWorksProps): Object {
   const url = `${rootUri}/v2/works?include=${includes.join(',')}` +
     `&pageSize=100` +
-    '&workType=q,k' +
-    '&items.locations.locationType=iiif-image,iiif-presentation' +
+    // '&workType=q,k' +
+    // '&items.locations.locationType=iiif-image,iiif-presentation' +
     (query ? `&query=${encodeURIComponent(query)}` : '') +
     (page ? `&page=${page}` : '');
 

--- a/common/views/components/WorkPromo/WorkPromo.js
+++ b/common/views/components/WorkPromo/WorkPromo.js
@@ -5,25 +5,32 @@ import Image from '../Image/Image';
 import type {Props as ImageProps} from '../Image/Image';
 import NextLink from 'next/link';
 
+type Link = {|
+  pathname: string,
+  query: Object
+|}
+type LinkProps = {|
+  href: Link,
+  as: Link
+|}
+
 type Props = {|
-  url: string,
   id: string,
   image: ImageProps,
   datePublished?: string,
-  title?: string
+  title?: string,
+  link: LinkProps
 |}
 
 const WorkPromo = ({
-  url,
   id,
   image,
   datePublished,
-  title
+  title,
+  link
 }: Props) => {
   return (
-    <NextLink
-      href={`/work?id=${id}`}
-      as={url}>
+    <NextLink {...link}>
       <a
         id={id}
         data-component='WorkPromo'


### PR DESCRIPTION
Feels like a decent way to get about it.
Links are always programmatically defined, and turned into things next can understand.

Could work for content as well, where you just pass a type too.