### PR TITLE
Send work id to GA

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -489,13 +489,13 @@ export const WorkPage = ({
                       trackingEvent={{
                         category: 'component',
                         action: 'download-button:click',
-                        label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
+                        label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
                       }}
                       clickHandler={() => {
                         ReactGA.event({
                           category: 'component',
                           action: 'download-button:click',
-                          label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
+                          label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
                         });
                       }}
                       icon='download'
@@ -512,13 +512,13 @@ export const WorkPage = ({
                       trackingEvent={{
                         category: 'component',
                         action: 'download-button:click',
-                        label: `id: work.id , size:760, title:${work.title.substring(50)}`
+                        label: `id: ${work.id} , size:760, title:${work.title.substring(50)}`
                       }}
                       clickHandler={() => {
                         ReactGA.event({
                           category: 'component',
                           action: 'download-button:click',
-                          label: `id: work.id , size:760, title:${work.title.substring(50)}`
+                          label: `id: ${work.id} , size:760, title:${work.title.substring(50)}`
                         });
                       }}
                       icon='download'

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -245,13 +245,13 @@ export const WorkPage = ({
                         trackingEvent={{
                           category: 'component',
                           action: 'download-button:click',
-                          label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
+                          label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
                         }}
                         clickHandler={() => {
                           ReactGA.event({
                             category: 'component',
                             action: 'download-button:click',
-                            label: `id: work.id , size:original, title:${encodeURI(work.title.substring(50))}`
+                            label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
                           });
                         }}
                         icon='download'
@@ -267,13 +267,13 @@ export const WorkPage = ({
                         trackingEvent={{
                           category: 'component',
                           action: 'download-button:click',
-                          label: `id: work.id , size:760, title:${work.title.substring(50)}`
+                          label: `id: $work.id} , size:760, title:${work.title.substring(50)}`
                         }}
                         clickHandler={() => {
                           ReactGA.event({
                             category: 'component',
                             action: 'download-button:click',
-                            label: `id: work.id , size:760, title:${work.title.substring(50)}`
+                            label: `id: $work.id} , size:760, title:${work.title.substring(50)}`
                           });
                         }}
                         icon='download'


### PR DESCRIPTION
We're just sending the string 'work.id' at the moment, which isn't very helpful.
