### PR TITLE
remove v2 10 second engagement timer

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -28,12 +28,6 @@ function triggerEngagement() {
     action: 'Time on page >=',
     label: '10 seconds'
   });
-  ReactGA.ga('v2.send', {
-    hitType: 'event',
-    eventCategory: 'Engagement',
-    eventAction: 'Time on page >=',
-    eventLabel: '10 seconds'
-  });
 }
 
 function trackRouteChange() {


### PR DESCRIPTION
I've added (and paused) this in tag manager.
It's proving a nice testing ground to see if we could move over the `Collection` account to GTM.