### PR TITLE
remove references to V1 in nginx

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -36,11 +36,6 @@ http {
     return 301 https://wellcomecollection.org$request_uri;
   }
 
-  # Old (Drupal) Wellcome Collection site
-  upstream v1 {
-    server prev.wellcomecollection.org;
-  }
-
   # Current Wellcome Collection site
   upstream v2 {
     # We're not using as it's already redirecting to the root
@@ -57,42 +52,9 @@ http {
     server_name      _;
     add_header       x-wc-router true;
 
-    location @v1 {
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-      proxy_set_header           Host $host;
-      proxy_pass                 http://v1;
-    }
-
     location @v2 {
       proxy_set_header           Host $host;
       proxy_pass                 http://v2;
-    }
-
-    # v1
-    location ~ ^/admin/.* {
-      # Added for supporting the Drupal administration functions.
-      proxy_buffer_size          512k;
-      proxy_buffers              8 256k;
-      client_body_buffer_size    512k;
-      client_max_body_size       200M;
-
-      proxy_pass                 http://v1;
-      proxy_set_header           Host wellcomecollection.org;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-    }
-
-    # Most popular v1 content that we're going to continue to serve from v1 for now
-    location ~ ^/articles/william-harvey-and-circulation-blood|^/sexwomenlibrary|^/whats/sex-afternoon|^/articles/birth|^/articles/introduction-alzheimers-disease|^/articles/stereotyping-and-fatism|^/medieval-bodies|^/sex-numbers-0 {
-      proxy_pass                 http://v1;
-      proxy_set_header           Host wellcomecollection.org;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-    }
-
-    # Assets from V1
-    location ~ ^/sites/default/files/.* {
-      proxy_pass                 http://v1;
-      proxy_set_header           Host wellcomecollection.org;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
 
     location / {
@@ -100,16 +62,6 @@ http {
       proxy_set_header           Host wellcomecollection.org;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
-  }
-
-  # Wellcome Images deprecation
-  map $arg_MIRO $miro_uri {
-    ""      https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
-    default https://iiif.wellcomecollection.org/image/$arg_MIRO.jpg/full/125,/0/default.jpg;
-  }
-  map $arg_MIROPAC $miropac_uri {
-    ""      https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
-    default https://wellcomecollection.org/works?query=$arg_MIROPAC&wellcomeImagesUrl=$request_uri;
   }
 
   server {
@@ -133,13 +85,6 @@ http {
       rewrite '^/indexplus/gallery/Poster design\.html.*$' https://wellcomecollection.org/works?query=Poster&wellcomeImagesUrl=$request_uri permanent;
 
       return 301 https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
-    }
-
-    location = '/ixbin/imageserv' {
-      return 301 $miro_uri;
-    }
-    location = '/ixbin/hixclient.exe' {
-      return 301 $miropac_uri;
     }
   }
 }


### PR DESCRIPTION
I'd like to deprecate the router app (but keep the infrastructure).
Next up I'll start getting the rest of the Wellcome Images stuff into the lambda@edge.
