### PR TITLE
Remove block from promo links

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -346,7 +346,6 @@
 }
 
 .promo-link {
-  display: block;
   height: 100%;
   color: color('black');
 


### PR DESCRIPTION
We set a class of `flex` on promos, so shouldn't be adding `display: block` to the `promo-link` properties. Prefer this to #3853?
