### PR TITLE
account for empty arrays when tallying works metadata

### DIFF
--- a/works_analysis/get_metadata_by_work_type_tally.py
+++ b/works_analysis/get_metadata_by_work_type_tally.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     for work in get_all_works():
         for field_name in work.keys():
             all_fields.add(field_name)
-            if (work[field_name]):
+            if work[field_name]:
                 tally[work["workType"]["label"]][field_name] += 1
 
     headings = ["field"] + [k for k in sorted(tally.keys())]

--- a/works_analysis/get_metadata_by_work_type_tally.py
+++ b/works_analysis/get_metadata_by_work_type_tally.py
@@ -13,7 +13,8 @@ if __name__ == '__main__':
     for work in get_all_works():
         for field_name in work.keys():
             all_fields.add(field_name)
-            tally[work["workType"]["label"]][field_name] += 1
+            if (work[field_name]):
+                tally[work["workType"]["label"]][field_name] += 1
 
     headings = ["field"] + [k for k in sorted(tally.keys())]
 


### PR DESCRIPTION
Turns out the assumption that everything doesn't have subjects, genres and any field that is an array was true.

This checks for empty array before adding to the tally.