### PR TITLE
only error when we override the status code from getInitialProps

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -37,7 +37,7 @@ export default class WecoApp extends App {
       ctx.query.toggles = toggles;
       pageProps = await Component.getInitialProps(ctx);
 
-      // If we override the statausCode from getInitialProps, make sure we
+      // If we override the statusCode from getInitialProps, make sure we
       // set that on the server response too
       if (ctx.res && pageProps.statusCode) {
         ctx.res.statusCode = pageProps.statusCode;

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -37,14 +37,10 @@ export default class WecoApp extends App {
       ctx.query.toggles = toggles;
       pageProps = await Component.getInitialProps(ctx);
 
-      // If we're on the server, apply any statusCode sent from `getInitialProps`
-      // To the res, or set the `pageProps.statusCode` from the res (200)
-      if (ctx.res) {
-        if (pageProps.statusCode) {
-          ctx.res.statusCode = pageProps.statusCode;
-        } else {
-          pageProps.statusCode = ctx.res.statusCode;
-        }
+      // If we override the statausCode from getInitialProps, make sure we
+      // propegate that down the line.
+      if (pageProps.statusCode) {
+        ctx.res.statusCode = pageProps.statusCode;
       }
     }
 
@@ -229,7 +225,7 @@ export default class WecoApp extends App {
         <TogglesContext.Provider value={toggles}>
           <OpeningTimesContext.Provider value={parsedOpeningTimes}>
             <GlobalAlertContext.Provider value={globalAlert.text}>
-              {pageProps.statusCode === 200 && <Component {...pageProps} />}
+              {!pageProps.statusCode && <Component {...pageProps} />}
               {pageProps.statusCode !== 200 && <ErrorPage statusCode={pageProps.statusCode} />}
             </GlobalAlertContext.Provider>
           </OpeningTimesContext.Provider>

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -38,8 +38,8 @@ export default class WecoApp extends App {
       pageProps = await Component.getInitialProps(ctx);
 
       // If we override the statausCode from getInitialProps, make sure we
-      // propegate that down the line.
-      if (pageProps.statusCode) {
+      // set that on the server response too
+      if (ctx.res && pageProps.statusCode) {
         ctx.res.statusCode = pageProps.statusCode;
       }
     }

--- a/content/webapp/pages/articles.js
+++ b/content/webapp/pages/articles.js
@@ -1,8 +1,10 @@
 // @flow
 import type {Context} from 'next';
-import type {PrismicApiError} from '@weco/common/services/prismic/types';
 import type {Article} from '@weco/common/model/articles';
-import type {PaginatedResults} from '@weco/common/services/prismic/types';
+import type {
+  PaginatedResults,
+  PrismicApiError
+} from '@weco/common/services/prismic/types';
 import {Component} from 'react';
 import {getArticles} from '@weco/common/services/prismic/articles';
 import {convertImageUri} from '@weco/common/utils/convert-image-uri';
@@ -16,10 +18,10 @@ type Props = {|
 
 const pageDescription = 'Our words and pictures explore the connections between science, medicine, life and art. Dive into one no matter where in the world you are.';
 export class ArticlesPage extends Component<Props> {
-  static getInitialProps = async (ctx: Context): Promise<??Props | PrismicApiError> => {
+  static getInitialProps = async (ctx: Context): Promise<?Props | PrismicApiError> => {
     const {page = 1} = ctx.query;
     const articles = await getArticles(ctx.req, {page});
-    if (articles) {
+    if (articles && articles.results.length > 0) {
       return {
         articles
       };

--- a/content/webapp/pages/events.js
+++ b/content/webapp/pages/events.js
@@ -28,7 +28,7 @@ export class ArticleSeriesPage extends Component<Props> {
       period,
       order: period === 'past' ? 'desc' : 'asc'
     });
-    if (events) {
+    if (events && events.results.length > 0) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'vents';
       return {
         events,
@@ -37,7 +37,7 @@ export class ArticleSeriesPage extends Component<Props> {
         displayTitle: title
       };
     } else {
-      return { statusCode: 404 };
+      return {statusCode: 404};
     }
   }
 

--- a/content/webapp/pages/exhibitions.js
+++ b/content/webapp/pages/exhibitions.js
@@ -22,7 +22,7 @@ export class ExhibitionsPage extends Component<Props> {
     const { page = 1 } = ctx.query;
     const { period } = ctx.query;
     const exhibitions = await getExhibitions(ctx.req, { page, period });
-    if (exhibitions) {
+    if (exhibitions && exhibitions.results.length > 0) {
       const title = (period === 'past' ? 'Past e' : 'E') + 'xhibitions';
       return {
         exhibitions,
@@ -30,7 +30,7 @@ export class ExhibitionsPage extends Component<Props> {
         period
       };
     } else {
-      return { statusCode: 404 };
+      return {statusCode: 404};
     }
   }
 


### PR DESCRIPTION
Error handling was overcomplicated, and only worked on the server.
Now we only show an error in `_app` if the caller `getIntialProps` sends an override.

Otherwise other errors will be picked up by `_error`.

Fixes #3884 