### PR TITLE
Add plain-text class to contributor to add link-hover style

### DIFF
--- a/common/views/components/Contributor/Contributor.js
+++ b/common/views/components/Contributor/Contributor.js
@@ -68,7 +68,7 @@ const Contributor = ({
             <div className={classNames({
               [spacing({s: 1}, {margin: ['top']})]: true,
               [font({s: 'HNL4'})]: true,
-              'spaced-text': true})}>
+              'spaced-text plain-text': true})}>
               <PrismicHtmlBlock html={descriptionToRender} />
             </div>
           }


### PR DESCRIPTION
Fixes #3621

![contributor_links](https://user-images.githubusercontent.com/1394592/48357447-81abd000-e690-11e8-837e-2b2de00a2c0e.gif)
