### PR TITLE
Edge lambda deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,6 +259,8 @@ workflows:
       - cardigan:
           requires:
             - checkout_code
+  edge_lambdas:
+    jobs:
       - edge_lambdas:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -243,11 +243,6 @@ jobs:
           name: Install awscli
           command: sudo apt-get install awscli
       - run:
-          name: HMMMM
-          command: |
-            pwd
-            ls artifacts
-      - run:
           name: Deploy lambda to S3
           command: aws s3 cp ./artifacts/edge_lambda_origin.zip s3://weco-lambdas/edge_lambda_origin.zip
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,10 +227,29 @@ jobs:
             zip -r edge_lambda_origin.zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
             mkdir -p /tmp/artifacts
             cp edge_lambda_origin.zip /tmp/artifacts
+            ls /tmp/artifacts
       - persist_to_workspace:
           root: /tmp/artifacts
           paths:
             - edge_lambda_origin.zip
+  edge_lambdas_deploy:
+    docker:
+      - image: circleci/node:8.11.3
+    working_directory: /tmp
+    steps:
+      - attach_workspace:
+          at: /tmp/artifacts
+      - run:
+          name: Install awscli
+          command: sudo apt-get install awscli
+      - run:
+          name: HMMMM
+          command: |
+            pwd
+            ls artifacts
+      - run:
+          name: Deploy lambda to S3
+          command: aws s3 cp ./artifacts/edge_lambda_origin.zip s3://weco-lambdas/edge_lambda_origin.zip
 workflows:
   version: 2
   build_and_deploy:
@@ -275,3 +294,10 @@ workflows:
       - edge_lambdas_build:
           requires:
             - checkout_code
+      - edge_lambdas_deploy:
+          requires:
+            - edge_lambdas_build
+          filters:
+            branches:
+              only:
+                - edge_lambda_deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,11 +216,14 @@ jobs:
       - restore_cache:
           key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - run:
-            name: Install deps
-            command: yarn
+          name: Install deps
+          command: yarn
       - run:
-            name: Run tests
-            command: yarn test
+          name: Run tests
+          command: yarn test
+      - run:
+          name: Build lambda ZIP
+          command: zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,8 @@ jobs:
     working_directory: /home/circleci/wellcomecollection.org/router/webapp
     steps:
       - add_ssh_keys
+      - restore_cache:
+          key: repo_{{ .Environment.CIRCLE_SHA1 }}
       - run:
             name: Install deps
             command: yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
                     aws s3 sync --only-show-errors . s3://cardigan.wellcomecollection.org
                 popd
             fi
-  edge_lambdas:
+  edge_lambdas_build:
     docker:
       - image: circleci/node:8.11.3
     working_directory: /home/circleci/wellcomecollection.org/router/webapp
@@ -224,6 +224,9 @@ jobs:
       - run:
           name: Build lambda ZIP
           command: zip -r edge_lambda_origin.zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
+      - store_artifacts:
+          path: edge_lambda_origin.zip
+          destination: edge_lambdas
 workflows:
   version: 2
   build_and_deploy:
@@ -265,6 +268,6 @@ workflows:
   edge_lambdas:
     jobs:
       - checkout_code
-      - edge_lambdas:
+      - edge_lambdas_build:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,7 +225,7 @@ jobs:
           name: Build lambda ZIP
           command: |
             zip -r edge_lambda_origin.zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
-            mkdirp /tmp/artifacts
+            mkdir -p /tmp/artifacts
             cp edge_lambda_origin.zip /tmp/artifacts
       - persist_to_workspace:
           root: /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
           command: yarn test
       - run:
           name: Build lambda ZIP
-          command: zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
+          command: zip -r edge_lambda_origin.zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ jobs:
       - persist_to_workspace:
           root: /tmp/artifacts
           paths:
-            - edge_lambdas.zip
+            - edge_lambda_origin.zip
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,9 +224,10 @@ jobs:
       - run:
           name: Build lambda ZIP
           command: zip -r edge_lambda_origin.zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
-      - store_artifacts:
-          path: edge_lambda_origin.zip
-          destination: edge_lambdas
+      - persist_to_workspace:
+          root: /tmp/artifacts/edge_lambdas
+          paths:
+            - edge_lambdas.zip
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,18 @@ jobs:
                     aws s3 sync --only-show-errors . s3://cardigan.wellcomecollection.org
                 popd
             fi
+  edge_lambdas:
+    docker:
+      - image: circleci/node:8.11.3
+    working_directory: /home/circleci/wellcomecollection.org/router/webapp
+    steps:
+      - add_ssh_keys
+      - run:
+            name: Install deps
+            command: yarn
+      - run:
+            name: Run tests
+            command: yarn test
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2.0
 jobs:
   checkout_code:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,3 +257,6 @@ workflows:
       - cardigan:
           requires:
             - checkout_code
+      - edge_lambdas:
+          requires:
+            - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,7 @@ workflows:
             - checkout_code
   edge_lambdas:
     jobs:
+      - checkout_code
       - edge_lambdas:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   checkout_code:
     docker:
@@ -223,9 +223,12 @@ jobs:
           command: yarn test
       - run:
           name: Build lambda ZIP
-          command: zip -r edge_lambda_origin.zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
+          command: |
+            zip -r edge_lambda_origin.zip ab_testing.js origin.js redirector.js redirects.js wiRedirector.js
+            mkdirp /tmp/artifacts
+            cp edge_lambda_origin.zip /tmp/artifacts
       - persist_to_workspace:
-          root: /tmp/artifacts/edge_lambdas
+          root: /tmp/artifacts
           paths:
             - edge_lambdas.zip
 workflows:

--- a/router/terraform/edge_lambdas.tf
+++ b/router/terraform/edge_lambdas.tf
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "edge_lambda_response" {
   publish = true
 }
 
-data "aws_s3_bucket_object" "edge_lambda_request" {
+data "aws_s3_bucket_object" "edge_lambda_origin" {
   provider = "aws.us-east-1"
   bucket = "weco-lambdas"
   key = "edge_lambda_origin.zip"
@@ -87,6 +87,6 @@ resource "aws_lambda_function" "edge_lambda_response_test" {
   handler = "origin.response"
   s3_bucket = "weco-lambdas"
   s3_key = "edge_lambda_origin.zip"
-  s3_object_version = "${data.aws_s3_bucket_object.edge_lambda_request.version_id}"
+  s3_object_version = "${data.aws_s3_bucket_object.edge_lambda_origin.version_id}"
   publish = true
 }

--- a/router/terraform/edge_lambdas.tf
+++ b/router/terraform/edge_lambdas.tf
@@ -72,3 +72,21 @@ resource "aws_lambda_function" "edge_lambda_response" {
   handler = "origin.response"
   publish = true
 }
+
+data "aws_s3_bucket_object" "edge_lambda_request" {
+  provider = "aws.us-east-1"
+  bucket = "weco-lambdas"
+  key = "edge_lambda_origin.zip"
+}
+
+resource "aws_lambda_function" "edge_lambda_response_test" {
+  provider = "aws.us-east-1"
+  function_name = "edge_lambda_response_test"
+  role = "${aws_iam_role.basic_lambda_role.arn}"
+  runtime = "nodejs8.10"
+  handler = "origin.response"
+  s3_bucket = "weco-lambdas"
+  s3_key = "edge_lambda_origin.zip"
+  s3_object_version = "${data.aws_s3_bucket_object.edge_lambda_request.version_id}"
+  publish = true
+}


### PR DESCRIPTION
The very starts of lambda deployments.
In short:
* Build lambda ZIP super simply in circle after testing (event having the test in there are making me less 💦 )
* Push Lambda to S3
* If we deploy `aws_lambda_function.edge_lambda_response_test` it reads the version from the Terrraform provider `aws_s3_bucket_object.edge_lambda_request` and deploys it.

What we need to go through:
* Once that the lambda is deployed, does it deploy the CloudFront lambda, or is that another step?
* If that's another step, how can we make it 1 less step?
