### PR TITLE
Account for non-rendered standfirst being in body props

### DIFF
--- a/common/views/components/ContentPage/ContentPage.js
+++ b/common/views/components/ContentPage/ContentPage.js
@@ -36,6 +36,13 @@ const ContentPage = ({
   Siblings = [],
   outroProps
 }: Props) => {
+  // We don't want to add a spacing unit if there's nothing to render
+  // in the body (we don't render the 'standfirst' here anymore).
+  function shouldRenderBody() {
+    if (Body.props.body.length === 1 && Body.props.body[0].type === 'standfirst') return false;
+    if (Body.props.body.length > 0) return true;
+  }
+
   return (
     <PageBackgroundContext.Provider value={isCreamy ? 'cream' : 'white'}>
       <article data-wio-id={id}>
@@ -43,7 +50,7 @@ const ContentPage = ({
         <div className={classNames({
           'bg-cream': isCreamy
         })}>
-          {Body.props.body.length > 0 &&
+          {shouldRenderBody() &&
             <SpacingSection>
               <div className='basic-page'>
                 <Fragment>{Body}</Fragment>


### PR DESCRIPTION
We're still potentially adding an empty spacing component because the check for a non-empty body section didn't account for a standfirst slice ([which we now ignore since it has been moved to the header](https://github.com/wellcometrust/wellcomecollection.org/blob/master/common/views/components/Body/Body.js#L41)). 👇 Twice as much space as desired 👇 
 
<img width="650" alt="screen shot 2018-11-15 at 11 54 13" src="https://user-images.githubusercontent.com/1394592/48551359-392d2600-e8cd-11e8-9537-9808d2188c8d.png">

