### PR TITLE
add autofocus back to form

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -39,7 +39,8 @@ type Props = {|
   initialQuery: string,
   initialWorkType: string[],
   initialItemsLocationsLocationType: string[],
-  showFilters: boolean
+  showFilters: boolean,
+  ariaDescribedBy: string
 |}
 
 const SearchInputWrapper = styled.div`
@@ -70,7 +71,8 @@ const SearchForm = ({
   initialQuery = '',
   initialWorkType = [],
   initialItemsLocationsLocationType = [],
-  showFilters
+  showFilters,
+  ariaDescribedBy
 }: Props) => {
   const [query, setQuery] = useState(initialQuery);
   const [workType, setWorkType] = useState(initialWorkType);
@@ -79,6 +81,7 @@ const SearchForm = ({
   return (
     <form
       action='/works'
+      aria-describedby={ariaDescribedBy}
       onSubmit={(event) => {
         event.preventDefault();
         const link = worksUrl({
@@ -98,6 +101,7 @@ const SearchForm = ({
             placeholder={'Search for artworks, photos and more'}
             name='query'
             value={query}
+            autoFocus={query === ''}
             onChange={(event) => setQuery(event.currentTarget.value)} />
 
           {query &&

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -121,13 +121,15 @@ export const Works = ({
                   initialWorkType={workType}
                   initialItemsLocationsLocationType={itemsLocationsLocationType}
                   showFilters={showCatalogueSearchFilters}
+                  ariaDescribedBy='search-form-description'
                 />
-                {!works
-                  ? <p className={classNames([
-                    spacing({s: 4}, {margin: ['top']}),
-                    font({s: 'HNL4', m: 'HNL3'})
-                  ])}>Find thousands of Creative Commons licensed images from historical library materials and museum objects to contemporary digital photographs.</p>
-                  : <p className={classNames([
+                <p className={classNames({
+                  [spacing({s: 4}, {margin: ['top']})]: true,
+                  [font({s: 'HNL4', m: 'HNL3'})]: true,
+                  'visually-hidden': Boolean(works)
+                })} id='search-form-description'>Find thousands of Creative Commons licensed images from historical library materials and museum objects to contemporary digital photographs.</p>
+                {works &&
+                  <p className={classNames([
                     spacing({s: 2}, {margin: ['top', 'bottom']}),
                     font({s: 'LR3', m: 'LR2'})
                   ])}>{works.totalResults !== 0 ? works.totalResults : 'No'} results for &apos;{query}&apos;

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -44,7 +44,9 @@ const TextInput = ({
         className={font({s: 'HNL3', m: 'HNL2'})}
         type='text'
         {...inputProps}/>
-      <VisuallyHidden>{label}</VisuallyHidden>
+      <VisuallyHidden>
+        <label>{label}</label>
+      </VisuallyHidden>
     </label>
   );
 };


### PR DESCRIPTION
Autofocuses form element if there is not query.
It would be good to know if we should when there is no query.

Based on the fact we had it, and on the feedback:
> I use your website almost every day and previously, on the search page, there was a cursor already in the box, so you didn’t have to click on it to use it. For regular users, this saved a lot of time. That has now disappeared. Any chance it could be reinstated and make my and many other researchers’ live easier?

[And using this as inspiration to the execution](https://www.brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/).