### PR TITLE
remove engagement metric from works

### DIFF
--- a/catalogue/webapp/pages/_app.js
+++ b/catalogue/webapp/pages/_app.js
@@ -73,14 +73,6 @@ export default class WecoApp extends App {
       ReactGA.pageview(page, ['v2']);
     });
 
-    setTimeout(() => {
-      ReactGA.event({
-        category: 'Engagement',
-        action: 'Time on page >=',
-        label: '10 seconds'
-      });
-    }, 10000);
-
     // Fonts
     const FontFaceObserver = require('fontfaceobserver');
 


### PR DESCRIPTION
It would be buggy to release in this form as the page counter starts once you land on the age and doesn't reset when you search etc.

This just removes it till now until we get GA setup properly on works.