### PR TITLE
add images and books filter checkboxes

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -71,19 +71,22 @@ type SearchTagProps = {
   label: string,
   name: string,
   value: string,
-  checked: boolean
+  checked: boolean,
+  onChange: (event: SyntheticEvent<HTMLInputElement>) => void
 }
 const SearchTag = ({
   label,
   name,
   value,
-  checked
+  checked,
+  onChange
 }: SearchTagProps) => {
   return (
     <label className={classNames({
       'bg-pumice': true,
       'flex-inline': true,
       'flex--v-center': true,
+      'pointer': true,
       [spacing({ s: 1 }, { padding: ['left', 'right'] })]: true,
       [spacing({ s: 1 }, { margin: ['right'] })]: true,
       [font({ s: 'HNL3' })]: true
@@ -95,7 +98,8 @@ const SearchTag = ({
         type='checkbox'
         name={name}
         value={value}
-        checked={checked} />
+        checked={checked}
+        onChange={onChange} />
       {label}
     </label>
   );
@@ -110,7 +114,10 @@ const SearchForm = ({
 }: Props) => {
   const [query, setQuery] = useState(initialQuery);
   const [workType, setWorkType] = useState(initialWorkType);
-  const [itemsLocationsLocationType, setItemsLocationsLocationType] = useState(initialItemsLocationsLocationType);
+  const [
+    itemsLocationsLocationType,
+    setItemsLocationsLocationType
+  ] = useState(initialItemsLocationsLocationType);
   const searchInput = useRef(null);
 
   return (
@@ -185,74 +192,54 @@ const SearchForm = ({
         </SearchButtonWrapper>
       </div>
 
-      <Fragment>
-        <fieldset className={classNames({
-          [spacing({ s: 1 }, { margin: ['top'] })]: true
-        })}>
-          <SearchTag
-            name={'workType'}
-            label='Images'
-            value='k,q'
-            checked={workType.indexOf('k') !== -1 && workType.indexOf('q') !== -1} />
-          <SearchTag
-            name={'workType'}
-            label='Books'
-            value='a'
-            checked={workType.indexOf('a') !== -1} />
-          <SearchTag
-            name={'items.locations.locationType'}
-            label='Online'
-            value='iiif-image,iiif-presentation'
-            checked={
-              itemsLocationsLocationType.indexOf('iiif-image') !== -1 &&
-              itemsLocationsLocationType.indexOf('iiif-presentation') !== -1
-            } />
-        </fieldset>
-      </Fragment>
-
       {showFilters &&
         <Fragment>
-          <fieldset>
-            {workTypes.map(({id, label}) => {
-              return (
-                <label key={id}>
-                  <input
-                    type='checkbox'
-                    name='workType'
-                    value={id}
-                    defaultChecked={workType.indexOf(id) !== -1}
-                    onChange={(event) => {
-                      const input = event.currentTarget;
-                      const newWorkType = input.checked
-                        ? [...workType, input.value]
-                        : workType.filter(i => i !== input.value);
-
-                      setWorkType(newWorkType);
-                    }} />
-                  {label}
-                </label>
-              );
-            })}
-          </fieldset>
-
-          <fieldset>
-            <label>
-              <input
-                type='checkbox'
-                name='items.locations.locationType'
-                value={'iiif-image'}
-                defaultChecked={itemsLocationsLocationType.indexOf('iiif-image') !== -1}
-                onChange={(event) => {
-                  const input = event.currentTarget;
-                  if (input.checked) {
-                    itemsLocationsLocationType.push(input.value);
-                  } else {
-                    itemsLocationsLocationType.splice(itemsLocationsLocationType.indexOf(input.value, 1));
-                  }
-                  setItemsLocationsLocationType(itemsLocationsLocationType);
-                }} />
-              Images only
-            </label>
+          <fieldset className={classNames({
+            [spacing({ s: 1 }, { margin: ['top'] })]: true
+          })}>
+            <SearchTag
+              name={'workType'}
+              label='Images'
+              value='k,q'
+              checked={
+                workType.indexOf('k') !== -1 &&
+                workType.indexOf('q') !== -1
+              }
+              onChange={(event) => {
+                const input = event.currentTarget;
+                const newWorkType = input.checked
+                  ? [...workType, 'k', 'q']
+                  : workType.filter(val => val !== 'k' && val !== 'q');
+                setWorkType(newWorkType);
+              }} />
+            <SearchTag
+              name={'workType'}
+              label='Books'
+              value='a'
+              checked={workType.indexOf('a') !== -1}
+              onChange={(event) => {
+                const input = event.currentTarget;
+                const newWorkType = input.checked
+                  ? [...workType, 'a']
+                  : workType.filter(val => val !== 'a');
+                setWorkType(newWorkType);
+              }}/>
+            <SearchTag
+              name={'items.locations.locationType'}
+              label='Online'
+              value='iiif-image,iiif-presentation'
+              checked={
+                itemsLocationsLocationType.indexOf('iiif-image') !== -1 &&
+                itemsLocationsLocationType.indexOf('iiif-presentation') !== -1
+              }
+              onChange={(event) => {
+                const input = event.currentTarget;
+                if (input.checked) {
+                  setItemsLocationsLocationType(['iiif-image', 'iiif-presentation']);
+                } else {
+                  setItemsLocationsLocationType([]);
+                }
+              }}/>
           </fieldset>
         </Fragment>
       }

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -197,6 +197,11 @@ const SearchForm = ({
           <fieldset className={classNames({
             [spacing({ s: 1 }, { margin: ['top'] })]: true
           })}>
+            <legend className={classNames({
+              'float-l': true,
+              [spacing({ s: 1 }, {margin: ['right']})]: true,
+              [font({ s: 'HNL4' })]: true
+            })} style={{ marginTop: '3px' }}>Filter by:</legend>
             <SearchTag
               name={'workType'}
               label='Images'

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -151,6 +151,26 @@ const SearchForm = ({
         </SearchButtonWrapper>
       </div>
 
+      <Fragment>
+        <fieldset>
+          <label>
+            <input
+              type='checkbox'
+              name='workType'
+              value='k,q' />
+            Images
+          </label>
+
+          <label>
+            <input
+              type='checkbox'
+              name='workType'
+              value='a' />
+            Books
+          </label>
+        </fieldset>
+      </Fragment>
+
       {showFilters &&
         <Fragment>
           <fieldset>

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -5,7 +5,7 @@ import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
-import {classNames, font} from '@weco/common/utils/classnames';
+import {classNames, font, spacing} from '@weco/common/utils/classnames';
 import {trackEvent} from '@weco/common/utils/ga';
 import {worksUrl} from '../../services/catalogue/urls';
 
@@ -66,6 +66,40 @@ const SearchButtonWrapper = styled.div`
 const ClearSearch = styled.button`
   right: 12px;
 `;
+
+type SearchTagProps = {
+  label: string,
+  name: string,
+  value: string,
+  checked: boolean
+}
+const SearchTag = ({
+  label,
+  name,
+  value,
+  checked
+}: SearchTagProps) => {
+  return (
+    <label className={classNames({
+      'bg-pumice': true,
+      'flex-inline': true,
+      'flex--v-center': true,
+      [spacing({ s: 1 }, { padding: ['left', 'right'] })]: true,
+      [spacing({ s: 1 }, { margin: ['right'] })]: true,
+      [font({ s: 'HNL3' })]: true
+    })} style={{ borderRadius: '3px' }}>
+      <input
+        className={classNames({
+          [spacing({ s: 1 }, { margin: ['right'] })]: true
+        })}
+        type='checkbox'
+        name={name}
+        value={value}
+        checked={checked} />
+      {label}
+    </label>
+  );
+};
 
 const SearchForm = ({
   initialQuery = '',
@@ -152,22 +186,27 @@ const SearchForm = ({
       </div>
 
       <Fragment>
-        <fieldset>
-          <label>
-            <input
-              type='checkbox'
-              name='workType'
-              value='k,q' />
-            Images
-          </label>
-
-          <label>
-            <input
-              type='checkbox'
-              name='workType'
-              value='a' />
-            Books
-          </label>
+        <fieldset className={classNames({
+          [spacing({ s: 1 }, { margin: ['top'] })]: true
+        })}>
+          <SearchTag
+            name={'workType'}
+            label='Images'
+            value='k,q'
+            checked={workType.indexOf('k') !== -1 && workType.indexOf('q') !== -1} />
+          <SearchTag
+            name={'workType'}
+            label='Books'
+            value='a'
+            checked={workType.indexOf('a') !== -1} />
+          <SearchTag
+            name={'items.locations.locationType'}
+            label='Online'
+            value='iiif-image,iiif-presentation'
+            checked={
+              itemsLocationsLocationType.indexOf('iiif-image') !== -1 &&
+              itemsLocationsLocationType.indexOf('iiif-presentation') !== -1
+            } />
         </fieldset>
       </Fragment>
 

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -24,7 +24,8 @@ type Props = {|
   query: ?string,
   page: ?number,
   showNewMetaDataGrouping: boolean,
-  itemsLocationsLocationType: string[]
+  itemsLocationsLocationType: string[],
+  showCatalogueSearchFilters: boolean
 |}
 
 export const WorkPage = ({
@@ -33,7 +34,8 @@ export const WorkPage = ({
   page,
   workType,
   itemsLocationsLocationType,
-  showNewMetaDataGrouping
+  showNewMetaDataGrouping,
+  showCatalogueSearchFilters
 }: Props) => {
   if (work.type === 'Error') {
     return (
@@ -95,7 +97,7 @@ export const WorkPage = ({
                 initialQuery={query || ''}
                 initialWorkType={workType}
                 initialItemsLocationsLocationType={itemsLocationsLocationType}
-                showFilters={false}
+                showFilters={showCatalogueSearchFilters}
                 ariaDescribedBy='search-form-description' />
             </div>
           </div>
@@ -154,6 +156,7 @@ WorkPage.getInitialProps = async (ctx): Promise<Props | CatalogueApiRedirect> =>
   const {id, query, page} = ctx.query;
   const workOrError = await getWork({ id });
   const showNewMetaDataGrouping = Boolean(ctx.query.toggles.showWorkMetaDataGrouping);
+  const showCatalogueSearchFilters = Boolean(ctx.query.toggles.showCatalogueSearchFilters);
 
   if (workOrError && workOrError.type === 'Redirect') {
     const {res} = ctx;
@@ -173,7 +176,8 @@ WorkPage.getInitialProps = async (ctx): Promise<Props | CatalogueApiRedirect> =>
       page: page ? parseInt(page, 10) : null,
       showNewMetaDataGrouping,
       workType,
-      itemsLocationsLocationType
+      itemsLocationsLocationType,
+      showCatalogueSearchFilters
     };
   }
 };

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -108,7 +108,12 @@ export const WorkPage = ({
                 [grid({s: 12})]: true,
                 [spacing({s: 1}, {padding: ['top', 'bottom']})]: true
               })}>
-                <BackToResults nextLink={worksUrl({query, page})} />
+                <BackToResults nextLink={worksUrl({
+                  query,
+                  page,
+                  workType,
+                  itemsLocationsLocationType
+                })} />
               </div>
             </div>
           }

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -302,8 +302,17 @@ Works.getInitialProps = async (
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
   const workTypeQuery = ctx.query.workType;
+  // We sometimes get workType=k%2Cq&workType=a as some checkboxes are
+  // considered multiple workTypes
   const workType = Array.isArray(workTypeQuery) ? workTypeQuery
+    .map(workType => workType.split(','))
+    .reduce((workTypes, workTypeStringArray) => [
+      ...workTypes,
+      ...workTypeStringArray
+    ], [])
     : typeof workTypeQuery === 'string' ? workTypeQuery.split(',') : ['k', 'q'];
+
+  console.info(workType);
 
   const itemsLocationsLocationType = 'items.locations.locationType' in ctx.query
     ? ctx.query['items.locations.locationType'].split(',') : ['iiif-image'];

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -1,7 +1,6 @@
 // @flow
 import type {Context} from 'next';
 import type {CatalogueApiError, CatalogueResultsList} from '../services/catalogue/works';
-// $FlowFixMe: using react aloha for hooks, which isn't in the typedefs
 import {Fragment, useEffect, useState} from 'react';
 import Router from 'next/router';
 import Head from 'next/head';
@@ -14,7 +13,6 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 import WorkPromo from '@weco/common/views/components/WorkPromo/WorkPromo';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
-import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
 import {getWorks} from '../services/catalogue/works';

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -312,8 +312,6 @@ Works.getInitialProps = async (
     ], [])
     : typeof workTypeQuery === 'string' ? workTypeQuery.split(',') : ['k', 'q'];
 
-  console.info(workType);
-
   const itemsLocationsLocationType = 'items.locations.locationType' in ctx.query
     ? ctx.query['items.locations.locationType'].split(',') : ['iiif-image'];
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -216,16 +216,31 @@ export const Works = ({
                               'block': true,
                               [spacing({ s: 3 }, { padding: ['bottom'] })]: true
                             })}>
-                            <div className={classNames({
-                              'bg-pumice': true,
-                              'inline-block': true,
-                              [spacing({s: 1}, {margin: ['top', 'bottom']})]: true,
-                              [spacing({ s: 1 }, { padding: ['left', 'right'] })]: true,
-                              [font({ s: 'HNL4' })]: true
-                            })}  style={{ borderRadius: '3px' }}>{result.workType.label}</div>
-                            <h2 className={classNames({
-                              [font({ s: 'HNM3' })]: true
-                            })}>{result.title}</h2>
+                            <div>
+                              <div className={classNames({
+                                'bg-pumice': true,
+                                'inline-block': true,
+                                [spacing({s: 1}, {margin: ['top', 'bottom']})]: true,
+                                [spacing({ s: 1 }, { padding: ['left', 'right'] })]: true,
+                                [font({ s: 'HNL4' })]: true
+                              })}  style={{ borderRadius: '3px' }}>{result.workType.label}</div>
+                            </div>
+                            <div className='flex'>
+                              <div style={{ flexGrow: 1 }}>
+                                <h2 className={classNames({
+                                  [font({ s: 'HNM3' })]: true
+                                })}>{result.title}</h2>
+                              </div>
+                              {result.thumbnail &&
+                                <div
+                                  className={classNames({
+                                    [spacing({ s: 2 }, { margin: ['left'] })]: true
+                                  })}
+                                  style={{ width: '100px' }}>
+                                  <img src={result.thumbnail.url} style={{ width: '100px' }} />
+                                </div>
+                              }
+                            </div>
                           </a>
                         </NextLink>
                       </div>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -188,29 +188,48 @@ export const Works = ({
               <div className='container'>
                 <div className='grid'>
                   {showCatalogueSearchFilters && works.results.map(result => (
-                    <NextLink
-                      href={workUrl({ id: result.id, query, page, workType, itemsLocationsLocationType }).href}
-                      as={workUrl({ id: result.id, query, page, workType, itemsLocationsLocationType }).as}
-                      key={result.id}>
-                      <a
-                        style={{
-                          padding: '24px 0',
-                          borderTop: '1px solid'
-                        }}
-                        className={'plain-link ' + grid({s: 12, m: 10, l: 8, xl: 8, shiftXL: 2})}>
-                        <div className={classNames({
-                          [spacing({s: 1}, {margin: ['top', 'bottom']})]: true
-                        })}>
-                          <LinkLabels items={[
-                            {
-                              url: null,
-                              text: result.workType.label
-                            }
-                          ]} />
-                        </div>
-                        <h2 className='h4'>{result.title}</h2>
-                      </a>
-                    </NextLink>
+                    <div className={classNames({
+                      [grid({ s: 12, m: 10, l: 8, xl: 8 })]: true
+                    })} key={result.id}>
+                      <div className={classNames({
+                        'border-color-pumice': true,
+                        'border-top-width-1': true
+                      })}>
+                        <NextLink
+                          href={workUrl({
+                            id: result.id,
+                            query,
+                            page,
+                            workType,
+                            itemsLocationsLocationType
+                          }).href}
+                          as={workUrl({
+                            id: result.id,
+                            query,
+                            page,
+                            workType,
+                            itemsLocationsLocationType
+                          }).as}>
+                          <a
+                            className={classNames({
+                              'plain-link': true,
+                              'block': true,
+                              [spacing({ s: 3 }, { padding: ['bottom'] })]: true
+                            })}>
+                            <div className={classNames({
+                              'bg-pumice': true,
+                              'inline-block': true,
+                              [spacing({s: 1}, {margin: ['top', 'bottom']})]: true,
+                              [spacing({ s: 1 }, { padding: ['left', 'right'] })]: true,
+                              [font({ s: 'HNL4' })]: true
+                            })}  style={{ borderRadius: '3px' }}>{result.workType.label}</div>
+                            <h2 className={classNames({
+                              [font({ s: 'HNM3' })]: true
+                            })}>{result.title}</h2>
+                          </a>
+                        </NextLink>
+                      </div>
+                    </div>
                   ))}
                   {!showCatalogueSearchFilters && works.results.map(result => (
                     <div key={result.id} className={grid({s: 6, m: 4, l: 3, xl: 2})}>
@@ -312,10 +331,12 @@ Works.getInitialProps = async (
     ], [])
     : typeof workTypeQuery === 'string' ? workTypeQuery.split(',') : ['k', 'q'];
 
-  const itemsLocationsLocationType = 'items.locations.locationType' in ctx.query
-    ? ctx.query['items.locations.locationType'].split(',') : ['iiif-image'];
-
   const {showCatalogueSearchFilters} = ctx.query.toggles;
+
+  const itemsLocationsLocationType = 'items.locations.locationType' in ctx.query
+    ? ctx.query['items.locations.locationType'].split(',')
+    : showCatalogueSearchFilters ? ['iiif-image', 'iiif-presentation'] : ['iiif-image'];
+
   const filters = {
     'items.locations.locationType': itemsLocationsLocationType,
     workType


### PR DESCRIPTION
Ref #4034 

We're adding two filters to the search bar to be able to search for images (`Pictures` and `Digital images`), Books, or both.

![screenshot 2019-02-05 at 09 59 43](https://user-images.githubusercontent.com/31692/52265805-c8763280-292c-11e9-8ddd-26dc71bcd74e.png)

---

<img width="828" alt="screenshot 2019-02-04 at 16 03 30" src="https://user-images.githubusercontent.com/31692/52220346-89959d80-2896-11e9-9cd7-547a75365d42.png">
