### PR TITLE
Underline CompactCard titles in green on hover

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -562,6 +562,7 @@
   &:focus {
     .card-link__title {
       text-decoration: underline;
+      text-decoration-color: color('green');
     }
   }
 }


### PR DESCRIPTION
☝️ 

(to be consistent with other cards, as reported by @GarethOrmerod).

![screenshot 2019-01-16 at 15 22 40](https://user-images.githubusercontent.com/1394592/51258745-96635780-19a2-11e9-9d64-0365db041d2d.png)
