### PR TITLE
use marc subfield ordering for Physical description

### DIFF
--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -122,7 +122,7 @@ export const WorkPage = ({
                   }
 
                   {(work.physicalDescription || work.extent || work.dimensions) &&
-                    <MetaUnit headingText='Physical description' text={[[work.physicalDescription, work.extent, work.dimensions].filter(Boolean).join(' ')]} />
+                    <MetaUnit headingText='Physical description' text={[[work.extent, work.physicalDescription, work.dimensions].filter(Boolean).join(' ')]} />
                   }
 
                   {work.workType &&


### PR DESCRIPTION
As per the [Marc spec](https://www.loc.gov/marc/bibliographic/bd300.html), it should be extent, other physical description, dimensions.