### PR TITLE
Static cors

### DIFF
--- a/client/terraform/terraform.tf
+++ b/client/terraform/terraform.tf
@@ -10,7 +10,7 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 1.0"
+  version = "~> 1.57"
   region  = "eu-west-1"
 }
 
@@ -20,13 +20,17 @@ provider "aws" {
   alias   = "us-east-1"
 }
 
+provider "template" {
+  version = "~> 2.0"
+}
+
 data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
   provider = "aws.us-east-1"
   domain   = "wellcomecollection.org"
 }
 
 module "static" {
-  source = "../../terraform-modules/https_s3_website"
-  website_uri = "i.wellcomecollection.org"
+  source              = "../../terraform-modules/https_s3_website"
+  website_uri         = "i.wellcomecollection.org"
   acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
 }

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -23,6 +23,12 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
     forwarded_values {
       query_string = false
 
+      headers = [
+        "Origin",
+        "Access-Control-Request-Headers",
+        "Access-Control-Request-Method",
+      ]
+
       cookies {
         forward = "none"
       }

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -15,8 +15,8 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
     cached_methods         = ["HEAD", "GET", "OPTIONS"]
     viewer_protocol_policy = "redirect-to-https"
     target_origin_id       = "S3-${var.website_uri}"
-    min_ttl                = 0
-    default_ttl            = 3600
+    min_ttl                = 86400
+    default_ttl            = 86400
     max_ttl                = 86400
     compress               = true
 

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -11,8 +11,8 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
   aliases = ["${var.website_uri}"]
 
   default_cache_behavior {
-    allowed_methods        = ["HEAD", "GET"]
-    cached_methods         = ["HEAD", "GET"]
+    allowed_methods        = ["HEAD", "GET", "OPTIONS"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
     viewer_protocol_policy = "redirect-to-https"
     target_origin_id       = "S3-${var.website_uri}"
     min_ttl                = 0


### PR DESCRIPTION
Clears up the pesky font loading error.

Also pumps up the cache times, as these never change, and if they do, we can clear the cache.
We could probably bump it up further too, but would like to start measuring impact before we do.