### PR TITLE
Hide 'Show all' button for single-sequence works

### DIFF
--- a/common/views/components/IIIFPresentationDisplay/IIIFPresentationDisplay.js
+++ b/common/views/components/IIIFPresentationDisplay/IIIFPresentationDisplay.js
@@ -26,7 +26,7 @@ const IIIFPresentationDisplay = ({
 
   return manifestData && (
     <div>
-      {validSequences
+      {validSequences.length > 1 && validSequences
         .map(sequence => (
           <div
             key={sequence['@id']}
@@ -44,7 +44,7 @@ const IIIFPresentationDisplay = ({
           </div>
         ))
       }
-      {!showAll && validSequences.length > 0  &&
+      {!showAll && validSequences.length > 1  &&
         <Button type={'primary'} text={'Show all'} clickHandler={(event) => setShowAll(true)} />
       }
 


### PR DESCRIPTION
Looks like some single image works have IIIF manifest data sequences containing one item. We're currently displaying a 'Show all' button to reveal all images if these sequence lengths are greater than 0. So we can end up with something like this:

![screenshot 2019-02-04 at 14 35 56](https://user-images.githubusercontent.com/1394592/52214840-8d232780-288a-11e9-8e53-f149feb2137c.png)

Checking the sequence length is greater than one feels like it makes sense.