### PR TITLE
Adds assume roles from platform account

### DIFF
--- a/shared-infra/terraform/account_iam.tf
+++ b/shared-infra/terraform/account_iam.tf
@@ -1,0 +1,19 @@
+locals {
+  platform_account_root = "arn:aws:iam::760097843905:root"
+}
+
+module "account" {
+  source = "git::https://github.com/wellcometrust/terraform.git//iam/prebuilt/account?ref=v18.0.0"
+
+  admin_principals          = ["${local.platform_account_root}"]
+  read_only_principals      = ["${local.platform_account_root}"]
+  billing_principals        = ["${local.platform_account_root}"]
+  developer_principals      = ["${local.platform_account_root}"]
+  infrastructure_principals = ["${local.platform_account_root}"]
+
+  pgp_key = "${data.template_file.pgp_key.rendered}"
+}
+
+data "template_file" "pgp_key" {
+  template = "${file("${path.module}/wellcomedigitalplatform.key")}"
+}


### PR DESCRIPTION
## Who is this for?

Developers who want to easily switch roles when working in AWS.

## What is it doing for them?

Allows developers from the platform account to easily switch roles into the wellcomecollection.org account.

This module can also be used to allow access to any other users, including assuming roles from your own account.