### PR TITLE
Use green instead of orange for accessible contrast

### DIFF
--- a/common/model/color-selections.js
+++ b/common/model/color-selections.js
@@ -3,8 +3,8 @@
 export const ColorSelections = {
   Turquoise: 'turquoise',
   Red: 'red',
-  Orange: 'orange',
-  Purple: 'purple'
+  Green: 'green',
+  Purple: 'purple',
 };
 
 export type ColorSelection = $Values<typeof ColorSelections>;

--- a/common/model/editorial-series.js
+++ b/common/model/editorial-series.js
@@ -1,7 +1,7 @@
-type EditorialSeriesColour = 'turquoise' | 'red' | 'orange' | 'purple'
+type EditorialSeriesColour = 'turquoise' | 'red' | 'green' | 'purple';
 
 export type EditorialSeries = {
   name: string,
   description: string,
   colour: EditorialSeriesColour,
-}
+};

--- a/prismic-model/js/series.js
+++ b/prismic-model/js/series.js
@@ -16,9 +16,6 @@ const ArticleSeries = {
   'Article series': {
     title: title,
     color: select('Colour', ['teal', 'red', 'green', 'purple']),
-    description: structuredText(
-      '[Deprecated] Description. Please use standfirst slice'
-    ),
     body,
   },
   Schedule: {
@@ -35,6 +32,9 @@ const ArticleSeries = {
     metadataDescription: structuredText('Metadata description', 'single'),
   },
   Deprecated: {
+    description: structuredText(
+      '[Deprecated] Description. Please use standfirst slice'
+    ),
     commissionedLength: number('[Deprecated] Commissioned length'),
     wordpressSlug: text('[Deprecated] Wordpress slug'),
   },

--- a/prismic-model/js/series.js
+++ b/prismic-model/js/series.js
@@ -15,27 +15,29 @@ import structuredText from './parts/structured-text';
 const ArticleSeries = {
   'Article series': {
     title: title,
-    color: select('Colour', [ 'teal', 'red', 'orange', 'purple' ]),
-    description: structuredText('[Deprecated] Description. Please use standfirst slice'),
-    body
+    color: select('Colour', ['teal', 'red', 'green', 'purple']),
+    description: structuredText(
+      '[Deprecated] Description. Please use standfirst slice'
+    ),
+    body,
   },
   Schedule: {
     schedule: list('Schedule', {
       title: title,
-      publishDate: timestamp('Date to be published')
-    })
+      publishDate: timestamp('Date to be published'),
+    }),
   },
   Contributors: contributorsWithTitle(),
   Promo: {
-    promo
+    promo,
   },
   Metadata: {
-    metadataDescription: structuredText('Metadata description', 'single')
+    metadataDescription: structuredText('Metadata description', 'single'),
   },
   Deprecated: {
     commissionedLength: number('[Deprecated] Commissioned length'),
-    wordpressSlug: text('[Deprecated] Wordpress slug')
-  }
+    wordpressSlug: text('[Deprecated] Wordpress slug'),
+  },
 };
 
 export default ArticleSeries;

--- a/prismic-model/json/series.json
+++ b/prismic-model/json/series.json
@@ -20,13 +20,6 @@
         ]
       }
     },
-    "description": {
-      "type": "StructuredText",
-      "config": {
-        "multi": "paragraph,hyperlink,strong,em",
-        "label": "[Deprecated] Description. Please use standfirst slice"
-      }
-    },
     "body": {
       "fieldset": "Body content",
       "type": "Slices",
@@ -481,6 +474,13 @@
     }
   },
   "Deprecated": {
+    "description": {
+      "type": "StructuredText",
+      "config": {
+        "multi": "paragraph,hyperlink,strong,em",
+        "label": "[Deprecated] Description. Please use standfirst slice"
+      }
+    },
     "commissionedLength": {
       "type": "Number",
       "config": {

--- a/prismic-model/json/series.json
+++ b/prismic-model/json/series.json
@@ -15,7 +15,7 @@
         "options": [
           "teal",
           "red",
-          "orange",
+          "green",
           "purple"
         ]
       }


### PR DESCRIPTION
The orange which was an option for content editors to change the background colour for series isn't accessible. Have switched it out for our green (#007868) and updated the two series that were using orange (architecture and yoga).

__5.40:1__
![screenshot 2019-02-05 at 16 25 39](https://user-images.githubusercontent.com/1394592/52289268-a0ef8c00-2965-11e9-98fb-dc14e4a09b9f.png)

