### PR TITLE
Make content the fallback app in the ALB

### DIFF
--- a/content/terraform/terraform.tf
+++ b/content/terraform/terraform.tf
@@ -87,219 +87,32 @@ module "content" {
   deployment_maximum_percent         = "200"
   env_vars_length                    = 0
   desired_count                      = 2
+
   # CPU: (1024/2) - 128
   # Mem: (2000/2) - 128
-  cpu                                = "384"
-  memory                             = "872"
-  primary_container_port             = "80"
-  secondary_container_port           = "3000"
-  host_name                          = "content.wellcomecollection.org"
-  healthcheck_path                   = "/content/management/healthcheck"
-  alb_priority                       = "700"
+  cpu = "384"
+
+  memory                   = "872"
+  primary_container_port   = "80"
+  secondary_container_port = "3000"
+  healthcheck_path         = "/content/management/healthcheck"
+
+  # The content listener is the last listener to deal with things like vanity
+  # URLs and 404 pages. We could create a service that deals with this, but there seems
+  # little gain at the moment
+  path_name = "/*"
+
+  # This is the highest number, thus lower priority
+  alb_priority = "50000"
 }
 
-module "pages_listener" {
-  source = "../../terraform-modules/service_alb_listener"
+# This is used for the static assets served from _next with multiple next apps
+# See: https://github.com/zeit/next.js#multi-zones
+module "subdomain_listener" {
+  source                 = "../../terraform-modules/service_alb_listener"
   alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "100"
-  path = "/pages/*"
-}
-module "visit_us_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "101"
-  path = "/visit-us"
-}
-module "what_we_do_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "102"
-  path = "/what-we-do"
-}
-module "press_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "103"
-  path = "/press"
-}
-module "venue_hire_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "104"
-  path = "/venue-hire"
-}
-module "access_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "105"
-  path = "/access"
-}
-module "youth_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "106"
-  path = "/youth"
-}
-module "schools_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "107"
-  path = "/schools"
-}
-
-module "opening_times_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "108"
-  path = "/opening-times"
-}
- module "newsletter_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "109"
-  path = "/newsletter"
-}
-
-module "installations_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "110"
-  path = "/installations/*"
-}
-
-module "exhibitions_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "111"
-  path = "/exhibitions*"
-}
-
-module "events_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "112"
-  path = "/events*"
-}
-
-module "articles_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "113"
-  # TODO: (wordpress)
-  # We're supporting wordpress articles for the time being
-  path = "/articles*"
-}
-
-module "article_series_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "114"
-  # TODO: (wordpress)
-  # We're supporting wordpress articles for the time being
-  path = "/series*"
-}
-
-module "event_series_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "115"
-  path = "/event-series/*"
-}
-
-module "books_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "116"
-  path = "/books*"
-}
-
-module "homepage_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "117"
-  path = "/"
-}
-
-module "whats_on_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "118"
-  path = "/whats-on*"
-}
-
-module "stories_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "119"
-  path = "/stories"
-}
-
-module "preview_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "120"
-  path = "/preview"
-}
-
-module "management_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "121"
-  path = "/content/management*"
-}
-
-module "articles_list_listener" {
-  source = "../../terraform-modules/service_alb_listener"
-  alb_listener_https_arn = "${local.alb_listener_https_arn}"
-  alb_listener_http_arn = "${local.alb_listener_http_arn}"
-  target_group_arn = "${module.content.target_group_arn}"
-  priority = "130"
-  # TODO: (wordpress)
-  # We're supporting wordpress articles for the time being,
-  # we'll be able to deprecate this for `/articles*`
-  path = "/articles"
+  alb_listener_http_arn  = "${local.alb_listener_http_arn}"
+  target_group_arn       = "${module.content.target_group_arn}"
+  priority               = "49999"
+  values                 = ["content.wellcomecollection.org"]
 }

--- a/terraform-modules/service_alb_listener/alb_listener.tf
+++ b/terraform-modules/service_alb_listener/alb_listener.tf
@@ -2,8 +2,14 @@ variable "alb_listener_https_arn" {}
 variable "alb_listener_http_arn" {}
 variable "target_group_arn" {}
 variable "priority" {}
-variable "path" {}
 
+variable "values" {
+  type = "list"
+}
+
+variable "field" {
+  default = "host-header"
+}
 
 resource "aws_alb_listener_rule" "https" {
   listener_arn = "${var.alb_listener_https_arn}"
@@ -15,8 +21,8 @@ resource "aws_alb_listener_rule" "https" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["${var.path}"]
+    field  = "${var.field}"
+    values = "${var.values}"
   }
 }
 
@@ -30,7 +36,7 @@ resource "aws_alb_listener_rule" "http" {
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["${var.path}"]
+    field  = "${var.field}"
+    values = "${var.values}"
   }
 }


### PR DESCRIPTION
Remove all the very specific rules that have been added for the very special routes that all inevitably fallback to the content app.

This makes the content app a priority of 50000, and we can work down from there.

While doing this, I made the terraform module more generic to be able to handle more options.

Once this is done, the router nginx app can be removed (not the infra).