### PR TITLE
remove iiif-presentation from query

### DIFF
--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -40,8 +40,7 @@ export const WorkPage = ({
 }: Props) => {
   const [iiifImageLocation] = work.items.map(
     item => item.locations.find(
-      location => location.locationType.id === 'iiif-image' ||
-                  location.locationType.id === 'iiif-presentation'
+      location => location.locationType.id === 'iiif-image'
     )
   ).filter(Boolean);
   const iiifInfoUrl = iiifImageLocation && iiifImageLocation.url;

--- a/catalogue/webapp/services/catalogue/worksv2.js
+++ b/catalogue/webapp/services/catalogue/worksv2.js
@@ -17,7 +17,7 @@ export async function getWorks({ query, page }: GetWorksProps): Object {
   const url = `${rootUri}/v2/works?include=${includes.join(',')}` +
     `&pageSize=100` +
     '&workType=q,k' +
-    '&items.locations.locationType=iiif-image,iiif-presentation' +
+    '&items.locations.locationType=iiif-image' +
     (query ? `&query=${encodeURIComponent(query)}` : '') +
     (page ? `&page=${page}` : '');
 


### PR DESCRIPTION
Fixes #3714

From the Platform team:
* We will be serving unmerged miro results
* They will have a `iiif-image` `locationType`
* They will have a thumbnail

This means we can swap to V2 without losing results, but not having gained many.
Also means we can look at things that have `iiif-presentation` locations properly, and no thumbnails properly.

;