### PR TITLE
remap twitterHandle to sameAs

### DIFF
--- a/prismic_remapper/people_remodel/after.json
+++ b/prismic_remapper/people_remodel/after.json
@@ -1,0 +1,110 @@
+{
+  "type": "people",
+  "tags": [],
+  "lang": "en-gb",
+  "grouplang": "W03I9yYAACUAgx99",
+  "name": "Charlie Williams",
+  "description": [
+    {
+      "type": "paragraph",
+      "content": {
+        "text": "Charlie Williams is a postdoctoral researcher working with the Hidden Persuaders project at Birkbeck, University of London. His research explores Cold War culture through the lens of the human sciences with an emphasis on the psychological, emotional and economic relationships between humans and emerging 'psy' technologies. ",
+        "spans": []
+      }
+    }
+  ],
+  "image": {
+    "origin": {
+      "id": "W03I0iYAACgAgx7V",
+      "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+      "width": 298,
+      "height": 300
+    },
+    "width": 298,
+    "height": 300,
+    "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/a3a032444c04c541dc68a97032efa8122ffe3bf0_charlie-williams-150x150.jpg",
+    "edit": {
+      "background": "#fff",
+      "zoom": 1,
+      "crop": {
+        "x": 0,
+        "y": 0
+      }
+    },
+    "credits": null,
+    "alt": null,
+    "thumbnails": {
+      "16:9": {
+        "origin": {
+          "id": "W03I0iYAACgAgx7V",
+          "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+          "width": 298,
+          "height": 300
+        },
+        "width": 3200,
+        "height": 1800,
+        "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/3bc193f3528ae74fd824afdd1ccd03e8f30dc811_charlie-williams-150x150.jpg",
+        "edit": {
+          "background": "#fff",
+          "zoom": 10.738255033557047,
+          "crop": {
+            "x": 0,
+            "y": -711
+          }
+        },
+        "credits": null,
+        "alt": null
+      },
+      "32:15": {
+        "origin": {
+          "id": "W03I0iYAACgAgx7V",
+          "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+          "width": 298,
+          "height": 300
+        },
+        "width": 3200,
+        "height": 1500,
+        "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/0d209139e6a904a803be2e514f1b7919ef68d893_charlie-williams-150x150.jpg",
+        "edit": {
+          "background": "#fff",
+          "zoom": 10.738255033557047,
+          "crop": {
+            "x": 0,
+            "y": -861
+          }
+        },
+        "credits": null,
+        "alt": null
+      },
+      "square": {
+        "origin": {
+          "id": "W03I0iYAACgAgx7V",
+          "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+          "width": 298,
+          "height": 300
+        },
+        "width": 3200,
+        "height": 3200,
+        "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/267d7073c70dca7a3f24efe8ef4c33f86a741ee2_charlie-williams-150x150.jpg",
+        "edit": {
+          "background": "#fff",
+          "zoom": 10.738255033557047,
+          "crop": {
+            "x": 0,
+            "y": -11
+          }
+        },
+        "credits": null,
+        "alt": null
+      }
+    }
+  },
+  "sameAs": [
+    [
+      {
+        "link": "https://twitter.com/HPersuaders",
+        "title": "@HPersuaders"
+      }
+    ]
+  ]
+}

--- a/prismic_remapper/people_remodel/before.json
+++ b/prismic_remapper/people_remodel/before.json
@@ -1,0 +1,111 @@
+{
+  "type": "people",
+  "tags": [],
+  "lang": "en-gb",
+  "grouplang": "W03I9yYAACUAgx99",
+  "name": "Charlie Williams",
+  "description": [
+    {
+      "type": "paragraph",
+      "content": {
+        "text": "Charlie Williams is a postdoctoral researcher working with the Hidden Persuaders project at Birkbeck, University of London. His research explores Cold War culture through the lens of the human sciences with an emphasis on the psychological, emotional and economic relationships between humans and emerging 'psy' technologies. ",
+        "spans": []
+      }
+    }
+  ],
+  "image": {
+    "origin": {
+      "id": "W03I0iYAACgAgx7V",
+      "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+      "width": 298,
+      "height": 300
+    },
+    "width": 298,
+    "height": 300,
+    "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/a3a032444c04c541dc68a97032efa8122ffe3bf0_charlie-williams-150x150.jpg",
+    "edit": {
+      "background": "#fff",
+      "zoom": 1,
+      "crop": {
+        "x": 0,
+        "y": 0
+      }
+    },
+    "credits": null,
+    "alt": null,
+    "thumbnails": {
+      "16:9": {
+        "origin": {
+          "id": "W03I0iYAACgAgx7V",
+          "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+          "width": 298,
+          "height": 300
+        },
+        "width": 3200,
+        "height": 1800,
+        "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/3bc193f3528ae74fd824afdd1ccd03e8f30dc811_charlie-williams-150x150.jpg",
+        "edit": {
+          "background": "#fff",
+          "zoom": 10.738255033557047,
+          "crop": {
+            "x": 0,
+            "y": -711
+          }
+        },
+        "credits": null,
+        "alt": null
+      },
+      "32:15": {
+        "origin": {
+          "id": "W03I0iYAACgAgx7V",
+          "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+          "width": 298,
+          "height": 300
+        },
+        "width": 3200,
+        "height": 1500,
+        "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/0d209139e6a904a803be2e514f1b7919ef68d893_charlie-williams-150x150.jpg",
+        "edit": {
+          "background": "#fff",
+          "zoom": 10.738255033557047,
+          "crop": {
+            "x": 0,
+            "y": -861
+          }
+        },
+        "credits": null,
+        "alt": null
+      },
+      "square": {
+        "origin": {
+          "id": "W03I0iYAACgAgx7V",
+          "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection%2F31686b03-f537-42b7-8dbe-70bfe436c458_charlie-williams-150x150.jpg",
+          "width": 298,
+          "height": 300
+        },
+        "width": 3200,
+        "height": 3200,
+        "url": "https://prismic-io.s3.amazonaws.com/wellcomecollection/267d7073c70dca7a3f24efe8ef4c33f86a741ee2_charlie-williams-150x150.jpg",
+        "edit": {
+          "background": "#fff",
+          "zoom": 10.738255033557047,
+          "crop": {
+            "x": 0,
+            "y": -11
+          }
+        },
+        "credits": null,
+        "alt": null
+      }
+    }
+  },
+  "twitterHandle": "HPersuaders",
+  "sameAs": [
+    [
+      {
+        "link": "https://twitter.com/HPersuaders",
+        "title": "@HPersuaders"
+      }
+    ]
+  ]
+}

--- a/prismic_remapper/people_remodel/remap.js
+++ b/prismic_remapper/people_remodel/remap.js
@@ -18,7 +18,13 @@ module.exports = {
       const twitterHandle = removeAt(doc.twitterHandle);
       const twitterSameAs = [{
         link: `https://twitter.com/${twitterHandle}`,
-        title: `@${twitterHandle}`
+        title: [{
+          type: 'heading1',
+          content: {
+            text: `@${twitterHandle}`,
+            spans: []
+          }
+        }]
       }];
       if (doc.sameAs) {
         const currentTwitterSameAsIndex = doc.sameAs.findIndex(item => `https://twitter.com/${twitterHandle}` === item.link);

--- a/prismic_remapper/people_remodel/remap.js
+++ b/prismic_remapper/people_remodel/remap.js
@@ -1,0 +1,38 @@
+// people.twitterHandle has been deprecated in favour of the more generic people.sameAs
+
+// some of the twitterHandles start with @; we don't want that
+function removeAt(twitterHandle) {
+  const twitterHandleStart = twitterHandle.charAt(0);
+  if (twitterHandleStart === '@') {
+    return twitterHandle.substr(1);
+  } else {
+    return twitterHandle;
+  }
+}
+module.exports = {
+  filter({filename, doc}) {
+    return doc.type === 'people';
+  },
+  map({filename, doc}) {
+    if (doc.twitterHandle) {
+      const twitterHandle = removeAt(doc.twitterHandle);
+      const twitterSameAs = [{
+        link: `https://twitter.com/${twitterHandle}`,
+        title: `@${twitterHandle}`
+      }];
+
+      if (doc.sameAs) {
+        const currentTwitterSameAsIndex = doc.sameAs.findIndex(item => `https://twitter.com/${twitterHandle}` === item.link);
+        if (currentTwitterSameAsIndex === -1) {
+          doc.sameAs = doc.sameAs.concat(twitterSameAs).filter(Boolean);
+        } else {
+          doc.sameAs[currentTwitterSameAsIndex] = twitterSameAs; // some of the current sameAs objects with twitter links don't have the title, so we make sure they do
+        }
+      } else {
+        doc.sameAs = twitterSameAs.filter(Boolean);
+      }
+    }
+    delete doc.twitterHandle;
+    return {doc, filename};
+  }
+};

--- a/prismic_remapper/people_remodel/remap.js
+++ b/prismic_remapper/people_remodel/remap.js
@@ -20,16 +20,15 @@ module.exports = {
         link: `https://twitter.com/${twitterHandle}`,
         title: `@${twitterHandle}`
       }];
-
       if (doc.sameAs) {
         const currentTwitterSameAsIndex = doc.sameAs.findIndex(item => `https://twitter.com/${twitterHandle}` === item.link);
         if (currentTwitterSameAsIndex === -1) {
-          doc.sameAs = doc.sameAs.concat(twitterSameAs).filter(Boolean);
+          doc.sameAs = doc.sameAs.concat(twitterSameAs).filter(item => Object.keys(item).length > 0);
         } else {
           doc.sameAs[currentTwitterSameAsIndex] = twitterSameAs; // some of the current sameAs objects with twitter links don't have the title, so we make sure they do
         }
       } else {
-        doc.sameAs = twitterSameAs.filter(Boolean);
+        doc.sameAs = twitterSameAs.filter(item => Object.keys(item).length > 0);
       }
     }
     delete doc.twitterHandle;


### PR DESCRIPTION
A while back we updated the people model to deprecate twitterHandle and add sameAs #3034

I've just noticed that we have 130 out of 271 people in Prismic, with a twitterHandle, which is not being rendered. Running the remapper in this PR will create a sameAs link for each twitterHandle and remove the twitterHandle 