### PR TITLE
account for the year when grouping events by month

### DIFF
--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -19,7 +19,7 @@ type State = {|
 // recursive - TODO: make tail recursive?
 function getMonthsInDateRange({start, end}, acc = []) {
   if (start.isSameOrBefore(end, 'month')) {
-    const newAcc = acc.concat([start.format('MMMM')]);
+    const newAcc = acc.concat([start.format('YYYY-MM')]);
     const newStart = start.add(1, 'month');
     return getMonthsInDateRange({start: newStart, end}, newAcc);
   } else {
@@ -63,7 +63,11 @@ class EventsByMonth extends Component<Props, State> {
         // Only add if it has a time in the month that is the same or after today
         const hasDateInMonthRemaining = event.times.find(time => {
           const end = london(time.range.endDateTime);
-          return end.isSame(london({M: monthsIndex[month]}), 'month') && end.isSameOrAfter(london(), 'day');
+          const monthAndYear = london(month);
+          return end.isSame(london({
+            M: monthAndYear.month(),
+            Y: monthAndYear.year()
+          }), 'month') && end.isSameOrAfter(london(), 'day');
         });
         if (hasDateInMonthRemaining) {
           if (!acc[month]) {
@@ -78,13 +82,13 @@ class EventsByMonth extends Component<Props, State> {
     // Order months correctly
     const orderedMonths = {};
     Object.keys(eventsInMonths).sort((a, b) => {
-      return monthsIndex[a] - monthsIndex[b];
+      return london(a).toDate() > london(b).toDate();
     }).map(key => orderedMonths[key] = eventsInMonths[key]);
 
     const months = Object.keys(orderedMonths).map(month => ({
       id: month,
       url: `#${month}`,
-      text: month
+      text: london(month).format('MMMM')
     }));
 
     // Need to order the events for each month based on their earliest future date range


### PR DESCRIPTION
We are now accounting for the year when grouping events by month.

Could definitely do with a tidy up, and potentially some mocks to test against.
Works is the priority though.

![screenshot 2018-11-30 at 14 57 42](https://user-images.githubusercontent.com/31692/49296475-4f7fd800-f4b0-11e8-8c0c-8331836b08e4.png)
