### PR TITLE
Header improvements

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -24,6 +24,7 @@ type Props = {|
   iiifImageLocationCredit: ?string,
   iiifImageLocationLicenseId: ?LicenseType,
   encoreLink: ?string,
+  excludeTitle: boolean,
 |};
 
 const WorkDetails = ({
@@ -33,6 +34,7 @@ const WorkDetails = ({
   iiifImageLocationCredit,
   iiifImageLocationLicenseId,
   encoreLink,
+  excludeTitle,
 }: Props) => {
   return (
     <div className={`row ${spacing({ s: 6 }, { padding: ['top', 'bottom'] })}`}>
@@ -44,17 +46,19 @@ const WorkDetails = ({
               spacing({ s: 4 }, { margin: ['bottom'] }),
             ])}
           >
-            <SpacingComponent>
-              <h1
-                id="work-info"
-                className={classNames([
-                  font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' }),
-                  spacing({ s: 0 }, { margin: ['top'] }),
-                ])}
-              >
-                {work.title}
-              </h1>
-            </SpacingComponent>
+            {!excludeTitle && (
+              <SpacingComponent>
+                <h1
+                  id="work-info"
+                  className={classNames([
+                    font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' }),
+                    spacing({ s: 0 }, { margin: ['top'] }),
+                  ])}
+                >
+                  {work.title}
+                </h1>
+              </SpacingComponent>
+            )}
 
             {iiifImageLocationUrl && (
               <SpacingComponent>

--- a/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
@@ -44,99 +44,101 @@ const WorkDetails = ({
               spacing({ s: 4 }, { margin: ['bottom'] }),
             ])}
           >
-            <SpacingComponent>
-              <h1
-                id="work-info"
-                className={classNames([
-                  font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' }),
-                  spacing({ s: 0 }, { margin: ['top'] }),
-                ])}
-              >
-                {work.title}
-              </h1>
+            {!excludeTitle && (
+              <SpacingComponent>
+                <h1
+                  id="work-info"
+                  className={classNames([
+                    font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' }),
+                    spacing({ s: 0 }, { margin: ['top'] }),
+                  ])}
+                >
+                  {work.title}
+                </h1>
 
-              {work.contributors.length > 0 && (
-                <MetaUnit
-                  headingText=""
-                  links={work.contributors.map(contributor => {
-                    const linkAttributes = worksUrl({
-                      query: `"${contributor.agent.label}"`,
-                      page: undefined,
-                    });
-                    return (
-                      <NextLink key={1} {...linkAttributes}>
-                        <a
-                          className={`plain-link font-green font-hover-turquoise ${font(
-                            { s: 'HNM5', m: 'HNM4' }
-                          )}`}
-                        >
-                          {contributor.agent.label}
-                        </a>
-                      </NextLink>
-                    );
-                  })}
-                />
-              )}
-
-              {work.workType && (
-                <MetaUnit
-                  headingText=""
-                  links={[
-                    <NextLink
-                      key={1}
-                      {...worksUrl({
-                        query: `"${work.workType.label}"`,
+                {work.contributors.length > 0 && (
+                  <MetaUnit
+                    headingText=""
+                    links={work.contributors.map(contributor => {
+                      const linkAttributes = worksUrl({
+                        query: `"${contributor.agent.label}"`,
                         page: undefined,
-                      })}
-                    >
-                      <a
-                        className={`plain-link font-green font-hover-turquoise ${font(
-                          { s: 'HNM5', m: 'HNM4' }
-                        )}`}
-                      >
-                        {work.workType.label}
-                      </a>
-                    </NextLink>,
-                  ]}
-                />
-              )}
+                      });
+                      return (
+                        <NextLink key={1} {...linkAttributes}>
+                          <a
+                            className={`plain-link font-green font-hover-turquoise ${font(
+                              { s: 'HNM5', m: 'HNM4' }
+                            )}`}
+                          >
+                            {contributor.agent.label}
+                          </a>
+                        </NextLink>
+                      );
+                    })}
+                  />
+                )}
 
-              {work.genres.length > 0 && (
-                <MetaUnit
-                  headingText=""
-                  links={work.genres.map(genre => {
-                    const linkAttributes = worksUrl({
-                      query: `"${genre.label}"`,
-                      page: undefined,
-                    });
-                    return (
-                      <NextLink key={1} {...linkAttributes}>
+                {work.workType && (
+                  <MetaUnit
+                    headingText=""
+                    links={[
+                      <NextLink
+                        key={1}
+                        {...worksUrl({
+                          query: `"${work.workType.label}"`,
+                          page: undefined,
+                        })}
+                      >
                         <a
                           className={`plain-link font-green font-hover-turquoise ${font(
                             { s: 'HNM5', m: 'HNM4' }
                           )}`}
                         >
-                          {genre.label}
+                          {work.workType.label}
                         </a>
-                      </NextLink>
+                      </NextLink>,
+                    ]}
+                  />
+                )}
+
+                {work.genres.length > 0 && (
+                  <MetaUnit
+                    headingText=""
+                    links={work.genres.map(genre => {
+                      const linkAttributes = worksUrl({
+                        query: `"${genre.label}"`,
+                        page: undefined,
+                      });
+                      return (
+                        <NextLink key={1} {...linkAttributes}>
+                          <a
+                            className={`plain-link font-green font-hover-turquoise ${font(
+                              { s: 'HNM5', m: 'HNM4' }
+                            )}`}
+                          >
+                            {genre.label}
+                          </a>
+                        </NextLink>
+                      );
+                    })}
+                  />
+                )}
+
+                {work.production.length > 0 &&
+                  work.production.map((production, i) => {
+                    return (
+                      production.dates.length > 0 && (
+                        <MetaUnit
+                          headingLevel={2}
+                          headingText="Dates"
+                          text={production.dates.map(date => date.label)}
+                        />
+                      )
                     );
                   })}
-                />
-              )}
-
-              {work.production.length > 0 &&
-                work.production.map((production, i) => {
-                  return (
-                    production.dates.length > 0 && (
-                      <MetaUnit
-                        headingLevel={2}
-                        headingText="Dates"
-                        text={production.dates.map(date => date.label)}
-                      />
-                    )
-                  );
-                })}
-            </SpacingComponent>
+              </SpacingComponent>
+            )}
 
             <SpacingComponent>
               <Divider

--- a/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
@@ -24,6 +24,7 @@ type Props = {|
   iiifImageLocationCredit: ?string,
   iiifImageLocationLicenseId: ?LicenseType,
   encoreLink: ?string,
+  excludeTitle: boolean,
 |};
 
 const WorkDetails = ({
@@ -33,6 +34,7 @@ const WorkDetails = ({
   iiifImageLocationCredit,
   iiifImageLocationLicenseId,
   encoreLink,
+  excludeTitle,
 }: Props) => {
   return (
     <div className={`row ${spacing({ s: 6 }, { padding: ['top', 'bottom'] })}`}>

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -193,6 +193,7 @@ export const WorkPage = ({
             iiifImageLocationCredit={iiifImageLocationCredit}
             iiifImageLocationLicenseId={iiifImageLocationLicenseId}
             encoreLink={encoreLink}
+            excludeTitle={showWorkHeader}
           />
         ) : (
           <WorkDetails
@@ -202,6 +203,7 @@ export const WorkPage = ({
             iiifImageLocationCredit={iiifImageLocationCredit}
             iiifImageLocationLicenseId={iiifImageLocationLicenseId}
             encoreLink={encoreLink}
+            excludeTitle={showWorkHeader}
           />
         )}
       </Fragment>

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -30,6 +30,7 @@ import {
   getWorkTypeIcon,
 } from '@weco/common/utils/works';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
+import WorkHeader from '@weco/common/views/components/WorkHeader/WorkHeader';
 
 type Props = {|
   work: Work | CatalogueApiError,
@@ -105,11 +106,6 @@ export const WorkPage = ({
     iiifImageLocationUrl &&
     iiifImageTemplate(iiifImageLocationUrl)({ size: `800,` });
 
-  const digitalLocations = getDigitalLocations(work);
-  const physicalLocations = getPhysicalLocations(work);
-  const productionDates = getProductionDates(work);
-  const workTypeIcon = getWorkTypeIcon(work);
-
   return (
     <PageLayout
       title={work.title}
@@ -173,110 +169,7 @@ export const WorkPage = ({
         </div>
       </div>
 
-      {showWorkHeader && (
-        <div
-          className={`row ${spacing({ s: 6 }, { padding: ['top', 'bottom'] })}`}
-        >
-          <div className="container">
-            <div className="grid">
-              <div
-                className={classNames([
-                  grid({ s: 12, m: 12, l: 10, xl: 10 }),
-                  spacing({ s: 4 }, { margin: ['bottom'] }),
-                ])}
-              >
-                <SpacingComponent>
-                  <div
-                    className={classNames({
-                      flex: true,
-                      'flex--v-center': true,
-                      [font({ s: 'HNL3' })]: true,
-                    })}
-                  >
-                    {workTypeIcon && (
-                      <Icon
-                        name={workTypeIcon}
-                        extraClasses={classNames({
-                          [spacing({ s: 1 }, { margin: ['right'] })]: true,
-                        })}
-                      />
-                    )}
-                    {work.workType.label}
-                  </div>
-
-                  <h1
-                    id="work-info"
-                    className={classNames([
-                      font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' }),
-                      spacing({ s: 0 }, { margin: ['top'] }),
-                    ])}
-                  >
-                    {work.title}
-                  </h1>
-
-                  <div
-                    className={classNames({
-                      flex: true,
-                    })}
-                  >
-                    {work.contributors.length > 0 && (
-                      <LinkLabels
-                        items={work.contributors.map(({ agent }) => ({
-                          text: agent.label,
-                          url: `/works?query="${agent.label}"`,
-                        }))}
-                      />
-                    )}
-                    {productionDates && (
-                      <div
-                        className={classNames({
-                          [spacing({ s: 2 }, { margin: ['left'] })]: true,
-                        })}
-                      >
-                        <LinkLabels
-                          heading={'Date'}
-                          items={productionDates.map(date => ({
-                            text: date,
-                            url: null,
-                          }))}
-                        />
-                      </div>
-                    )}
-                  </div>
-
-                  {(digitalLocations.length > 0 ||
-                    physicalLocations.length > 0) && (
-                    <div
-                      className={classNames({
-                        [spacing({ s: 2 }, { margin: ['top'] })]: true,
-                      })}
-                    >
-                      <LinkLabels
-                        heading={'See it'}
-                        icon={'eye'}
-                        items={[
-                          digitalLocations.length > 0
-                            ? {
-                                text: 'Online',
-                                url: null,
-                              }
-                            : null,
-                          physicalLocations.length > 0
-                            ? {
-                                text: 'Wellcome Library',
-                                url: null,
-                              }
-                            : null,
-                        ].filter(Boolean)}
-                      />
-                    </div>
-                  )}
-                </SpacingComponent>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      {showWorkHeader && <WorkHeader work={work} />}
 
       <Fragment>
         {iiifPresentationLocation && (

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -169,7 +169,20 @@ export const WorkPage = ({
         </div>
       </div>
 
-      {showWorkHeader && <WorkHeader work={work} />}
+      {showWorkHeader && (
+        <div
+          className={classNames({
+            row: true,
+            [spacing({ s: 6 }, { padding: ['top'] })]: true,
+          })}
+        >
+          <div className="container">
+            <div className="grid">
+              <WorkHeader work={work} />
+            </div>
+          </div>
+        </div>
+      )}
 
       <Fragment>
         {iiifPresentationLocation && (

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -267,7 +267,7 @@ WorkPage.getInitialProps = async (
       workType,
       itemsLocationsLocationType,
       showNewMetaDataGrouping,
-      showWorkHeader: true,
+      showWorkHeader,
       showCatalogueSearchFilters,
     };
   }

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -254,7 +254,7 @@ WorkPage.getInitialProps = async (
       workType,
       itemsLocationsLocationType,
       showNewMetaDataGrouping,
-      showWorkHeader,
+      showWorkHeader: true,
       showCatalogueSearchFilters,
     };
   }

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -21,13 +21,13 @@ type Props = {|
 function getClassName(i) {
   return conditionalClassNames({
     [`${font({ s: 'HNM4' })}`]: true,
-    'border-left-width-1 border-color-smoke': i !== 0,
+    'border-left-width-1 border-color-marble': i !== 0,
     [spacing({ s: 1 }, { padding: ['left'] })]: i !== 0,
     [spacing({ s: 1 }, { margin: ['right'] })]: true,
   });
 }
 const LinkLabels = ({ items, heading, icon }: Props) => (
-  <div
+  <dl
     className={classNames({
       flex: true,
       'flex--wrap': true,
@@ -35,46 +35,41 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
     })}
   >
     {heading && (
-      <span
+      <dt
         className={classNames({
           flex: true,
           [spacing({ s: 1 }, { margin: ['right'] })]: true,
+          [spacing({ s: 0 }, { margin: ['left', 'top', 'bottom'] })]: true,
         })}
       >
         {icon && (
-          <span
-            className={classNames({
+          <Icon
+            name={icon}
+            extraClasses={classNames({
               [spacing({ s: 1 }, { margin: ['right'] })]: true,
             })}
-          >
-            <Icon name={icon} />
-          </span>
+          />
         )}
-        <span>{heading}</span>
-      </span>
+        {heading}
+      </dt>
     )}
-    <ul
-      className={classNames({
-        flex: true,
-        'plain-list': true,
-        'no-margin': true,
-        'no-padding': true,
-        'line-height-1': true,
-      })}
-    >
-      {items.map(({ url, text }, i) => (
-        <li key={url || text}>
-          {url ? (
-            <a className={getClassName(i)} href={url}>
-              {text}
-            </a>
-          ) : (
-            <span className={getClassName(i)}>{text}</span>
-          )}
-        </li>
-      ))}
-    </ul>
-  </div>
+    {items.map(({ url, text }, i) => (
+      <dd
+        key={url || text}
+        className={classNames({
+          'no-margin': true,
+        })}
+      >
+        {url ? (
+          <a className={getClassName(i)} href={url}>
+            {text}
+          </a>
+        ) : (
+          <span className={getClassName(i)}>{text}</span>
+        )}
+      </dd>
+    ))}
+  </dl>
 );
 
 export default LinkLabels;

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -30,6 +30,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
   <div
     className={classNames({
       flex: true,
+      'flex--wrap': true,
       [font({ s: 'HNL4' })]: true,
     })}
   >

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -31,6 +31,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
     className={classNames({
       flex: true,
       'flex--wrap': true,
+      'no-margin': true,
       [font({ s: 'HNL4' })]: true,
     })}
   >

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -72,6 +72,7 @@ const WorkHeader = ({ work }: Props) => {
                     }))}
                   />
                 )}
+
                 {productionDates.length > 0 && (
                   <div
                     className={classNames({

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -46,7 +46,7 @@ const WorkHeader = ({ work }: Props) => {
                     })}
                   />
                 )}
-                {work.workType.label}
+                <div className="line-height-1">{work.workType.label}</div>
               </div>
 
               <h1

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -62,31 +62,32 @@ const WorkHeader = ({ work }: Props) => {
               <div
                 className={classNames({
                   flex: true,
+                  'flex--wrap': true,
                 })}
               >
                 {work.contributors.length > 0 && (
-                  <LinkLabels
-                    items={work.contributors.map(({ agent }) => ({
-                      text: agent.label,
-                      url: `/works?query="${agent.label}"`,
-                    }))}
-                  />
-                )}
-
-                {productionDates.length > 0 && (
                   <div
                     className={classNames({
-                      [spacing({ s: 2 }, { margin: ['left'] })]: true,
+                      [spacing({ s: 2 }, { margin: ['right'] })]: true,
                     })}
                   >
                     <LinkLabels
-                      heading={'Date'}
-                      items={productionDates.map(date => ({
-                        text: date,
-                        url: null,
+                      items={work.contributors.map(({ agent }) => ({
+                        text: agent.label,
+                        url: `/works?query="${agent.label}"`,
                       }))}
                     />
                   </div>
+                )}
+
+                {productionDates.length > 0 && (
+                  <LinkLabels
+                    heading={'Date'}
+                    items={productionDates.map(date => ({
+                      text: date,
+                      url: null,
+                    }))}
+                  />
                 )}
               </div>
 

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -21,107 +21,103 @@ const WorkHeader = ({ work }: Props) => {
   const productionDates = getProductionDates(work);
   const workTypeIcon = getWorkTypeIcon(work);
   return (
-    <div className={`row ${spacing({ s: 6 }, { padding: ['top', 'bottom'] })}`}>
-      <div className="container">
-        <div className="grid">
-          <div
-            className={classNames([
-              grid({ s: 12, m: 12, l: 10, xl: 10 }),
-              spacing({ s: 4 }, { margin: ['bottom'] }),
-            ])}
-          >
-            <SpacingComponent>
-              <div
-                className={classNames({
-                  flex: true,
-                  'flex--v-center': true,
-                  [font({ s: 'HNL3' })]: true,
-                })}
-              >
-                {workTypeIcon && (
-                  <Icon
-                    name={workTypeIcon}
-                    extraClasses={classNames({
-                      [spacing({ s: 1 }, { margin: ['right'] })]: true,
-                    })}
-                  />
-                )}
-                <div className="line-height-1">{work.workType.label}</div>
-              </div>
-
-              <h1
-                id="work-info"
-                className={classNames([
-                  font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' }),
-                  spacing({ s: 0 }, { margin: ['top'] }),
-                ])}
-              >
-                {work.title}
-              </h1>
-
-              <div
-                className={classNames({
-                  flex: true,
-                  'flex--wrap': true,
-                })}
-              >
-                {work.contributors.length > 0 && (
-                  <div
-                    className={classNames({
-                      [spacing({ s: 2 }, { margin: ['right'] })]: true,
-                    })}
-                  >
-                    <LinkLabels
-                      items={work.contributors.map(({ agent }) => ({
-                        text: agent.label,
-                        url: `/works?query="${agent.label}"`,
-                      }))}
-                    />
-                  </div>
-                )}
-
-                {productionDates.length > 0 && (
-                  <LinkLabels
-                    heading={'Date'}
-                    items={productionDates.map(date => ({
-                      text: date,
-                      url: null,
-                    }))}
-                  />
-                )}
-              </div>
-
-              {(digitalLocations.length > 0 ||
-                physicalLocations.length > 0) && (
-                <div
-                  className={classNames({
-                    [spacing({ s: 2 }, { margin: ['top'] })]: true,
-                  })}
-                >
-                  <LinkLabels
-                    heading={'See it'}
-                    icon={'eye'}
-                    items={[
-                      digitalLocations.length > 0
-                        ? {
-                            text: 'Online',
-                            url: null,
-                          }
-                        : null,
-                      physicalLocations.length > 0
-                        ? {
-                            text: 'Wellcome Library',
-                            url: null,
-                          }
-                        : null,
-                    ].filter(Boolean)}
-                  />
-                </div>
-              )}
-            </SpacingComponent>
-          </div>
+    <div
+      className={classNames([
+        grid({ s: 12, m: 12, l: 10, xl: 10 }),
+        spacing({ s: 4 }, { margin: ['bottom'] }),
+      ])}
+    >
+      <SpacingComponent>
+        <div
+          className={classNames({
+            flex: true,
+            'flex--v-center': true,
+            [font({ s: 'HNL3' })]: true,
+          })}
+        >
+          {workTypeIcon && (
+            <Icon
+              name={workTypeIcon}
+              extraClasses={classNames({
+                [spacing({ s: 1 }, { margin: ['right'] })]: true,
+              })}
+            />
+          )}
+          <div className="line-height-1">{work.workType.label}</div>
         </div>
-      </div>
+
+        <h1
+          id="work-info"
+          className={classNames({
+            'no-margin': true,
+            [font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' })]: true,
+          })}
+        >
+          {work.title}
+        </h1>
+
+        {(work.contributors.length > 0 || productionDates.length > 0) && (
+          <div
+            className={classNames({
+              flex: true,
+              'flex--wrap': true,
+              [spacing({ s: 6 }, { margin: ['top'] })]: true,
+            })}
+          >
+            {work.contributors.length > 0 && (
+              <div
+                className={classNames({
+                  [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                })}
+              >
+                <LinkLabels
+                  items={work.contributors.map(({ agent }) => ({
+                    text: agent.label,
+                    url: `/works?query="${agent.label}"`,
+                  }))}
+                />
+              </div>
+            )}
+
+            {productionDates.length > 0 && (
+              <LinkLabels
+                heading={'Date'}
+                items={productionDates.map(date => ({
+                  text: date,
+                  url: null,
+                }))}
+              />
+            )}
+          </div>
+        )}
+
+        {(digitalLocations.length > 0 || physicalLocations.length > 0) && (
+          <div
+            className={classNames({
+              [spacing({ s: 2 }, { margin: ['top'] })]: true,
+            })}
+          >
+            <LinkLabels
+              heading={'See it'}
+              icon={'eye'}
+              items={[
+                digitalLocations.length > 0
+                  ? {
+                      text: 'Online',
+                      url: null,
+                    }
+                  : null,
+                physicalLocations.length > 0
+                  ? {
+                      text: 'Wellcome Library',
+                      url: null,
+                    }
+                  : null,
+              ].filter(Boolean)}
+            />
+          </div>
+        )}
+      </SpacingComponent>
     </div>
   );
 };

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -1,0 +1,126 @@
+// @flow
+import { type Work } from '../../../model/work';
+import { font, classNames, spacing, grid } from '../../../utils/classnames';
+import {
+  getDigitalLocations,
+  getPhysicalLocations,
+  getProductionDates,
+  getWorkTypeIcon,
+} from '../../../utils/works';
+import Icon from '../Icon/Icon';
+import SpacingComponent from '../SpacingComponent/SpacingComponent';
+import LinkLabels from '../LinkLabels/LinkLabels';
+
+type Props = {|
+  work: Work,
+|};
+
+const WorkHeader = ({ work }: Props) => {
+  const digitalLocations = getDigitalLocations(work);
+  const physicalLocations = getPhysicalLocations(work);
+  const productionDates = getProductionDates(work);
+  const workTypeIcon = getWorkTypeIcon(work);
+  return (
+    <div className={`row ${spacing({ s: 6 }, { padding: ['top', 'bottom'] })}`}>
+      <div className="container">
+        <div className="grid">
+          <div
+            className={classNames([
+              grid({ s: 12, m: 12, l: 10, xl: 10 }),
+              spacing({ s: 4 }, { margin: ['bottom'] }),
+            ])}
+          >
+            <SpacingComponent>
+              <div
+                className={classNames({
+                  flex: true,
+                  'flex--v-center': true,
+                  [font({ s: 'HNL3' })]: true,
+                })}
+              >
+                {workTypeIcon && (
+                  <Icon
+                    name={workTypeIcon}
+                    extraClasses={classNames({
+                      [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                    })}
+                  />
+                )}
+                {work.workType.label}
+              </div>
+
+              <h1
+                id="work-info"
+                className={classNames([
+                  font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' }),
+                  spacing({ s: 0 }, { margin: ['top'] }),
+                ])}
+              >
+                {work.title}
+              </h1>
+
+              <div
+                className={classNames({
+                  flex: true,
+                })}
+              >
+                {work.contributors.length > 0 && (
+                  <LinkLabels
+                    items={work.contributors.map(({ agent }) => ({
+                      text: agent.label,
+                      url: `/works?query="${agent.label}"`,
+                    }))}
+                  />
+                )}
+                {productionDates && (
+                  <div
+                    className={classNames({
+                      [spacing({ s: 2 }, { margin: ['left'] })]: true,
+                    })}
+                  >
+                    <LinkLabels
+                      heading={'Date'}
+                      items={productionDates.map(date => ({
+                        text: date,
+                        url: null,
+                      }))}
+                    />
+                  </div>
+                )}
+              </div>
+
+              {(digitalLocations.length > 0 ||
+                physicalLocations.length > 0) && (
+                <div
+                  className={classNames({
+                    [spacing({ s: 2 }, { margin: ['top'] })]: true,
+                  })}
+                >
+                  <LinkLabels
+                    heading={'See it'}
+                    icon={'eye'}
+                    items={[
+                      digitalLocations.length > 0
+                        ? {
+                            text: 'Online',
+                            url: null,
+                          }
+                        : null,
+                      physicalLocations.length > 0
+                        ? {
+                            text: 'Wellcome Library',
+                            url: null,
+                          }
+                        : null,
+                    ].filter(Boolean)}
+                  />
+                </div>
+              )}
+            </SpacingComponent>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default WorkHeader;

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -72,7 +72,7 @@ const WorkHeader = ({ work }: Props) => {
                     }))}
                   />
                 )}
-                {productionDates && (
+                {productionDates.length > 0 && (
                   <div
                     className={classNames({
                       [spacing({ s: 2 }, { margin: ['left'] })]: true,


### PR DESCRIPTION
As per the commits:
* Makes the `WorkHeader` a component 
* Hides the date label if there are no production dates
* Hides the title on WorkDetails (and alternative) if the header is present
* Fix wrapping on smaller screens
  __Before__
  ![screenshot 2019-02-06 at 13 42 17](https://user-images.githubusercontent.com/31692/52345448-2716db80-2a15-11e9-8366-33e308a23b9a.png)  
  
  __After__
  ![screenshot 2019-02-06 at 13 41 58](https://user-images.githubusercontent.com/31692/52345447-2716db80-2a15-11e9-8784-3c888d272218.png)




Next up
* Add `WorkHeader` to cardigan
