### PR TITLE
setup basic structure for document => app => page rendering in nextjs

### DIFF
--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -84,6 +84,7 @@ module.exports = app.prepare().then(async () => {
   // Next routing
   route('/embed/works/:id', '/embed', router, app);
   route('/works/progress', '/progress', router, app);
+  route('/works/progresss', '/progresss', router, app);
   route('/works/:id', '/work', router, app);
   route('/worksv2/:id', '/workv2', router, app);
   route('/worksv2', '/worksv2', router, app);

--- a/catalogue/webapp/pages/_app.js
+++ b/catalogue/webapp/pages/_app.js
@@ -1,0 +1,38 @@
+// @flow
+import React from 'react';
+import App, { Container } from 'next/app';
+
+const isServer = typeof window === 'undefined';
+const isClient = !isServer;
+let toggles = {};
+
+class WecoApp extends App {
+  static async getInitialProps({ Component, router, ctx }) {
+    toggles = isServer ? router.query.toggles : toggles;
+
+    let pageProps = {};
+    if (Component.getInitialProps) {
+      pageProps = await Component.getInitialProps(ctx);
+    }
+
+    return { pageProps, toggles: toggles };
+  }
+
+  constructor(props) {
+    if (isClient && !toggles) { toggles = props.toggles; }
+
+    super(props);
+  }
+
+  render () {
+    const { Component, pageProps } = this.props;
+
+    return (
+      <Container>
+        <Component {...pageProps} />
+      </Container>
+    );
+  }
+}
+
+export default WecoApp;

--- a/catalogue/webapp/pages/_document.js
+++ b/catalogue/webapp/pages/_document.js
@@ -1,4 +1,29 @@
-import WecoDoc from '@weco/common/views/pages/_document';
-// $FlowFixMe
-import css from '@weco/common/styles/works.scss';
-export default WecoDoc(css);
+// _document is only rendered on the server side and not on the client side
+// Event handlers like onClick can't be added to this file
+
+// ./pages/_document.js
+import Document, { Head, Main, NextScript } from 'next/document';
+import getConfig from 'next/config';
+const {serverRuntimeConfig} = getConfig();
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    const openingTimes = serverRuntimeConfig.getPrismicOpeningTimes();
+    return (
+      <html>
+        <Head>
+          <style>{`body { margin: 0 } /* custom! */`}</style>
+        </Head>
+        <body className='custom_class'>
+          <Main />
+          <NextScript />
+        </body>
+      </html>
+    );
+  }
+}

--- a/catalogue/webapp/pages/progresss.js
+++ b/catalogue/webapp/pages/progresss.js
@@ -1,8 +1,8 @@
 // @flow
-import ReactMarkdown from 'react-markdown';
 import Link from 'next/link';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import {spacing, grid} from '@weco/common/utils/classnames';
+import ReactMarkdown from 'react-markdown';
 // $FlowFixMe
 import PROGRESS_NOTES from './PROGRESS_NOTES.md';
 
@@ -20,9 +20,7 @@ const ProgressPage = () => (
     imageUrl={null}
     imageAltText={null}
     oEmbedUrl={null}>
-
-    <Link href='/progresss' as='/works/progresss'><a>Prog</a></Link>
-
+    <Link href='/progress'><a>BACK!</a></Link>
     <div className={`row ${spacing({s: 5}, {padding: ['top']})}`}>
       <div className='container'>
         <div className='grid'>

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -35,7 +35,7 @@ export const Works = ({
   const [page, setPage] = useState(initialPage);
   const [loading, setLoading] = useState(false);
   useEffect(() => {
-    document.title = `${query} | Catalogue search | Wellcome Collection`;
+    document.title = `${query ? `${query} | ` : ''}Catalogue search | Wellcome Collection`;
   }, [query]);
 
   // 1. If `initialWorks` are sent down, we don't fetch them on initial render
@@ -256,7 +256,7 @@ Works.getInitialProps = async (
     initialWorks: works,
     initialQuery: query,
     filters,
-    title: `${query} | Catalogue search | Wellcome Collection`,
+    title: `${query ? `${query} | ` : ''}Catalogue search | Wellcome Collection`,
     description: 'Search through the Wellcome Collection image catalogue',
     analyticsCategory: 'collections',
     siteSection: 'images',

--- a/catalogue/webapp/yarn.lock
+++ b/catalogue/webapp/yarn.lock
@@ -1126,6 +1126,7 @@
     react "^16.2.0"
     react-dom "^16.2.0"
     react-ga "^2.4.1"
+    react-transition-group "^2.5.0"
     search-query-parser "^1.3.0"
     superagent "^3.8.3"
     unleash-client "^3.1.0"
@@ -6020,7 +6021,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-tokens@^4.0.0:
+"js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
@@ -6442,6 +6443,13 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -8350,6 +8358,16 @@ react-transition-group@^2.4.0:
   dependencies:
     dom-helpers "^3.3.1"
     loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.5.0.tgz#70bca0e3546102c4dc5cf3f5f57f73447cce6874"
+  integrity sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==
+  dependencies:
+    dom-helpers "^3.3.1"
+    loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 

--- a/common/koa-middleware/withToggles.js
+++ b/common/koa-middleware/withToggles.js
@@ -21,7 +21,7 @@ function withToggles(ctx, next) {
     });
   }, {});
 
-  ctx.toggles = toggles;
+  ctx.toggles = {...toggles, help: 1};
 
   return next();
 }

--- a/common/next/get-prismic-global-alert.js
+++ b/common/next/get-prismic-global-alert.js
@@ -1,0 +1,19 @@
+const Prismic = require('prismic-javascript');
+
+let globalAlert = {
+  text: [ { type: 'paragraph',
+    text: null,
+    spans: null } ],
+  isShown: 'hide'
+};
+async function getAndSetGlobalAlert() {
+  try {
+    const api = await Prismic.getApi('https://wellcomecollection.prismic.io/api/v2');
+    const document = await api.getSingle('global-alert');
+    globalAlert = document.data;
+  } catch (e) {
+    // TODO: Alert to sentry
+  }
+}
+setInterval(getAndSetGlobalAlert, 6000);
+module.exports = { getPrismicGlobalAlert: () => globalAlert };

--- a/common/next/get-prismic-opening-times.js
+++ b/common/next/get-prismic-opening-times.js
@@ -1,0 +1,14 @@
+const Prismic = require('prismic-javascript');
+
+let openingTimes = {results: []};
+async function getAndSetOpeningTimes() {
+  try {
+    const api = await Prismic.getApi('https://wellcomecollection.prismic.io/api/v2');
+    openingTimes = await api.query([Prismic.Predicates.any('document.type', ['collection-venue'])]);
+  } catch (e) {
+
+  }
+}
+
+setInterval(getAndSetOpeningTimes, 6000);
+module.exports = {getPrismicOpeningTimes: () => openingTimes};

--- a/common/next/next.config.js
+++ b/common/next/next.config.js
@@ -1,6 +1,9 @@
 const path = require('path');
 const withTM = require('@weco/next-plugin-transpile-modules');
 const withBundleAnalyzer = require('@zeit/next-bundle-analyzer');
+const {getPrismicOpeningTimes} = require('./get-prismic-opening-times');
+const {getPrismicGlobalAlert} = require('./get-prismic-global-alert');
+
 const buildHash = process.env.BUILD_HASH || 'test';
 const commonDirRegExp = /@weco(?!.*node_modules)/;
 
@@ -59,6 +62,10 @@ module.exports = function(webpack, assetPrefix) {
   const isProd = process.env.NODE_ENV === 'production';
   return withTM({
     assetPrefix: isProd ? `https://${assetPrefix}.wellcomecollection.org` : '',
+    serverRuntimeConfig: {
+      getPrismicOpeningTimes,
+      getPrismicGlobalAlert
+    },
     transpileModules: ['@weco'],
     ...withBundleAnalyzerConfig
   });

--- a/common/views/components/DefaultPageLayout/DefaultPageLayout.config.js
+++ b/common/views/components/DefaultPageLayout/DefaultPageLayout.config.js
@@ -1,1 +1,0 @@
-export const hidden = true;

--- a/common/views/components/PageLayout/JsonLd.js
+++ b/common/views/components/PageLayout/JsonLd.js
@@ -1,0 +1,20 @@
+// @flow
+
+export type JsonLdType = { '@type': string }
+
+type Props = {|
+  data: JsonLdType
+|}
+
+const JsonLd = ({
+  data
+}: Props) => {
+  return (
+    <script
+      type='application/ld+json'
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}>
+    </script>
+  );
+};
+
+export default JsonLd;

--- a/common/views/components/PageLayout/OpenGraphMetadata.js
+++ b/common/views/components/PageLayout/OpenGraphMetadata.js
@@ -1,0 +1,85 @@
+// @flow
+import {Fragment} from 'react';
+
+type GenericProps = {|
+  type: 'website',
+  title: string,
+  description: string,
+  url: string,
+  imageUrl: ?string,
+|}
+
+export type OgWebsite = {|
+  ...GenericProps,
+  type: 'website'
+|}
+
+export type OgProfile = {|
+  ...GenericProps,
+  type: 'profile',
+  first_name: OgProfile[],
+  username: string,
+  // Let's not use this, it's crap, but it is defined in the spec
+  // see: http://ogp.me/#type_profile
+  gender: 'male' | 'female'
+|}
+
+export type OgArticle = {|
+  ...GenericProps,
+  type: 'article',
+  modified_time: Date,
+  expiration_time: ?Date,
+  author: OgProfile[],
+  section: ?string,
+  tag: ?string[],
+|}
+
+export type OgBook = {|
+  ...GenericProps,
+  type: 'book',
+  author: OgProfile[],
+  isbn: string,
+  release_date: Date,
+  tag: ?string[],
+|}
+
+type Props = GenericProps;
+
+// type Props =
+//   | OgWebsite
+//   | OgProfile
+//   | OgArticle
+//   | OgBook;
+
+const OpenGraphMetaData = (props: Props) => {
+  const {
+    type,
+    title,
+    description,
+    url,
+    imageUrl
+  } = props;
+  return (
+    <Fragment>
+      <meta property='og:site_name' content='Wellcome Collection' />
+      <meta property='og:type' content={type} />
+      <meta property='og:title' content={title} />
+      <meta property='og:description' content={description} />
+      <meta property='og:url' content={url} />
+      {/* we add itemprop="image" as it's required for WhatsApp */}
+      {imageUrl && <meta key='og:image' property='og:image' content={imageUrl} itemProp='image' />}
+      {imageUrl && <meta key='og:image:width' property='og:image:width' content='1200' />}
+      {/* Object.keys(typeProps).map(key => {
+        return  (
+          <meta
+            key={`og:${type}:${key}`}
+            property={`og:${type}:${key}`}
+            // For some reason flow allows all keys from all union types here
+            // $FlowFixMe
+            content={typeProps[key]} />
+        );
+      }) */}
+    </Fragment>
+  );
+};
+export default OpenGraphMetaData;

--- a/common/views/components/PageLayout/PageLayout.js
+++ b/common/views/components/PageLayout/PageLayout.js
@@ -1,0 +1,92 @@
+// @flow
+import type {Node} from 'react';
+import type {JsonLdType} from './JsonLd';
+import {Component, Fragment} from 'react';
+import Head from 'next/head';
+import JsonLd from './JsonLd';
+import OpenGraphMetadata from './OpenGraphMetadata';
+import TwitterMetadata from './TwitterMetadata';
+
+const polyfillFeatures = [
+  'default',
+  'Array.prototype.find',
+  'Array.prototype.includes',
+  'WeakMap'
+];
+
+type Props = {|
+  title: string,
+  description: string,
+  url: string,
+  jsonLd: JsonLdType,
+  ogType: 'website',
+  oEmbedUrl: ?string,
+  imageUrl: ?string,
+  imageAltText: ?string,
+  children: Node
+|}
+
+class PageLayout extends Component<Props> {
+  render() {
+    const {
+      title,
+      description,
+      url,
+      jsonLd,
+      ogType,
+      imageUrl,
+      imageAltText,
+      oEmbedUrl,
+      children
+    } = this.props;
+    const absoluteUrl = `https://wellcomecollection.org${url}`;
+
+    return (
+      <Fragment>
+        <Head>
+          <meta charSet='utf-8' />
+          <meta httpEquiv='X-UA-Compatible' content='IE=edge,chrome=1' />
+          <title>{title}</title>
+          <link rel='canonical' href={absoluteUrl} />
+          <script src={`https://cdn.polyfill.io/v2/polyfill.js?features=${polyfillFeatures.join(',')}`}></script>
+          <meta name='viewport' content='width=device-width, initial-scale=1' />
+          <meta name='theme-color' content='#000000' />
+          <meta name='description' content={description} />
+          <link rel='apple-touch-icon' sizes='180x180' href='https://i.wellcomecollection.org/assets/icons/apple-touch-icon.png' />
+          <link rel='shortcut icon' href='https://i.wellcomecollection.org/assets/icons/favicon.ico' type='image/ico' />
+          <link rel='icon' type='image/png' href='https://i.wellcomecollection.org/assets/icons/favicon-32x32.png' sizes='32x32' />
+          <link rel='icon' type='image/png' href='https://i.wellcomecollection.org/assets/icons/favicon-16x16.png' sizes='16x16' />
+          <link rel='manifest' href='https://i.wellcomecollection.org/assets/icons/manifest.json' />
+          <link rel='mask-icon' href='https://i.wellcomecollection.org/assets/icons/safari-pinned-tab.svg' color='#000000' />
+          <script src='https://i.wellcomecollection.org/assets/libs/picturefill.min.js' async />
+
+          <JsonLd data={jsonLd} />
+
+          <OpenGraphMetadata
+            type={ogType}
+            title={title}
+            description={description}
+            url={absoluteUrl}
+            imageUrl={imageUrl}
+          />
+          <TwitterMetadata
+            title={title}
+            description={description}
+            url={absoluteUrl}
+            imageUrl={imageUrl}
+            imageAltText={imageAltText}
+          />
+
+          {oEmbedUrl && <link
+            rel='alternate'
+            type='application/json+oembed'
+            href={oEmbedUrl}
+            title={title} />}
+        </Head>
+        {children}
+      </Fragment>
+    );
+  }
+}
+
+export default PageLayout;

--- a/common/views/components/PageLayout/TwitterMetadata.js
+++ b/common/views/components/PageLayout/TwitterMetadata.js
@@ -1,0 +1,28 @@
+// @flow
+import {Fragment} from 'react';
+type Props = {|
+  title: string,
+  description: string,
+  url: string,
+  imageUrl: ?string,
+  imageAltText: ?string,
+|}
+
+const TwitterMetadata = ({
+  title,
+  description,
+  url,
+  imageUrl,
+  imageAltText
+}: Props) => (
+  <Fragment>
+    <meta key='twitter:card' name='twitter:card' content='summary_large_image' />
+    <meta key='twitter:site' name='twitter:site' content='@ExploreWellcome' />
+    <meta key='twitter:url' name='twitter:url' content={url} />
+    <meta key='twitter:title' name='twitter:title' content={title} />
+    <meta key='twitter:description' name='twitter:description' content={description} />
+    <meta key='twitter:image' name='twitter:image' content={imageUrl} />
+    {imageAltText && <meta name='twitter:image:alt' content={imageAltText} />}
+  </Fragment>
+);
+export default TwitterMetadata;

--- a/router/terraform/alb.tf
+++ b/router/terraform/alb.tf
@@ -11,5 +11,5 @@ module "router_alb" {
   certificate_domain = "wellcomecollection.org"
   vpc_id             = "${local.vpc_id}"
 
-  alb_access_log_bucket = "${aws_s3_bucket.alb-logs.id}"
+  alb_access_log_bucket = "${aws_s3_bucket.alb-logs.bucket}"
 }


### PR DESCRIPTION
#3790 

This is probably more a spike to be able to sort our page rendering out.

It was inspired by works V2 reporting to GA twice, and having absolutely no idea where to look to find the problem in the spaghetti that has formed over time.

I'll keep working on this and pulling things out into smaller PRs.

The basic setup though is:
* `_document` is rendered on the server only. This can include things like the footer, and we can inject interval cached objects into it via `next`'s [`serverRuntimeConfig`](https://github.com/zeit/next.js#exposing-configuration-to-the-server--client-side). As these have to be fetched via a function (otherwise they're serialised and frozen in time when the app starts), they can only be used on the server. When serialised on the client, they return `{}`.
* `_app` renders every time a page is loaded, I imagine this will be everything from the header to the footer.
* `_page` the rest.

@wellcometrust/experience-dev does this feel like it would add more clarity to how the system works, as I feel we're a little stuck in the current setup?