### PR TITLE
Revert "Don't check for grid before displaying promo links as flex"

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -358,6 +358,11 @@
   @include respond-to('medium') {
     min-height: 370px;
   }
+
+  @supports (display: grid) {
+    display: flex;
+  }
+
 }
 
 .promo-link__title {


### PR DESCRIPTION
Reverts wellcometrust/wellcomecollection.org#3836

Fixes 👇 
![screenshot 2018-12-06 at 11 42 16](https://user-images.githubusercontent.com/31692/49582161-02868080-f94c-11e8-9805-8b24a8a0db82.png)
