### PR TITLE
allow works specific query parameters through the cache

### DIFF
--- a/cache/cloudfront_dev.tf
+++ b/cache/cloudfront_dev.tf
@@ -37,12 +37,17 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
         "current",
         "query",
         "uri",
-        "MIROPAC", # Wellcome Images redirect
-        "MIRO",    # Wellcome Images redirect
+        "MIROPAC",                      # Wellcome Images redirect
+        "MIRO",                         # Wellcome Images redirect
 
         # dotmailer gives us a 'result' (if we run out of params,
         # consider making new urls for newsletter pages instead)
         "result",
+
+        # Works specific
+        "workType",
+
+        "items.locations.locationType",
       ]
 
       cookies {

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -54,12 +54,17 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         "current",
         "query",
         "uri",
-        "MIROPAC", # Wellcome Images redirect
-        "MIRO",    # Wellcome Images redirect
+        "MIROPAC",                      # Wellcome Images redirect
+        "MIRO",                         # Wellcome Images redirect
 
         # dotmailer gives us a 'result' (if we run out of params,
         # consider making new urls for newsletter pages instead)
         "result",
+
+        # Works specific
+        "workType",
+
+        "items.locations.locationType",
       ]
 
       cookies {


### PR DESCRIPTION
At some stage we might create a catalogue specific cache, but for now this will do.