### PR TITLE
Fix footer link a11y

### DIFF
--- a/common/styles/components/_footer.scss
+++ b/common/styles/components/_footer.scss
@@ -91,13 +91,9 @@ $footer-strap-width: 220px;
 }
 
 .footer__licensing-link {
-  color: color('green');
-  transition: color 600ms ease;
-  text-decoration: none;
-
   &:hover,
   &:focus {
-    color: color('white');
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
Darkening the green made the link in footer inaccessible. This leaves the default underline on the link in the footer and removes it on hover.

![screen shot 2018-11-13 at 18 02 03](https://user-images.githubusercontent.com/1394592/48433135-42ec4780-e76e-11e8-8d2c-ad5a9ecacb2f.png)
