### PR TITLE
Tidy up error page spacing/list

### DIFF
--- a/common/views/components/BasePage/BasePage.js
+++ b/common/views/components/BasePage/BasePage.js
@@ -43,11 +43,13 @@ const BasePage = ({
         <div className={classNames({
           'bg-cream': isCreamy
         })}>
-          <SpacingSection>
-            <div className='basic-page'>
-              <Fragment>{Body}</Fragment>
-            </div>
-          </SpacingSection>
+          {Body.props.body.length > 0 &&
+            <SpacingSection>
+              <div className='basic-page'>
+                <Fragment>{Body}</Fragment>
+              </div>
+            </SpacingSection>
+          }
 
           {children &&
             <SpacingSection>

--- a/common/views/components/BasePage/BasePage.js
+++ b/common/views/components/BasePage/BasePage.js
@@ -7,7 +7,7 @@ import PageHeader from '../PageHeader/PageHeader';
 import Outro from '../Outro/Outro';
 import {classNames} from '../../../utils/classnames';
 import type {Node, Element, ElementProps} from 'react';
-import type Body from '../Body/Body';
+import Body from '../Body/Body';
 import SpacingSection from '../SpacingSection/SpacingSection';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 
@@ -18,7 +18,7 @@ type Props = {|
   id: string,
   isCreamy?: boolean,
   Header: Element<typeof PageHeader>,
-  Body: Body,
+  Body: Element<typeof Body>,
   // This is used for content type specific components e.g. InfoBox
   children?: ?Node,
   contributorProps?: ElementProps<typeof Contributors>,

--- a/common/views/components/BasePage/ErrorPage.js
+++ b/common/views/components/BasePage/ErrorPage.js
@@ -28,37 +28,35 @@ const ErrorPage = ({ errorStatus }: Props) => {
       Body={<Body body={[]} />}
     >
       <div className='body-text'>
-        <ul>
-          <div className={classNames({
-            [spacing({ s: 5 }, {margin: ['top']})]: true
-          })}>
+        <ul className='no-margin'>
+          <li>
             <PrimaryLink url='/whats-on' name='Our exhibitions and events' />
-          </div>
-          <div className={classNames({
+          </li>
+          <li className={classNames({
             [spacing({ s: 5 }, {margin: ['top']})]: true
           })}>
             <PrimaryLink url='https://wellcomelibrary.org' name='Our library' />
-          </div>
-          <div className={classNames({
+          </li>
+          <li className={classNames({
             [spacing({ s: 5 }, {margin: ['top']})]: true
           })}>
             <PrimaryLink url='/stories' name='Our stories' />
-          </div>
-          <div className={classNames({
+          </li>
+          <li className={classNames({
             [spacing({ s: 5 }, {margin: ['top']})]: true
           })}>
             <PrimaryLink url='/books' name='Our books' />
-          </div>
-          <div className={classNames({
+          </li>
+          <li className={classNames({
             [spacing({ s: 5 }, {margin: ['top']})]: true
           })}>
             <PrimaryLink url='/works' name='Our images' />
-          </div>
-          <div className={classNames({
+          </li>
+          <li className={classNames({
             [spacing({ s: 5 }, {margin: ['top']})]: true
           })}>
             <PrimaryLink url='/pages/Wuw2MSIAACtd3Ssg' name='Our youth programme' />
-          </div>
+          </li>
         </ul>
 
         <div className={classNames({


### PR DESCRIPTION
Only render the `SpacingSection` that wraps the `Body` if the `Body` has something in it.

Also, use `li`s inside the `ul` on the 404 page.

![screen shot 2018-11-12 at 14 12 40](https://user-images.githubusercontent.com/1394592/48352774-89b24280-e685-11e8-94a7-ea5241076b53.png)


