### PR TITLE
null check on parsing displayTime property on event

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -168,8 +168,8 @@ export function parseEventDoc(
     isCompletelySoldOut: data.times && data.times.filter(time => !time.isFullyBooked).length === 0,
     ticketSalesStart: data.ticketSalesStart,
     times: times,
-    displayStart: displayTime.range.startDateTime || null,
-    displayEnd: displayTime.range.endDateTime || null,
+    displayStart: (displayTime && displayTime.range.startDateTime) || null,
+    displayEnd: (displayTime && displayTime.range.endDateTime) || null,
     dateRange: determineDateRange(data.times),
     isPast: lastEndTime ? isPast(lastEndTime) : true,
     isRelaxedPerformance

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -234,7 +234,7 @@ class EventPage extends Component<Props, State> {
             'flex flex--wrap': true,
             [spacing({s: 1}, {margin: ['bottom']})]: true
           })}>
-            {EventDateRange({event})}
+            <EventDateRange event={event} />
             <div className={classNames({
               [spacing({s: 0, m: 2}, {margin: ['left']})]: true
             })}>


### PR DESCRIPTION
We seem to have hijacked the model quite substantially to be able to fit loads of our business logic around dates and times. This goes for opening times too.

It might be good to define the shape of the simplest model / type (and thus the type) and then write some functions, that'll be testable, on how we process the information about that model.

