### PR TITLE
 Promote search box from toggle to A/B test

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -85,13 +85,22 @@ const SearchForm = ({
       aria-describedby={ariaDescribedBy}
       onSubmit={(event) => {
         event.preventDefault();
+
+        trackEvent({
+          category: 'SearchForm',
+          action: 'submit search',
+          label: query
+        });
+
         const link = worksUrl({
           query,
           workType,
           itemsLocationsLocationType,
           page: 1
         });
+
         Router.push(link.href, link.as);
+
         return false;
       }}>
 
@@ -111,7 +120,7 @@ const SearchForm = ({
               className='absolute line-height-1 plain-button v-center no-padding'
               onClick={() => {
                 trackEvent({
-                  category: 'SearchBox',
+                  category: 'SearchForm',
                   action: 'clear search',
                   label: 'works-search'
                 });

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -26,11 +26,10 @@ type Props = {|
   encoreLink: ?string
 |}
 
-const SingleColumnWork = ({
+const WorkDetails = ({
   work,
   iiifImageLocationUrl,
   licenseInfo,
-  LicenseData,
   iiifImageLocationCredit,
   iiifImageLocationLicenseId,
   encoreLink
@@ -244,4 +243,4 @@ const SingleColumnWork = ({
   );
 };
 
-export default SingleColumnWork;
+export default WorkDetails;

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -14,7 +14,7 @@ import WorkRedesign from '../components/WorkRedesign/WorkRedesign';
 import {getWork} from '../services/catalogue/works';
 import {worksUrl} from '../services/catalogue/urls';
 import BackToResults from '@weco/common/views/components/BackToResults/BackToResults';
-import SingleColumnWork from '../components/SingleColumnWork/SingleColumnWork';
+import WorkDetails from '../components/WorkDetails/WorkDetails';
 import SearchForm from '../components/SearchForm/SearchForm';
 
 type Props = {|
@@ -137,7 +137,7 @@ export const WorkPage = ({
           iiifUrl={iiifImageLocationUrl}
           title={work.title} />}
 
-        <SingleColumnWork
+        <WorkDetails
           work={work}
           iiifImageLocationUrl={iiifImageLocationUrl}
           licenseInfo={licenseInfo}

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -25,7 +25,13 @@ function setCookie(name, value) {
   document.cookie = `toggle_${name}=${value || ''}; Path=/; Domain=wellcomecollection.org; ${expiration}`;
 }
 
-const abTests = [];
+const abTests = [{
+  id: 'showSearchBoxOnWork',
+  title: 'Show the search box on work pages',
+  description:
+    `Puts a search box above the image viewer on work pages to see if ` +
+    `it has an effect on number of searches per session/pogo-sticking behaviour.`
+}];
 
 const featureToggles = [{
   id: 'showCatalogueSearchFilters',
@@ -34,12 +40,6 @@ const featureToggles = [{
     'We currently filter the results of the catalogue to show Pictures and ' +
     'Digital images work types, and only results with images.' +
     'This will show unfilter those results, and allow for filtering.'
-}, {
-  id: 'showSearchBoxOnWork',
-  title: 'Show the search box on work pages',
-  description:
-    `Puts a search box above the image viewer on work pages to see if ` +
-    `it has an effect on number of searches per session/pogo-sticking behaviour.`
 }, {
   id: 'showRevisedOpeningHours',
   title: 'Show revised opening hours 4 weeks in advance rather than 2 weeks',

--- a/router/webapp/ab_testing.js
+++ b/router/webapp/ab_testing.js
@@ -10,7 +10,13 @@
 // }
 
 // This is mutable for testing
-let tests = [];
+let tests = [{
+  id: 'showSearchBoxOnWork',
+  title: 'Show search box on work pages',
+  shouldRun(request) {
+    return request.uri.match(/^\/works\/.+/);
+  }
+}];
 
 exports.setTests = function(newTests) {
   tests = newTests;


### PR DESCRIPTION
References #3956 

Because we're not sure we can rely on GA's search console data for an accurate count in the A/B test, we've added a new tracking event when a visitor submits the `SearchForm`:

```
category: 'SearchForm',
action: 'submit search',
label: {the search query}
```

@hthair – the condition a visitor is in will be available in the 'Toggles' dimension as `showSearchBoxOnWork: true` or `showSearchBoxOnWork: false`.