### PR TITLE
remove coupling of state and showing tasl

### DIFF
--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -130,6 +130,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
       showTasl = true,
       isWidthAuto = false
     } = this.props;
+
     return (
       <Fragment>
         <noscript dangerouslySetInnerHTML={{__html: `
@@ -159,7 +160,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
           sizes={sizesQueries}
           alt={alt || ''} />
 
-        {showTasl && isWidthAuto && <Tasl {...tasl} isFull={isFull} />}
+        {showTasl && <Tasl {...tasl} isFull={isFull} />}
       </Fragment>
     );
   }


### PR DESCRIPTION
The only thing I can see this affects is that TASL is visible when the image isn't.
Better than not showing it on any image that doesn't inherit the logic from `CaptionedImage`