### PR TITLE
Work single column

### DIFF
--- a/catalogue/webapp/components/SingleColumnWork/SingleColumnWork.js
+++ b/catalogue/webapp/components/SingleColumnWork/SingleColumnWork.js
@@ -197,11 +197,12 @@ const SingleColumnWork = ({
                 ]} />
               }
             </SpacingComponent>
-            <SpacingComponent>
-              {encoreLink &&
+
+            {encoreLink &&
+              <SpacingComponent>
                 <MoreLink name='View Wellcome Library catalogue record' url={encoreLink} />
-              }
-            </SpacingComponent>
+              </SpacingComponent>
+            }
 
             {licenseInfo &&
               <Fragment>

--- a/catalogue/webapp/components/SingleColumnWork/SingleColumnWork.js
+++ b/catalogue/webapp/components/SingleColumnWork/SingleColumnWork.js
@@ -1,4 +1,6 @@
 // @flow
+import type {LicenseData} from '@weco/common/utils/get-license-info';
+import type {LicenseType} from '@weco/common/model/license';
 
 import NextLink from 'next/link';
 import {Fragment} from 'react';
@@ -13,7 +15,6 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
-import type {LicenseData} from '@weco/common/utils/get-license-info';
 
 type Work = Object;
 type Props = {|
@@ -21,7 +22,7 @@ type Props = {|
   iiifImageLocationUrl: ?string,
   licenseInfo: ?LicenseData,
   iiifImageLocationCredit: ?string,
-  iiifImageLocationLicenseId: ?string,
+  iiifImageLocationLicenseId: ?LicenseType,
   encoreLink: ?string
 |}
 
@@ -213,7 +214,9 @@ const SingleColumnWork = ({
                 <SpacingComponent>
                   <MetaUnit headingLevel={3} headingText='License information' text={licenseInfo.humanReadableText} />
                   <MetaUnit headingLevel={3} headingText='Credit' text={[
-                    `${work.title}. Credit: <a href="https://wellcomecollection.org/works/${work.id}">${iiifImageLocationCredit}</a>. ${licenseInfo.url ? `<a href="${licenseInfo.url}">${licenseInfo.text}</a>` : licenseInfo.text}`]} />
+                    `${work.title}.{' '}
+                    ${iiifImageLocationCredit ? `Credit: <a href="https://wellcomecollection.org/works/${work.id}">${iiifImageLocationCredit}</a>. ` : ` `}
+                    ${licenseInfo.url ? `<a href="${licenseInfo.url}">${licenseInfo.text}</a>` : licenseInfo.text}`]} />
                 </SpacingComponent>
               </Fragment>
             }

--- a/catalogue/webapp/components/SingleColumnWork/SingleColumnWork.js
+++ b/catalogue/webapp/components/SingleColumnWork/SingleColumnWork.js
@@ -1,0 +1,253 @@
+// @flow
+
+import NextLink from 'next/link';
+import {Fragment} from 'react';
+import {font, spacing, grid, classNames} from '@weco/common/utils/classnames';
+import {convertImageUri} from '@weco/common/utils/convert-image-uri';
+import {worksUrl} from '../../services/catalogue/urls';
+import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
+import License from '@weco/common/views/components/License/License';
+import Divider from '@weco/common/views/components/Divider/Divider';
+import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
+import Button from '@weco/common/views/components/Buttons/Button/Button';
+import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
+import type {LicenseData} from '@weco/common/utils/get-license-info';
+
+type Work = Object;
+type Props = {|
+  work: Work,
+  iiifImageLocationUrl: ?string,
+  licenseInfo: ?LicenseData,
+  iiifImageLocationCredit: ?string,
+  iiifImageLocationLicenseId: ?string,
+  encoreLink: ?string
+|}
+
+const SingleColumnWork = ({
+  work,
+  iiifImageLocationUrl,
+  licenseInfo,
+  LicenseData,
+  iiifImageLocationCredit,
+  iiifImageLocationLicenseId,
+  encoreLink
+}: Props) => {
+  return (
+    <div className={`row ${spacing({s: 6}, {padding: ['top', 'bottom']})}`}>
+      <div className='container'>
+        <div className='grid'>
+          <div className={classNames([
+            grid({s: 12, m: 12, l: 10, xl: 10}),
+            spacing({s: 4}, {margin: ['bottom']})
+          ])}>
+            <SpacingComponent>
+              <h1 id='work-info'
+                className={classNames([
+                  font({s: 'HNM3', m: 'HNM2', l: 'HNM1'}),
+                  spacing({s: 0}, {margin: ['top']})
+                ])}>{work.title}</h1>
+            </SpacingComponent>
+
+            {iiifImageLocationUrl &&
+              <SpacingComponent>
+                <div className={spacing({s: 2}, {margin: ['bottom']})}>
+                  <Button
+                    type='tertiary'
+                    url={convertImageUri(iiifImageLocationUrl, 'full')}
+                    target='_blank'
+                    download={`${work.id}.jpg`}
+                    rel='noopener noreferrer'
+                    trackingEvent={{
+                      category: 'component',
+                      action: 'download-button:click',
+                      label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
+                    }}
+                    trackingEventV2={{
+                      eventCategory: 'Button',
+                      eventAction: 'download large work image',
+                      eventLabel: work.id
+                    }}
+                    icon='download'
+                    text='Download full size' />
+                </div>
+                <div className={spacing({s: 3}, {margin: ['bottom']})}>
+                  <Button
+                    type='tertiary'
+                    url={convertImageUri(iiifImageLocationUrl, 760)}
+                    target='_blank'
+                    download={`${work.id}.jpg`}
+                    rel='noopener noreferrer'
+                    trackingEvent={{
+                      category: 'component',
+                      action: 'download-button:click',
+                      label: `id: $work.id} , size:760, title:${work.title.substring(50)}`
+                    }}
+                    trackingEventV2={{
+                      eventCategory: 'Button',
+                      eventAction: 'download small work image',
+                      eventLabel: work.id
+                    }}
+                    icon='download'
+                    text='Download small (760px)' />
+                </div>
+
+                {(iiifImageLocationCredit || iiifImageLocationLicenseId) &&
+                  <div className={spacing({s: 4}, {margin: ['bottom']})}>
+                    {iiifImageLocationCredit && <p className={classNames([
+                      font({s: 'HNL5', m: 'HNL4'}),
+                      spacing({s: 1}, {margin: ['bottom']})
+                    ])}>Credit: {iiifImageLocationCredit}</p>}
+                    {iiifImageLocationLicenseId && <License subject={''} licenseType={iiifImageLocationLicenseId} /> }
+                  </div>
+                }
+              </SpacingComponent>
+
+            }
+
+            <SpacingComponent>
+              <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
+              <h2 className={classNames([
+                font({s: 'HNM4', m: 'HNM3'})
+              ])}>Item details</h2>
+            </SpacingComponent>
+
+            <SpacingComponent>
+              {work.description &&
+                <MetaUnit headingText='Description' text={[work.description]} />
+              }
+
+              {(work.physicalDescription || work.extent || work.dimensions) &&
+                <MetaUnit headingText='Physical description' text={[[work.extent, work.physicalDescription, work.dimensions].filter(Boolean).join(' ')]} />
+              }
+
+              {work.workType &&
+                <MetaUnit headingText='Work type' links={[
+                  <NextLink key={1} {...worksUrl({ query: `workType:"${work.workType.label}"`, page: undefined })}>
+                    <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.workType.label}</a>
+                  </NextLink>
+                ]} />
+              }
+
+              {work.lettering &&
+                <MetaUnit headingText='Lettering' text={[work.lettering]} />
+              }
+
+              {work.createdDate &&
+                <MetaUnit headingText='Created date' text={[work.createdDate.label]} />
+              }
+
+              {work.contributors.length > 0 &&
+                <MetaUnit headingText='Contributors' links={work.contributors.map(contributor => {
+                  const linkAttributes = worksUrl({ query: `contributors:"${contributor.agent.label}"`, page: undefined });
+                  return (<NextLink key={1} {...linkAttributes}>
+                    <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{contributor.agent.label}</a>
+                  </NextLink>);
+                }
+                )} />
+              }
+
+              {work.subjects.length > 0 &&
+                <MetaUnit headingText='Subjects' links={work.subjects.map(subject => {
+                  const linkAttributes = worksUrl({ query: `subjects:"${subject.label}"`, page: undefined });
+                  return (<NextLink key={1} {...linkAttributes}>
+                    <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{subject.label}</a>
+                  </NextLink>);
+                }
+                )} />
+              }
+
+              {work.genres.length > 0 &&
+                <MetaUnit headingText='Genres' links={work.genres.map(genre => {
+                  const linkAttributes = worksUrl({ query: `genres:"${genre.label}"`, page: undefined });
+                  return (<NextLink key={1} {...linkAttributes}>
+                    <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{genre.label}</a>
+                  </NextLink>);
+                }
+                )} />
+              }
+
+              {work.production.length > 0 &&
+                <Fragment>
+                  <h2 className={`${font({s: 'HNM5', m: 'HNM4'})} ${spacing({s: 0}, {margin: ['top']})} ${spacing({s: 2}, {margin: ['bottom']})}`}>
+                  Production
+                  </h2>
+                  {work.production.map((production, i) => {
+                    return (
+                      <Fragment key={i}>
+                        {production.places.length > 0 &&
+                        <MetaUnit headingLevel={3} headingText='Places' list={production.places.map(place => place.label)} />}
+                        {production.agents.length > 0 &&
+                        <MetaUnit headingLevel={3} headingText='Agents' list={production.agents.map(agent => agent.label)} />}
+                        {production.dates.length > 0 &&
+                        <MetaUnit headingLevel={3} headingText='Dates' list={production.dates.map(date => date.label)} />}
+                      </Fragment>
+                    );
+                  })}
+                </Fragment>
+              }
+
+              {work.language &&
+                <MetaUnit headingText='Language' links={[
+                  <NextLink key={1} {...worksUrl({ query: `language:"${work.language.label}"`, page: undefined })}>
+                    <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.language.label}</a>
+                  </NextLink>
+                ]} />
+              }
+            </SpacingComponent>
+            <SpacingComponent>
+              {encoreLink &&
+                <MoreLink name='View Wellcome Library catalogue record' url={encoreLink} />
+              }
+            </SpacingComponent>
+
+            {licenseInfo &&
+              <Fragment>
+                <SpacingComponent>
+                  <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
+                  <h2 className={classNames([
+                    font({s: 'HNM4', m: 'HNM3'})
+                  ])}>Using this image</h2>
+                </SpacingComponent>
+                <SpacingComponent>
+                  <MetaUnit headingLevel={3} headingText='License information' text={licenseInfo.humanReadableText} />
+                  <MetaUnit headingLevel={3} headingText='Credit' text={[
+                    `${work.title}. Credit: <a href="https://wellcomecollection.org/works/${work.id}">${iiifImageLocationCredit}</a>. ${licenseInfo.url ? `<a href="${licenseInfo.url}">${licenseInfo.text}</a>` : licenseInfo.text}`]} />
+                </SpacingComponent>
+              </Fragment>
+            }
+
+            <SpacingComponent>
+              <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
+              <h2 className={classNames([
+                font({s: 'HNM4', m: 'HNM3'})
+              ])}>Share</h2>
+            </SpacingComponent>
+
+            <SpacingComponent>
+              <CopyUrl id={work.id} url={`https://wellcomecollection.org/works/${work.id}`} />
+            </SpacingComponent>
+
+            <SpacingComponent>
+              <div className={classNames([
+                spacing({s: 2}, {padding: ['top', 'bottom']}),
+                spacing({s: 4}, {padding: ['left', 'right']}),
+                spacing({s: 4}, {margin: ['top', 'bottom']}),
+                'bg-cream rounded-diagonal flex flex--v-center'
+              ])}>
+                <Icon name='underConstruction' extraClasses='margin-right-s2' />
+                <p className={`${font({s: 'HNL5', m: 'HNL4'})} no-margin`}>
+                    We’re improving the information on this page. <a href='/works/progress'>Find out more</a>.
+                </p>
+              </div>
+            </SpacingComponent>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SingleColumnWork;

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -265,11 +265,10 @@ export const WorkPage = ({
                       </NextLink>
                     ]} />
                   }
-
+                </SpacingComponent>
+                <SpacingComponent>
                   {encoreLink &&
-                    <div className={spacing({s: 2}, {margin: ['top']})}>
-                      <MoreLink name='View Wellcome Library catalogue record' url={encoreLink} />
-                    </div>
+                    <MoreLink name='View Wellcome Library catalogue record' url={encoreLink} />
                   }
                 </SpacingComponent>
 

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -1,13 +1,21 @@
 // @flow
 import type {Work, CatalogueApiError, CatalogueApiRedirect} from '../services/catalogue/works';
 import {Fragment} from 'react';
+import NextLink from 'next/link';
 import Router from 'next/router';
-import {grid} from '@weco/common/utils/classnames';
-import {iiifImageTemplate} from '@weco/common/utils/convert-image-uri';
+import {font, spacing, grid, classNames} from '@weco/common/utils/classnames';
+import {convertImageUri, iiifImageTemplate} from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
 import {workLd} from '@weco/common/utils/json-ld';
 import WorkMedia from '@weco/common/views/components/WorkMedia/WorkMedia';
+import Icon from '@weco/common/views/components/Icon/Icon';
+import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
+import License from '@weco/common/views/components/License/License';
+import Divider from '@weco/common/views/components/Divider/Divider';
+import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
+import Button from '@weco/common/views/components/Buttons/Button/Button';
+import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
 import getLicenseInfo from '@weco/common/utils/get-license-info';
 import WorkRedesign from '../components/WorkRedesign/WorkRedesign';
@@ -20,14 +28,16 @@ type Props = {|
   work: Work | CatalogueApiError,
   query: ?string,
   page: ?number,
-  showRedesign: boolean
+  showRedesign: boolean,
+  showSingleColumnWork: boolean
 |}
 
 export const WorkPage = ({
   work,
   query,
   page,
-  showRedesign
+  showRedesign,
+  showSingleColumnWork
 }: Props) => {
   if (work.type === 'Error') {
     return (
@@ -97,14 +107,227 @@ export const WorkPage = ({
           iiifUrl={iiifImageLocationUrl}
           title={work.title} />}
 
-        <SingleColumnWork
-          work={work}
-          iiifImageLocationUrl={iiifImageLocationUrl}
-          licenseInfo={licenseInfo}
-          iiifImageLocationCredit={iiifImageLocationCredit}
-          iiifImageLocationLicenseId={iiifImageLocationLicenseId}
-          encoreLink={encoreLink} />
+        {showSingleColumnWork
+          ? <SingleColumnWork
+            work={work}
+            iiifImageLocationUrl={iiifImageLocationUrl}
+            licenseInfo={licenseInfo}
+            iiifImageLocationCredit={iiifImageLocationCredit}
+            iiifImageLocationLicenseId={iiifImageLocationLicenseId}
+            encoreLink={encoreLink} />
 
+          : <div className={`row ${spacing({s: 6}, {padding: ['top', 'bottom']})}`}>
+            <div className='container'>
+              <div className='grid'>
+                <div className={classNames([
+                  grid({s: 12, m: 10, shiftM: 1, l: 7, xl: 7}),
+                  spacing({s: 4}, {margin: ['bottom']})
+                ])}>
+                  <div className={spacing({s: 5}, {margin: ['bottom']})}>
+                    <h1 id='work-info'
+                      className={classNames([
+                        font({s: 'HNM3', m: 'HNM2', l: 'HNM1'}),
+                        spacing({s: 0}, {margin: ['top']})
+                      ])}>{work.title}</h1>
+
+                    <div className={classNames([
+                      spacing({s: 2}, {padding: ['top', 'bottom']}),
+                      spacing({s: 4}, {padding: ['left', 'right']}),
+                      spacing({s: 4}, {margin: ['bottom']}),
+                      'bg-cream rounded-diagonal flex flex--v-center'
+                    ])}>
+                      <Icon name='underConstruction' extraClasses='margin-right-s2' />
+                      <p className={`${font({s: 'HNL5', m: 'HNL4'})} no-margin`}>
+                        We’re improving the information on this page. <a href='/works/progress'>Find out more</a>.
+                      </p>
+                    </div>
+
+                    {work.description &&
+                      <MetaUnit headingText='Description' text={[work.description]} />
+                    }
+
+                    {(work.physicalDescription || work.extent || work.dimensions) &&
+                      <MetaUnit headingText='Physical description' text={[[work.extent, work.physicalDescription, work.dimensions].filter(Boolean).join(' ')]} />
+                    }
+
+                    {work.workType &&
+                      <MetaUnit headingText='Work type' links={[
+                        <NextLink key={1} {...worksUrl({ query: `workType:"${work.workType.label}"`, page: undefined })}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.workType.label}</a>
+                        </NextLink>
+                      ]} />
+                    }
+
+                    {work.lettering &&
+                      <MetaUnit headingText='Lettering' text={[work.lettering]} />
+                    }
+
+                    {work.createdDate &&
+                      <MetaUnit headingText='Created date' text={[work.createdDate.label]} />
+                    }
+
+                    {work.contributors.length > 0 &&
+                      <MetaUnit headingText='Contributors' links={work.contributors.map(contributor => {
+                        const linkAttributes = worksUrl({ query: `contributors:"${contributor.agent.label}"`, page: undefined });
+                        return (<NextLink key={1} {...linkAttributes}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{contributor.agent.label}</a>
+                        </NextLink>);
+                      }
+                      )} />
+
+                    }
+
+                    {work.subjects.length > 0 &&
+                      <MetaUnit headingText='Subjects' links={work.subjects.map(subject => {
+                        const linkAttributes = worksUrl({ query: `subjects:"${subject.label}"`, page: undefined });
+                        return (<NextLink key={1} {...linkAttributes}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{subject.label}</a>
+                        </NextLink>);
+                      }
+                      )} />
+                    }
+
+                    {work.genres.length > 0 &&
+                      <MetaUnit headingText='Genres' links={work.genres.map(genre => {
+                        const linkAttributes = worksUrl({ query: `genres:"${genre.label}"`, page: undefined });
+                        return (<NextLink key={1} {...linkAttributes}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{genre.label}</a>
+                        </NextLink>);
+                      }
+                      )} />
+                    }
+
+                    {work.production.length > 0 &&
+                      <Fragment>
+                        <h2 className={`${font({s: 'HNM5', m: 'HNM4'})} ${spacing({s: 0}, {margin: ['top']})} ${spacing({s: 2}, {margin: ['bottom']})}`}>
+                        Production
+                        </h2>
+                        {work.production.map((production, i) => {
+                          return (
+                            <Fragment key={i}>
+                              {production.places.length > 0 &&
+                              <MetaUnit headingLevel={3} headingText='Places' list={production.places.map(place => place.label)} />}
+                              {production.agents.length > 0 &&
+                              <MetaUnit headingLevel={3} headingText='Agents' list={production.agents.map(agent => agent.label)} />}
+                              {production.dates.length > 0 &&
+                              <MetaUnit headingLevel={3} headingText='Dates' list={production.dates.map(date => date.label)} />}
+                            </Fragment>
+                          );
+                        })}
+                      </Fragment>
+                    }
+
+                    {work.language &&
+                      <MetaUnit headingText='Language' links={[
+                        <NextLink key={1} {...worksUrl({ query: `language:"${work.language.label}"`, page: undefined })}>
+                          <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.language.label}</a>
+                        </NextLink>
+                      ]} />
+                    }
+
+                    {encoreLink &&
+                      <div className={spacing({s: 2}, {margin: ['top']})}>
+                        <MoreLink name='View Wellcome Library catalogue record' url={encoreLink} />
+                      </div>
+                    }
+
+                  </div>
+
+                  {licenseInfo &&
+                    <Fragment>
+                      <h2 className={`${font({s: 'HNM5', m: 'HNM4'})} ${spacing({s: 0}, {margin: ['top']})} ${spacing({s: 2}, {margin: ['bottom']})}`}>
+                    Using this Image
+                      </h2>
+                      <MetaUnit headingLevel={3} headingText='License information' text={licenseInfo.humanReadableText} />
+                      <MetaUnit headingLevel={3} headingText='Credit' text={[
+                        `${work.title}. Credit: <a href="https://wellcomecollection.org/works/${work.id}">${iiifImageLocationCredit}</a>. ${licenseInfo.url ? `<a href="${licenseInfo.url}">${licenseInfo.text}</a>` : licenseInfo.text}`]} />
+                    </Fragment>
+                  }
+
+                </div>
+
+                <div className={classNames([
+                  grid({s: 12, m: 10, shiftM: 1, l: 5, xl: 5}),
+                  spacing({s: 1}, {margin: ['top']})
+                ])}>
+                  {iiifImageLocationUrl &&
+                    <Fragment>
+                      <h2 className={classNames([
+                        font({s: 'HNM4', m: 'HNM3'}),
+                        spacing({s: 0}, {margin: ['top']}),
+                        spacing({s: 2}, {margin: ['bottom']})
+                      ])}>
+                      Download
+                      </h2>
+
+                      <div className={spacing({s: 2}, {margin: ['bottom']})}>
+                        <Button
+                          type='tertiary'
+                          url={convertImageUri(iiifImageLocationUrl, 'full')}
+                          target='_blank'
+                          download={`${work.id}.jpg`}
+                          rel='noopener noreferrer'
+                          trackingEvent={{
+                            category: 'component',
+                            action: 'download-button:click',
+                            label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
+                          }}
+                          trackingEventV2={{
+                            eventCategory: 'Button',
+                            eventAction: 'download large work image',
+                            eventLabel: work.id
+                          }}
+                          icon='download'
+                          text='Download full size' />
+                      </div>
+                      <div className={spacing({s: 3}, {margin: ['bottom']})}>
+                        <Button
+                          type='tertiary'
+                          url={convertImageUri(iiifImageLocationUrl, 760)}
+                          target='_blank'
+                          download={`${work.id}.jpg`}
+                          rel='noopener noreferrer'
+                          trackingEvent={{
+                            category: 'component',
+                            action: 'download-button:click',
+                            label: `id: $work.id} , size:760, title:${work.title.substring(50)}`
+                          }}
+                          trackingEventV2={{
+                            eventCategory: 'Button',
+                            eventAction: 'download small work image',
+                            eventLabel: work.id
+                          }}
+                          icon='download'
+                          text='Download small (760px)' />
+                      </div>
+                    </Fragment>
+                  }
+
+                  {(iiifImageLocationCredit ||  iiifImageLocationLicenseId) &&
+                    <div className={spacing({s: 4}, {margin: ['bottom']})}>
+                      {iiifImageLocationCredit && <p className={classNames([
+                        font({s: 'HNL5', m: 'HNL4'}),
+                        spacing({s: 1}, {margin: ['bottom']})
+                      ])}>Credit: {iiifImageLocationCredit}</p>}
+                      {iiifImageLocationLicenseId && <License subject={''} licenseType={iiifImageLocationLicenseId} /> }
+                    </div>}
+
+                  <div className={spacing({s: 2}, {margin: ['top']})}>
+                    <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
+                    <h2 className={classNames([
+                      font({s: 'HNM4', m: 'HNM3'}),
+                      spacing({s: 2}, {margin: ['top']}),
+                      spacing({s: 1}, {margin: ['bottom']})
+                    ])}>
+                      Share
+                    </h2>
+                    <CopyUrl id={work.id} url={`https://wellcomecollection.org/works/${work.id}`} />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        }
       </Fragment>
     </PageLayout>
   );
@@ -114,6 +337,7 @@ WorkPage.getInitialProps = async (ctx): Promise<Props | CatalogueApiRedirect> =>
   const {id, query, page} = ctx.query;
   const workOrError = await getWork({ id });
   const showRedesign = Boolean(ctx.query.toggles.showWorkRedesign);
+  const showSingleColumnWork = Boolean(ctx.query.toggles.showSingleColumnWork);
 
   if (workOrError && workOrError.type === 'Redirect') {
     const {res} = ctx;
@@ -131,7 +355,8 @@ WorkPage.getInitialProps = async (ctx): Promise<Props | CatalogueApiRedirect> =>
       query,
       work: workOrError,
       page: page ? parseInt(page, 10) : null,
-      showRedesign
+      showRedesign,
+      showSingleColumnWork
     };
   }
 };

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -22,6 +22,7 @@ import WorkRedesign from '../components/WorkRedesign/WorkRedesign';
 import {getWork} from '../services/catalogue/works';
 import {worksUrl} from '../services/catalogue/urls';
 import BackToResults from '@weco/common/views/components/BackToResults/BackToResults';
+import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 
 type Props = {|
   work: Work | CatalogueApiError,
@@ -108,28 +109,81 @@ export const WorkPage = ({
           <div className='container'>
             <div className='grid'>
               <div className={classNames([
-                grid({s: 12, m: 10, shiftM: 1, l: 7, xl: 7}),
+                grid({s: 12, m: 12, l: 10, xl: 10}),
                 spacing({s: 4}, {margin: ['bottom']})
               ])}>
-                <div className={spacing({s: 5}, {margin: ['bottom']})}>
+                <SpacingComponent>
                   <h1 id='work-info'
                     className={classNames([
                       font({s: 'HNM3', m: 'HNM2', l: 'HNM1'}),
                       spacing({s: 0}, {margin: ['top']})
                     ])}>{work.title}</h1>
+                </SpacingComponent>
 
-                  <div className={classNames([
-                    spacing({s: 2}, {padding: ['top', 'bottom']}),
-                    spacing({s: 4}, {padding: ['left', 'right']}),
-                    spacing({s: 4}, {margin: ['bottom']}),
-                    'bg-cream rounded-diagonal flex flex--v-center'
-                  ])}>
-                    <Icon name='underConstruction' extraClasses='margin-right-s2' />
-                    <p className={`${font({s: 'HNL5', m: 'HNL4'})} no-margin`}>
-                      We’re improving the information on this page. <a href='/works/progress'>Find out more</a>.
-                    </p>
-                  </div>
+                {iiifImageLocationUrl &&
+                  <SpacingComponent>
+                    <div className={spacing({s: 2}, {margin: ['bottom']})}>
+                      <Button
+                        type='tertiary'
+                        url={convertImageUri(iiifImageLocationUrl, 'full')}
+                        target='_blank'
+                        download={`${work.id}.jpg`}
+                        rel='noopener noreferrer'
+                        trackingEvent={{
+                          category: 'component',
+                          action: 'download-button:click',
+                          label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
+                        }}
+                        trackingEventV2={{
+                          eventCategory: 'Button',
+                          eventAction: 'download large work image',
+                          eventLabel: work.id
+                        }}
+                        icon='download'
+                        text='Download full size' />
+                    </div>
+                    <div className={spacing({s: 3}, {margin: ['bottom']})}>
+                      <Button
+                        type='tertiary'
+                        url={convertImageUri(iiifImageLocationUrl, 760)}
+                        target='_blank'
+                        download={`${work.id}.jpg`}
+                        rel='noopener noreferrer'
+                        trackingEvent={{
+                          category: 'component',
+                          action: 'download-button:click',
+                          label: `id: $work.id} , size:760, title:${work.title.substring(50)}`
+                        }}
+                        trackingEventV2={{
+                          eventCategory: 'Button',
+                          eventAction: 'download small work image',
+                          eventLabel: work.id
+                        }}
+                        icon='download'
+                        text='Download small (760px)' />
+                    </div>
 
+                    {(iiifImageLocationCredit || iiifImageLocationLicenseId) &&
+                      <div className={spacing({s: 4}, {margin: ['bottom']})}>
+                        {iiifImageLocationCredit && <p className={classNames([
+                          font({s: 'HNL5', m: 'HNL4'}),
+                          spacing({s: 1}, {margin: ['bottom']})
+                        ])}>Credit: {iiifImageLocationCredit}</p>}
+                        {iiifImageLocationLicenseId && <License subject={''} licenseType={iiifImageLocationLicenseId} /> }
+                      </div>
+                    }
+                  </SpacingComponent>
+
+                }
+
+                <SpacingComponent>
+                  <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
+                  <h2 className={classNames([
+                    font({s: 'HNM4', m: 'HNM3'})
+                  ])}>Item details</h2>
+                </SpacingComponent>
+
+                <SpacingComponent>
                   {work.description &&
                     <MetaUnit headingText='Description' text={[work.description]} />
                   }
@@ -162,7 +216,6 @@ export const WorkPage = ({
                       </NextLink>);
                     }
                     )} />
-
                   }
 
                   {work.subjects.length > 0 &&
@@ -218,99 +271,49 @@ export const WorkPage = ({
                       <MoreLink name='View Wellcome Library catalogue record' url={encoreLink} />
                     </div>
                   }
-
-                </div>
+                </SpacingComponent>
 
                 {licenseInfo &&
                   <Fragment>
-                    <h2 className={`${font({s: 'HNM5', m: 'HNM4'})} ${spacing({s: 0}, {margin: ['top']})} ${spacing({s: 2}, {margin: ['bottom']})}`}>
-                  Using this Image
-                    </h2>
-                    <MetaUnit headingLevel={3} headingText='License information' text={licenseInfo.humanReadableText} />
-                    <MetaUnit headingLevel={3} headingText='Credit' text={[
-                      `${work.title}. Credit: <a href="https://wellcomecollection.org/works/${work.id}">${iiifImageLocationCredit}</a>. ${licenseInfo.url ? `<a href="${licenseInfo.url}">${licenseInfo.text}</a>` : licenseInfo.text}`]} />
+                    <SpacingComponent>
+                      <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
+                      <h2 className={classNames([
+                        font({s: 'HNM4', m: 'HNM3'})
+                      ])}>Using this image</h2>
+                    </SpacingComponent>
+                    <SpacingComponent>
+                      <MetaUnit headingLevel={3} headingText='License information' text={licenseInfo.humanReadableText} />
+                      <MetaUnit headingLevel={3} headingText='Credit' text={[
+                        `${work.title}. Credit: <a href="https://wellcomecollection.org/works/${work.id}">${iiifImageLocationCredit}</a>. ${licenseInfo.url ? `<a href="${licenseInfo.url}">${licenseInfo.text}</a>` : licenseInfo.text}`]} />
+                    </SpacingComponent>
                   </Fragment>
                 }
 
-              </div>
-
-              <div className={classNames([
-                grid({s: 12, m: 10, shiftM: 1, l: 5, xl: 5}),
-                spacing({s: 1}, {margin: ['top']})
-              ])}>
-                {iiifImageLocationUrl &&
-                  <Fragment>
-                    <h2 className={classNames([
-                      font({s: 'HNM4', m: 'HNM3'}),
-                      spacing({s: 0}, {margin: ['top']}),
-                      spacing({s: 2}, {margin: ['bottom']})
-                    ])}>
-                    Download
-                    </h2>
-
-                    <div className={spacing({s: 2}, {margin: ['bottom']})}>
-                      <Button
-                        type='tertiary'
-                        url={convertImageUri(iiifImageLocationUrl, 'full')}
-                        target='_blank'
-                        download={`${work.id}.jpg`}
-                        rel='noopener noreferrer'
-                        trackingEvent={{
-                          category: 'component',
-                          action: 'download-button:click',
-                          label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
-                        }}
-                        trackingEventV2={{
-                          eventCategory: 'Button',
-                          eventAction: 'download large work image',
-                          eventLabel: work.id
-                        }}
-                        icon='download'
-                        text='Download full size' />
-                    </div>
-                    <div className={spacing({s: 3}, {margin: ['bottom']})}>
-                      <Button
-                        type='tertiary'
-                        url={convertImageUri(iiifImageLocationUrl, 760)}
-                        target='_blank'
-                        download={`${work.id}.jpg`}
-                        rel='noopener noreferrer'
-                        trackingEvent={{
-                          category: 'component',
-                          action: 'download-button:click',
-                          label: `id: $work.id} , size:760, title:${work.title.substring(50)}`
-                        }}
-                        trackingEventV2={{
-                          eventCategory: 'Button',
-                          eventAction: 'download small work image',
-                          eventLabel: work.id
-                        }}
-                        icon='download'
-                        text='Download small (760px)' />
-                    </div>
-                  </Fragment>
-                }
-
-                {(iiifImageLocationCredit ||  iiifImageLocationLicenseId) &&
-                  <div className={spacing({s: 4}, {margin: ['bottom']})}>
-                    {iiifImageLocationCredit && <p className={classNames([
-                      font({s: 'HNL5', m: 'HNL4'}),
-                      spacing({s: 1}, {margin: ['bottom']})
-                    ])}>Credit: {iiifImageLocationCredit}</p>}
-                    {iiifImageLocationLicenseId && <License subject={''} licenseType={iiifImageLocationLicenseId} /> }
-                  </div>}
-
-                <div className={spacing({s: 2}, {margin: ['top']})}>
+                <SpacingComponent>
                   <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
                   <h2 className={classNames([
-                    font({s: 'HNM4', m: 'HNM3'}),
-                    spacing({s: 2}, {margin: ['top']}),
-                    spacing({s: 1}, {margin: ['bottom']})
-                  ])}>
-                    Share
-                  </h2>
+                    font({s: 'HNM4', m: 'HNM3'})
+                  ])}>Share</h2>
+                </SpacingComponent>
+
+                <SpacingComponent>
                   <CopyUrl id={work.id} url={`https://wellcomecollection.org/works/${work.id}`} />
-                </div>
+                </SpacingComponent>
+
+                <SpacingComponent>
+                  <div className={classNames([
+                    spacing({s: 2}, {padding: ['top', 'bottom']}),
+                    spacing({s: 4}, {padding: ['left', 'right']}),
+                    spacing({s: 4}, {margin: ['top', 'bottom']}),
+                    'bg-cream rounded-diagonal flex flex--v-center'
+                  ])}>
+                    <Icon name='underConstruction' extraClasses='margin-right-s2' />
+                    <p className={`${font({s: 'HNL5', m: 'HNL4'})} no-margin`}>
+                        We’re improving the information on this page. <a href='/works/progress'>Find out more</a>.
+                    </p>
+                  </div>
+                </SpacingComponent>
+
               </div>
             </div>
           </div>

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -1,19 +1,11 @@
 // @flow
 import type {Work, CatalogueApiError, CatalogueApiRedirect} from '../services/catalogue/works';
 import {Fragment} from 'react';
-import NextLink from 'next/link';
 import Router from 'next/router';
-import {font, spacing, grid, classNames} from '@weco/common/utils/classnames';
-import {convertImageUri, iiifImageTemplate} from '@weco/common/utils/convert-image-uri';
+import {grid} from '@weco/common/utils/classnames';
+import {iiifImageTemplate} from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
-import Icon from '@weco/common/views/components/Icon/Icon';
-import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
-import License from '@weco/common/views/components/License/License';
-import Divider from '@weco/common/views/components/Divider/Divider';
-import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
-import Button from '@weco/common/views/components/Buttons/Button/Button';
-import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import {workLd} from '@weco/common/utils/json-ld';
 import WorkMedia from '@weco/common/views/components/WorkMedia/WorkMedia';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
@@ -22,7 +14,7 @@ import WorkRedesign from '../components/WorkRedesign/WorkRedesign';
 import {getWork} from '../services/catalogue/works';
 import {worksUrl} from '../services/catalogue/urls';
 import BackToResults from '@weco/common/views/components/BackToResults/BackToResults';
-import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
+import SingleColumnWork from '../components/SingleColumnWork/SingleColumnWork';
 
 type Props = {|
   work: Work | CatalogueApiError,
@@ -105,218 +97,14 @@ export const WorkPage = ({
           iiifUrl={iiifImageLocationUrl}
           title={work.title} />}
 
-        <div className={`row ${spacing({s: 6}, {padding: ['top', 'bottom']})}`}>
-          <div className='container'>
-            <div className='grid'>
-              <div className={classNames([
-                grid({s: 12, m: 12, l: 10, xl: 10}),
-                spacing({s: 4}, {margin: ['bottom']})
-              ])}>
-                <SpacingComponent>
-                  <h1 id='work-info'
-                    className={classNames([
-                      font({s: 'HNM3', m: 'HNM2', l: 'HNM1'}),
-                      spacing({s: 0}, {margin: ['top']})
-                    ])}>{work.title}</h1>
-                </SpacingComponent>
+        <SingleColumnWork
+          work={work}
+          iiifImageLocationUrl={iiifImageLocationUrl}
+          licenseInfo={licenseInfo}
+          iiifImageLocationCredit={iiifImageLocationCredit}
+          iiifImageLocationLicenseId={iiifImageLocationLicenseId}
+          encoreLink={encoreLink} />
 
-                {iiifImageLocationUrl &&
-                  <SpacingComponent>
-                    <div className={spacing({s: 2}, {margin: ['bottom']})}>
-                      <Button
-                        type='tertiary'
-                        url={convertImageUri(iiifImageLocationUrl, 'full')}
-                        target='_blank'
-                        download={`${work.id}.jpg`}
-                        rel='noopener noreferrer'
-                        trackingEvent={{
-                          category: 'component',
-                          action: 'download-button:click',
-                          label: `id: ${work.id} , size:original, title:${encodeURI(work.title.substring(50))}`
-                        }}
-                        trackingEventV2={{
-                          eventCategory: 'Button',
-                          eventAction: 'download large work image',
-                          eventLabel: work.id
-                        }}
-                        icon='download'
-                        text='Download full size' />
-                    </div>
-                    <div className={spacing({s: 3}, {margin: ['bottom']})}>
-                      <Button
-                        type='tertiary'
-                        url={convertImageUri(iiifImageLocationUrl, 760)}
-                        target='_blank'
-                        download={`${work.id}.jpg`}
-                        rel='noopener noreferrer'
-                        trackingEvent={{
-                          category: 'component',
-                          action: 'download-button:click',
-                          label: `id: $work.id} , size:760, title:${work.title.substring(50)}`
-                        }}
-                        trackingEventV2={{
-                          eventCategory: 'Button',
-                          eventAction: 'download small work image',
-                          eventLabel: work.id
-                        }}
-                        icon='download'
-                        text='Download small (760px)' />
-                    </div>
-
-                    {(iiifImageLocationCredit || iiifImageLocationLicenseId) &&
-                      <div className={spacing({s: 4}, {margin: ['bottom']})}>
-                        {iiifImageLocationCredit && <p className={classNames([
-                          font({s: 'HNL5', m: 'HNL4'}),
-                          spacing({s: 1}, {margin: ['bottom']})
-                        ])}>Credit: {iiifImageLocationCredit}</p>}
-                        {iiifImageLocationLicenseId && <License subject={''} licenseType={iiifImageLocationLicenseId} /> }
-                      </div>
-                    }
-                  </SpacingComponent>
-
-                }
-
-                <SpacingComponent>
-                  <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
-                  <h2 className={classNames([
-                    font({s: 'HNM4', m: 'HNM3'})
-                  ])}>Item details</h2>
-                </SpacingComponent>
-
-                <SpacingComponent>
-                  {work.description &&
-                    <MetaUnit headingText='Description' text={[work.description]} />
-                  }
-
-                  {(work.physicalDescription || work.extent || work.dimensions) &&
-                    <MetaUnit headingText='Physical description' text={[[work.extent, work.physicalDescription, work.dimensions].filter(Boolean).join(' ')]} />
-                  }
-
-                  {work.workType &&
-                    <MetaUnit headingText='Work type' links={[
-                      <NextLink key={1} {...worksUrl({ query: `workType:"${work.workType.label}"`, page: undefined })}>
-                        <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.workType.label}</a>
-                      </NextLink>
-                    ]} />
-                  }
-
-                  {work.lettering &&
-                    <MetaUnit headingText='Lettering' text={[work.lettering]} />
-                  }
-
-                  {work.createdDate &&
-                    <MetaUnit headingText='Created date' text={[work.createdDate.label]} />
-                  }
-
-                  {work.contributors.length > 0 &&
-                    <MetaUnit headingText='Contributors' links={work.contributors.map(contributor => {
-                      const linkAttributes = worksUrl({ query: `contributors:"${contributor.agent.label}"`, page: undefined });
-                      return (<NextLink key={1} {...linkAttributes}>
-                        <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{contributor.agent.label}</a>
-                      </NextLink>);
-                    }
-                    )} />
-                  }
-
-                  {work.subjects.length > 0 &&
-                    <MetaUnit headingText='Subjects' links={work.subjects.map(subject => {
-                      const linkAttributes = worksUrl({ query: `subjects:"${subject.label}"`, page: undefined });
-                      return (<NextLink key={1} {...linkAttributes}>
-                        <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{subject.label}</a>
-                      </NextLink>);
-                    }
-                    )} />
-                  }
-
-                  {work.genres.length > 0 &&
-                    <MetaUnit headingText='Genres' links={work.genres.map(genre => {
-                      const linkAttributes = worksUrl({ query: `genres:"${genre.label}"`, page: undefined });
-                      return (<NextLink key={1} {...linkAttributes}>
-                        <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{genre.label}</a>
-                      </NextLink>);
-                    }
-                    )} />
-                  }
-
-                  {work.production.length > 0 &&
-                    <Fragment>
-                      <h2 className={`${font({s: 'HNM5', m: 'HNM4'})} ${spacing({s: 0}, {margin: ['top']})} ${spacing({s: 2}, {margin: ['bottom']})}`}>
-                      Production
-                      </h2>
-                      {work.production.map((production, i) => {
-                        return (
-                          <Fragment key={i}>
-                            {production.places.length > 0 &&
-                            <MetaUnit headingLevel={3} headingText='Places' list={production.places.map(place => place.label)} />}
-                            {production.agents.length > 0 &&
-                            <MetaUnit headingLevel={3} headingText='Agents' list={production.agents.map(agent => agent.label)} />}
-                            {production.dates.length > 0 &&
-                            <MetaUnit headingLevel={3} headingText='Dates' list={production.dates.map(date => date.label)} />}
-                          </Fragment>
-                        );
-                      })}
-                    </Fragment>
-                  }
-
-                  {work.language &&
-                    <MetaUnit headingText='Language' links={[
-                      <NextLink key={1} {...worksUrl({ query: `language:"${work.language.label}"`, page: undefined })}>
-                        <a className={`plain-link font-green font-hover-turquoise ${font({s: 'HNM5', m: 'HNM4'})}`}>{work.language.label}</a>
-                      </NextLink>
-                    ]} />
-                  }
-                </SpacingComponent>
-                <SpacingComponent>
-                  {encoreLink &&
-                    <MoreLink name='View Wellcome Library catalogue record' url={encoreLink} />
-                  }
-                </SpacingComponent>
-
-                {licenseInfo &&
-                  <Fragment>
-                    <SpacingComponent>
-                      <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
-                      <h2 className={classNames([
-                        font({s: 'HNM4', m: 'HNM3'})
-                      ])}>Using this image</h2>
-                    </SpacingComponent>
-                    <SpacingComponent>
-                      <MetaUnit headingLevel={3} headingText='License information' text={licenseInfo.humanReadableText} />
-                      <MetaUnit headingLevel={3} headingText='Credit' text={[
-                        `${work.title}. Credit: <a href="https://wellcomecollection.org/works/${work.id}">${iiifImageLocationCredit}</a>. ${licenseInfo.url ? `<a href="${licenseInfo.url}">${licenseInfo.text}</a>` : licenseInfo.text}`]} />
-                    </SpacingComponent>
-                  </Fragment>
-                }
-
-                <SpacingComponent>
-                  <Divider extraClasses={`divider--pumice divider--keyline ${spacing({s: 1}, {margin: ['top', 'bottom']})}`} />
-                  <h2 className={classNames([
-                    font({s: 'HNM4', m: 'HNM3'})
-                  ])}>Share</h2>
-                </SpacingComponent>
-
-                <SpacingComponent>
-                  <CopyUrl id={work.id} url={`https://wellcomecollection.org/works/${work.id}`} />
-                </SpacingComponent>
-
-                <SpacingComponent>
-                  <div className={classNames([
-                    spacing({s: 2}, {padding: ['top', 'bottom']}),
-                    spacing({s: 4}, {padding: ['left', 'right']}),
-                    spacing({s: 4}, {margin: ['top', 'bottom']}),
-                    'bg-cream rounded-diagonal flex flex--v-center'
-                  ])}>
-                    <Icon name='underConstruction' extraClasses='margin-right-s2' />
-                    <p className={`${font({s: 'HNL5', m: 'HNL4'})} no-margin`}>
-                        We’re improving the information on this page. <a href='/works/progress'>Find out more</a>.
-                    </p>
-                  </div>
-                </SpacingComponent>
-
-              </div>
-            </div>
-          </div>
-        </div>
       </Fragment>
     </PageLayout>
   );

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -36,9 +36,15 @@ const featureToggles = [{
     'This will show unfilter those results, and allow for filtering.'
 }, {
   id: 'showWorkRedesign',
-  title: 'Show the new work page',
+  title: 'Show the work page prototype',
   description:
-    'Uses the new work page design.'
+    `Uses the work page prototype. Note, being in this group will take precedence ` +
+    `over the 'Show the single column work page' group.`
+}, {
+  id: 'showSingleColumnWork',
+  title: 'Show the single column work page',
+  description:
+    `Uses a single column to display work information.`
 }, {
   id: 'showRevisedOpeningHours',
   title: 'Show revised opening hours 4 weeks in advance rather than 2 weeks',
@@ -67,7 +73,7 @@ const IndexPage = () => {
     }, {});
 
     setToggles(initialToggles)
-  }, [])
+  }, []);
 
   return (
     <div style={{

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -42,7 +42,7 @@ const featureToggles = [{
     `over the 'Show the single column work page' group.`
 }, {
   id: 'showSingleColumnWork',
-  title: 'Show the single column work page',
+  title: 'Show work metadata in a single column',
   description:
     `Uses a single column to display work information.`
 }, {
@@ -72,7 +72,7 @@ const IndexPage = () => {
       return acc;
     }, {});
 
-    setToggles(initialToggles)
+    setToggles(initialToggles);
   }, []);
 
   return (


### PR DESCRIPTION
☝️ 

Before working on any iterations of the components in the work page, we agreed to get everything into a single column.

- added an 'Item details' heading above the data groupings
- removed the 'Download' heading
- moved 'Share' and 'We're improving…' to the bottom
- added some spacing with the `SpacingComponent` wrapper

I added a keyline above section headings ('Item details', 'Using this image' and 'Share') in an attempt to make it feel section-y. This is almost certainly a thing we're going to need (not sure if we've got anything formalised for this yet – maybe one for @GarethOrmerod and @Heesoomoon to look at).

![localhost_3000_works_dmxdvqvs_query optics 1](https://user-images.githubusercontent.com/1394592/50919565-0de13600-143b-11e9-8601-5eb6fac038b9.png)
