### PR TITLE
start adding workType filters

### DIFF
--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -4,6 +4,7 @@ import type {CatalogueApiError, CatalogueResultsList} from '../services/catalogu
 // $FlowFixMe: using react aloha for hooks, which isn't in the typedefs
 import {Fragment, useState, useEffect, useRef} from 'react';
 import Router from 'next/router';
+import NextLink from 'next/link';
 import {font, grid, spacing, classNames} from '@weco/common/utils/classnames';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
@@ -13,6 +14,7 @@ import StaticWorksContent from '@weco/common/views/components/StaticWorksContent
 import WorkPromo from '@weco/common/views/components/WorkPromo/WorkPromo';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
+import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import {getWorks} from '../services/catalogue/works';
 import {workLink, worksLink} from '../services/catalogue/links';
 
@@ -267,7 +269,32 @@ export const Works = ({
             style={{ opacity: loading ? 0 : 1 }}>
             <div className='container'>
               <div className='grid'>
-                {works.results.map(result => (
+                {showCatalogueSearchFilters && works.results.map(result => (
+                  <NextLink
+                    href={workLink({ id: result.id, query, page }).href}
+                    as={workLink({ id: result.id, query, page }).as}
+                    key={result.id}>
+                    <a
+                      style={{
+                        padding: '24px 0',
+                        borderTop: '1px solid'
+                      }}
+                      className={'plain-link ' + grid({s: 12, m: 10, l: 8, xl: 8, shiftXL: 2})}>
+                      <div className={classNames({
+                        [spacing({s: 1}, {margin: ['top', 'bottom']})]: true
+                      })}>
+                        <LinkLabels items={[
+                          {
+                            url: `/works?query=workType:"${result.workType.label}"`,
+                            text: result.workType.label
+                          }
+                        ]} />
+                      </div>
+                      <h2 className='h4'>{result.title}</h2>
+                    </a>
+                  </NextLink>
+                ))}
+                {!showCatalogueSearchFilters && works.results.map(result => (
                   <div key={result.id} className={grid({s: 6, m: 4, l: 3, xl: 2})}>
                     <WorkPromo
                       id={result.id}

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -108,7 +108,7 @@ export const Works = ({
       { shallow: true }
     ).then(() => window.scrollTo(0, 0));
 
-    if (query && query !== '') {
+    if ((query && query !== '') || workType !== ['q', 'k']) {
       setLoading(true);
       // TODO: Look into memoiszing results so we don't hit the API again
       //       See: https://reactjs.org/docs/hooks-reference.html#usememo
@@ -189,12 +189,21 @@ export const Works = ({
                 {showCatalogueSearchFilters &&
                     <Fragment>
                       {workTypes.map(({id, label}) => (
-                        <label key={id}>
+                        <label key={id} style={{
+                          display: 'inline-block',
+                          padding: '0 6px',
+                          borderRadius: '4px',
+                          border: '2px solid #5cb8bf',
+                          marginBottom: '6px'
+                        }}>
                           <input
                             type='checkbox'
                             name='workType'
                             value={id}
                             checked={workType.indexOf(id) !== -1}
+                            style={{
+                              marginRight: '6px'
+                            }}
                             onChange={(event) => {
                               if (event.target.checked) {
                                 workType.push(id);
@@ -235,7 +244,7 @@ export const Works = ({
         </div>
       </div>
 
-      {!query &&
+      {!works &&
         <StaticWorksContent />
       }
 

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -20,14 +20,14 @@ type Props = {|
   initialQuery: ?string,
   initialWorks: ?CatalogueResultsList | CatalogueApiError,
   initialPage: ?number,
-  filters: Object
+  initialFilters: Object
 |}
 
 export const Works = ({
   initialQuery,
   initialWorks,
-  filters,
-  initialPage
+  initialPage,
+  initialFilters
 }: Props) => {
   if (initialWorks && initialWorks.type === 'Error') {
     return (
@@ -50,6 +50,7 @@ export const Works = ({
   const [query, setQuery] = useState(initialQuery);
   const [works, setWorks] = useState(initialWorks);
   const [page, setPage] = useState(initialPage);
+  const [filters, setFilters] = useState(initialFilters);
   const [loading, setLoading] = useState(false);
   useEffect(() => {
     document.title = `${query} | Catalogue search | Wellcome Collection`;
@@ -132,6 +133,7 @@ export const Works = ({
                 name='query'
                 query={query || ''}
                 autofocus={true}
+                filters={filters}
                 onSubmit={async (event) => {
                   event.preventDefault();
                   const form = event.currentTarget;
@@ -139,6 +141,14 @@ export const Works = ({
                   const newQuery = form.elements.query.value;
                   setQuery(newQuery);
                   setPage(1);
+
+                  // $FlowFixMe
+                  const workTypes = Array.from(form.elements.workType).map(input => {
+                    if (input.checked) {
+                      return input.value;
+                    }
+                  }).filter(Boolean);
+                  console.info(workTypes);
                 }} />
               {!works
                 ? <p className={classNames([
@@ -276,7 +286,7 @@ Works.getInitialProps = async (
     initialPage: page,
     initialWorks: worksOrError,
     initialQuery: query,
-    filters
+    initialFilters: filters
   };
 };
 

--- a/common/views/components/SearchBox/SearchBox.js
+++ b/common/views/components/SearchBox/SearchBox.js
@@ -9,14 +9,50 @@ type Props = {|
   id: string,
   name: string,
   query: string,
+  filters: Object,
   autofocus: boolean,
   onSubmit?: (SyntheticEvent<HTMLFormElement>) => any,
   onChange?: (SyntheticEvent<HTMLInputElement>) => any
 |}
 
-const SearchBox = ({action, id, name, query, autofocus, onChange, onSubmit}: Props) => (
-  <div className='search-box js-search-box'>
-    <form action={action} onSubmit={onSubmit}>
+const workTypes = [
+  { id: 'a', label: 'Books' },
+  { id: 'b', label: 'Manuscripts, Asian' },
+  { id: 'c', label: 'Music' },
+  { id: 'd', label: 'Journals' },
+  { id: 'e', label: 'Maps' },
+  { id: 'f', label: 'E-videos' },
+  { id: 'g', label: 'Videorecordings' },
+  { id: 'h', label: 'Archives and manuscripts' },
+  { id: 'i', label: 'Sound' },
+  { id: 'j', label: 'E-journals' },
+  { id: 'k', label: 'Pictures' },
+  { id: 'l', label: 'Ephemera' },
+  { id: 'm', label: 'CD-Roms' },
+  { id: 'n', label: 'Cinefilm' },
+  { id: 'p', label: 'Mixed materials' },
+  { id: 'q', label: 'Digital images' },
+  { id: 'r', label: '3-D Objects' },
+  { id: 's', label: 'E-sound' },
+  { id: 'u', label: 'Standing order' },
+  { id: 'v', label: 'E-books' },
+  { id: 'w', label: 'Student dissertations' },
+  { id: 'x', label: 'E-manuscripts, Asian' },
+  { id: 'z', label: 'Web sites ' }
+];
+
+const SearchBox = ({
+  action,
+  id,
+  name,
+  query,
+  filters,
+  autofocus,
+  onChange,
+  onSubmit
+}: Props) => (
+  <form action={action} onSubmit={onSubmit}>
+    <div className='search-box js-search-box'>
       <HTMLInput
         id={id}
         type='text'
@@ -35,17 +71,38 @@ const SearchBox = ({action, id, name, query, autofocus, onChange, onSubmit}: Pro
           </span>
         </button>
       </div>
-    </form>
-    <button className='search-box__clear absolute line-height-1 plain-button v-center no-padding js-clear'
-      onClick={() => trackEvent({
-        category: 'component',
-        action: `clear-search:click`,
-        label: `input-id:${id}`
-      })}
-      type='button'>
-      <Icon name='clear' title='Clear' />
-    </button>
-  </div>
+
+      <button className='search-box__clear absolute line-height-1 plain-button v-center no-padding js-clear'
+        onClick={() => trackEvent({
+          category: 'component',
+          action: `clear-search:click`,
+          label: `input-id:${id}`
+        })}
+        type='button'>
+        <Icon name='clear' title='Clear' />
+      </button>
+    </div>
+
+    {workTypes.map(({id, label}) => (
+      <label key={id}>
+        <input
+          type='checkbox'
+          name='workType'
+          value={id}
+          checked={filters.workType.indexOf(id) !== -1} />
+        {label}
+      </label>
+    ))}
+    <hr />
+    <label>
+      <input
+        type='checkbox'
+        name='workType'
+        value={id}
+        checked={filters['items.locations.locationType']} />
+      Images only
+    </label>
+  </form>
 );
 
 export default SearchBox;

--- a/common/views/components/SearchBox/SearchBox.js
+++ b/common/views/components/SearchBox/SearchBox.js
@@ -9,100 +9,45 @@ type Props = {|
   id: string,
   name: string,
   query: string,
-  filters: Object,
-  autofocus: boolean,
-  onSubmit?: (SyntheticEvent<HTMLFormElement>) => any,
-  onChange?: (SyntheticEvent<HTMLInputElement>) => any
+  autofocus: boolean
 |}
-
-const workTypes = [
-  { id: 'a', label: 'Books' },
-  { id: 'b', label: 'Manuscripts, Asian' },
-  { id: 'c', label: 'Music' },
-  { id: 'd', label: 'Journals' },
-  { id: 'e', label: 'Maps' },
-  { id: 'f', label: 'E-videos' },
-  { id: 'g', label: 'Videorecordings' },
-  { id: 'h', label: 'Archives and manuscripts' },
-  { id: 'i', label: 'Sound' },
-  { id: 'j', label: 'E-journals' },
-  { id: 'k', label: 'Pictures' },
-  { id: 'l', label: 'Ephemera' },
-  { id: 'm', label: 'CD-Roms' },
-  { id: 'n', label: 'Cinefilm' },
-  { id: 'p', label: 'Mixed materials' },
-  { id: 'q', label: 'Digital images' },
-  { id: 'r', label: '3-D Objects' },
-  { id: 's', label: 'E-sound' },
-  { id: 'u', label: 'Standing order' },
-  { id: 'v', label: 'E-books' },
-  { id: 'w', label: 'Student dissertations' },
-  { id: 'x', label: 'E-manuscripts, Asian' },
-  { id: 'z', label: 'Web sites ' }
-];
 
 const SearchBox = ({
   action,
   id,
   name,
   query,
-  filters,
-  autofocus,
-  onChange,
-  onSubmit
+  autofocus
 }: Props) => (
-  <form action={action} onSubmit={onSubmit}>
-    <div className='search-box js-search-box'>
-      <HTMLInput
-        id={id}
-        type='text'
-        name={name}
-        label='search'
-        defaultValue={query}
-        placeholder='Search for artworks, photos and more'
-        autofocus={autofocus}
-        isLabelHidden={true}
-        onChange={onChange} />
-      <div className='search-box__button-wrap absolute bg-green'>
-        <button className={`search-box__button line-height-1 plain-button no-padding ${font({s: 'HNL3', m: 'HNL2'})}`}>
-          <span className='visually-hidden'>Search</span>
-          <span className='flex flex--v-center flex--h-center'>
-            <Icon name='search' title='Search' extraClasses='icon--white' />
-          </span>
-        </button>
-      </div>
-
-      <button className='search-box__clear absolute line-height-1 plain-button v-center no-padding js-clear'
-        onClick={() => trackEvent({
-          category: 'component',
-          action: `clear-search:click`,
-          label: `input-id:${id}`
-        })}
-        type='button'>
-        <Icon name='clear' title='Clear' />
+  <div className='search-box js-search-box'>
+    <HTMLInput
+      id={id}
+      type='text'
+      name={name}
+      label='search'
+      defaultValue={query}
+      placeholder='Search for artworks, photos and more'
+      autofocus={autofocus}
+      isLabelHidden={true} />
+    <div className='search-box__button-wrap absolute bg-green'>
+      <button className={`search-box__button line-height-1 plain-button no-padding ${font({s: 'HNL3', m: 'HNL2'})}`}>
+        <span className='visually-hidden'>Search</span>
+        <span className='flex flex--v-center flex--h-center'>
+          <Icon name='search' title='Search' extraClasses='icon--white' />
+        </span>
       </button>
     </div>
 
-    {workTypes.map(({id, label}) => (
-      <label key={id}>
-        <input
-          type='checkbox'
-          name='workType'
-          value={id}
-          checked={filters.workType.indexOf(id) !== -1} />
-        {label}
-      </label>
-    ))}
-    <hr />
-    <label>
-      <input
-        type='checkbox'
-        name='workType'
-        value={id}
-        checked={filters['items.locations.locationType']} />
-      Images only
-    </label>
-  </form>
+    <button className='search-box__clear absolute line-height-1 plain-button v-center no-padding js-clear'
+      onClick={() => trackEvent({
+        category: 'component',
+        action: `clear-search:click`,
+        label: `input-id:${id}`
+      })}
+      type='button'>
+      <Icon name='clear' title='Clear' />
+    </button>
+  </div>
 );
 
 export default SearchBox;

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -30,17 +30,12 @@ function setCookie(name, value) {
 const abTests = [];
 
 const featureToggles = [{
-  id: 'unfilteredCatalogueResults',
-  title: 'Unfiltered catalogue results',
+  id: 'showCatalogueSearchFilters',
+  title: 'Catalogue search filters',
   description:
-    'We currently filter the results of the catalogue to only how' +
-    'results that we know we have images for. This will disable that' +
-    'and show everything.'
-}, {
-  id: 'showWorksFilters',
-  title: 'Show filters on works search',
-  description:
-    'Exposes the filters we have available on the API on the UI.'
+    'We currently filter the results of the catalogue to show Pictures and ' +
+    'Digital images work types, and only results with images.' +
+    'This will show unfilter those results, and allow for filtering.'
 }, {
   id: 'showRevisedOpeningHours',
   title: 'Show revised opening hours 4 weeks in advance rather than 2 weeks',


### PR DESCRIPTION
Adds a toggle to allow us to turn on the `workType` filters, and to sow things without images.
The reason being so people that aren't used to using the API JSON responses can see what we have.

---

Technically I've moved the `SearchBox` out of the form, as the filters need to be part of the request.

I haven't done anything with the URL yet, as it feels like it starts to open up the potential to introduce bugs for non-wc users.

I'm assuming we will try to mimic the API request `/works?query=huddle&workType=q`, but let's see when we get closer to implementing filters.

The UI is rubbish
![screenshot 2018-12-06 at 08 55 40](https://user-images.githubusercontent.com/31692/49573156-3bffc180-f935-11e8-8b44-45c4b9249917.png)