### PR TITLE
Make sizesQueries configurable for StoryPromoFeatured

### DIFF
--- a/common/views/components/StoryPromo/StoryPromo.js
+++ b/common/views/components/StoryPromo/StoryPromo.js
@@ -11,14 +11,16 @@ type Props = {|
   item: Article,
   position: number,
   hidePromoText?: boolean,
-  hasTransparentBackground?: boolean
+  hasTransparentBackground?: boolean,
+  sizesQueries?: string
 |}
 
 const StoryPromo = ({
   item,
   position,
   hidePromoText = false,
-  hasTransparentBackground = false
+  hasTransparentBackground = false,
+  sizesQueries = `(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)`
 }: Props) => {
   const positionInSeries = getPositionInSeries(item);
   return (
@@ -44,7 +46,7 @@ const StoryPromo = ({
         {/* FIXME: Image type tidy */}
         {/* $FlowFixMe */}
         {item.promoImage && <UiImage {...item.promoImage}
-          sizesQueries='(min-width: 1420px) 386px, (min-width: 960px) calc(28.64vw - 15px), (min-width: 600px) calc(50vw - 54px), calc(100vw - 36px)'
+          sizesQueries={sizesQueries}
           showTasl={false} />}
 
         {item.labels.length > 0 &&

--- a/common/views/components/StoryPromoFeatured/StoryPromoFeatured.js
+++ b/common/views/components/StoryPromoFeatured/StoryPromoFeatured.js
@@ -10,7 +10,7 @@ const StoryPromoFeatured = ({item}: Props) => (
       item={item}
       position={`1`}
       hasTransparentBackground={true}
-    />
+      sizesQueries={`(min-width: 1420px) 812px, (min-width: 600px) 58.5vw, calc(100vw - 36px)`} />
   </div>
 );
 


### PR DESCRIPTION
The `srcset` sizes for the first `StoryPromo`  on `/stories` needs to be able to handle a larger image. Currently, we're only loading a ~380px-wide image in a ~800px-wide space.