### PR TITLE
November 2018 release notes

### DIFF
--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -11,7 +11,7 @@ We have a lot of work to do, and we’ve only just begun.
 ## What's new?
 
 [The Platform team at Wellcome Collection](https://github.com/wellcometrust/platform),
-who looks after [our API](https://developers.wellcomecollection.org/catalogue)],
+who looks after [our API](https://developers.wellcomecollection.org/catalogue),
 have been up to beavering away to help enrich and expand the data we have
 available through our search.
 

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -11,7 +11,7 @@ We have a lot of work to do, and we’ve only just begun.
 ## What's new?
 
 [The Platform team at Wellcome Collection](https://github.com/wellcometrust/platform),
-who looks after (our API)[(https://developers.wellcomecollection.org/catalogue)],
+who looks after [our API](https://developers.wellcomecollection.org/catalogue)],
 have been up to beavering away to help enrich and expand the data we have
 available through our search.
 

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -12,11 +12,11 @@ We have a lot of work to do, and we’ve only just begun.
 
 [The Platform team at Wellcome Collection](https://github.com/wellcometrust/platform),
 who look after [our API](https://developers.wellcomecollection.org/catalogue),
-have been up to beavering away to help enrich and expand the data we have
+have been beavering away to help enrich and expand the data we have
 available through our search.
 
 We have been working on surfacing that data in a clear, purposeful, and
-beautiful fashion.
+beautiful fashion, to yourselves.
 
 * Works now come with a broader set of metadata
   * The creators field has been usurped by the richer contributors field which

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -18,13 +18,12 @@ available through our search.
 We have been working on surfacing that data in a clear, purposeful, and
 beautiful fashion, to yourselves.
 
-* Works now come with a broader set of metadata from the library catalogue
+* Works now come with a richer and more accurate set of data from the library catalogue
   * The creators field has been usurped by the richer contributors field which
     contains more information about the contributor's role, and more information about
-    the contributor
-  * Subjects and genres now have been expanded to have concepts attached to them
-  * The production of an object has now been split into production events, which
-    are made up of places, agents (people, organisation etc), and dates
+    the contributor, where the data is available.
+  * Subjects and genres now use the authoritative Library of Congress and Medical Subject Headings.
+  * The production of an object has now been split into production events, made up of places, agents (people, organisation etc), and dates.
 
 
 ## What's improved

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -11,7 +11,7 @@ We have a lot of work to do, and we’ve only just begun.
 ## What's new?
 
 [The Platform team at Wellcome Collection](https://github.com/wellcometrust/platform),
-who looks after [our API](https://developers.wellcomecollection.org/catalogue),
+who look after [our API](https://developers.wellcomecollection.org/catalogue),
 have been up to beavering away to help enrich and expand the data we have
 available through our search.
 

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -18,23 +18,23 @@ available through our search.
 We have been working on surfacing that data in a clear, purposeful, and
 beautiful fashion, to yourselves.
 
-* Works now come with a broader set of metadata
+* Works now come with a broader set of metadata from the library catalogue
   * The creators field has been usurped by the richer contributors field which
-    contains more information about the contributors role, and more information about
+    contains more information about the contributor's role, and more information about
     the contributor
-  * Subjects and genres have been expanded to have concepts attached to them
+  * Subjects and genres now have been expanded to have concepts attached to them
   * The production of an object has now been split into production events, which
     are made up of places, agents (people, organisation etc), and dates
 
 
 ## What's improved
 
-* Performance of search has been improved. When requesting 100 results,
+* Search performance has been improved. When requesting 100 results,
 they are, on average, rendered in less than a second.
 * When following the links in the metadata of a work, results will be more
 specific to the field you were linked from
   e.g. [Caricature as a subject](https://wellcomecollection.org/works?query=subject:"Caricature")
-  vs [Caricature as a general search](https://wellcomecollection.org/works?query="Caricature")
+  vs [Caricature as a keyword search](https://wellcomecollection.org/works?query="Caricature")
   ![Screenshot of the subject metadata on a work](https://user-images.githubusercontent.com/31692/48776683-6b24fa80-ecc8-11e8-9f2e-f66224f21dbf.png)
 
 We are always collecting feedback, so if you have any

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -4,6 +4,46 @@ We are working to make [wellcomecollection.org](https://wellcomecollection.org) 
 
 We have a lot of work to do, and we’ve only just begun.
 
+---
+
+# November 2018
+
+## What's new?
+
+[The Platform team here](https://github.com/wellcometrust/platform),
+who looks after (our API)[(https://developers.wellcomecollection.org/catalogue)]
+and the data in it, have been up to beavering away to help enrich and expand the
+data we have available through our search.
+
+We have been working on surfacing that data in a clear, purposeful, and
+beautiful fashion.
+
+* Works now come with a broader set of metadata
+  * The creators field has been usurped by the richer contributors field which.
+    contains more information about the contributors role, and more information about
+    the contributor.
+  * Subjects and genres have been expanded to have concepts attached to them
+  * The production of an object has now been split into production events, which
+    are made up of places, agents (people, organisation etc), and dates.
+
+
+## What's improved
+
+* Performance of search has been improved, averaging sub-second returning of 100
+results, and only loading in the interface data once, to save you your data.
+* We now search the field that the value was liked to from a work page, surfacing
+results more specifically relevant.
+  e.g. [Caricature as a subject](https://wellcomecollection.org/works?query=subject:"Caricature")
+  vs [Caricature as a general search](https://wellcomecollection.org/works?query="Caricature")
+  ![Screenshot of the subject metadata on a work](https://user-images.githubusercontent.com/31692/48776683-6b24fa80-ecc8-11e8-9f2e-f66224f21dbf.png)
+
+We are always collecting feedback, so if you have any
+[get involved, we’re listening!](#get-involved)
+
+---
+
+# January 2018
+
 ## What's changed?
 You can now find more than 110,000 free to use and openly licensed images from our former picture library, Wellcome Images.
 
@@ -41,7 +81,9 @@ Throughout 2018, you can expect to see improvements to the search experience. We
 
 For now, if you need any help in identifying items from library collections, please email collections@wellcome.ac.uk.
 
-## Get involved
+---
+
+# Get involved
 We want to share our work in progress with you, and to get your feedback throughout the development.
 
 If you’d like to help shape how this website works, we invite you to join our User Panel. We're looking for people at all levels of research experience to participate in the design process.

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -29,16 +29,16 @@ beautiful fashion, to yourselves.
 
 ## What's improved
 
-* Performance of search has been improved, averaging sub-second returning of 100
-results, and only loading in the interface data once, to save you your data
-* We now search the field that the value was liked to from a work page, surfacing
-results more specifically relevant
+* Performance of search has been improved. When requesting 100 results,
+they are, on average, rendered in less than a second.
+* When following the links in the metadata of a work, results will be more
+specific to the field you were linked from
   e.g. [Caricature as a subject](https://wellcomecollection.org/works?query=subject:"Caricature")
   vs [Caricature as a general search](https://wellcomecollection.org/works?query="Caricature")
   ![Screenshot of the subject metadata on a work](https://user-images.githubusercontent.com/31692/48776683-6b24fa80-ecc8-11e8-9f2e-f66224f21dbf.png)
 
 We are always collecting feedback, so if you have any
-[get involved, we’re listening!](#get-involved)
+[👂 get involved, we’re listening 👂!](#get-involved)
 
 ---
 

--- a/catalogue/webapp/pages/PROGRESS_NOTES.md
+++ b/catalogue/webapp/pages/PROGRESS_NOTES.md
@@ -10,29 +10,29 @@ We have a lot of work to do, and we’ve only just begun.
 
 ## What's new?
 
-[The Platform team here](https://github.com/wellcometrust/platform),
-who looks after (our API)[(https://developers.wellcomecollection.org/catalogue)]
-and the data in it, have been up to beavering away to help enrich and expand the
-data we have available through our search.
+[The Platform team at Wellcome Collection](https://github.com/wellcometrust/platform),
+who looks after (our API)[(https://developers.wellcomecollection.org/catalogue)],
+have been up to beavering away to help enrich and expand the data we have
+available through our search.
 
 We have been working on surfacing that data in a clear, purposeful, and
 beautiful fashion.
 
 * Works now come with a broader set of metadata
-  * The creators field has been usurped by the richer contributors field which.
+  * The creators field has been usurped by the richer contributors field which
     contains more information about the contributors role, and more information about
-    the contributor.
+    the contributor
   * Subjects and genres have been expanded to have concepts attached to them
   * The production of an object has now been split into production events, which
-    are made up of places, agents (people, organisation etc), and dates.
+    are made up of places, agents (people, organisation etc), and dates
 
 
 ## What's improved
 
 * Performance of search has been improved, averaging sub-second returning of 100
-results, and only loading in the interface data once, to save you your data.
+results, and only loading in the interface data once, to save you your data
 * We now search the field that the value was liked to from a work page, surfacing
-results more specifically relevant.
+results more specifically relevant
   e.g. [Caricature as a subject](https://wellcomecollection.org/works?query=subject:"Caricature")
   vs [Caricature as a general search](https://wellcomecollection.org/works?query="Caricature")
   ![Screenshot of the subject metadata on a work](https://user-images.githubusercontent.com/31692/48776683-6b24fa80-ecc8-11e8-9f2e-f66224f21dbf.png)


### PR DESCRIPTION
Adds the new release notes at the top of the page, beneath the general blurb.

Notes:
* I've left off the fact that there are more results, as there actually aren't. It's about even. Some queries are returning more, some less, I am trying to chat to the content team to see what's going on with those.
* I've left off anything coming up, as it feel like, if we do tis regularly, that would be better. We might need to remember when we've used user feedback so we can let people know! Maybe we do this every Demo?
- [x] WIP: There's a couple of sentences to finish

Good read on this: https://slackhq.com/a-little-thing-about-release-notes#