### PR TITLE
add paginator to catalogue

### DIFF
--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -35,17 +35,15 @@ export const Works = ({
   const [works, setWorks] = useState(initialWorks);
   const [page, setPage] = useState(initialPage);
   const [loading, setLoading] = useState(false);
-  // 1. We use this as we get the `initalWorks` from `getInitialProps`
-  //    Whereas standard React apps would fetch on first render
-  //    See: https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables
-  const firstRender = useRef(true);
-
   useEffect(() => {
     document.title = `${query} | Catalogue search | Wellcome Collection`;
   }, [query]);
 
+  // 1. We use this as we get the `initalWorks` from `getInitialProps`
+  //    Whereas standard React apps would fetch on first render
+  //    See: https://reactjs.org/docs/hooks-faq.html#is-there-something-like-instance-variables
+  const firstRender = useRef(true);
   useEffect(() => {
-    // Don't run this on first render, see comment 1. above
     if (firstRender.current) {
       firstRender.current = false;
       return;

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -216,7 +216,18 @@ export const Works = ({
           <div className='container'>
             <div className='grid'>
               <div className={grid({s: 12, m: 10, l: 8, xl: 8})}>
-                <p className='h1'>We couldn{`'`}t find anything that matched {query}.</p>
+                <p className='h1'>
+                  We couldn{`'`}t find anything that matched
+                  {' '}
+                  <span
+                    className={classNames({
+                      [font({s: 'HNL1'})]: true
+                    })}
+                    style={{fontWeight: '400'}}
+                  >
+                    {query}
+                  </span>.
+                </p>
               </div>
             </div>
           </div>

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -10,7 +10,7 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import SearchBox from '@weco/common/views/components/SearchBox/SearchBox';
 import StaticWorksContent from '@weco/common/views/components/StaticWorksContent/StaticWorksContent';
 import WorkPromo from '@weco/common/views/components/WorkPromo/WorkPromo';
-import Pagination, {PaginationFactory} from '@weco/common/views/components/Pagination/Pagination';
+import Paginator from '@weco/common/views/components/Paginator/Paginator';
 import type {
   GetInitialPropsProps,
   ExtraProps
@@ -34,21 +34,6 @@ export const Works = ({
   const [query, setQuery] = useState(initialQuery);
   const [works, setWorks] = useState(initialWorks);
   const [page, setPage] = useState(initialPage);
-  const pagination = works ? PaginationFactory.fromList(
-    works.results,
-    Number(works.totalResults) || 1,
-    Number(page) || 1,
-    works.pageSize || 1,
-    {query: query || ''}
-  ) : null;
-
-  // https://reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops
-  // Make sure if we're using the Pagination element, which reinitialised the
-  // `getInitialProps` we set the works to the `initialWorks` from that function
-  if (page !== initialPage && query === initialQuery) {
-    setPage(initialPage);
-    setWorks(initialWorks);
-  }
 
   useEffect(() => {
     // Update the document title using the browser API
@@ -97,16 +82,16 @@ export const Works = ({
                   event.preventDefault();
                   const form = event.currentTarget;
                   // $FlowFixMe
-                  const value = form.elements.query.value;
+                  const query = form.elements.query.value;
                   const page = 1;
-                  const newWorks = value ? await getWorks({ query: value, page, filters }) : null;
+                  const newWorks = query ? await getWorks({ query, page, filters }) : null;
                   setWorks(newWorks);
-                  setQuery(value);
+                  setQuery(query);
                   setPage(1);
 
                   Router.push(
-                    worksV2Link({ query: value, page: undefined }).href,
-                    worksV2Link({ query: value, page: undefined }).as,
+                    worksV2Link({ query, page: undefined }).href,
+                    worksV2Link({ query, page: undefined }).as,
                     { shallow: true }
                   );
                 }} />
@@ -130,34 +115,38 @@ export const Works = ({
         <StaticWorksContent />
       }
 
-      {query &&
+      {works && works.results.length > 0 &&
         <Fragment>
-          {pagination && pagination.range &&
-            <div className={`row ${spacing({s: 3, m: 5}, {padding: ['top']})}`}>
-              <div className='container'>
-                <div className='grid'>
-                  <div className='grid__cell'>
-                    <div className='flex flex--h-space-between flex--v-center'>
+          <div className={`row ${spacing({s: 3, m: 5}, {padding: ['top']})}`}>
+            <div className='container'>
+              <div className='grid'>
+                <div className='grid__cell'>
+                  <div className='flex flex--h-space-between flex--v-center'>
+                    <Fragment>
+                      <Paginator
+                        currentPage={page}
+                        pageSize={works.pageSize}
+                        totalResults={works.totalResults}
+                        link={worksV2Link({query, page})}
+                        onPageChange={async (event, page) => {
+                          event.preventDefault();
+                          const newWorks = await getWorks({ query, page, filters });
+                          setWorks(newWorks);
+                          setPage(page);
 
-                      <Fragment>
-                        <div className={`flex flex--v-center font-pewter ${font({s: 'LR3', m: 'LR2'})}`}>
-                            Showing {pagination.range.beginning} - {pagination.range.end}
-                        </div>
-                        <Pagination
-                          total={pagination.total}
-                          prevPage={pagination.prevPage}
-                          currentPage={pagination.currentPage}
-                          pageCount={pagination.pageCount}
-                          nextPage={pagination.nextPage}
-                          nextQueryString={pagination.nextQueryString}
-                          prevQueryString={pagination.prevQueryString} />
-                      </Fragment>
-                    </div>
+                          Router.push(
+                            worksV2Link({ query, page }).href,
+                            worksV2Link({ query, page }).as,
+                            { shallow: true }
+                          );
+                        }}
+                      />
+                    </Fragment>
                   </div>
                 </div>
               </div>
             </div>
-          }
+          </div>
 
           <div className={`row ${spacing({s: 4}, {padding: ['top']})}`}>
             <div className='container'>
@@ -181,32 +170,36 @@ export const Works = ({
             </div>
           </div>
 
-          {pagination && pagination.range &&
-            <div className={`row ${spacing({s: 10}, {padding: ['top', 'bottom']})}`}>
-              <div className='container'>
-                <div className='grid'>
-                  <div className='grid__cell'>
-                    <div className='flex flex--h-space-between flex--v-center'>
+          <div className={`row ${spacing({s: 10}, {padding: ['top', 'bottom']})}`}>
+            <div className='container'>
+              <div className='grid'>
+                <div className='grid__cell'>
+                  <div className='flex flex--h-space-between flex--v-center'>
+                    <Fragment>
+                      <Paginator
+                        currentPage={page}
+                        pageSize={works.pageSize}
+                        totalResults={works.totalResults}
+                        link={worksV2Link({query, page})}
+                        onPageChange={async (event, page) => {
+                          event.preventDefault();
+                          const newWorks = await getWorks({ query, page, filters });
+                          setWorks(newWorks);
+                          setPage(page);
 
-                      <Fragment>
-                        <div className={`flex flex--v-center font-pewter ${font({s: 'LR3', m: 'LR2'})}`}>
-                          Showing {pagination.range.beginning} - {pagination.range.end}
-                        </div>
-                        <Pagination
-                          total={pagination.total}
-                          prevPage={pagination.prevPage}
-                          currentPage={pagination.currentPage}
-                          pageCount={pagination.pageCount}
-                          nextPage={pagination.nextPage}
-                          nextQueryString={pagination.nextQueryString}
-                          prevQueryString={pagination.prevQueryString} />
-                      </Fragment>
-                    </div>
+                          Router.push(
+                            worksV2Link({ query, page }).href,
+                            worksV2Link({ query, page }).as,
+                            { shallow: true }
+                          );
+                        }}
+                      />
+                    </Fragment>
                   </div>
                 </div>
               </div>
             </div>
-          }
+          </div>
         </Fragment>
       }
     </Fragment>

--- a/common/views/components/Buttons/Control/Control.js
+++ b/common/views/components/Buttons/Control/Control.js
@@ -1,5 +1,4 @@
 // @flow
-import NextLink from 'next/link';
 import Icon from '../../Icon/Icon';
 import type {GaEvent} from '../../../../utils/ga';
 
@@ -36,6 +35,7 @@ const Control = ({
 }: Props) => {
   const attrs = {
     id: id,
+    href: url,
     className: `control control--${type} ${extraClasses || ''}`,
     'data-track-event': trackingEvent && JSON.stringify(trackingEvent),
     disabled: disabled,
@@ -43,7 +43,7 @@ const Control = ({
   };
 
   return url
-    ? <NextLink href={url}><a {...attrs}><InnerControl text={text} icon={icon} /></a></NextLink>
+    ? <a {...attrs}><InnerControl text={text} icon={icon} /></a>
     : <button {...attrs}><InnerControl text={text} icon={icon} /></button>;
 };
 

--- a/common/views/components/Pagination/Pagination.js
+++ b/common/views/components/Pagination/Pagination.js
@@ -1,4 +1,5 @@
 // @flow
+import NextLink from 'next/link';
 import {font, spacing} from '../../../utils/classnames';
 import Control from '../Buttons/Control/Control';
 
@@ -26,23 +27,27 @@ const Pagination = ({
 }: Props) => (
   <div className={`pagination float-r flex-inline flex--v-center font-pewter ${font({s: 'LR3', m: 'LR2'})}`}>
     {prevPage && prevQueryString &&
-      <Control
-        type='light'
-        url={prevQueryString}
-        extraClasses={`icon--180 ${spacing({s: 2}, {margin: ['right']})}`}
-        icon='arrow'
-        text={`Previous (page ${prevPage})`} />
+      <NextLink href={prevQueryString}>
+        <Control
+          type='light'
+          url={prevQueryString}
+          extraClasses={`icon--180 ${spacing({s: 2}, {margin: ['right']})}`}
+          icon='arrow'
+          text={`Previous (page ${prevPage})`} />
+      </NextLink>
     }
 
     <span>Page {currentPage} of {pageCount}</span>
 
     {nextPage && nextQueryString &&
-      <Control
-        type='light'
-        url={nextQueryString}
-        extraClasses={`${spacing({s: 2}, {margin: ['left']})}`}
-        icon='arrow'
-        text={`Next (page ${nextPage})`} />
+      <NextLink href={nextQueryString}>
+        <Control
+          type='light'
+          url={nextQueryString}
+          extraClasses={`${spacing({s: 2}, {margin: ['left']})}`}
+          icon='arrow'
+          text={`Next (page ${nextPage})`} />
+      </NextLink>
     }
   </div>
 );

--- a/common/views/components/Pagination/Pagination.js
+++ b/common/views/components/Pagination/Pagination.js
@@ -28,12 +28,13 @@ const Pagination = ({
   <div className={`pagination float-r flex-inline flex--v-center font-pewter ${font({s: 'LR3', m: 'LR2'})}`}>
     {prevPage && prevQueryString &&
       <NextLink href={prevQueryString}>
-        <Control
-          type='light'
-          url={prevQueryString}
-          extraClasses={`icon--180 ${spacing({s: 2}, {margin: ['right']})}`}
-          icon='arrow'
-          text={`Previous (page ${prevPage})`} />
+        <a>
+          <Control
+            type='light'
+            extraClasses={`icon--180 ${spacing({s: 2}, {margin: ['right']})}`}
+            icon='arrow'
+            text={`Previous (page ${prevPage})`} />
+        </a>
       </NextLink>
     }
 
@@ -41,12 +42,13 @@ const Pagination = ({
 
     {nextPage && nextQueryString &&
       <NextLink href={nextQueryString}>
-        <Control
-          type='light'
-          url={nextQueryString}
-          extraClasses={`${spacing({s: 2}, {margin: ['left']})}`}
-          icon='arrow'
-          text={`Next (page ${nextPage})`} />
+        <a>
+          <Control
+            type='light'
+            extraClasses={`${spacing({s: 2}, {margin: ['left']})}`}
+            icon='arrow'
+            text={`Next (page ${nextPage})`} />
+        </a>
       </NextLink>
     }
   </div>

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -1,0 +1,120 @@
+// @flow
+import {Fragment} from 'react';
+import NextLink from 'next/link';
+import {classNames, font, spacing} from '../../../utils/classnames';
+import Control from '../Buttons/Control/Control';
+
+type Link = {|
+  pathname: string,
+  query: Object,
+|}
+
+type LinkProps = {|
+  href: Link,
+  as: Link
+|}
+
+type PageChangeFunction = (event: Event, page: number) => Promise<void>
+
+type Props = {|
+  currentPage: number,
+  pageSize: number,
+  totalResults: number,
+  link: LinkProps,
+  onPageChange: PageChangeFunction
+|}
+
+const Paginator = ({
+  currentPage,
+  pageSize,
+  totalResults,
+  link,
+  onPageChange
+}: Props) => {
+  const totalPages = Math.ceil(totalResults / pageSize);
+  const next = currentPage < totalPages ? currentPage + 1 : null;
+  const prev = currentPage > 1 ? currentPage - 1 : null;
+  const rangeStart = (pageSize * currentPage) - (pageSize - 1);
+  const rangeEnd = (pageSize * currentPage);
+
+  const prevLink = prev ? {
+    href: {
+      ...link.href,
+      query: {
+        ...link.href.query,
+        page: prev
+      }
+    },
+    as: {
+      ...link.as,
+      query: {
+        ...link.as.query,
+        page: prev
+      }
+    }
+  } : null;
+
+  const nextLink = next ? {
+    href: {
+      ...link.href,
+      query: {
+        ...link.href.query,
+        page: next
+      }
+    },
+    as: {
+      ...link.as,
+      query: {
+        ...link.as.query,
+        page: next
+      }
+    }
+  } : null;
+
+  return (
+    <Fragment>
+      <div className={`flex flex--v-center font-pewter ${font({s: 'LR3', m: 'LR2'})}`}>
+        Showing {rangeStart} - {rangeEnd}
+      </div>
+      <div className={classNames({
+        'pagination': true,
+        'float-r': true,
+        'flex-inline': true,
+        'flex--v-center': true,
+        'font-pewter': true,
+        [font({s: 'LR3', m: 'LR2'})]: true
+      })}>
+        {prev &&
+          <NextLink {...prevLink}>
+            <a onClick={(event) => {
+              onPageChange(event, prev);
+            }}>
+              <Control
+                type='light'
+                extraClasses={`icon--180 ${spacing({s: 2}, {margin: ['right']})}`}
+                icon='arrow'
+                text={`Previous (page ${prev})`} />
+            </a>
+          </NextLink>
+        }
+
+        <span>Page {currentPage} of {totalPages}</span>
+
+        {next &&
+          <NextLink {...nextLink}>
+            <a onClick={(event) => {
+              onPageChange(event, next);
+            }}>
+              <Control
+                type='light'
+                extraClasses={`${spacing({s: 2}, {margin: ['left']})}`}
+                icon='arrow'
+                text={`Next (page ${next})`} />
+            </a>
+          </NextLink>
+        }
+      </div>
+    </Fragment>
+  );
+};
+export default Paginator;


### PR DESCRIPTION
Starts to use the `useEffect` hooks for fetching data.

We now have the `query` and `page` state, that when changed, trigger the effect of setting loading, change the URL and fetching the works.

There's a couple of `TODO`s but it feels like the code is concise and then interface responds much more fluidly.

![hooks](https://user-images.githubusercontent.com/31692/48831230-53a04d00-ed6e-11e8-8beb-1cdb4940cd3b.gif)
 