### PR TITLE
Download link styling

### DIFF
--- a/common/services/prismic/html-serialisers.js
+++ b/common/services/prismic/html-serialisers.js
@@ -72,7 +72,7 @@ export const defaultSerializer: HtmlSerializer = (type, element, content, childr
       const target = element.data.target ? `target="${element.data.target}" rel="noopener"` : '';
       const linkUrl = PrismicDOM.Link.url(element.data, linkResolver);
       const isDocument = element.data.kind === 'document';
-      const documentSize = isDocument ? Math.round(element.data.size / 1000) : null;
+      const documentSize = isDocument ? Math.round(element.data.size / 1000) : '';
       const fileExtension = linkUrl.match(/\.[0-9a-z]+$/i);
       const documentType = fileExtension && fileExtension[0].substr(1).toUpperCase();
       if (isDocument) {

--- a/common/services/prismic/html-serialisers.js
+++ b/common/services/prismic/html-serialisers.js
@@ -6,7 +6,7 @@ import {sized} from '../../utils/style';
 
 const { Elements } = PrismicDOM.RichText;
 
-export type HtmlSeriliser = (
+export type HtmlSerializer = (
   type: string,
   element: Object, // There are so many types here
   content: string,
@@ -14,7 +14,7 @@ export type HtmlSeriliser = (
   i: number
 ) =>?string
 
-export const dropCapSerialiser: HtmlSeriliser = (
+export const dropCapSerializer: HtmlSerializer = (
   type,
   element,
   content,
@@ -33,7 +33,7 @@ export const dropCapSerialiser: HtmlSeriliser = (
   return defaultSerializer(type, element, content, children, i);
 };
 
-export const defaultSerializer: HtmlSeriliser = (type, element, content, children, i) => {
+export const defaultSerializer: HtmlSerializer = (type, element, content, children, i) => {
   switch (type) {
     case Elements.heading1: return `<h1>${children.join('')}</h1>`;
     case Elements.heading2: return `<h2>${children.join('')}</h2>`;

--- a/common/services/prismic/html-serialisers.js
+++ b/common/services/prismic/html-serialisers.js
@@ -2,6 +2,8 @@
 import PrismicDOM from 'prismic-dom';
 import linkResolver from './link-resolver';
 import { font } from '../../utils/classnames';
+import {sized} from '../../utils/style';
+
 const { Elements } = PrismicDOM.RichText;
 
 export type HtmlSeriliser = (
@@ -31,7 +33,7 @@ export const dropCapSerialiser: HtmlSeriliser = (
   return defaultSerializer(type, element, content, children, i);
 };
 
-const defaultSerializer: HtmlSeriliser = (type, element, content, children, i) => {
+export const defaultSerializer: HtmlSeriliser = (type, element, content, children, i) => {
   switch (type) {
     case Elements.heading1: return `<h1>${children.join('')}</h1>`;
     case Elements.heading2: return `<h2>${children.join('')}</h2>`;
@@ -69,7 +71,30 @@ const defaultSerializer: HtmlSeriliser = (type, element, content, children, i) =
     case Elements.hyperlink:
       const target = element.data.target ? `target="${element.data.target}" rel="noopener"` : '';
       const linkUrl = PrismicDOM.Link.url(element.data, linkResolver);
-      return `<a ${target} href="${linkUrl}">${children.join('')}</a>`;
+      const isDocument = element.data.kind === 'document';
+      const documentSize = isDocument ? Math.round(element.data.size / 1000) : null;
+      const fileExtension = linkUrl.match(/\.[0-9a-z]+$/i);
+      const documentType = fileExtension && fileExtension[0].substr(1).toUpperCase();
+      if (isDocument) {
+        return `<a ${target} class="no-margin plain-link font-green font-HNM3-s flex-inline" href="${linkUrl}">
+            <span class="icon" style="margin-top: ${sized(1)}">
+              <canvas class="icon__canvas" height="20" width="20"></canvas>
+              <svg class="icon__svg no-margin" role="img" aria-labelledby="icon-download-title" style="width: 20px; height: 20px;">
+                <title id="icon-download-title">download</title>
+                <svg viewBox="0 0 26 26"><path class="icon__shape" d="M21.2 21.1H4.8a1 1 0 0 0 0 2h16.4a1 1 0 0 0 0-2zm-8.98-2.38a1 1 0 0 0 1.56 0l4-5a1 1 0 0 0-1.56-1.25L14 15.25V4.1a1 1 0 0 0-2 0v11.15l-2.22-2.78a1 1 0 1 0-1.56 1.25z"/></svg>
+              </svg>
+            </span>
+            <span class="no-margin">
+              <span class="no-margin underline-on-hover">${children.join('')}</span>
+              <span style="white-space: nowrap">
+                <span class="no-margin font-pewter font-HNM4-s">${documentType}</span>
+                <span class="no-margin font-pewter font-HNL4-s">${documentSize}kb</span>
+              </span>
+            </span>
+        </a>`;
+      } else {
+        return `<a ${target} href="${linkUrl}">${children.join('')}</a>`;
+      }
     case Elements.label:
       const label = element.data.label ? ` class="${element.data.label}"` : '';
       return `<span ${label}>${children.join('')}</span>`;

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -13,7 +13,7 @@ import type { ImagePromo } from '../../model/image-promo';
 import type { GenericContentFields } from '../../model/generic-content-fields';
 import type { LabelField } from '../../model/label-field';
 import type { SameAs } from '../../model/same-as';
-import type { HtmlSeriliser } from './html-serialisers';
+import type { HtmlSerializer } from './html-serialisers';
 import { licenseTypeArray } from '../../model/license';
 import { parsePage } from './pages';
 import { parseEventSeries } from './event-series';
@@ -46,11 +46,11 @@ export function asText(maybeContent: ?HTMLString): ?string {
   return maybeContent && RichText.asText(maybeContent).trim();
 }
 
-export function asHtml(maybeContent: ?HTMLString, htmlSerialiser?: HtmlSeriliser) {
+export function asHtml(maybeContent: ?HTMLString, htmlSerializer?: HtmlSerializer) {
   // Prismic can send us empty html elements which can lead to unwanted UI in templates.
   // Check that `asText` wouldn't return an empty string.
   const isEmpty = !maybeContent || (asText(maybeContent) || '').trim() === '';
-  return isEmpty ? null : RichText.asHtml(maybeContent, linkResolver, htmlSerialiser).trim();
+  return isEmpty ? null : RichText.asHtml(maybeContent, linkResolver, htmlSerializer).trim();
 }
 
 function isMissingOrEmpty(maybeContent: any) {

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -50,6 +50,10 @@
 @each $color-key, $color-value in $colors {
   .font-#{$color-key} {
     color: nth($color-value, 1);
+
+    .icon__shape {
+      fill: nth($color-value, 1);
+    }
   }
 
   .font-hover-#{$color-key}:hover,
@@ -214,8 +218,21 @@
   text-align: left;
 }
 
-.plain-link {
+.plain-link,
+.plain-link:link,
+.plain-link:visited {
   text-decoration: none;
+  border: none;
+
+  .body-text & {
+    text-decoration: none;
+    border: none;
+  }
+}
+
+.underline-on-hover:hover,
+:link:hover .underline-on-hover {
+  text-decoration: underline;
 }
 
 .text-align-right {

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -16,7 +16,7 @@ import DeprecatedImageList from '../DeprecatedImageList/DeprecatedImageList';
 import Layout8 from '../Layout8/Layout8';
 import Layout10 from '../Layout10/Layout10';
 import Layout12 from '../Layout12/Layout12';
-import {dropCapSerialiser} from '../../../services/prismic/html-serialisers';
+import {dropCapSerializer} from '../../../services/prismic/html-serialisers';
 import type {Weight} from '../../../services/prismic/parsers';
 
 type BodySlice = {|
@@ -61,7 +61,7 @@ const Body = ({
                     {slice.weight === 'featured' && <FeaturedText html={slice.value} />}
                     {slice.weight !== 'featured' &&
                       (firstTextSliceIndex === i && isDropCapped
-                        ? <PrismicHtmlBlock html={slice.value} htmlSerialiser={dropCapSerialiser} />
+                        ? <PrismicHtmlBlock html={slice.value} htmlSerialiser={dropCapSerializer} />
                         : <PrismicHtmlBlock html={slice.value} />)
                     }
                   </div>

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -16,7 +16,7 @@ import DeprecatedImageList from '../DeprecatedImageList/DeprecatedImageList';
 import Layout8 from '../Layout8/Layout8';
 import Layout10 from '../Layout10/Layout10';
 import Layout12 from '../Layout12/Layout12';
-import {dropCapSerializer} from '../../../services/prismic/html-serialisers';
+import {defaultSerializer, dropCapSerializer} from '../../../services/prismic/html-serialisers';
 import type {Weight} from '../../../services/prismic/parsers';
 
 type BodySlice = {|
@@ -62,7 +62,7 @@ const Body = ({
                     {slice.weight !== 'featured' &&
                       (firstTextSliceIndex === i && isDropCapped
                         ? <PrismicHtmlBlock html={slice.value} htmlSerialiser={dropCapSerializer} />
-                        : <PrismicHtmlBlock html={slice.value} />)
+                        : <PrismicHtmlBlock html={slice.value} htmlSerialiser={defaultSerializer} />)
                     }
                   </div>
                 </Layout8>


### PR DESCRIPTION
Refs 3800

- uses rich text templating to style links to documents as per designs

Before:
<img width="602" alt="screen shot 2019-01-07 at 10 14 32" src="https://user-images.githubusercontent.com/6051896/50762553-2ac41080-1265-11e9-930d-25c64edd849f.png">

After:
![download](https://user-images.githubusercontent.com/6051896/50762570-33b4e200-1265-11e9-90f7-a0df04780a47.gif)

