### PR TITLE
Work pagev2

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -504,7 +504,7 @@ export const WorkPage = ({
                     {/* TODO: the download links once this is in
                     https://github.com/wellcometrust/wellcomecollection.org/pull/2164/files#diff-f9d8c53a2dbf55f0c9190e6fbd99e45cR21 */}
                     {/* the small one is 760 */}
-                    <License subject={''} licenseType={work.thumbnail.license.licenseType} />
+                    <License subject={''} licenseType={work.thumbnail.license.licenseType.toLowerCase()} />
                   </div>
 
                   <div className={spacing({s: 2}, {margin: ['top']})}>

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -250,15 +250,16 @@ export const WorkPage = ({
                     </div>
                   }
 
-                  <WorkDrawer data={[{
-                    headingText: 'License information',
-                    text: getLicenseInfo(iiifImageLocationLicenseId).humanReadableText
-                  }, {
-                    headingText: 'Credit',
-                    text: constructAttribution(work, {}, iiifImageLocationCredit, iiifImageLocationLicenseId, `https://wellcomecollection.org/works/${work.id}`)
-                  }]} />
-
                 </div>
+
+                <WorkDrawer data={[{
+                  headingText: 'License information',
+                  text: getLicenseInfo(iiifImageLocationLicenseId).humanReadableText
+                }, {
+                  headingText: 'Credit',
+                  text: constructAttribution(work, {}, iiifImageLocationCredit, iiifImageLocationLicenseId, `https://wellcomecollection.org/works/${work.id}`)
+                }]} />
+
               </div>
 
               <div className={classNames([

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -255,8 +255,7 @@ export const WorkPage = ({
                     text: getLicenseInfo(iiifImageLocationLicenseId).humanReadableText
                   }, {
                     headingText: 'Credit',
-                    text: constructAttribution(work, {}, iiifImageLocationCredit, iiifImageLocationLicenseId, '/')
-                    // constructAttribution(work, contributors, credit, licenseType, canonicalUri)
+                    text: constructAttribution(work, {}, iiifImageLocationCredit, iiifImageLocationLicenseId, `https://wellcomecollection.org/works/${work.id}`)
                   }]} />
 
                 </div>

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -40,18 +40,16 @@ export const WorkPage = ({
 }: Props) => {
   const [iiifImageLocation] = work.items.map(
     item => item.locations.find(
-      location => location.locationType.id === 'iiif-image' ||
-                  location.locationType.id === 'iiif-presentation'
+      location => location.locationType.id === 'iiif-image'
     )
   ).filter(Boolean);
-  const iiifInfoUrl = iiifImageLocation && iiifImageLocation.url;
+  const iiifImageLocationUrl = iiifImageLocation && iiifImageLocation.url;
 
   const sierraId = (work.identifiers.find(identifier =>
     identifier.identifierType.id === 'sierra-system-number'
   ) || {}).value;
   // We strip the last character as that's what Wellcome Library expect
   const encoreLink = sierraId && `http://search.wellcomelibrary.org/iii/encore/record/C__R${sierraId.substr(0, sierraId.length - 1)}`;
-  const workImageUrl = work.items.length > 0 && work.items[0].locations.length > 0 && work.items[0].locations[0].url;
 
   return (
     <Fragment>
@@ -78,9 +76,9 @@ export const WorkPage = ({
       }
 
       <Fragment>
-        {iiifInfoUrl && <WorkMedia
+        {iiifImageLocationUrl && <WorkMedia
           id={work.id}
-          iiifUrl={iiifInfoUrl}
+          iiifUrl={iiifImageLocationUrl}
           title={work.title} />}
 
         <div className={`row ${spacing({s: 6}, {padding: ['top', 'bottom']})}`}>
@@ -232,10 +230,10 @@ export const WorkPage = ({
                   Download
                 </h2>
 
-                {workImageUrl && <div className={spacing({s: 2}, {margin: ['bottom']})}>
+                {iiifImageLocationUrl && <div className={spacing({s: 2}, {margin: ['bottom']})}>
                   <Button
                     type='tertiary'
-                    url={convertImageUri(workImageUrl, 'full')}
+                    url={convertImageUri(iiifImageLocationUrl, 'full')}
                     target='_blank'
                     download={`${work.id}.jpg`}
                     rel='noopener noreferrer'
@@ -255,10 +253,10 @@ export const WorkPage = ({
                     text='Download full size' />
                 </div>}
 
-                {workImageUrl && <div className={spacing({s: 3}, {margin: ['bottom']})}>
+                {iiifImageLocationUrl && <div className={spacing({s: 3}, {margin: ['bottom']})}>
                   <Button
                     type='tertiary'
-                    url={convertImageUri(workImageUrl, 760)}
+                    url={convertImageUri(iiifImageLocationUrl, 760)}
                     target='_blank'
                     download={`${work.id}.jpg`}
                     rel='noopener noreferrer'

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -27,24 +27,6 @@ export type Link = {|
   url: string;
 |};
 
-function constructCreatorsString(creators) { // TODO use contributors
-  // if (creators.length > 0) {
-  //   const creatorsString =  creators.reduce((acc, creator, index) => {
-  //     if (index === 0) {
-  //       return `${acc} ${creator.label}`;
-  //     } else if (index + 1 === creators.length) {
-  //       return `${acc} and ${creator.label}`;
-  //     } else {
-  //       return `${acc}, ${creator.label}`;
-  //     }
-  //   }, 'by');
-  //   return creatorsString;
-  // } else {
-  //   return '';
-  // }
-  return '';
-}
-
 function constructLicenseString(licenseType) {
   const licenseInfo = getLicenseInfo(licenseType);
   return `<a href="${licenseInfo.url}">${licenseInfo.text}</a>`;
@@ -52,9 +34,9 @@ function constructLicenseString(licenseType) {
 
 function constructAttribution(work, contributors, credit, licenseType, canonicalUri) {
   const title = work.title ? `'${work.title}' ` : '';
-  const creators = constructCreatorsString(contributors);
+  // const contributorsString = '';
   const license = constructLicenseString(licenseType);
-  return [`${title} ${creators}. Credit: <a href="${canonicalUri}">${credit}</a>. ${license}`];
+  return [`${title}. Credit: <a href="${canonicalUri}">${credit}</a>. ${license}`];
 }
 
 // Not sure we want to type this not dynamically
@@ -252,12 +234,12 @@ export const WorkPage = ({
 
                 </div>
 
-                <WorkDrawer data={[{
+                <WorkDrawer data={[{ // TODO cope with contributors in attribution
                   headingText: 'License information',
                   text: getLicenseInfo(iiifImageLocationLicenseId).humanReadableText
                 }, {
                   headingText: 'Credit',
-                  text: constructAttribution(work, {}, iiifImageLocationCredit, iiifImageLocationLicenseId, `https://wellcomecollection.org/works/${work.id}`)
+                  text: constructAttribution(work, 'contributors go here', iiifImageLocationCredit, iiifImageLocationLicenseId, `https://wellcomecollection.org/works/${work.id}`)
                 }]} />
 
               </div>

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -17,13 +17,45 @@ import Button from '@weco/common/views/components/Buttons/Button/Button';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import {workLd} from '@weco/common/utils/json-ld';
 import WorkMedia from '../components/WorkMedia/WorkMedia';
+import WorkDrawer from '@weco/common/views/components/WorkDrawer/WorkDrawer';
 import {getWork} from '../services/catalogue/worksv2';
 import {worksV2Link} from '../services/catalogue/links';
+import getLicenseInfo from '@weco/common/utils/get-license-info';
 
 export type Link = {|
   text: string;
   url: string;
 |};
+
+function constructCreatorsString(creators) { // TODO use contributors
+  // if (creators.length > 0) {
+  //   const creatorsString =  creators.reduce((acc, creator, index) => {
+  //     if (index === 0) {
+  //       return `${acc} ${creator.label}`;
+  //     } else if (index + 1 === creators.length) {
+  //       return `${acc} and ${creator.label}`;
+  //     } else {
+  //       return `${acc}, ${creator.label}`;
+  //     }
+  //   }, 'by');
+  //   return creatorsString;
+  // } else {
+  //   return '';
+  // }
+  return '';
+}
+
+function constructLicenseString(licenseType) {
+  const licenseInfo = getLicenseInfo(licenseType);
+  return `<a href="${licenseInfo.url}">${licenseInfo.text}</a>`;
+}
+
+function constructAttribution(work, contributors, credit, licenseType, canonicalUri) {
+  const title = work.title ? `'${work.title}' ` : '';
+  const creators = constructCreatorsString(contributors);
+  const license = constructLicenseString(licenseType);
+  return [`${title} ${creators}. Credit: <a href="${canonicalUri}">${credit}</a>. ${license}`];
+}
 
 // Not sure we want to type this not dynamically
 // as the API is subject to change?
@@ -217,6 +249,16 @@ export const WorkPage = ({
                       <PrimaryLink name='View Wellcome Library catalogue record' url={encoreLink} />
                     </div>
                   }
+
+                  <WorkDrawer data={[{
+                    headingText: 'License information',
+                    text: getLicenseInfo(iiifImageLocationLicenseId).humanReadableText
+                  }, {
+                    headingText: 'Credit',
+                    text: constructAttribution(work, {}, iiifImageLocationCredit, iiifImageLocationLicenseId, '/')
+                    // constructAttribution(work, contributors, credit, licenseType, canonicalUri)
+                  }]} />
+
                 </div>
               </div>
 

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -44,6 +44,8 @@ export const WorkPage = ({
     )
   ).filter(Boolean);
   const iiifImageLocationUrl = iiifImageLocation && iiifImageLocation.url;
+  const iiifImageLocationCredit = iiifImageLocation && iiifImageLocation.credit;
+  const iiifImageLocationLicenseId = iiifImageLocation && iiifImageLocation.license && iiifImageLocation.license.id;
 
   const sierraId = (work.identifiers.find(identifier =>
     identifier.identifierType.id === 'sierra-system-number'
@@ -276,19 +278,14 @@ export const WorkPage = ({
                     text='Download small (760px)' />
                 </div>}
 
-                {work.thumbnail && work.thumbnail.license && <div className={spacing({s: 4}, {margin: ['bottom']})}>
-                  {work.items.length > 0 && work.items[0].locations.length > 0 &&
-                    <p className={classNames([
+                {(iiifImageLocationCredit ||  iiifImageLocationLicenseId) &&
+                  <div className={spacing({s: 4}, {margin: ['bottom']})}>
+                    {iiifImageLocationCredit && <p className={classNames([
                       font({s: 'HNL5', m: 'HNL4'}),
                       spacing({s: 1}, {margin: ['bottom']})
-                    ])}>Credit: {work.items[0].locations[0].credit}</p>
-                  }
-
-                  {/* TODO: the download links once this is in
-                  https://github.com/wellcometrust/wellcomecollection.org/pull/2164/files#diff-f9d8c53a2dbf55f0c9190e6fbd99e45cR21 */}
-                  {/* the small one is 760 */}
-                  <License subject={''} licenseType={work.thumbnail.license.licenseType} />
-                </div>}
+                    ])}>Credit: {iiifImageLocationCredit}</p>}
+                    {iiifImageLocationLicenseId && <License subject={''} licenseType={iiifImageLocationLicenseId} /> }
+                  </div>}
 
                 <div className={spacing({s: 2}, {margin: ['top']})}>
                   <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />

--- a/catalogue/webapp/services/catalogue/worksv2.js
+++ b/catalogue/webapp/services/catalogue/worksv2.js
@@ -17,7 +17,7 @@ export async function getWorks({ query, page }: GetWorksProps): Object {
   const url = `${rootUri}/v2/works?include=${includes.join(',')}` +
     `&pageSize=100` +
     '&workType=q,k' +
-    '&items.locations.locationType=iiif-image,iiif-presentation' +
+    '&items.locations.locationType=iiif-image' +
     (query ? `&query=${encodeURIComponent(query)}` : '') +
     (page ? `&page=${page}` : '');
 

--- a/common/utils/get-license-info.js
+++ b/common/utils/get-license-info.js
@@ -12,34 +12,34 @@ const licenseMap = {
     text: 'Copyright not cleared',
     humanReadableText: ['Copyright for this work has not been cleared. You are responsible for identifying the rights owner to seek permission to use this work.']
   },
-  'PDM': {
+  'pdm': {
     url: 'https://creativecommons.org/publicdomain/mark/1.0/',
     text: 'Public Domain',
     icons: ['ccPdm'],
     humanReadableText: ['You can use this work for any purpose without restriction under copyright law.', 'Public Domain Mark (PDM) terms and conditions <a href="https://creativecommons.org/publicdomain/mark/1.0">https://creativecommons.org/publicdomain/mark/1.0</a>']
   },
-  'CC-0': {
+  'cc-0': {
     url: 'https://creativecommons.org/publicdomain/zero/1.0/',
     text: 'CC0',
     icons: ['ccZero'],
     description: 'Free to use for any purpose',
     humanReadableText: ['You can use this work for any purpose without restriction under copyright law.', 'Creative Commons Zero (CC0) terms and conditions <a href="https://creativecommons.org/publicdomain/zero/1.0">https://creativecommons.org/publicdomain/zero/1.0</a>']
   },
-  'CC-BY': {
+  'cc-by': {
     url: 'https://creativecommons.org/licenses/by/4.0/',
     text: 'CC BY',
     icons: ['cc', 'ccBy'],
     description: 'Free to use with attribution',
     humanReadableText: ['You can use this work for any purpose, including commercial uses, without restriction under copyright law. You should also provide attribution to the original work, source and licence.', 'Creative Commons Attribution (CC BY 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by/4.0">https://creativecommons.org/licenses/by/4.0</a>']
   },
-  'CC-BY-NC': {
+  'cc-by-nc': {
     url: 'https://creativecommons.org/licenses/by-nc/4.0/',
     text: 'CC BY-NC',
     icons: ['cc', 'ccBy', 'ccNc'],
     description: 'Free to use with attribution for non-commercial purposes',
     humanReadableText: ['You can use this work for any purpose, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.', 'Creative Commons Attribution Non-Commercial (CC BY-NC 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc/4.0">https://creativecommons.org/licenses/by-nc/4.0</a>']
   },
-  'CC-BY-NC-ND': {
+  'cc-by-nc-nd': {
     url: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
     text: 'CC BY-NC-ND',
     icons: ['cc', 'ccBy', 'ccNc', 'ccNd'],


### PR DESCRIPTION
references #3705

Adds download links, credit/ licence info. and using this image info. with the correct data sources from the new API

<img width="428" alt="screen shot 2018-11-13 at 15 57 14" src="https://user-images.githubusercontent.com/6051896/48425594-0fed8800-e75d-11e8-8212-0cf9e5cc1cee.png">

<img width="593" alt="screen shot 2018-11-13 at 15 57 26" src="https://user-images.githubusercontent.com/6051896/48425612-17ad2c80-e75d-11e8-844c-5b88ff7ba822.png">

Still need to think about how we add Contributors to the attribution. The data structure is different to the Creators from the old API

