### PR TITLE
don't set values in URL if they are default

### DIFF
--- a/catalogue/webapp/services/catalogue/urls.js
+++ b/catalogue/webapp/services/catalogue/urls.js
@@ -46,14 +46,16 @@ export function worksUrl({
   workType,
   itemsLocationsLocationType
 }: WorksUrlProps): NextLinkType {
+  const isDefaultWorkType = JSON.stringify(workType) === JSON.stringify(['k', 'q']);
+  const isDefaultItemsLocationsLocationType = JSON.stringify(itemsLocationsLocationType) === JSON.stringify(['iiif-image']);
   return {
     href: {
       pathname: `/works`,
       query: removeEmpty({
         query: query || undefined,
         page: page && page > 1 ? page : undefined,
-        workType: workType ? workType.join(',') : undefined,
-        'items.locations.locationType': itemsLocationsLocationType ? itemsLocationsLocationType.join(',') : undefined
+        workType: workType && !isDefaultWorkType ? workType.join(',') : undefined,
+        'items.locations.locationType': itemsLocationsLocationType && !isDefaultItemsLocationsLocationType ? itemsLocationsLocationType.join(',') : undefined
       })
     },
     as: {
@@ -61,8 +63,8 @@ export function worksUrl({
       query: removeEmpty({
         query: query || undefined,
         page: page && page > 1 ? page : undefined,
-        workType: workType ? workType.join(',') : undefined,
-        'items.locations.locationType': itemsLocationsLocationType ? itemsLocationsLocationType.join(',') : undefined
+        workType: workType && !isDefaultWorkType ? workType.join(',') : undefined,
+        'items.locations.locationType': itemsLocationsLocationType && !isDefaultItemsLocationsLocationType ? itemsLocationsLocationType.join(',') : undefined
       })
     }
   };


### PR DESCRIPTION
We don't want to the URL to reflect the `workType` and `items.locations.locationType` if they are "default".

"default" meaning filtered.

It raises some interesting thoughts around how we might want to measure search, and also that our implementation is the opposite of what we really have, AKA, lots of data filtered is default, not the filters applied to all data.