### PR TITLE
Remove unused rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,6 @@
     "no-multi-spaces": "off",
     "no-multi-str": "off",
     "no-mixed-operators": "off",
-    "flowtype/no-types-missing-file-annotation": "off",
     "no-return-assign": "off",
     "react/react-in-jsx-scope": "off",
     "prettier/prettier": "error"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,24 +1,26 @@
 {
   "parser": "babel-eslint",
-  "plugins": ["flowtype", "react", "jest", "prettier"],
+  "plugins": ["flowtype", "react", "jest", "prettier", "standard"],
   "env": {
     "jest/globals": true
   },
   "extends": [
     "standard",
+    "plugin:flowtype/recommended",
     "plugin:react/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "prettier",
+    "prettier/react",
+    "prettier/standard",
+    "prettier/flowtype"
   ],
   "rules": {
     "no-multi-spaces": "off",
     "no-multi-str": "off",
     "no-mixed-operators": "off",
-    "flowtype/define-flow-type": "warn",
-    "flowtype/space-after-type-colon": ["error", "always"],
-    "flowtype/space-before-type-colon": ["error", "never"],
+    "flowtype/no-types-missing-file-annotation": "off",
     "no-return-assign": "off",
     "react/react-in-jsx-scope": "off",
-    "standard/computed-property-even-spacing": "off",
     "prettier/prettier": "error"
   },
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "parser": "babel-eslint",
-  "plugins": ["flowtype", "import", "react", "jest", "prettier"],
+  "plugins": ["flowtype", "react", "jest", "prettier"],
   "env": {
     "jest/globals": true
   },
@@ -16,10 +16,9 @@
     "flowtype/define-flow-type": "warn",
     "flowtype/space-after-type-colon": ["error", "always"],
     "flowtype/space-before-type-colon": ["error", "never"],
-    "no-duplicate-imports": "off",
     "no-return-assign": "off",
-    "import/no-duplicates": "error",
     "react/react-in-jsx-scope": "off",
+    "standard/computed-property-even-spacing": "off",
     "prettier/prettier": "error"
   },
   "parserOptions": {

--- a/cardigan/stories/components/InfoBanner.js
+++ b/cardigan/stories/components/InfoBanner.js
@@ -11,5 +11,4 @@ const InfoBannerExample = () => {
 };
 
 const stories = storiesOf('Components', module);
-stories
-  .add('InfoBanner', InfoBannerExample, {info: Readme});
+stories.add('InfoBanner', InfoBannerExample, { info: Readme });

--- a/common/views/components/ExceptionalOpeningHoursTable/ExceptionalOpeningHoursTable.js
+++ b/common/views/components/ExceptionalOpeningHoursTable/ExceptionalOpeningHoursTable.js
@@ -1,3 +1,4 @@
+// @flow
 import { spacing, font } from '../../../utils/classnames';
 import { formatDayDate } from '../../../utils/format-date';
 import type { ExceptionalVenueHours } from '../../../model/opening-hours';
@@ -15,7 +16,8 @@ const ExceptionalOpeningHoursTable = ({
 }: Props) => (
   <div className={extraClasses || ''}>
     <table
-      className={`opening-hours__table ${font({ s: 'HNL5' })} ${extraClasses}`}
+      className={`opening-hours__table ${font({ s: 'HNL5' })} ${extraClasses ||
+        ''}`}
     >
       <caption
         className={`opening-hours__caption ${font({ s: 'HNM4' })} ${spacing(
@@ -23,7 +25,7 @@ const ExceptionalOpeningHoursTable = ({
           { padding: ['bottom'] }
         )}`}
       >
-        {formatDayDate(caption)}
+        {formatDayDate(new Date(caption))}
       </caption>
       <thead
         className={`opening-hours__thead ${font({

--- a/common/views/components/GifVideo/GifVideo.js
+++ b/common/views/components/GifVideo/GifVideo.js
@@ -30,7 +30,7 @@ class GifVideo extends Component<Props, State> {
     computedVideoWidth: null,
   };
 
-  videoRef = createRef<HTMLVideoElement>();
+  videoRef: { current: HTMLVideoElement } = createRef();
 
   inViewport = (video: HTMLElement) => {
     const rect = video.getBoundingClientRect();

--- a/common/views/components/HighlightedHeading/HighlightedHeading.js
+++ b/common/views/components/HighlightedHeading/HighlightedHeading.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { spacing } from '../../../utils/classnames';
 
 type Props = {|

--- a/common/views/components/Iframe/Iframe.js
+++ b/common/views/components/Iframe/Iframe.js
@@ -20,7 +20,7 @@ class Iframe extends Component<Props, State> {
     iframeShowing: false,
   };
 
-  iframeRef = createRef<HTMLIFrameElement>();
+  iframeRef: { current: HTMLIFrameElement } = createRef();
 
   toggleIframeDisplay = () => {
     if (!this.state.iframeShowing) {

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -83,7 +83,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
     isLazyLoaded: false,
   };
 
-  imgRef = createRef<HTMLImageElement>();
+  imgRef: { current: HTMLImageElement } = createRef();
 
   getImageSize = () => {
     this.state.imgRef &&

--- a/common/views/components/InfoBanner/InfoBanner.js
+++ b/common/views/components/InfoBanner/InfoBanner.js
@@ -49,6 +49,7 @@ class InfoBanner extends React.Component<Props, State> {
 
   render() {
     const { text } = this.props;
+
     if (this.state.showInfoBanner) {
       return (
         <div
@@ -78,7 +79,7 @@ class InfoBanner extends React.Component<Props, State> {
                       </div>
                       <div
                         className="first-para-no-margin"
-                        dangerouslySetInnerHTML={{ __html: this.props.text }}
+                        dangerouslySetInnerHTML={{ __html: text }}
                       />
                     </span>
                   </div>

--- a/common/views/components/Layout10/Layout10.js
+++ b/common/views/components/Layout10/Layout10.js
@@ -1,3 +1,5 @@
+// @flow
+
 import type { Node } from 'react';
 import Layout from '../Layout/Layout';
 

--- a/common/views/components/Layout8/Layout8.js
+++ b/common/views/components/Layout8/Layout8.js
@@ -1,3 +1,5 @@
+// @flow
+
 import type { Node } from 'react';
 import Layout from '../Layout/Layout';
 

--- a/common/views/components/Map/Map.js
+++ b/common/views/components/Map/Map.js
@@ -1,3 +1,5 @@
+// @flow
+
 type Props = {|
   title: string,
   latitude: number,

--- a/common/views/components/NewsletterSignup/NewsletterSignup.js
+++ b/common/views/components/NewsletterSignup/NewsletterSignup.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { spacing, font } from '../../../utils/classnames';
 import HTMLInput from '../HTMLInput/HTMLInput';
 import Button from '../Buttons/Button/Button';

--- a/common/views/components/OpeningHoursTable/OpeningHoursTable.js
+++ b/common/views/components/OpeningHoursTable/OpeningHoursTable.js
@@ -1,9 +1,11 @@
+// @flow
+
 import { spacing, font } from '../../../utils/classnames';
-import type { Place } from '../../../model/opening-hours';
+import type { Venue } from '../../../model/opening-hours';
 
 type Props = {|
   id?: string,
-  place: Place,
+  place: Venue,
   extraClasses?: string,
 |};
 

--- a/common/views/components/OpeningHoursTableGrouped/OpeningHoursTableGrouped.js
+++ b/common/views/components/OpeningHoursTableGrouped/OpeningHoursTableGrouped.js
@@ -1,3 +1,5 @@
+// @flow
+
 import type { Venue } from '../../../model/opening-hours';
 import { Fragment } from 'react';
 
@@ -7,12 +9,14 @@ type Props = {|
 |};
 
 function times(day, place) {
-  const opensTime = place.openingHours.regular.find(
+  const opensDay = place.openingHours.regular.find(
     times => times.dayOfWeek === day
-  ).opens;
-  const closesTime = place.openingHours.regular.find(
+  );
+  const opensTime = opensDay && opensDay.opens;
+  const closesDay = place.openingHours.regular.find(
     times => times.dayOfWeek === day
-  ).closes;
+  );
+  const closesTime = closesDay && closesDay.closes;
   return (
     <Fragment>
       {opensTime ? (

--- a/common/views/components/PageHeaders/FramedHeader/FramedHeader.js
+++ b/common/views/components/PageHeaders/FramedHeader/FramedHeader.js
@@ -1,9 +1,11 @@
+// @flow
+
 import { spacing } from '../../../../utils/classnames';
 import type { BackgroundTexture } from '../../../../model/background-texture';
 
 type Props = {|
   backgroundTexture: BackgroundTexture,
-  children: React.node,
+  children: React.Node,
 |};
 
 const FramedHeader = ({ backgroundTexture, children }: Props) => (

--- a/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.js
+++ b/common/views/components/PrismicHtmlBlock/PrismicHtmlBlock.js
@@ -1,15 +1,17 @@
+// @flow
+
 import { asHtml } from '../../../services/prismic/parsers';
-import type { HtmlSerialiser } from '../../../services/prismic/html-serialisers';
+import type { HtmlSerializer } from '../../../services/prismic/html-serialisers';
 import type { HTMLString } from '../../../services/prismic/types';
 
 type Props = {|
   html: HTMLString,
-  htmlSerialiser?: HtmlSerialiser,
+  htmlSerializer?: HtmlSerializer,
 |};
 
 // TODO: Find a way to not include the `<div>`
-const PrismicHtmlBlock = ({ html, htmlSerialiser }: Props) => (
-  <span dangerouslySetInnerHTML={{ __html: asHtml(html, htmlSerialiser) }} />
+const PrismicHtmlBlock = ({ html, htmlSerializer }: Props) => (
+  <span dangerouslySetInnerHTML={{ __html: asHtml(html, htmlSerializer) }} />
 );
 
 export default PrismicHtmlBlock;

--- a/common/views/components/StoryPromoFeatured/StoryPromoFeatured.js
+++ b/common/views/components/StoryPromoFeatured/StoryPromoFeatured.js
@@ -1,4 +1,7 @@
+// @flow
+
 import StoryPromo from '../StoryPromo/StoryPromo';
+import { type Article } from '@weco/common/model/articles';
 
 type Props = {|
   item: Article,
@@ -8,7 +11,7 @@ const StoryPromoFeatured = ({ item }: Props) => (
   <div className="story-promo-featured">
     <StoryPromo
       item={item}
-      position={`1`}
+      position={1}
       hasTransparentBackground={true}
       sizesQueries={`(min-width: 1420px) 812px, (min-width: 600px) 58.5vw, calc(100vw - 36px)`}
     />

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -35,7 +35,7 @@ type Props = {
 };
 
 // $FlowFixMe (forwardRef)
-const TextInput = React.forwardRef(({ label, ...inputProps }: Props, ref) => (
+const TextInput = React.forwardRef(({ label, ...inputProps }: Props, ref) => ( // eslint-disable-line
   <label className="flex flex--v-center">
     <StyledInput
       ref={ref}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "eslint-config-prettier": "^4.0.0",
     "eslint-config-standard": "^11.0.0-beta.0",
     "eslint-plugin-flowtype": "^3.2.0",
-    "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-node": "^7.0.0",
     "eslint-plugin-prettier": "^3.0.1",


### PR DESCRIPTION
Now that we can import types and modules in the same declaration, we should do so (makes IntelliSense™ work).

@wellcometrust/experience-devs I found that having `"eslint.autoFixOnSave": true` in my IDE settings, and _removing_ `"editor.formatOnSave": true` prevented a bit of weirdness I was seeing.

YMMV.

This change leaves the formatting in the same shape as it was after the mega-lint yesterday, but removes a conflicting error we then had with Standard.