### PR TITLE
Cached values handler

### DIFF
--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -1,8 +1,9 @@
+const { parse } = require('url');
 const Koa = require('koa');
 const Router = require('koa-router');
 const next = require('next');
 const {
-  middleware, route
+  middleware, route, handleAllRoute
 } = require('@weco/common/koa-middleware/withCachedValues');
 
 const dev = process.env.NODE_ENV !== 'production';
@@ -27,10 +28,7 @@ module.exports = app.prepare().then(async () => {
     ctx.body = 'ok';
   });
 
-  router.get('*', async ctx => {
-    await handle(ctx.req, ctx.res);
-    ctx.respond = false;
-  });
+  router.get('*', handleAllRoute(handle));
 
   server.use(async (ctx, next) => {
     ctx.res.statusCode = 200;

--- a/common/koa-middleware/withCachedValues.js
+++ b/common/koa-middleware/withCachedValues.js
@@ -1,4 +1,5 @@
 
+const {parse} = require('url');
 const compose = require('koa-compose');
 const withGlobalAlert = require('./withGlobalAlert');
 const withOpeningtimes = require('./withOpeningTimes');
@@ -28,7 +29,27 @@ async function route(path, page, router, app, extraParams = {}) {
   });
 }
 
+function handleAllRoute(handle) {
+  return async function (ctx) {
+    const parsedUrl = parse(ctx.request.url, true);
+    const {toggles, globalAlert, openingTimes} = ctx;
+    const query = {
+      ...parsedUrl.query,
+      toggles,
+      globalAlert,
+      openingTimes
+    };
+    const url = {
+      ...parsedUrl,
+      query
+    };
+    await handle(ctx.req, ctx.res, url);
+    ctx.respond = false;
+  };
+}
+
 module.exports = {
   middleware: withCachedValues,
-  route
+  route,
+  handleAllRoute
 };

--- a/content/webapp/app.js
+++ b/content/webapp/app.js
@@ -5,7 +5,7 @@ const Prismic = require('prismic-javascript');
 const linkResolver = require('@weco/common/services/prismic/link-resolver');
 
 const {
-  middleware, route
+  middleware, route, handleAllRoute
 } = require('@weco/common/koa-middleware/withCachedValues');
 
 // FIXME: Find a way to import this.
@@ -90,10 +90,7 @@ module.exports = app.prepare().then(async () => {
     ctx.body = 'ok';
   });
 
-  router.get('*', async ctx => {
-    await handle(ctx.req, ctx.res);
-    ctx.respond = false;
-  });
+  router.get('*', handleAllRoute(handle));
 
   server.use(async (ctx, next) => {
     ctx.res.statusCode = 200;


### PR DESCRIPTION
~Forked from #3891~

If we ever hit a page that isn't handed with out routes, our error page can't render as we don't have the `openingHours`, `globalAlert`, nor `toggles`.

I keep hitting 500s and ignoring it, but it felt like a thing to button up before it bites us.