### PR TITLE
only include component that has openseadragon on the client

### DIFF
--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -8,7 +8,7 @@ import {trackEventV2} from '../../../utils/ga';
 import dynamic from 'next/dynamic';
 import ReactGA from 'react-ga';
 
-const ImageViewerImage = dynamic(import('./ImageViewerImage'));
+const ImageViewerImage = dynamic(import('./ImageViewerImage'), {ssr: false});
 
 type LaunchViewerButtonProps = {|
   classes: string,


### PR DESCRIPTION
Openseadragon is a client only lib.
We should be only including it on the client.

This gets rid of that really annoying hot reloading error of "document is not defined".