### PR TITLE
an idea around some of the combined fields from API

### DIFF
--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -15,6 +15,7 @@ import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import SecondaryLink from '@weco/common/views/components/Links/SecondaryLink/SecondaryLink';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
+import {withToggler} from '@weco/common/views/hocs/withToggler';
 import {workLd} from '@weco/common/utils/json-ld';
 import WorkMedia from '../components/WorkMedia/WorkMedia';
 import {getWork} from '../services/catalogue/worksv2';
@@ -33,6 +34,78 @@ type Props = {|
   previousQueryString: ?string,
   page: ?number
 |}
+
+function trimCataloguingPunctuation(text: string) {
+  return text.trim().replace(/(.*)[;,:]+$/, '$1').trim();
+}
+function titleCase(text: string) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+type PhysicalDescriptionProps = {|
+  work: Work,
+  isActive: boolean,
+  toggle: () => void
+|}
+const PhysicalDescription = withToggler(
+  ({
+    work,
+    isActive,
+    toggle
+  }: PhysicalDescriptionProps) => {
+    return (
+      <Fragment>
+        <MetaUnit
+          headingLevel={1}
+          headingText={'Physical description'}
+          text={[
+            titleCase(trimCataloguingPunctuation(work.physicalDescription)) +
+            (work.extent && ` of ${trimCataloguingPunctuation(work.extent)}`) +
+            (work.dimensions && `. It's dimensions are "${trimCataloguingPunctuation(work.dimensions)}"`) +
+            '.'
+          ]}
+        />
+
+        <button onClick={toggle} className='plain-button no-padding no-margin flex flex--v-center font-teal font-HNL5-s'>
+          <Icon name='plus' extraClasses={`icon--match-text icon--green ${spacing({s: 1}, {margin: ['right']})}`} />
+          More details
+        </button>
+        <div style={{
+          display: isActive ? 'block' : 'none'
+        }}>
+          <MetaUnit headingLevel={3} headingText={'Catalogue entry'} text={[
+            [work.physicalDescription, work.extent, work.dimensions].filter(Boolean).join()
+          ]} />
+
+          <ul className={classNames({
+            'plain-list': true,
+            [font({s: 'HNL5'})]: true,
+            'no-margin': true,
+            'no-padding': true
+          })}>
+            {work.physicalDescription &&
+              <li>
+                <MetaUnit headingText='Physical description' headingLevel={3} text={[work.physicalDescription]} />
+              </li>
+            }
+            {work.extent &&
+              <li>
+                <MetaUnit headingText='Extent' headingLevel={3} text={[work.extent]} />
+              </li>
+            }
+            {work.dimensions &&
+              <li>
+                {work.dimensions &&
+                  <MetaUnit headingText='Dimensions' headingLevel={3} text={[work.dimensions]} />
+                }
+              </li>
+            }
+          </ul>
+        </div>
+      </Fragment>
+    );
+  }
+);
 
 export const WorkPage = ({
   work,
@@ -145,7 +218,6 @@ export const WorkPage = ({
                       </NextLink>);
                     }
                     )} />
-
                   }
 
                   {work.subjects.length > 0 &&
@@ -210,6 +282,10 @@ export const WorkPage = ({
                         <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.type}</a>
                       </NextLink>
                     ]} />
+                  }
+
+                  {(work.physicalDescription || work.extent || work.dimensions) &&
+                    <PhysicalDescription work={work} />
                   }
 
                   {encoreLink &&


### PR DESCRIPTION
Quick lunch time thought on data that is:
* Made from fields with subfields in Marc
* Then exploded into those subfields when ingested by the API
* But left with subfield punctuation in it

I wondered about or design principles<sup>draft</sup>, two being:
* Purposeful
* Language is explicit and informative

They seem they could be i contradiction on occasion, so I wondered, what if we apply both.

In the video is an attempt to turn the three fields into a sentence, explicit.
This is just `{description} of {extent}. It's dimensions are {dimensions}` with trailing `;,:` removed.

Then we explain how this sentence was formed, and what data we used to create it.
This is just the three separate fields, with them joined as they are in the catalogue record...

Felt it was easier to get my idea into code than explaining - so to be clear that's all it is.
![screencast-localhost-3000-2018 11 14-13-14-52](https://user-images.githubusercontent.com/31692/48485401-9c0cb780-e810-11e8-8e53-32a2946499fa.gif)



