### PR TITLE
Remove StoryPromo ids (to prevent duplicates on page)

### DIFF
--- a/common/views/components/StoryPromo/StoryPromo.js
+++ b/common/views/components/StoryPromo/StoryPromo.js
@@ -37,7 +37,6 @@ const StoryPromo = ({
           eventLabel: `${item.id} | position: ${position}`
         });
       }}
-      id={item.id}
       href={item.promo && item.promo.link || `/articles/${item.id}`}
       className={classNames({
         'story-promo': true,


### PR DESCRIPTION
☝️ 

Solves an a11y issue reported on the pa11y dashboard.
