### PR TITLE
Wellcome images redirects at edge

### DIFF
--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -36,11 +36,6 @@ http {
     return 301 https://wellcomecollection.org$request_uri;
   }
 
-  # Old (Drupal) Wellcome Collection site
-  upstream v1 {
-    server prev.wellcomecollection.org;
-  }
-
   # Current Wellcome Collection site
   upstream v2 {
     # We're not using as it's already redirecting to the root
@@ -57,42 +52,9 @@ http {
     server_name      _;
     add_header       x-wc-router true;
 
-    location @v1 {
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-      proxy_set_header           Host $host;
-      proxy_pass                 http://v1;
-    }
-
     location @v2 {
       proxy_set_header           Host $host;
       proxy_pass                 http://v2;
-    }
-
-    # v1
-    location ~ ^/admin/.* {
-      # Added for supporting the Drupal administration functions.
-      proxy_buffer_size          512k;
-      proxy_buffers              8 256k;
-      client_body_buffer_size    512k;
-      client_max_body_size       200M;
-
-      proxy_pass                 http://v1;
-      proxy_set_header           Host wellcomecollection.org;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-    }
-
-    # Most popular v1 content that we're going to continue to serve from v1 for now
-    location ~ ^/articles/william-harvey-and-circulation-blood|^/sexwomenlibrary|^/whats/sex-afternoon|^/articles/birth|^/articles/introduction-alzheimers-disease|^/articles/stereotyping-and-fatism|^/medieval-bodies|^/sex-numbers-0 {
-      proxy_pass                 http://v1;
-      proxy_set_header           Host wellcomecollection.org;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
-    }
-
-    # Assets from V1
-    location ~ ^/sites/default/files/.* {
-      proxy_pass                 http://v1;
-      proxy_set_header           Host wellcomecollection.org;
-      proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
 
     location / {
@@ -100,16 +62,6 @@ http {
       proxy_set_header           Host wellcomecollection.org;
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
-  }
-
-  # Wellcome Images deprecation
-  map $arg_MIRO $miro_uri {
-    ""      https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
-    default https://iiif.wellcomecollection.org/image/$arg_MIRO.jpg/full/125,/0/default.jpg;
-  }
-  map $arg_MIROPAC $miropac_uri {
-    ""      https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
-    default https://wellcomecollection.org/works?query=$arg_MIROPAC&wellcomeImagesUrl=$request_uri;
   }
 
   server {
@@ -133,13 +85,6 @@ http {
       rewrite '^/indexplus/gallery/Poster design\.html.*$' https://wellcomecollection.org/works?query=Poster&wellcomeImagesUrl=$request_uri permanent;
 
       return 301 https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
-    }
-
-    location = '/ixbin/imageserv' {
-      return 301 $miro_uri;
-    }
-    location = '/ixbin/hixclient.exe' {
-      return 301 $miropac_uri;
     }
   }
 }

--- a/router/nginx.conf
+++ b/router/nginx.conf
@@ -63,28 +63,4 @@ http {
       proxy_set_header           HTTP_X_FORWARDED_PROTO https;
     }
   }
-
-  server {
-    listen      80;
-    listen      443 ssl;
-    server_name wellcomeimages.org *.wellcomeimages.org;
-
-    location / {
-      # Send URLs containing '%0A' (newline character that will cause a 500) to /works
-      rewrite '^/indexplus/.*t%0A.*$' https://wellcomecollection.org/works;
-      rewrite '^/indexplus/page/About Us\.html$' https://wellcomecollection.org/what-we-do/about-wellcome-collection?wellcomeImagesUrl=$request_uri permanent;
-      rewrite '^/indexplus/page/Contact Us\.html$' https://wellcomecollection.org/what-we-do/collection-enquiries?wellcomeImagesUrl=$request_uri permanent;
-      rewrite '^/indexplus/page/Privacy Statement\.html$' https://wellcome.ac.uk/about-us/terms-use?wellcomeImagesUrl=$request_uri permanent;
-      rewrite ^/indexplus/image/(.*)\.html$ https://wellcomecollection.org/works?query=$1&wellcomeImagesUrl=$request_uri permanent;
-      rewrite ^/indexplus/image/(.*)\.htm$ https://wellcomecollection.org/works?query=$1&wellcomeImagesUrl=$request_uri permanent;
-      rewrite '^/indexplus/gallery/AIDS posters\.html.*$' https://wellcomecollection.org/works?query=aids+poster&wellcomeImagesUrl=$request_uri permanent;
-      rewrite ^/indexplus/gallery/Witchcraft\.html.*$ https://wellcomecollection.org/works?query=witchcraft&wellcomeImagesUrl=$request_uri permanent;
-      rewrite ^/indexplus/gallery/DNA.html\.*$ https://wellcomecollection.org/works?query=dna&wellcomeImagesUrl=$request_uri permanent;
-      rewrite '^/indexplus/gallery/Florence Nightingale\.html.*$' https://wellcomecollection.org/works?query=florence+nightingale&wellcomeImagesUrl=$request_uri;
-      rewrite ^/indexplus/gallery/Portraits\.html.*$ https://wellcomecollection.org/works?query=portrait&wellcomeImagesUrl=$request_uri permanent;
-      rewrite '^/indexplus/gallery/Poster design\.html.*$' https://wellcomecollection.org/works?query=Poster&wellcomeImagesUrl=$request_uri permanent;
-
-      return 301 https://wellcomecollection.org/works?wellcomeImagesUrl=$request_uri;
-    }
-  }
 }

--- a/router/webapp/wiRedirector.js
+++ b/router/webapp/wiRedirector.js
@@ -30,9 +30,8 @@ exports.wiRedirector = (event, context) => {
   ) {
     // This is for images that we're serving from wellcomelibrary.org
     if (request.querystring && request.uri.match('/ixbin/imageserv')) {
-      const params = querystring.parse(request.querystring);
-
       // e.g. http://wellcomeimages.org/ixbin/imageserv?MIRO=L0054052
+      const params = querystring.parse(request.querystring);
       if (params.MIRO) {
         const redirect = createRedirect(
           `https://iiif.wellcomecollection.org/image/${params.MIRO}.jpg/full/125,/0/default.jpg`,
@@ -41,14 +40,45 @@ exports.wiRedirector = (event, context) => {
         cf.response = redirect;
         return;
       }
+    }
 
+    if (request.querystring && request.uri.match('/ixbin/hixclient.exe')) {
       // e.g. http://wellcomeimages.org/ixbin/hixclient.exe?MIROPAC=V0042017
+      const params = querystring.parse(request.querystring);
       if (params.MIROPAC) {
         const redirect = createRedirect(
           `/works?query=${params.MIROPAC}&wellcomeImagesUrl=${request.uri}`
         );
         cf.response = redirect;
+        return;
       }
+    }
+
+    // e.g. http://wellcomeimages.org/indexplus/image/hats.html
+    const searchTermMatch = request.uri.match(/\/indexplus\/image\/(.*)\.html/i);
+    if (searchTermMatch) {
+      const redirect = createRedirect(
+        `/works?query=${searchTermMatch[1]}&wellcomeImagesUrl=${request.uri}`
+      );
+      cf.response = redirect;
+      return;
+    }
+
+    // e.g. http://wellcomeimages.org/indexplus/gallery/AIDS posters.html
+    const galleryMatch = request.uri.match(/\/indexplus\/gallery\/(.*)\.html/i);
+    if (galleryMatch) {
+      const redirect = createRedirect(
+        `/works?query=${galleryMatch[1]}&wellcomeImagesUrl=${request.uri}`
+      );
+      cf.response = redirect;
+      return;
+    }
+
+    if (!cf.response) {
+      const redirect = createRedirect(
+        `/works?wellcomeImagesUrl=${request.uri}`
+      );
+      cf.response = redirect;
     }
   }
 };


### PR DESCRIPTION
Forked from #3950 

In an attempt to have functionality in 1 place, this migrates _all_ the wellcomeimages.org redirects to the lambda.

