### PR TITLE
add getArticleColor function to do exactly that

### DIFF
--- a/common/model/articles.js
+++ b/common/model/articles.js
@@ -28,3 +28,7 @@ export function getPositionInSeries(article: Article): ?number {
     return index > -1 ? index + 1 : null;
   }
 }
+
+export function getArticleColor(article: Article): string {
+  return article.series.map(series => series.color).find(Boolean) || 'purple';
+}

--- a/common/views/components/StoryPromo/StoryPromo.js
+++ b/common/views/components/StoryPromo/StoryPromo.js
@@ -1,11 +1,11 @@
 // @flow
+import type { Article } from '../../../model/articles';
 import { spacing, font, classNames } from '../../../utils/classnames';
-import {trackEvent} from '../../../utils/ga';
-import { getPositionInSeries } from '../../../model/articles';
+import { trackEvent } from '../../../utils/ga';
+import { getPositionInSeries, getArticleColor } from '../../../model/articles';
 import { UiImage } from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
-import type { Article } from '../../../model/articles';
 
 type Props = {|
   item: Article,
@@ -66,7 +66,7 @@ const StoryPromo = ({
         [spacing({s: 4}, {padding: ['bottom']})]: true
       })}>
         <div>
-          {positionInSeries && <PartNumberIndicator number={positionInSeries} color={item.color} />}
+          {positionInSeries && <PartNumberIndicator number={positionInSeries} color={getArticleColor(item)} />}
           <h2 className={`
             promo-link__title
             ${font({s: 'WB5'})}


### PR DESCRIPTION
Noticed it while reading the new series.

Moved it off of the model, as it it feels like we should keep that in line with the Prismic model, and then have calculations from there to keep things more immutable (if it were on the model, you could change it whenever).

![color](https://user-images.githubusercontent.com/31692/51896006-71f47b80-23a3-11e9-9fd7-659f431bbe94.png)

![color1](https://user-images.githubusercontent.com/31692/51896007-728d1200-23a3-11e9-885c-f0c0b26b662e.png)
