### PR TITLE
create new events getter that only works with past and future events

### DIFF
--- a/common/services/prismic/eventsV2.js
+++ b/common/services/prismic/eventsV2.js
@@ -195,8 +195,18 @@ function getNextDateInFuture(event: UiEvent): EventTime {
   });
 }
 
+export function filterEventsForNext7Days(events: UiEvent[]): UiEvent[] {
+  const startOfToday = london().startOf('day');
+  const endOfNext7Days = startOfToday.clone().add(7, 'day').endOf('day');
+  return events.filter(event => {
+    return event.times.find(time => {
+      return london(time.range.endDateTime).isBetween(startOfToday, endOfNext7Days);
+    });
+  });
+}
+
 export function orderEventsByNextAvailableDate(events: UiEvent[]): UiEvent[] {
-  const reorderedEvents = events.sort((a, b) => {
+  const reorderedEvents = [...events].sort((a, b) => {
     const aNextDate = getNextDateInFuture(a);
     const bNextDate = getNextDateInFuture(a);
 

--- a/common/services/prismic/eventsV2.js
+++ b/common/services/prismic/eventsV2.js
@@ -1,0 +1,207 @@
+
+// @flow
+import Prismic from 'prismic-javascript';
+import {getDocument, getTypeByIds, getDocuments} from './api';
+import {parseEventDoc} from './events';
+import {
+  eventAccessOptionsFields,
+  teamsFields,
+  eventFormatsFields,
+  placesFields,
+  interpretationTypesFields,
+  audiencesFields,
+  eventSeriesFields,
+  organisationsFields,
+  peopleFields,
+  contributorsFields,
+  eventPoliciesFields
+} from './fetch-links';
+import {london} from '../../utils/format-date';
+import {getPeriodPredicates} from './utils';
+import type {UiEvent, EventTime} from '../../model/events';
+
+import type {
+  PaginatedResults,
+  PrismicQueryOpts
+} from './types';
+import type {Period} from '../../model/periods';
+
+const startField = 'my.events.times.startDateTime';
+const endField = 'my.events.times.endDateTime';
+
+const fetchLinks = [].concat(
+  eventAccessOptionsFields,
+  teamsFields,
+  eventFormatsFields,
+  placesFields,
+  interpretationTypesFields,
+  audiencesFields,
+  eventSeriesFields,
+  organisationsFields,
+  peopleFields,
+  contributorsFields,
+  eventSeriesFields,
+  eventPoliciesFields
+);
+
+type EventQueryProps = {|
+  id: string
+|}
+
+export async function getEvent(req: ?Request, {id}: EventQueryProps): Promise<?UiEvent> {
+  const document = await getDocument(req, id, {
+    fetchLinks: fetchLinks
+  });
+
+  if (document && document.type === 'events') {
+    const scheduleIds = document.data.schedule.map(({event}) => event.id).filter(Boolean);
+    const eventScheduleDocs = scheduleIds.length > 0 && await getTypeByIds(req, ['events'], scheduleIds, {fetchLinks});
+    const event = parseEventDoc(document, eventScheduleDocs || null);
+
+    return event;
+  }
+}
+
+type EventsQueryProps = {|
+  predicates?: Prismic.Predicates[],
+  period?: 'current-and-coming-up' | 'past',
+  ...PrismicQueryOpts
+|}
+
+export async function getEvents(req: ?Request,  {
+  predicates = [],
+  period,
+  ...opts
+}: EventsQueryProps): Promise<PaginatedResults<UiEvent>> {
+  const graphQuery = `{
+    events {
+      ...eventsFields
+      format {
+        ...formatFields
+      }
+      place {
+        ...placeFields
+      }
+      series {
+        series {
+          ...seriesFields
+          contributors {
+            ...contributorsFields
+            role {
+              ...roleFields
+            }
+            contributor {
+              ... on people {
+                ...peopleFields
+              }
+              ... on organisations {
+                ...organisationsFields
+              }
+            }
+          }
+          promo {
+            ... on editorialImage {
+              non-repeat {
+                caption
+                image
+              }
+            }
+          }
+        }
+      }
+      interpretations {
+        interpretationType {
+          ...interpretationTypeFields
+        }
+      }
+      policies {
+        policy {
+          ...policyFields
+        }
+      }
+      audiences {
+        audience {
+          ...audienceFields
+        }
+      }
+      contributors {
+        ...contributorsFields
+        role {
+          ...roleFields
+        }
+        contributor {
+          ... on people {
+            ...peopleFields
+          }
+          ... on organisations {
+            ...organisationsFields
+          }
+        }
+      }
+      promo {
+        ... on editorialImage {
+          non-repeat {
+            caption
+            image
+          }
+        }
+      }
+    }
+  }`;
+
+  const order = period === 'past' ? 'desc' : 'asc';
+  const orderings = `[my.events.times.startDateTime${order === 'desc' ? ' desc' : ''}]`;
+  const dateRangePredicates = period ? getPeriodPredicates(
+    period,
+    startField,
+    endField
+  ) : [];
+  const paginatedResults = await getDocuments(req, [
+    Prismic.Predicates.at('document.type', 'events')
+  ].concat(predicates, dateRangePredicates), {
+    orderings,
+    page: opts.page,
+    pageSize: opts.pageSize,
+    graphQuery
+  });
+
+  const events = paginatedResults.results.map(doc => {
+    return parseEventDoc(doc, null);
+  });
+
+  return {
+    currentPage: paginatedResults.currentPage,
+    pageSize: paginatedResults.pageSize,
+    totalResults: paginatedResults.totalResults,
+    totalPages: paginatedResults.totalPages,
+    results: events
+  };
+}
+
+function getNextDateInFuture(event: UiEvent): EventTime {
+  const now = london();
+  return event.times.filter(time => {
+    const end = london(time.range.endDateTime);
+    return end.isAfter(now, 'day');
+  }).reduce((closestStartingDate, time) => {
+    const start = london(time.range.startDateTime);
+    if (
+      start.isBefore(closestStartingDate.range.startDateTime)
+    ) {
+      return time;
+    } else {
+      return closestStartingDate;
+    }
+  });
+}
+
+export function orderEventsByNextAvailableDate(events: UiEvent[]): UiEvent[] {
+  const reorderedEvents = events.sort((a, b) => {
+    const aNextDate = getNextDateInFuture(a);
+    const bNextDate = getNextDateInFuture(a);
+
+    return london(aNextDate.range.startDateTime)
+      .isBefore(bNextDate.range.startDateTime) ? -1  : 1;
+  });
+  return reorderedEvents;
+}

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -5,7 +5,8 @@ import {classNames, font, spacing, cssGrid} from '@weco/common/utils/classnames'
 import {getExhibitions} from '@weco/common/services/prismic/exhibitions';
 import {
   getEvents,
-  orderEventsByNextAvailableDate
+  orderEventsByNextAvailableDate,
+  filterEventsForNext7Days
 } from '@weco/common/services/prismic/eventsV2';
 import {getArticles} from '@weco/common/services/prismic/articles';
 import {convertJsonToDates} from './event';
@@ -110,7 +111,9 @@ export class HomePage extends Component<Props> {
           />
           <ExhibitionsAndEvents
             exhibitions={exhibitions}
-            events={orderEventsByNextAvailableDate(events)}
+            events={filterEventsForNext7Days(
+              orderEventsByNextAvailableDate(events)
+            )}
             extras={[pharmacyOfColourData]}
           />
         </SpacingSection>

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -3,7 +3,10 @@ import type {Context} from 'next';
 import {Component} from 'react';
 import {classNames, font, spacing, cssGrid} from '@weco/common/utils/classnames';
 import {getExhibitions} from '@weco/common/services/prismic/exhibitions';
-import {getEvents} from '@weco/common/services/prismic/events';
+import {
+  getEvents,
+  orderEventsByNextAvailableDate
+} from '@weco/common/services/prismic/eventsV2';
 import {getArticles} from '@weco/common/services/prismic/articles';
 import {convertJsonToDates} from './event';
 import pharmacyOfColourData from '@weco/common/data/the-pharmacy-of-colour';
@@ -37,8 +40,7 @@ export class HomePage extends Component<Props> {
       order: 'asc'
     });
     const eventsPromise = getEvents(ctx.req, {
-      period: 'next-seven-days',
-      order: 'asc'
+      period: 'current-and-coming-up'
     });
     const articlesPromise = getArticles(ctx.req, {pageSize: 4});
     const [exhibitions, events, articles] = await Promise.all([
@@ -108,7 +110,7 @@ export class HomePage extends Component<Props> {
           />
           <ExhibitionsAndEvents
             exhibitions={exhibitions}
-            events={events}
+            events={orderEventsByNextAvailableDate(events)}
             extras={[pharmacyOfColourData]}
           />
         </SpacingSection>


### PR DESCRIPTION
With unpaginated results from the API, we're going to apply a consistent, programatic ordering and display.

These are, for now, only events in the future (an end date exists that is after today).
Ordering will then be by next available date in the times list.
The date displayed will be the date that it is ordered by.

This ordering will be considered business and display logic, therefor be kept on the edge.

I've pulled it out into it's own file as to not disrupt anything else.

Paginated results (the full list) will have to work off simpler logic.

Fixes #3914 