### PR TITLE
unsupport wordpress articles in the listnerns

### DIFF
--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -215,7 +215,7 @@ module "articles_listener" {
   priority = "113"
   # TODO: (wordpress)
   # We're supporting wordpress articles for the time being
-  path = "/articles/W*"
+  path = "/articles*"
 }
 
 module "article_series_listener" {
@@ -226,7 +226,7 @@ module "article_series_listener" {
   priority = "114"
   # TODO: (wordpress)
   # We're supporting wordpress articles for the time being
-  path = "/series/W*"
+  path = "/series*"
 }
 
 module "event_series_listener" {


### PR DESCRIPTION
We no longer support wordpress articles so don't need to support the `/W` URLs, which is no longer the case as we've moved onto `X...`