### PR TITLE
Opening times tweaks

### DIFF
--- a/common/views/components/OpeningHours/OpeningHours.js
+++ b/common/views/components/OpeningHours/OpeningHours.js
@@ -91,7 +91,7 @@ class OpeningHours extends Component<Props, State> {
                 }
               }
             })}
-            . Please check our <a href='/opening-times#exceptional'>modified opening times</a> for details before you travel.
+            . Please check our <a href='/opening-times#exceptional'>revised opening hours</a> for details before you travel.
           </p>
         }
         {groupedVenues && groupedVenues[Object.keys(groupedVenues)[0]].hours && groupedVenues[Object.keys(groupedVenues)[0]].hours.length > 1 &&

--- a/content/webapp/pages/opening-times.js
+++ b/content/webapp/pages/opening-times.js
@@ -93,7 +93,11 @@ export class OpeningTimesPage extends Component<Props> {
             <Fragment>
               <div className='spacing-component'>
                 <div className='body-text font-HNM4-s font-HNM3-m'>
-                  <p>Explore our opening hours across the different parts of our building. Keep in mind we&apos;re open late on Thursdays! We also have <a href='#exceptional'>revised opening hours over the festive holidays</a>. </p>
+                  <p>Explore our opening hours across the different parts of our building. Keep in mind we&apos;re open late on Thursdays!
+                    {openingHours.upcomingExceptionalOpeningPeriods && openingHours.upcomingExceptionalOpeningPeriods.length > 0 &&
+                    <span dangerouslySetInnerHTML={{__html: ` We also have <a href='#exceptional'>revised opening hours over the festive holidays</a>.`}} />
+                    }
+                  </p>
                 </div>
               </div>
               <h2 className={classNames({
@@ -105,7 +109,7 @@ export class OpeningTimesPage extends Component<Props> {
               })}>
                 <OpeningHours
                   extraClasses='opening-hours--light'
-                  upcomingExceptionalOpeningPeriods={openingHours.upcomingExceptionalOpeningPeriods}
+                  upcomingExceptionalOpeningPeriods={null}
                   groupedVenues={openingHours.groupedVenues} />
               </div>
               <Divider


### PR DESCRIPTION
references #3439

- make language consistent
- don't show link to revised opening hours when there aren't any
- only show message above regular opening hours in footer

