### PR TITLE
use next links for back to search

### DIFF
--- a/cardigan/stories/components/Links.js
+++ b/cardigan/stories/components/Links.js
@@ -18,5 +18,5 @@ stories.add('Links: Primary', () => (
   </Fragment>
 ));
 stories.add('Links: Secondary', () => (
-  <SecondaryLink url={`#`} text={`Our event terms and conditions`} />
+  <SecondaryLink url={{href: `#`, as: `#`}} text={`Our event terms and conditions`} />
 ));

--- a/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
+++ b/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
@@ -1,9 +1,10 @@
 // @flow
-import {spacing, font, grid} from '../../../utils/classnames';
-import {createPrismicParagraph} from '../../../utils/prismic';
 import {Fragment} from 'react';
-import Tags from '../Tags/Tags';
-import {CaptionedImage} from '../Images/Images';
+import {spacing, font, grid} from '@weco/common/utils/classnames';
+import {createPrismicParagraph} from '@weco/common/utils/prismic';
+import Tags from '@weco/common/views/components/Tags/Tags';
+import {CaptionedImage} from '@weco/common/views/components/Images/Images';
+import {worksUrl} from '../../services/catalogue/urls';
 
 const StaticWorksContent = () => (
   <Fragment>
@@ -15,14 +16,14 @@ const StaticWorksContent = () => (
             <p className={`${spacing({s: 2}, {margin: ['bottom']})} ${font({s: 'HNL4', m: 'HNL3'})}`}>Discover our collections through these topics.</p>
             <div className={spacing({s: 4}, {margin: ['bottom']})}>
               <Tags tags={[
-                {text: 'Quacks', url: '/works?query=quack+OR+quacks'},
-                {text: 'James Gillray', url: '/works?query=james+gillray'},
-                {text: 'Botany', url: '/works?query=botany'},
-                {text: 'Optics', url: '/works?query=optics'},
-                {text: 'Sun', url: '/works?query=sun'},
-                {text: 'Health', url: '/works?query=health'},
-                {text: 'Paintings', url: '/works?query=paintings'},
-                {text: 'Science', url: '/works?query=science'}
+                {text: 'Quacks', link: worksUrl({query: 'quack+OR+quacks', page: 1})},
+                {text: 'James Gillray', link: worksUrl({query: 'james+gillray', page: 1})},
+                {text: 'Botany', link: worksUrl({query: 'botany', page: 1})},
+                {text: 'Optics', link: worksUrl({query: 'optics', page: 1})},
+                {text: 'Sun', link: worksUrl({query: 'sun', page: 1})},
+                {text: 'Health', link: worksUrl({query: 'health', page: 1})},
+                {text: 'Paintings', link: worksUrl({query: 'paintings', page: 1})},
+                {text: 'Science', link: worksUrl({query: 'science', page: 1})}
               ]} />
             </div>
             <hr className={`divider divider--dashed ${spacing({s: 6}, {margin: ['bottom']})}`} />

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -352,7 +352,6 @@ Works.getInitialProps = async (
   const itemsLocationsLocationType = 'items.locations.locationType' in ctx.query
     ? ctx.query['items.locations.locationType'].split(',') : ['iiif-image'];
 
-  console.info(ctx.query['items.locations.locationType'], itemsLocationsLocationType, 'items.locations.locationType' in ctx.query);
   const {showCatalogueSearchFilters} = ctx.query.toggles;
   const filters = {
     'items.locations.locationType': itemsLocationsLocationType,

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -12,11 +12,11 @@ import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import SearchBox from '@weco/common/views/components/SearchBox/SearchBox';
-import StaticWorksContent from '@weco/common/views/components/StaticWorksContent/StaticWorksContent';
 import WorkPromo from '@weco/common/views/components/WorkPromo/WorkPromo';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
+import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import {getWorks} from '../services/catalogue/works';
 import {workUrl, worksUrl} from '../services/catalogue/urls';
 

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -32,13 +32,15 @@ export type Link = {|
 
 type Props = {|
   work: Work | CatalogueApiError,
-  previousQueryString: ?string,
+  query: ?string,
+  page: ?number,
   showRedesign: boolean
 |}
 
 export const WorkPage = ({
   work,
-  previousQueryString,
+  query,
+  page,
   showRedesign
 }: Props) => {
   if (work.type === 'Error') {
@@ -99,18 +101,18 @@ export const WorkPage = ({
       imageAltText={work.title}>
       <InfoBanner text={`Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`} cookieName='WC_wellcomeImagesRedirect' />
 
-      {previousQueryString &&
+      {query &&
         <div className='row'>
           <div className='container'>
             <div className='grid'>
               <div className={grid({s: 12})}>
                 <SecondaryLink
-                  url={`/works${previousQueryString || ''}#${work.id}`}
+                  link={worksUrl({query, page})}
                   text='Search results'
                   trackingEvent={{
                     category: 'component',
                     action: 'return-to-results:click',
-                    label: `id:${work.id}, query:${previousQueryString || ''}, title:${work.title}`
+                    label: `id:${work.id}, query:${query || ''}, title:${work.title}`
                   }} />
               </div>
             </div>
@@ -346,10 +348,7 @@ export const WorkPage = ({
 };
 
 WorkPage.getInitialProps = async (ctx): Promise<Props | CatalogueApiRedirect> => {
-  const {id} = ctx.query;
-  const {asPath} = ctx;
-  const queryStart = asPath.indexOf('?');
-  const previousQueryString = queryStart > -1 ? asPath.slice(queryStart) : null;
+  const {id, query, page} = ctx.query;
   const workOrError = await getWork({ id });
   const showRedesign = Boolean(ctx.query.toggles.showWorkRedesign);
 
@@ -366,7 +365,8 @@ WorkPage.getInitialProps = async (ctx): Promise<Props | CatalogueApiRedirect> =>
     return workOrError;
   } else {
     return {
-      previousQueryString,
+      query,
+      page: page ? parseInt(page, 10) : null,
       work: workOrError,
       showRedesign
     };

--- a/catalogue/webapp/services/catalogue/urls.js
+++ b/catalogue/webapp/services/catalogue/urls.js
@@ -9,7 +9,9 @@ type WorkUrlProps = {|
 
 type WorksUrlProps = {|
   query: ?string,
-  page: ?number
+  page: ?number,
+  workType?: string[],
+  itemsLocationsLocationType?: string[]
 |}
 
 type LinkProps = {|
@@ -43,20 +45,37 @@ export function workUrl({ id, query, page }: WorkUrlProps): LinkProps {
   };
 }
 
-export function worksUrl({ query, page }: WorksUrlProps): LinkProps {
+export function worksUrl({
+  query,
+  page,
+  workType = ['k', 'q'],
+  itemsLocationsLocationType = ['iiif-image']
+}: WorksUrlProps): LinkProps {
+  const workTypeWithDefaults =
+    JSON.stringify(workType) === JSON.stringify(['k', 'q'])
+      ? undefined : workType.join(',');
+
+  const itemsLocationsLocationTypeWithDefaults =
+    JSON.stringify(itemsLocationsLocationType) === JSON.stringify(['iiif-image'])
+      ? undefined : itemsLocationsLocationType.join(',');
+
   return {
     href: {
       pathname: `/worksv2`,
       query: removeEmpty({
         query: query || undefined,
-        page: page && page > 1 ? page : undefined
+        page: page && page > 1 ? page : undefined,
+        workType: workTypeWithDefaults,
+        'items.locations.locationType': itemsLocationsLocationTypeWithDefaults
       })
     },
     as: {
       pathname: `/works`,
       query: removeEmpty({
         query: query || undefined,
-        page: page && page > 1 ? page : undefined
+        page: page && page > 1 ? page : undefined,
+        workType: workTypeWithDefaults,
+        'items.locations.locationType': itemsLocationsLocationTypeWithDefaults
       })
     }
   };

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -27,7 +27,10 @@ export type CatalogueApiError = {|
 export type CatalogueResultsList = {
   type: 'ResultList',
   totalResults: number,
-  results: Work[]
+  results: Work[],
+  pageSize: nulber,
+  prevPage: ?string,
+  nextPage: ?string
 }
 
 export type CatalogueApiRedirect = {

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -28,7 +28,7 @@ export type CatalogueResultsList = {
   type: 'ResultList',
   totalResults: number,
   results: Work[],
-  pageSize: nulber,
+  pageSize: number,
   prevPage: ?string,
   nextPage: ?string
 }

--- a/common/model/next-link-type.js
+++ b/common/model/next-link-type.js
@@ -1,0 +1,8 @@
+// @flow
+import type {Url} from './url';
+// We've used Type here as we have the NextLink naming convention for importing
+// the module `next/link`
+export type NextLinkType = {|
+  href: Url,
+  as: Url
+|}

--- a/common/model/url.js
+++ b/common/model/url.js
@@ -1,4 +1,4 @@
-export type URL = {|
+export type Url = {|
   pathname: string,
   query: Object
 |}

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -2,7 +2,7 @@
 import {font, spacing, conditionalClassNames} from '../../../utils/classnames';
 
 type ItemProps = {|
-  url: string,
+  url: ?string,
   text: string
 |}
 

--- a/common/views/components/Links/SecondaryLink/SecondaryLink.js
+++ b/common/views/components/Links/SecondaryLink/SecondaryLink.js
@@ -1,4 +1,5 @@
 // @flow
+import type {NextLinkType} from '@weco/common/model/next-link-type';
 import NextLink from 'next/link';
 import {font, conditionalClassNames} from '../../../../utils/classnames';
 import {trackIfOutboundLink, trackEvent} from '../../../../utils/ga';
@@ -6,7 +7,7 @@ import Icon from '../../Icon/Icon';
 import type {GaEvent} from '../../../../utils/ga';
 
 type Props = {|
-  url: string,
+  link: NextLinkType,
   text: string,
   extraClasses?: string,
   trackingEvent?: GaEvent,
@@ -14,7 +15,7 @@ type Props = {|
 |}
 
 const SecondaryLink = ({
-  url,
+  link,
   text,
   extraClasses,
   trackingEvent,
@@ -28,7 +29,7 @@ const SecondaryLink = ({
   }
 
   return (
-    <NextLink href={url}>
+    <NextLink href={link.href} as={link.as}>
       <a
         onClick={handleClick}
         className={conditionalClassNames({
@@ -36,8 +37,7 @@ const SecondaryLink = ({
           'flex-inline': true,
           'flex-v-center': true,
           [font({s: 'HNM5', m: 'HNM4'})]: true,
-          [extraClasses || '']: Boolean(extraClasses),
-          'js-scroll-to-info': url.startsWith('#')
+          [extraClasses || '']: Boolean(extraClasses)
         })}>
         {icon &&
           <Icon name={icon} extraClasses='icon--black icon--90' />

--- a/common/views/components/StaticWorksContent/StaticWorksContent.config.js
+++ b/common/views/components/StaticWorksContent/StaticWorksContent.config.js
@@ -1,1 +1,0 @@
-export const hidden = true;

--- a/common/views/components/Tags/Tags.js
+++ b/common/views/components/Tags/Tags.js
@@ -1,11 +1,12 @@
 // @flow
+import type {NextLinkType} from '../../../model/next-link-type';
 import NextLink from 'next/link';
-import { spacing, font } from '../../../utils/classnames';
 import ReactGA from 'react-ga';
+import { spacing, font } from '../../../utils/classnames';
 
 export type TagProps = {|
   text: string,
-  url?: string
+  link?: NextLinkType
 |}
 
 export type Props = {|
@@ -16,26 +17,26 @@ const Tags = ({ tags }: Props) => {
   return (
     <div className='tags'>
       <ul className='tags__list plain-list no-margin no-padding flex flex--wrap'>
-        {tags.map(({ text, url }) => (
-          <Tag key={text} text={text} url={url} />
+        {tags.map(({ text, link }) => (
+          <Tag key={text} text={text} link={link} />
         ))}
       </ul>
     </div>
   );
 };
 
-const Tag = ({text, url}: TagProps) => {
+const Tag = ({text, link}: TagProps) => {
   function trackTagClick() {
     ReactGA.event({
       category: 'component',
       action: 'Tag:click',
-      label: `text:${text}${url ? `, url:${url}` : ''}`
+      label: `text:${text}`
     });
   }
 
   const className =
     `plain-link flex font-white bg-black rounded-diagonal
-    ${url ? 'bg-hover-green transition-bg' : ''}
+    ${link ? 'bg-hover-green transition-bg' : ''}
     ${spacing({s: 1}, {padding: ['top', 'bottom']})}
     ${spacing({s: 2}, {padding: ['left', 'right']})}`;
 
@@ -43,12 +44,12 @@ const Tag = ({text, url}: TagProps) => {
     <li
       onClick={trackTagClick}
       className={`tags__tag ${font({s: 'HNL5', m: 'WB7'})} ${spacing({s: 2}, {margin: ['right', 'bottom']})}`}>
-      {url &&
-        <NextLink href={url}>
+      {link &&
+        <NextLink href={link.href} as={link.as}>
           <a className={className}>{text}</a>
         </NextLink>
       }
-      {!url && <div className={className}>{text}</div>}
+      {!link && <div className={className}>{text}</div>}
     </li>
   );
 };

--- a/common/views/components/WorkPromo/WorkPromo.js
+++ b/common/views/components/WorkPromo/WorkPromo.js
@@ -1,25 +1,17 @@
 // @flow
+import type {NextLinkType} from '@weco/common/model/next-link-type';
+import type {Props as ImageProps} from '../Image/Image';
 import {font} from '../../../utils/classnames';
 import {trackEvent} from '../../../utils/ga';
 import Image from '../Image/Image';
-import type {Props as ImageProps} from '../Image/Image';
 import NextLink from 'next/link';
-
-type Link = {|
-  pathname: string,
-  query: Object
-|}
-type LinkProps = {|
-  href: Link,
-  as: Link
-|}
 
 type Props = {|
   id: string,
   image: ImageProps,
   datePublished?: string,
   title?: string,
-  link: LinkProps
+  link: NextLinkType
 |}
 
 const WorkPromo = ({

--- a/common/views/global/typography/typography.js
+++ b/common/views/global/typography/typography.js
@@ -26,7 +26,7 @@ const Typography = ({fonts}: Props) => (
     <div className='styleguide__font'>
       <h2 className='styleguide__font__name'>Secondary link</h2>
       <div>
-        <SecondaryLink url='#' text='Opening hours' />
+        <SecondaryLink link={{href: '#', as: '#'}} text='Opening hours' />
       </div>
       <h2 className='styleguide__font__usage-title'>Usage:</h2>
       <p className='styleguide__font__usage-text'>Standalone utility link. Uses text-decoration property for underline.</p>

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -240,7 +240,7 @@ class EventPage extends Component<Props, State> {
             })}>
               {!event.isPast &&
                 <SecondaryLink
-                  url='#dates'
+                  link={{href: '#dates', as: '#dates'}}
                   text={`See all dates`}
                   icon={'arrowSmall'}
                   trackingEvent={{
@@ -317,7 +317,10 @@ class EventPage extends Component<Props, State> {
                       text='Email to book' />
                   )}
                 <SecondaryLink
-                  url={`mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`}
+                  link={{
+                    href: `mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`,
+                    as: `mailto:${event.bookingEnquiryTeam.email}?subject=${event.title}`
+                  }}
                   text={event.bookingEnquiryTeam.email}
                   extraClasses={`block font-charcoal ${spacing({s: 1}, {margin: ['top']})}`} />
               </Fragment>

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -221,7 +221,10 @@ const Header = ({
                   </div>
                 }
                 <SecondaryLink
-                  url={'/opening-times'}
+                  link={{
+                    href: '/opening-times',
+                    as: '/opening-times'
+                  }}
                   text={'Full opening times'}
                 />
               </div>


### PR DESCRIPTION
Stops a bug where we `routeChange`, thus `pageview` GA, but then reload the page, and call GA again.

Should also fix the tag bug we have where the page looks for the `works` route, which no longer exists, it's `href: worksv2, as: works`. 