### PR TITLE
Use correct id for month h2

### DIFF
--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -137,7 +137,7 @@ class EventsByMonth extends Component<Props, State> {
             <div className='css-grid__container'>
               <div className='css-grid'>
                 <h2
-                  id={month}
+                  id={month.id}
                   className={classNames({
                     'tabfocus': true,
                     [cssGrid({s: 12, m: 12, l: 12, xl: 12})]: true


### PR DESCRIPTION
Fixes broken (when not enhanced by JavaScript) links on the /whats-on page (as reported by the pa11y dashboard).

![screenshot 2019-01-09 at 12 22 24](https://user-images.githubusercontent.com/1394592/50899165-41a36800-1409-11e9-8c36-25e978df7dba.png)
