### PR TITLE
null check fields that make up physical description

### DIFF
--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -121,8 +121,8 @@ export const WorkPage = ({
                     <MetaUnit headingText='Description' text={[work.description]} />
                   }
 
-                  {work.physicalDescription &&
-                    <MetaUnit headingText='Physical description' text={[`${work.physicalDescription} ${work.extent} ${work.dimensions}`]} />
+                  {(work.physicalDescription || work.extent || work.dimensions) &&
+                    <MetaUnit headingText='Physical description' text={[[work.physicalDescription, work.extent, work.dimensions].filter(Boolean).join(' ')]} />
                   }
 
                   {work.workType &&


### PR DESCRIPTION
For situations like this:
https://wellcomecollection.org/worksv2/bsp5r2cj

Because we don't have all the fields in there and the punctuation is still in there, we now land up with this:
![screenshot 2018-11-30 at 08 24 10](https://user-images.githubusercontent.com/31692/49277457-8e466b80-f479-11e8-895b-6c4bcffdb190.png)
