### PR TITLE
add some redirects for the old drupal content

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -82,7 +82,7 @@ http {
     }
 
     # Most popular v1 content that we're going to continue to serve from v1 for now
-    location ~ ^/exhibitions/institute-sexology|^/articles/aids-posters|^/what-we-do/wellcome-trust|^/articles/drugs-and-brain-quick-guide-brain-chemistry|^/forensics|^/articles/william-harvey-and-circulation-blood|^/bedlam|^/thisisavoice|^/sexwomenlibrary|^/whats/sex-afternoon|^/articles/birth|^/articles/introduction-alzheimers-disease|^/exhibitions/states-mind-ann-veronica-janssens|^/electricity|^/articles/science-art|^/articles/stereotyping-and-fatism|^/medieval-bodies|^/sex-numbers-0 {
+    location ~ ^/articles/william-harvey-and-circulation-blood|^/sexwomenlibrary|^/whats/sex-afternoon|^/articles/birth|^/articles/introduction-alzheimers-disease|^/articles/stereotyping-and-fatism|^/medieval-bodies|^/sex-numbers-0 {
       proxy_pass                 http://v1;
       proxy_set_header           Host wellcomecollection.org;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;

--- a/router/webapp/redirects.json
+++ b/router/webapp/redirects.json
@@ -124,5 +124,5 @@
   "/what-we-do/wellcome-trust": "/what-we-do",
   "/articles/nymphomania": "/articles/W_v8XxQAACgA_WKS",
   "/articles/museums-in-context-the-birth-of-the-public-museum": "/articles/W_0kHhEAADUAbHiJ",
-  "/articles/the-power-of-unicorns", "/articles/W_1gyREAADIAbXjT"
+  "/articles/the-power-of-unicorns": "/articles/W_1gyREAADIAbXjT"
 }

--- a/router/webapp/redirects.json
+++ b/router/webapp/redirects.json
@@ -120,5 +120,8 @@
   "/articles/a-drop-in-the-ocean-daniel-regan": "/articles/WsT4Ex8AAHruGfXJ",
   "/articles/paris-morgue": "/articles/W-RTBBEAAO5mfQ3M",
   "/articles/sockets-and-stumps": "/articles/W-VjexEAAJKKgbWt",
-  "/articles/ethical-taxidermy": "/articles/WsT4Ex8AAHruGfWx"
+  "/articles/ethical-taxidermy": "/articles/WsT4Ex8AAHruGfWx",
+  "/what-we-do/wellcome-trust": "/what-we-do",
+  "/articles/nymphomania": "/articles/W_v8XxQAACgA_WKS",
+  "/articles/museums-in-context-the-birth-of-the-public-museum": "/articles/W_0kHhEAADUAbHiJ"
 }

--- a/router/webapp/redirects.json
+++ b/router/webapp/redirects.json
@@ -123,5 +123,6 @@
   "/articles/ethical-taxidermy": "/articles/WsT4Ex8AAHruGfWx",
   "/what-we-do/wellcome-trust": "/what-we-do",
   "/articles/nymphomania": "/articles/W_v8XxQAACgA_WKS",
-  "/articles/museums-in-context-the-birth-of-the-public-museum": "/articles/W_0kHhEAADUAbHiJ"
+  "/articles/museums-in-context-the-birth-of-the-public-museum": "/articles/W_0kHhEAADUAbHiJ",
+  "/articles/the-power-of-unicorns", "/articles/W_1gyREAADIAbXjT"
 }


### PR DESCRIPTION
A few more added, and some of the older ones removed from router.
I want to get router cleared of all wellcomecollection.org content, then it can become a wellcomelibrary.org router.