### PR TITLE
remove old server and client steps from the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,20 +172,6 @@ jobs:
         name: Deploy
         command: |
           aws s3 sync ./out s3://dash.wellcomecollection.org/toggles --only-show-errors
-  install_server_modules:
-    docker:
-      - image: circleci/node:8.11.3
-    working_directory: ~/wellcomecollection.org/server
-    steps:
-      - restore_cache:
-          key: repo_{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: Install server modules
-          command: yarn install --production
-      - save_cache:
-          key: server_modules_circleci_node_8_{{ checksum "package.json" }}
-          paths:
-            -  node_modules
   install_common_modules:
     docker:
       - image: circleci/node:8.11.3
@@ -200,121 +186,6 @@ jobs:
           key: common_modules_circleci_node_8_{{ checksum "package.json" }}
           paths:
             -  node_modules
-  build_client:
-    docker:
-      - image: circleci/node:8.11.3
-    working_directory: ~/wellcomecollection.org/client
-    steps:
-      - restore_cache:
-          key: repo_{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: Install client modules
-          command: yarn install
-      - run:
-          name: Build client assets
-          command: yarn compile
-      - save_cache:
-          key: client_modules_circleci_node_8_{{ checksum "package.json" }}
-          paths:
-            -  node_modules
-      - save_cache:
-          key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
-          # We have the critical css here as it's the client app that is
-          # reponsible for compiling
-          paths:
-            -  ~/wellcomecollection.org/dist
-            -  ~/wellcomecollection.org/server/views/partials/critical.css.njk
-  build_common_webapp:
-    docker:
-      - image: circleci/node:8.11.3
-    working_directory: ~/wellcomecollection.org
-    steps:
-      - restore_cache:
-          key: repo_{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: server_modules_circleci_node_8_{{ checksum "server/package.json" }}
-      - restore_cache:
-          keys:
-            - common_modules_circleci_node_8_{{ checksum "package.json" }}
-            - common_modules_circleci_node_8_
-      - restore_cache:
-          key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: Build client
-          command: ./build-client.sh
-      - run:
-          name: Build prod config
-          command: ./build_prod_config.py
-      - run:
-          name: Build server
-          command: ./build-server.sh $CIRCLE_SHA1
-      - save_cache:
-          key: built_server_{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            -  ~/wellcomecollection.org/server
-      - save_cache:
-          key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            -  ~/wellcomecollection.org/dist
-  test_common_webapp:
-    docker:
-      - image: circleci/node:8.11.3
-    working_directory: ~/wellcomecollection.org
-    steps:
-      - restore_cache:
-          key: repo_{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: server_modules_circleci_node_8_{{ checksum "server/package.json" }}
-      - restore_cache:
-          keys:
-            - common_modules_circleci_node_8_{{ checksum "package.json" }}
-            - common_modules_circleci_node_8_
-      - restore_cache:
-          key: built_server_{{ .Environment.CIRCLE_SHA1 }}
-      - run:
-          name: Test server
-          command: pushd server && yarn run test && popd
-  deploy_common_webapp:
-    docker:
-      - image: circleci/node:8.11.3
-    working_directory: ~/wellcomecollection.org
-    steps:
-      - restore_cache:
-          key: repo_{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: built_server_{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
-      - add_ssh_keys
-      - setup_remote_docker
-      - run:
-          name: Deploy
-          command: |
-            docker login --username $DOCKER_USER --password $DOCKER_PASS
-            python ./.circleci/deploy_and_build_docker.py './' 'wellcome/wellcomecollection' $CIRCLE_SHA1
-            python ./.circleci/deploy_and_build_docker.py './nginx-proxy' 'wellcome/wellcomecollection-nginx-proxy' $CIRCLE_SHA1
-            python ./.circleci/deploy_and_build_docker.py './router' 'wellcome/wellcomecollection-router' $CIRCLE_SHA1
-            ./build-speedtracker.sh
-  deploy_assets:
-      docker:
-        - image: node:8.11.3
-      working_directory: /home/circleci/wellcomecollection.org/dist
-      steps:
-        - restore_cache:
-            key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
-        - add_ssh_keys
-        - run:
-            name: Install AWS CLI
-            command: |
-              # Taken from
-              # http://docs.aws.amazon.com/cli/latest/userguide/awscli-install-linux.html
-              apt-get -y -qq update
-              apt-get -y -qq install python3.4-dev
-              curl -O https://bootstrap.pypa.io/get-pip.py
-              python3.4 get-pip.py --user
-              export PATH=~/.local/bin:$PATH
-              pip install awscli --upgrade --user
-              aws s3 sync --only-show-errors . s3://i.wellcomecollection.org
   cardigan:
     docker:
       - image: node:8.11.3
@@ -322,8 +193,6 @@ jobs:
     steps:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
-      - restore_cache:
-          key: built_dist_{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
           keys:
             - common_modules_circleci_node_8_{{ checksum "package.json" }}
@@ -365,9 +234,6 @@ workflows:
       - content:
           requires:
             - checkout_code
-      - install_server_modules:
-          requires:
-            - checkout_code
       - install_common_modules:
           requires:
             - checkout_code
@@ -388,34 +254,6 @@ workflows:
       - root_tests:
           requires:
             - checkout_code
-      - build_client:
-          requires:
-            - checkout_code
-      - build_common_webapp:
-          requires:
-            - checkout_code
-            - root_tests
-            - build_client
-            - install_server_modules
-            - install_common_modules
-      - test_common_webapp:
-          requires:
-            - checkout_code
-            - build_common_webapp
-      - deploy_assets:
-          requires:
-            - test_common_webapp
-          filters:
-            branches:
-              only:
-                - master
-      - deploy_common_webapp:
-          requires:
-            - test_common_webapp
-          filters:
-            branches:
-              only:
-                - master
       - cardigan:
           requires:
             - checkout_code


### PR DESCRIPTION
Feels like removing it from here might show us the deps, which I think are none, then we can remove the code that this is relying on.

# removed steps:
* build_client
* build_common_webapp
* install_server_modules
* deploy_assets

# removed caches:
* client_modules_circleci_node_8_
* built_dist_
* built_server_