### PR TITLE
A/B test for work details in single column

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -93,9 +93,14 @@ export default class WecoApp extends App {
       }
     }]);
 
-    ReactGA.pageview(
-      `${window.location.pathname}${window.location.search}`
-    );
+    try {
+      ReactGA.set({'dimension5': JSON.stringify(toggles)});
+    } catch (error) {
+      // don't do anything
+    }
+
+    ReactGA.pageview(`${window.location.pathname}${window.location.search}`);
+
     engagement = setTimeout(triggerEngagement, 10000);
     Router.events.on('routeChangeStart', trackRouteChange);
 

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -25,7 +25,12 @@ function setCookie(name, value) {
   document.cookie = `toggle_${name}=${value || ''}; Path=/; Domain=wellcomecollection.org; ${expiration}`;
 }
 
-const abTests = [];
+const abTests = [{
+  id: 'showSingleColumnWork',
+  title: 'Show work metadata in a single column',
+  description:
+    `Uses a single column to display work information.`
+}];
 
 const featureToggles = [{
   id: 'showCatalogueSearchFilters',
@@ -40,11 +45,6 @@ const featureToggles = [{
   description:
     `Uses the work page prototype. Note, being in this group will take precedence ` +
     `over the 'Show the single column work page' group.`
-}, {
-  id: 'showSingleColumnWork',
-  title: 'Show work metadata in a single column',
-  description:
-    `Uses a single column to display work information.`
 }, {
   id: 'showRevisedOpeningHours',
   title: 'Show revised opening hours 4 weeks in advance rather than 2 weeks',

--- a/router/webapp/ab_testing.js
+++ b/router/webapp/ab_testing.js
@@ -10,7 +10,16 @@
 // }
 
 // This is mutable for testing
-let tests = [];
+let tests = [
+  {
+    id: 'showSingleColumnWork',
+    title: 'Show work metadata in a single column',
+    shouldRun(request) {
+      return request.url.match(/^\/works\/.+/);
+    }
+  }
+];
+
 exports.setTests = function(newTests) {
   tests = newTests;
 };
@@ -37,13 +46,17 @@ exports.request = (event, context) => {
   const newToggles = tests.map(test => {
     // Isn't already set
     const isSet = Boolean(toggleCookies.find(cookie => cookie.key === `toggle_${test.id}`));
-    if (test.shouldRun(request) && !isSet) {
-      // Flip the dice
-      if (Math.random() < 0.5) {
-        return { key: `toggle_${test.id}`, value: true };
-      } else {
-        return { key: `toggle_${test.id}`, value: false };
+    try {
+      if (test.shouldRun(request) && !isSet) {
+        // Flip the dice
+        if (Math.random() < 0.5) {
+          return { key: `toggle_${test.id}`, value: true };
+        } else {
+          return { key: `toggle_${test.id}`, value: false };
+        }
       }
+    } catch (error) {
+      console.log(`a/b test shouldRun() broke with error: ${error}`);
     }
   }).filter(Boolean);
 


### PR DESCRIPTION
Moving the single column work details from a toggle to an A/B test.

We've renamed the 'Test dimension' custom dimension (which we weren't using anymore) in GA to 'Toggles' and we're going to send any toggles a user has set (or that we've set for them) through in the format `{"toggle_nameoftoggle": true, "toggle_somethingelse": false}` which @hthair will be able to use to report on for A/B tests in Data Studio.

