### PR TITLE
Re-add serial ('series') dimension data to GA tracking

### DIFF
--- a/common/utils/analytics.js
+++ b/common/utils/analytics.js
@@ -53,6 +53,10 @@ export default ({ category, contentType, pageState, featuresCohort }: Props) => 
   if (category) {
     ReactGA.set({'dimension2': category});
   };
+
+  if (pageState.serial) {
+    ReactGA.set({'dimension3': pageState.serial});
+  }
   if (featuresCohort && featuresCohort !== 'default') {
     ReactGA.set({'dimension5': featuresCohort});
   }

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -41,6 +41,18 @@ function articleHasOutro(article: Article) {
   );
 }
 
+function serialForGa(article: Article) {
+  const serial = article.series.find(series => series.schedule.length > 0);
+  const serialTitles = serial && serial.schedule.map(item => item.title);
+  const serialIds = serial && serial.schedule.map(item => item.id);
+  const positionInSerial = serialTitles && serialTitles.indexOf(article.title) + 1;
+
+  return positionInSerial &&
+    serialTitles &&
+    serialIds &&
+    `${serialTitles[positionInSerial]}:${serialIds[positionInSerial]}`;
+}
+
 export class ArticlePage extends Component<Props, State> {
   state = {
     listOfSeries: []
@@ -64,7 +76,10 @@ export class ArticlePage extends Component<Props, State> {
         siteSection: 'stories',
         analyticsCategory: 'editorial',
         pageJsonLd: articleLd(article),
-        pageState: {hasOutro: articleHasOutro(article)}
+        pageState: {
+          serial: serialForGa(article),
+          hasOutro: articleHasOutro(article)
+        }
       };
     } else {
       return {statusCode: 404};


### PR DESCRIPTION
## Who is this for?
@hthair 

This reinstates the tracking in the form `title:id` e.g. `The Secret GP:W3RdtCkAACgAF706`. Is this still appropriate? Could/should this wait till we have a larger GA discussion/sprint?

## What is it doing for them?
Allowing them to track serial performance using a custom GA dimension (erroneously removed when moving to NextJS).