### PR TITLE
add initial outro research to outro readme

### DIFF
--- a/common/views/components/Outro/README.md
+++ b/common/views/components/Outro/README.md
@@ -3,3 +3,18 @@ To reduce exit rate on stories by providing up to three more paths to follow
 once they have finished reading. The general idea is to provide visit, read,
 or research paths.
 
+# Research
+## Hypothesis
+​​By providing people with links to other related content at the bottom of the
+page we would create more onward journey's and fewer people leaving the site
+from article pages.
+
+## Measurement
+_A:_ People visiting articles with an outro, when it is turned off
+_B:_ People visiting articles with an outro, when it is turned on
+
+|           | Condition A | Condition B |
+|-----------|-------------|-------------|
+| Users     | 1847        | 1892        |
+| Pageviews | 2266        | 2319        |
+| Exit rate | 84.51%      | 83.87%      |


### PR DESCRIPTION
Adding the research to the cardigan readme.
[Here's the MD file rendered](https://github.com/wellcometrust/wellcomecollection.org/blob/92da7d40805823927eda9139ab654be41b117539/common/views/components/Outro/README.md).

Seems to be a valuable place to store it, potentially adding any conclusions we might come to, or next steps to try and improve it?

@wellcometrust/experience thoughts?