### PR TITLE
Don't check for grid before displaying promo links as flex

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -358,11 +358,6 @@
   @include respond-to('medium') {
     min-height: 370px;
   }
-
-  @supports (display: grid) {
-    display: flex;
-  }
-
 }
 
 .promo-link__title {


### PR DESCRIPTION
☝️ 

Fixes first promo on /stories page in IE11.