### PR TITLE
make sure we put yarn.lock into the Dockerfiles

### DIFF
--- a/catalogue/webapp/Dockerfile
+++ b/catalogue/webapp/Dockerfile
@@ -4,6 +4,7 @@ ENV NODE_ENV=production
 
 WORKDIR /usr/src/app/webapp
 ADD ./package.json ./package.json
+ADD ./yarn.lock ./yarn.lock
 ADD ./common ./common
 ADD ./catalogue/webapp ./catalogue/webapp
 # This is needed for node-sass

--- a/content/webapp/Dockerfile
+++ b/content/webapp/Dockerfile
@@ -4,6 +4,7 @@ ENV NODE_ENV=production
 
 WORKDIR /usr/src/app/webapp
 ADD ./package.json ./package.json
+ADD ./yarn.lock ./yarn.lock
 ADD ./common ./common
 ADD ./content/webapp ./content/webapp
 # This is needed for node-sass


### PR DESCRIPTION
Turns out our builds were inconsistent with local as we weren't copying over the lock file.

The error was raised when we started getting the error that suggests that we were using two instantiations of React, that we had started using yarn workspaces to make sure we had 1 consistent React.

Adding the yarn.lock makes sure our builds are now consistent with local.