### PR TITLE
Scroll to top of page after using pagination

### DIFF
--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -53,7 +53,7 @@ export const Works = ({
       // $FlowFixMe
       worksV2Link({query, page}).as,
       { shallow: true }
-    );
+    ).then(() => window.scrollTo(0, 0));
 
     if (query && query !== '') {
       setLoading(true);


### PR DESCRIPTION
If you use the pagination at the bottom of the list of works, you don't go back to the top of the list because we're not doing a page refresh.

[This seems to be the approved way to do it](https://github.com/zeit/next.js/issues/3249#issuecomment-342735512).