### PR TITLE
remove getInitialProps from dash app

### DIFF
--- a/dash/webapp/next.config.js
+++ b/dash/webapp/next.config.js
@@ -1,7 +1,0 @@
-// We build and deploy from Circle
-// This let's us serve from https://dash.wc.org/toggles
-const isTest = process.env.NODE_ENV === 'test';
-module.exports = {
-  // You may only need to add assetPrefix in the production.
-  assetPrefix: isTest ? '/' : ''
-};

--- a/dash/webapp/pages/pa11y.js
+++ b/dash/webapp/pages/pa11y.js
@@ -1,4 +1,5 @@
-import React, {Fragment} from 'react';
+// $FlowFixMe
+import {Fragment, useState, useEffect} from 'react';
 import fetch from 'isomorphic-unfetch';
 import styled from 'styled-components';
 import Header from '../components/Header';
@@ -30,8 +31,16 @@ const Issue = styled.div`
     ` : ''}
 `;
 
-const Index = ({resultsList}: any) => {
-  return (
+const Index = () => {
+  const [resultsList, setResultsList] = useState(null);
+
+  useEffect(() => {
+    fetch('https://dash.wellcomecollection.org/pa11y/report.json')
+      .then(resp => resp.json())
+      .then(json => setResultsList(json))
+  }, []);
+
+  return resultsList && (
     <Fragment>
       <div style={{
         fontFamily
@@ -91,13 +100,6 @@ const Index = ({resultsList}: any) => {
       </div>
     </Fragment>
   );
-};
-
-Index.getInitialProps = async () => {
-  const results = await fetch('https://dash.wellcomecollection.org/pa11y/report.json');
-  const json = await results.json();
-
-  return {resultsList: json};
 };
 
 export default Index;

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -1,7 +1,7 @@
 
 // @flow
 // $FlowFixMe
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import styled from 'styled-components';
 import getCookies from 'next-cookies';
 import Header from '../components/Header';
@@ -22,7 +22,7 @@ const Button = styled.button`
 const aYear = 31536000;
 function setCookie(name, value) {
   const expiration = value ? ` Max-Age=${aYear}` : `Expires=${new Date('1970-01-01').toString()}`;
-  document.cookie = `toggle_${name}=${value || ''}; Path=/; Domain=wellcomecollection.org; ${expiration}`;
+  document.cookie = `toggle_${name}=${value || ''}; Path=/; ${expiration}`;
 }
 
 const abTests = [];
@@ -52,9 +52,22 @@ const featureToggles = [{
     'Shows the static version of the page to allow usability testing to be conducted.'
 }];
 
-type Props = {| initialToggles: Object |}
-const IndexPage = ({ initialToggles }: Props) => {
-  const [toggles, setToggles] = useState(initialToggles);
+const IndexPage = () => {
+  const [toggles, setToggles] = useState({});
+
+  // We use this over getInitialProps as it's ineffectual when an app is
+  // exported.
+  useEffect(() => {
+    const cookies = getCookies({});
+    const initialToggles = Object.keys(cookies).reduce((acc, key) => {
+      if (key.startsWith('toggle_')) {
+        acc[key.replace('toggle_', '')] = cookies[key] === 'true';
+      }
+      return acc;
+    }, {});
+
+    setToggles(initialToggles)
+  }, [])
 
   return (
     <div style={{
@@ -163,20 +176,6 @@ const IndexPage = ({ initialToggles }: Props) => {
       </div>
     </div>
   );
-};
-
-IndexPage.getInitialProps = (ctx) => {
-  const cookies = getCookies(ctx);
-  const initialToggles = Object.keys(cookies).reduce((acc, key) => {
-    if (key.startsWith('toggle_')) {
-      acc[key.replace('toggle_', '')] = cookies[key] === 'true';
-    }
-    return acc;
-  }, {});
-
-  return {
-    initialToggles
-  };
 };
 
 export default IndexPage;


### PR DESCRIPTION
`getIntialProps` runs differently on exported app.
On initial page load, it doesn't run (so selected toggles weren't been flagged as selected).

I moved everything into the standard JS lifecycle.