### PR TITLE
Change turquoise to teal in serial colours

### DIFF
--- a/prismic-model/js/series.js
+++ b/prismic-model/js/series.js
@@ -15,7 +15,7 @@ import structuredText from './parts/structured-text';
 const ArticleSeries = {
   'Article series': {
     title: title,
-    color: select('Colour', [ 'turquoise', 'red', 'orange', 'purple' ]),
+    color: select('Colour', [ 'teal', 'red', 'orange', 'purple' ]),
     description: structuredText('[Deprecated] Description. Please use standfirst slice'),
     body
   },

--- a/prismic-model/json/series.json
+++ b/prismic-model/json/series.json
@@ -13,7 +13,7 @@
       "config": {
         "label": "Colour",
         "options": [
-          "turquoise",
+          "teal",
           "red",
           "orange",
           "purple"


### PR DESCRIPTION
Fixes #3716

I've updated the handful of serials that were using turquoise to use teal in Prismic, too.