### PR TITLE
remove promoType field

### DIFF
--- a/cardigan/stories/components/Cards.js
+++ b/cardigan/stories/components/Cards.js
@@ -17,7 +17,6 @@ const labelList = {labels: [
 const FeaturedCardExample = () => <FeaturedCard
   url={'https://wellcomecollection.org'}
   title={'Wellcome Collection'}
-  promoType={'ExamplePromo'}
   description={singleLineOfText(10, 25)}
   Image={<UiImage {...imageProps} />}
   DateInfo={null}
@@ -26,7 +25,6 @@ const FeaturedCardExample = () => <FeaturedCard
 const CardExample = () => <Card
   url={'https://wellcomecollection.org'}
   title={'Wellcome Collection'}
-  promoType={'ExamplePromo'}
   description={singleLineOfText(10, 25)}
   Image={<UiImage {...imageProps} />}
   DateInfo={null}
@@ -35,7 +33,6 @@ const CardExample = () => <Card
 const CompactCardExample = () => <CompactCard
   url={'https://wellcomecollection.org'}
   title={'Wellcome Collection'}
-  promoType={'ExamplePromo'}
   description={singleLineOfText(10, 25)}
   Image={<UiImage {...imageProps} />}
   DateInfo={null}

--- a/common/views/components/ArticleCard/ArticleCard.js
+++ b/common/views/components/ArticleCard/ArticleCard.js
@@ -17,7 +17,6 @@ const ArticleCard = ({ article, showPosition }: Props) => {
     }).find(_ => _) : null;
 
   return (<CompactCard
-    promoType='ArticlePromo'
     url={`/articles/${article.id}`}
     title={article.title || ''}
     partNumber={partOfSerial}

--- a/common/views/components/Card/Card.js
+++ b/common/views/components/Card/Card.js
@@ -7,7 +7,6 @@ import {default as ImageType} from '../Image/Image';
 type Props = {|
   url: string,
   title: string,
-  promoType: string,
   description: ?string,
   urlOverride: ?string,
   extraClasses?: string,
@@ -19,7 +18,6 @@ type Props = {|
 const CompactCard = ({
   url,
   title,
-  promoType,
   description,
   urlOverride,
   extraClasses,

--- a/common/views/components/CompactCard/CompactCard.js
+++ b/common/views/components/CompactCard/CompactCard.js
@@ -14,7 +14,6 @@ import type {ColorSelection} from '../../../model/color-selections';
 type Props = {|
   url: ?string,
   title: string,
-  promoType: string,
   labels: ElementProps<typeof LabelsList>,
   description: ?string,
   urlOverride: ?string,
@@ -29,7 +28,6 @@ type Props = {|
 const CompactCard = ({
   url,
   title,
-  promoType,
   labels,
   description,
   urlOverride,
@@ -47,7 +45,6 @@ const CompactCard = ({
   const Tag = url ? 'a' : 'div';
   return (
     <Tag
-      data-component={promoType}
       href={urlOverride || url}
       className={conditionalClassNames({
         'grid': true,

--- a/common/views/components/EventCard/EventCard.js
+++ b/common/views/components/EventCard/EventCard.js
@@ -23,7 +23,6 @@ const EventCard = ({ event }: Props) => {
     title={event.title}
     partNumber={null}
     color={null}
-    promoType={'EventPromo'}
     labels={{labels: event.labels}}
     description={null}
     urlOverride={event.promo && event.promo.link}

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -7,7 +7,6 @@ import {default as ImageType} from '../Image/Image';
 type Props = {|
   url: string,
   title: string,
-  promoType: string,
   description: ?string,
   urlOverride: ?string,
   extraClasses?: string,
@@ -19,7 +18,6 @@ type Props = {|
 const CompactCard = ({
   url,
   title,
-  promoType,
   description,
   urlOverride,
   extraClasses,

--- a/common/views/components/Outro/Outro.js
+++ b/common/views/components/Outro/Outro.js
@@ -86,7 +86,6 @@ const Outro = ({
                   StatusIndicator={null}
                   DateInfo={null}
                   title={title}
-                  promoType={``}
                   labels={{labels: item.labels || []}}
                   url={item.type === 'weblinks' ? item.url : `/${item.type}/${item.id}`}
                   description={description} />

--- a/common/views/components/SearchResults/SearchResults.js
+++ b/common/views/components/SearchResults/SearchResults.js
@@ -44,7 +44,6 @@ const SearchResults = ({
         } key={item.id}>
           {item.type === 'pages' &&
             <CompactCard
-              promoType='PagePromo'
               url={`/pages/${item.id}`}
               title={item.title || ''}
               partNumber={null}
@@ -60,7 +59,6 @@ const SearchResults = ({
 
           {item.type === 'event-series' &&
             <CompactCard
-              promoType='EventSeriesPromo'
               url={`/event-series/${item.id}`}
               title={item.title || ''}
               partNumber={null}
@@ -76,7 +74,6 @@ const SearchResults = ({
 
           {item.type === 'books' &&
             <CompactCard
-              promoType='BooksPromo'
               url={`/books/${item.id}`}
               title={item.title || ''}
               labels={{labels: item.labels}}
@@ -96,7 +93,6 @@ const SearchResults = ({
 
           {item.type === 'article-schedule-items' &&
             <CompactCard
-              promoType='ArticlePromo'
               url={null}
               title={item.title || ''}
               partNumber={item.partNumber}
@@ -116,7 +112,6 @@ const SearchResults = ({
 
           {item.type === 'installations' &&
             <CompactCard
-              promoType='InstallationPromo'
               url={`/installations/${item.id}`}
               title={item.title}
               partNumber={null}


### PR DESCRIPTION
This remove the `promoType` prop as it wasn't doing anything.

It does raise the question that, if a card can take multiple `contentTypes` - do we, and how should we, track that.