### PR TITLE
add opening date to exhibition info box

### DIFF
--- a/common/icons/calendar.js
+++ b/common/icons/calendar.js
@@ -1,0 +1,5 @@
+const calendar = () => (
+  <svg xmlns='http://www.w3.org/2000/svg' data-name='Layer 1' viewBox='0 0 26 26'><path className='icon__shape' d='M17.89 5.27H17v-2a1 1 0 0 0-2 0v2H8.83v-2a1 1 0 0 0-2 0v2h-.94a4 4 0 0 0-4 4v9.45a4 4 0 0 0 4 4h12a4 4 0 0 0 4-4V9.27a4 4 0 0 0-4-4zm-12 2h.94v1a1 1 0 0 0 2 0v-1H15v1a1 1 0 0 0 2 0v-1h.94a2 2 0 0 1 2 2v1.25h-16V9.27a2 2 0 0 1 1.95-2zm12 13.45h-12a2 2 0 0 1-2-2v-6.2h16v6.2a2 2 0 0 1-2 2z'/><path d='M5.43 17.29h2v2h-2zM8.91 13.88h2v2h-2zM8.91 17.29h2v2h-2zM12.38 13.88h2v2h-2zM12.38 17.29h2v2h-2zM15.86 13.88h2v2h-2z'/></svg>
+);
+
+export default calendar;

--- a/common/icons/index.js
+++ b/common/icons/index.js
@@ -6,6 +6,7 @@ import audioDescribed from './audio_described';
 import speechToText from './speech_to_text';
 import britishSignLanguage from './british_sign_language';
 import {cc, ccBy, ccNc, ccNd, ccPdm, ccZero} from './licenses';
+import calendar from './calendar';
 import check from './check';
 import chevron from './chevron';
 import clock from './clock';
@@ -46,6 +47,7 @@ export {
   audioDescribed,
   speechToText,
   britishSignLanguage,
+  calendar,
   cc,
   ccBy,
   ccNc,

--- a/common/utils/dates.js
+++ b/common/utils/dates.js
@@ -13,6 +13,10 @@ export function isPast(date: Date): boolean {
   return london(date).isBefore(london(), 'day');
 }
 
+export function isFuture(date: Date): boolean {
+  return london(date).isAfter(london(), 'day');
+}
+
 export function getNextWeekendDateRange(date: Date): DateRange {
   const today = london(date);
   const todayInteger = today.day(); // day() return Sun as 0, Sat as 6

--- a/content/webapp/pages/exhibition.js
+++ b/content/webapp/pages/exhibition.js
@@ -1,7 +1,8 @@
 // @flow
 import {Fragment, Component} from 'react';
 import {getExhibition, getExhibitionRelatedContent} from '@weco/common/services/prismic/exhibitions';
-import {isPast} from '@weco/common/utils/dates';
+import {isPast, isFuture} from '@weco/common/utils/dates';
+import {formatDate} from '@weco/common/utils/format-date';
 import {exhibitionLd} from '@weco/common/utils/json-ld';
 import PageWrapper from '@weco/common/views/components/PageWrapper/PageWrapper';
 import ContentPage from '@weco/common/views/components/ContentPage/ContentPage';
@@ -144,6 +145,19 @@ export class ExhibitionPage extends Component<Props, State> {
       icon: 'ticket'
     };
 
+    const upcomingExhibitionObject = isFuture(exhibition.start) ? {
+      id: null,
+      title: null,
+      description: [
+        {
+          type: 'paragraph',
+          text: `Opening on ${formatDate(exhibition.start)}`,
+          spans: []
+        }
+      ],
+      icon: 'calendar'
+    } : null;
+
     const todaysHoursText = 'Galleries open Tuesday–Sunday, Opening times';
     const todaysHoursObject = {
       id: null,
@@ -217,6 +231,7 @@ export class ExhibitionPage extends Component<Props, State> {
     ];
 
     const infoItems = [
+      upcomingExhibitionObject,
       admissionObject,
       todaysHoursObject,
       placeObject,


### PR DESCRIPTION
From a message with @Heesoomoon, knowing that an exhibition isn't open yet is integral to the access information.

This just adds it to the top of the info box.

![screenshot 2018-11-30 at 13 17 42](https://user-images.githubusercontent.com/31692/49291468-569fe980-f4a2-11e8-9cc5-c36d11cba3fe.png)
