### PR TITLE
Add global option to change width of viewport column from select 'knob'

### DIFF
--- a/cardigan/.storybook/config.js
+++ b/cardigan/.storybook/config.js
@@ -2,7 +2,7 @@ import { default as React, Fragment } from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { setOptions } from '@storybook/addon-options';
 import { checkA11y } from '@storybook/addon-a11y';
-import { withKnobs } from '@storybook/addon-knobs/react';
+import { withKnobs, select } from '@storybook/addon-knobs/react';
 import { withInfo } from '@storybook/addon-info';
 import styleguideSass from '../../common/styles/styleguide.scss';
 
@@ -30,17 +30,22 @@ addDecorator(withInfo({
 const styles = {
   padding: '30px',
 };
-const CenterDecorator = (storyFn) => (
-  <Fragment>
-    <style id='styleguide-sass'>
-      {styleguideSass}
-    </style>
-    <div style={styles} className='enhanced'>
-      { storyFn() }
+const PageDecorator = storyFn => {
+  const width = select('Width', ['25%', '50%', '75%', '100%'], '100%');
+
+  return (
+    <div style={{width}}>
+      <style id='styleguide-sass'>
+        {styleguideSass}
+      </style>
+      <div style={styles} className='enhanced'>
+        { storyFn() }
+      </div>
     </div>
-  </Fragment>
-);
-addDecorator(CenterDecorator);
+  );
+};
+
+addDecorator(PageDecorator);
 
 setOptions({
   name: 'Cardigan',


### PR DESCRIPTION
An idea based on what @GarethOrmerod was saying about Cardigan always showing everything at 100% wide.

Adds an option to all stories to set the width of the displayed component to 25%, 50%, 75% or 100%.

Not sure if there's maybe a nicer way… maybe certain components could have e.g. a max-width knob defaulted to some value.

![screen shot 2018-11-20 at 17 56 40](https://user-images.githubusercontent.com/1394592/48793160-fbc20180-eced-11e8-94ae-a29c3ec4ce1a.png)
