### PR TITLE
Serve errors correctly to allow us to use Prismic script on 404

### DIFF
--- a/catalogue/webapp/components/WorkRedesign/WorkRedesign.js
+++ b/catalogue/webapp/components/WorkRedesign/WorkRedesign.js
@@ -102,13 +102,15 @@ class WorkRedesign extends Component<Props, State> {
               </Layout12>
             </SpacingSection>
 
-            <SpacingSection>
-              {iiifImageLocationUrl && <WorkMedia
-                id={work.id}
-                iiifUrl={iiifImageLocationUrl}
-                title={work.title}
-                isV2={true} />}
-            </SpacingSection>
+            {iiifImageLocationUrl &&
+              <SpacingSection>
+                <WorkMedia
+                  id={work.id}
+                  iiifUrl={iiifImageLocationUrl}
+                  title={work.title}
+                  isV2={true} />
+              </SpacingSection>
+            }
 
             <SpacingSection>
               <Layout10>

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -74,7 +74,7 @@ export const Works = ({
         imageUrl={null}
         imageAltText={null}>
         <ErrorPage
-          errorStatus={works.httpStatus}
+          statusCode={works.httpStatus}
         />
       </PageLayout>
     );

--- a/catalogue/webapp/pages/worksv2.js
+++ b/catalogue/webapp/pages/worksv2.js
@@ -63,20 +63,9 @@ export const Works = ({
 }: Props) => {
   if (works && works.type === 'Error') {
     return (
-      <PageLayout
-        title={works.httpStatus.toString()}
-        description={''}
-        url={{pathname: `/works`}}
-        openGraphType={'website'}
-        siteSection={'works'}
-        jsonLd={{ '@type': 'WebPage' }}
-        oEmbedUrl={`https://wellcomecollection.org/works`}
-        imageUrl={null}
-        imageAltText={null}>
-        <ErrorPage
-          statusCode={works.httpStatus}
-        />
-      </PageLayout>
+      <ErrorPage
+        statusCode={works.httpStatus}
+      />
     );
   }
 

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -52,7 +52,7 @@ export const WorkPage = ({
         imageAltText={null}>
         <ErrorPage
           title={work.httpStatus === 410 ? 'This catalogue item has been removed.' : null}
-          errorStatus={work.httpStatus}
+          statusCode={work.httpStatus}
         />
       </PageLayout>
     );

--- a/catalogue/webapp/pages/workv2.js
+++ b/catalogue/webapp/pages/workv2.js
@@ -40,21 +40,10 @@ export const WorkPage = ({
 }: Props) => {
   if (work.type === 'Error') {
     return (
-      <PageLayout
-        title={work.httpStatus.toString()}
-        description={work.description}
-        url={{pathname: `/works`}}
-        openGraphType={'website'}
-        siteSection={'works'}
-        jsonLd={{ '@type': 'WebPage' }}
-        oEmbedUrl={`https://wellcomecollection.org/works`}
-        imageUrl={null}
-        imageAltText={null}>
-        <ErrorPage
-          title={work.httpStatus === 410 ? 'This catalogue item has been removed.' : null}
-          statusCode={work.httpStatus}
-        />
-      </PageLayout>
+      <ErrorPage
+        title={work.httpStatus === 410 ? 'This catalogue item has been removed.' : null}
+        statusCode={work.httpStatus}
+      />
     );
   }
 

--- a/common/services/prismic/types.js
+++ b/common/services/prismic/types.js
@@ -73,6 +73,10 @@ export type PaginatedResults<T> = {|
   totalPages: number
 |}
 
+export type PrismicApiError = {|
+  statusCode: number
+|}
+
 export type DocumentType =
 | 'articles'
 | 'webcomics'

--- a/common/views/components/ErrorPage/ErrorPage.js
+++ b/common/views/components/ErrorPage/ErrorPage.js
@@ -1,103 +1,114 @@
 // @flow
 import {classNames, spacing} from '../../../utils/classnames';
+import PageLayout from '../PageLayout/PageLayout';
 import ContentPage from '../ContentPage/ContentPage';
 import PageHeader from '../PageHeader/PageHeader';
 import Body from '../Body/Body';
 import PrimaryLink from '../Links/PrimaryLink/PrimaryLink';
 
 type Props = {|
-  errorStatus: number,
+  statusCode: number,
   title?: ?string
 |}
 
 const ErrorPage = ({
-  errorStatus,
+  statusCode,
   title
 }: Props) => {
   return (
-    <ContentPage
-      id={'error'}
-      Header={
-        <PageHeader
-          breadcrumbs={{ items: [{url: '/', text: 'Home'}] }}
-          labels={null}
-          title={title || 'This isn’t the page you’re looking for, but how about these?'}
-          ContentTypeInfo={null}
-          Background={null}
-          backgroundTexture={'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg'}
-          FeaturedMedia={null}
-          HeroPicture={null}
-          highlightHeading={true} />
-      }
-      Body={<Body body={[]} />}
-    >
-      <div className='body-text'>
-        <ul className='no-margin'>
-          <li>
-            <PrimaryLink url='/whats-on' name='Our exhibitions and events' />
-          </li>
-          <li className={classNames({
-            [spacing({ s: 5 }, {margin: ['top']})]: true
-          })}>
-            <PrimaryLink url='https://wellcomelibrary.org' name='Our library' />
-          </li>
-          <li className={classNames({
-            [spacing({ s: 5 }, {margin: ['top']})]: true
-          })}>
-            <PrimaryLink url='/stories' name='Our stories' />
-          </li>
-          <li className={classNames({
-            [spacing({ s: 5 }, {margin: ['top']})]: true
-          })}>
-            <PrimaryLink url='/books' name='Our books' />
-          </li>
-          <li className={classNames({
-            [spacing({ s: 5 }, {margin: ['top']})]: true
-          })}>
-            <PrimaryLink url='/works' name='Our images' />
-          </li>
-          <li className={classNames({
-            [spacing({ s: 5 }, {margin: ['top']})]: true
-          })}>
-            <PrimaryLink url='/pages/Wuw2MSIAACtd3Ssg' name='Our youth programme' />
-          </li>
-        </ul>
+    <PageLayout
+      title={`${statusCode}`}
+      description={`${statusCode}`}
+      url={{pathname: `/`}}
+      jsonLd={{'@type': 'WebPage'}}
+      openGraphType={'website'}
+      siteSection={'stories'}
+      imageUrl={null}
+      imageAltText={null}>
+      <ContentPage
+        id={'error'}
+        Header={
+          <PageHeader
+            breadcrumbs={{ items: [{url: '/', text: 'Home'}] }}
+            labels={null}
+            title={title || 'This isn’t the page you’re looking for, but how about these?'}
+            ContentTypeInfo={null}
+            Background={null}
+            backgroundTexture={'https://wellcomecollection.cdn.prismic.io/wellcomecollection%2F9154df28-e179-47c0-8d41-db0b74969153_wc+brand+backgrounds+2_pattern+2+colour+1.svg'}
+            FeaturedMedia={null}
+            HeroPicture={null}
+            highlightHeading={true} />
+        }
+        Body={<Body body={[]} />}
+      >
+        <div className='body-text'>
+          <ul className='no-margin'>
+            <li>
+              <PrimaryLink url='/whats-on' name='Our exhibitions and events' />
+            </li>
+            <li className={classNames({
+              [spacing({ s: 5 }, {margin: ['top']})]: true
+            })}>
+              <PrimaryLink url='https://wellcomelibrary.org' name='Our library' />
+            </li>
+            <li className={classNames({
+              [spacing({ s: 5 }, {margin: ['top']})]: true
+            })}>
+              <PrimaryLink url='/stories' name='Our stories' />
+            </li>
+            <li className={classNames({
+              [spacing({ s: 5 }, {margin: ['top']})]: true
+            })}>
+              <PrimaryLink url='/books' name='Our books' />
+            </li>
+            <li className={classNames({
+              [spacing({ s: 5 }, {margin: ['top']})]: true
+            })}>
+              <PrimaryLink url='/works' name='Our images' />
+            </li>
+            <li className={classNames({
+              [spacing({ s: 5 }, {margin: ['top']})]: true
+            })}>
+              <PrimaryLink url='/pages/Wuw2MSIAACtd3Ssg' name='Our youth programme' />
+            </li>
+          </ul>
 
-        <div className={classNames({
-          [spacing({ s: 10 }, {margin: ['top']})]: true
-        })}>
-          <h2 className='h2'>Looking for something published before 2018?</h2>
-          <p>
-            Our websites have been archived by the{' '}
-            <a href='https://archive.org'>Internet Archive</a> in its{' '}
-            <a href='https://web.archive.org/'>Wayback Machine</a>.
-          </p>
-          <PrimaryLink
-            url='https://web.archive.org/web/*/wellcomecollection.org'
-            name='See the Wellcome Collection website from 2007-present' />
+          <div className={classNames({
+            [spacing({ s: 10 }, {margin: ['top']})]: true
+          })}>
+            <h2 className='h2'>Looking for something published before 2018?</h2>
+            <p>
+              Our websites have been archived by the{' '}
+              <a href='https://archive.org'>Internet Archive</a> in its{' '}
+              <a href='https://web.archive.org/'>Wayback Machine</a>.
+            </p>
+            <PrimaryLink
+              url='https://web.archive.org/web/*/wellcomecollection.org'
+              name='See the Wellcome Collection website from 2007-present' />
+
+            <div className={classNames({
+              [spacing({ s: 5 }, {margin: ['top']})]: true
+            })}>
+              <PrimaryLink
+                url='https://web.archive.org/web/*/blog.wellcomecollection.org'
+                name='Read blog posts from 2013-2017' />
+            </div>
+          </div>
 
           <div className={classNames({
             [spacing({ s: 5 }, {margin: ['top']})]: true
           })}>
-            <PrimaryLink
-              url='https://web.archive.org/web/*/blog.wellcomecollection.org'
-              name='Read blog posts from 2013-2017' />
+            <p>
+              If you{`'`}re looking for something specific you{`'`}d love to see return to
+              this website, email us at{' '}
+              <a href='mailto:digital@wellcomecollection.org'>
+                digital@wellcomecollection.org
+              </a>.
+            </p>
           </div>
         </div>
-
-        <div className={classNames({
-          [spacing({ s: 5 }, {margin: ['top']})]: true
-        })}>
-          <p>
-            If you{`'`}re looking for something specific you{`'`}d love to see return to
-            this website, email us at{' '}
-            <a href='mailto:digital@wellcomecollection.org'>
-              digital@wellcomecollection.org
-            </a>.
-          </p>
-        </div>
-      </div>
-    </ContentPage>
+      </ContentPage>
+    </PageLayout>
   );
 };
 

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -107,6 +107,61 @@ export default class WecoApp extends App {
       a.appendChild(r);
     })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
 
+        // Prismic preview and validation warnings
+    const isPreview = document.cookie.match('isPreview=true');
+    if (isPreview) {
+      window.prismic = {
+        endpoint: 'https://wellcomecollection.prismic.io/api/v2'
+      };
+      const prismicScript = document.createElement('script');
+      prismicScript.src = '//static.cdn.prismic.io/prismic.min.js';
+      document.head && document.head.appendChild(prismicScript);
+      (function () {
+        var validationBar = document.createElement('div');
+        validationBar.style.position = 'fixed';
+        validationBar.style.width = '375px';
+        validationBar.style.padding = '15px';
+        validationBar.style.background = '#e01b2f';
+        validationBar.style.color = '#ffffff';
+        validationBar.style.bottom = '0';
+        validationBar.style.right = '0';
+        validationBar.style.fontSize = '12px';
+        validationBar.style.zIndex = '2147483000';
+
+        var validationFails = [];
+
+        var descriptionEl = document.querySelector('meta[name="description"]');
+        if (descriptionEl && !descriptionEl.getAttribute('content')) {
+          validationFails.push(`
+            <b>Warning:</b>
+            This piece of content is missing its description.
+            This helps with search engine results and sharing on social channels.
+            (If this is from Prismic, it's the promo text).
+          `);
+        }
+
+        var imageEl = document.querySelector('meta[property="og:image"]');
+        if (imageEl && !imageEl.getAttribute('content')) {
+          validationFails.push(`
+            <b>Warning:</b>
+            This piece of content is missing its promo image.
+            This is the image that will be shown across our site,
+            as well as on social media.
+          `);
+        }
+
+        if (validationFails.length > 0) {
+          validationFails.forEach(function(validationFail) {
+            var div = document.createElement('div');
+            div.style.marginBottom = '6px';
+            div.innerHTML = validationFail;
+            validationBar.appendChild(div);
+          });
+          document.body && document.body.appendChild(validationBar);
+        }
+      })();
+    }
+
     // Raven
     Raven.config('https://f756b8d4b492473782987a054aa9a347@sentry.io/133634', {
       shouldSendCallback(data) {

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -6,6 +6,7 @@ import Head from 'next/head';
 import ReactGA from 'react-ga';
 import Raven from 'raven-js';
 import {parseOpeningTimesFromCollectionVenues} from '../../services/prismic/opening-times';
+import ErrorPage from '../../views/components/ErrorPage/ErrorPage';
 import TogglesContext from '../../views/components/TogglesContext/TogglesContext';
 import OpeningTimesContext from '../../views/components/OpeningTimesContext/OpeningTimesContext';
 import GlobalAlertContext from '../../views/components/GlobalAlertContext/GlobalAlertContext';
@@ -35,6 +36,10 @@ export default class WecoApp extends App {
     if (Component.getInitialProps) {
       ctx.query.toggles = toggles;
       pageProps = await Component.getInitialProps(ctx);
+      if (ctx.res && pageProps.statusCode) {
+        ctx.res.statusCode = pageProps.statusCode;
+        console.info('skdjhskdjhfjkdshfk');
+      }
     }
 
     return {
@@ -107,7 +112,7 @@ export default class WecoApp extends App {
       a.appendChild(r);
     })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
 
-        // Prismic preview and validation warnings
+    // Prismic preview and validation warnings
     const isPreview = document.cookie.match('isPreview=true');
     if (isPreview) {
       window.prismic = {
@@ -198,7 +203,6 @@ export default class WecoApp extends App {
       'WeakMap',
       'URL'
     ];
-    const isPreview = false;
     const parsedOpeningTimes = parseOpeningTimesFromCollectionVenues(openingTimes);
 
     return (
@@ -219,7 +223,8 @@ export default class WecoApp extends App {
         <TogglesContext.Provider value={toggles}>
           <OpeningTimesContext.Provider value={parsedOpeningTimes}>
             <GlobalAlertContext.Provider value={globalAlert.text}>
-              <Component {...pageProps} />
+              {pageProps.statusCode === 200 && <Component {...pageProps} />}
+              {pageProps.statusCode !== 200 && <ErrorPage statusCode={pageProps.statusCode} />}
             </GlobalAlertContext.Provider>
           </OpeningTimesContext.Provider>
         </TogglesContext.Provider>

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -36,9 +36,15 @@ export default class WecoApp extends App {
     if (Component.getInitialProps) {
       ctx.query.toggles = toggles;
       pageProps = await Component.getInitialProps(ctx);
-      if (ctx.res && pageProps.statusCode) {
-        ctx.res.statusCode = pageProps.statusCode;
-        console.info('skdjhskdjhfjkdshfk');
+
+      // If we're on the server, apply any statusCode sent from `getInitialProps`
+      // To the res, or set the `pageProps.statusCode` from the res (200)
+      if (ctx.res) {
+        if (pageProps.statusCode) {
+          ctx.res.statusCode = pageProps.statusCode;
+        } else {
+          pageProps.statusCode = ctx.res.statusCode;
+        }
       }
     }
 

--- a/content/webapp/pages/_error.js
+++ b/content/webapp/pages/_error.js
@@ -3,7 +3,6 @@ import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
 
 export default class Error extends React.Component {
   static getInitialProps({ res, err }) {
-    console.info('Error', res.statusCode);
     const statusCode = res ? res.statusCode : err ? err.statusCode : null;
     return { statusCode };
   }

--- a/content/webapp/pages/_error.js
+++ b/content/webapp/pages/_error.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
+
+export default class Error extends React.Component {
+  static getInitialProps({ res, err }) {
+    console.info('Error', res.statusCode);
+    const statusCode = res ? res.statusCode : err ? err.statusCode : null;
+    return { statusCode };
+  }
+
+  render() {
+    const {statusCode} = this.props;
+    return (
+      statusCode
+        ? <ErrorPage statusCode={this.props.statusCode} />
+        : <ErrorPage statusCode={500} />
+    );
+  }
+}

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -1,6 +1,9 @@
 // @flow
 import type {Context} from 'next';
 import {Fragment, Component} from 'react';
+import type {Article} from '@weco/common/model/articles';
+import type {ArticleScheduleItem} from '@weco/common/model/article-schedule-items';
+import type {PrismicApiError} from '@weco/common/services/prismic/types';
 import {getArticle} from '@weco/common/services/prismic/articles';
 import {getArticleSeries} from '@weco/common/services/prismic/article-series';
 import {classNames, spacing, font} from '@weco/common/utils/classnames';
@@ -17,8 +20,6 @@ import {
   getHeroPicture
 } from '@weco/common/views/components/PageHeader/PageHeader';
 import {convertImageUri} from '@weco/common/utils/convert-image-uri';
-import type {Article} from '@weco/common/model/articles';
-import type {ArticleScheduleItem} from '@weco/common/model/article-schedule-items';
 import {articleLd} from '@weco/common/utils/json-ld';
 import {ContentFormatIds} from '@weco/common/model/content-format-id';
 
@@ -43,13 +44,15 @@ export class ArticlePage extends Component<Props, State> {
     listOfSeries: []
   }
 
-  static getInitialProps = async (ctx: Context): Promise<?Props> => {
+  static getInitialProps = async (ctx: Context): Promise<?Props | PrismicApiError> => {
     const {id} = ctx.query;
     const article = await getArticle(ctx.req, id);
     if (article) {
       return {
         article
       };
+    } else {
+      return {statusCode: 404};
     }
   }
 

--- a/content/webapp/pages/articles.js
+++ b/content/webapp/pages/articles.js
@@ -1,13 +1,14 @@
 // @flow
 import type {Context} from 'next';
+import type {PrismicApiError} from '@weco/common/services/prismic/types';
+import type {Article} from '@weco/common/model/articles';
+import type {PaginatedResults} from '@weco/common/services/prismic/types';
 import {Component} from 'react';
 import {getArticles} from '@weco/common/services/prismic/articles';
 import {convertImageUri} from '@weco/common/utils/convert-image-uri';
 import {articleLd} from '@weco/common/utils/json-ld';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '@weco/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults';
-import type {Article} from '@weco/common/model/articles';
-import type {PaginatedResults} from '@weco/common/services/prismic/types';
 
 type Props = {|
   articles: PaginatedResults<Article>
@@ -15,13 +16,15 @@ type Props = {|
 
 const pageDescription = 'Our words and pictures explore the connections between science, medicine, life and art. Dive into one no matter where in the world you are.';
 export class ArticlesPage extends Component<Props> {
-  static getInitialProps = async (ctx: Context): Promise<?Props> => {
+  static getInitialProps = async (ctx: Context): Promise<??Props | PrismicApiError> => {
     const {page = 1} = ctx.query;
     const articles = await getArticles(ctx.req, {page});
     if (articles) {
       return {
         articles
       };
+    } else {
+      return {statusCode: 404};
     }
   }
 

--- a/content/webapp/pages/event-series.js
+++ b/content/webapp/pages/event-series.js
@@ -37,6 +37,8 @@ export class EventSeriesPage extends Component<Props> {
         series,
         events
       };
+    } else {
+      return {statusCode: 404};
     }
   }
 

--- a/content/webapp/pages/installation.js
+++ b/content/webapp/pages/installation.js
@@ -28,6 +28,8 @@ class InstallationPage extends Component<Props> {
       return {
         installation
       };
+    } else {
+      return {statusCode: 404};
     }
   }
 

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -28,6 +28,8 @@ export class Page extends Component<Props> {
       return {
         page
       };
+    } else {
+      return {statusCode: 404};
     }
   }
 

--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -69,6 +69,8 @@ export class StoriesPage extends Component<Props> {
         articles,
         series
       };
+    } else {
+      return {statusCode: 404};
     }
   }
 


### PR DESCRIPTION
There are two cases in which we need to serve errors.

1. There has been an error somewhere in the stack (generally 500)
1. There has been an error from an API request (generally 404)

The general error is dealt with by `_error`, and the other case is when the `getInitialProps` returns a `PrismicApiError`.  