### PR TITLE
check for image before using it

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -75,7 +75,7 @@ export const WorkPage = ({
     );
   }
 
-  const imageContentUrl = iiifImageTemplate(iiifImageLocationUrl)({ size: `800,` });
+  const imageContentUrl = iiifImageLocationUrl && iiifImageTemplate(iiifImageLocationUrl)({ size: `800,` });
   return (
     <PageLayout
       title={work.title}


### PR DESCRIPTION
Check for the iiif image before we use it.

Not sure why typing didn't pick this up. Will look later.
Only happens on items we don't surface.