### PR TITLE
Add prettier/standard, prettier/flowtype and prettier/react

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,5 +27,10 @@
     "ecmaFeatures": {
       "jsx": true
     }
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,13 +1,17 @@
 {
   "parser": "babel-eslint",
-  "plugins": ["flowtype", "import", "react", "jest", "prettier"],
+  "plugins": ["flowtype", "import", "react", "jest", "prettier", "standard"],
   "env": {
     "jest/globals": true
   },
   "extends": [
     "standard",
     "plugin:react/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "prettier",
+    "prettier/flowtype",
+    "prettier/react",
+    "prettier/standard"
   ],
   "rules": {
     "no-multi-spaces": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
   },
   "extends": [
     "standard",
+    "plugin:flowtype/recommended",
     "plugin:react/recommended",
     "plugin:prettier/recommended",
     "prettier",
@@ -17,12 +18,8 @@
     "no-multi-spaces": "off",
     "no-multi-str": "off",
     "no-mixed-operators": "off",
-    "flowtype/define-flow-type": "warn",
-    "flowtype/space-after-type-colon": ["error", "always"],
-    "flowtype/space-before-type-colon": ["error", "never"],
-    "no-duplicate-imports": "off",
     "no-return-assign": "off",
-    "import/no-duplicates": "error",
+    "flowtype/no-types-missing-file-annotation": "off",
     "react/react-in-jsx-scope": "off",
     "prettier/prettier": "error"
   },

--- a/common/views/components/ContributorTextList/ContributorTextList.js
+++ b/common/views/components/ContributorTextList/ContributorTextList.js
@@ -1,29 +1,34 @@
 // @flow
-import {Fragment} from 'react';
+import { Fragment } from 'react';
 import { spacing, font, classNames } from '../../../utils/classnames';
 
 type Props = {|
-  contributors: any[]
-|}
+  contributors: any[],
+|};
 
-const ContributorTextList = ({
-  contributors
-}: Props) => (
-  <p className={classNames({
-    [spacing({s: 1}, {margin: ['top']})]: true,
-    [spacing({s: 1}, {margin: ['right']})]: true,
-    [spacing({s: 0}, {margin: ['bottom']})]: true,
-    [font({s: 'HNL4'})]: true
-  })}>
+const ContributorTextList = ({ contributors }: Props) => (
+  <p
+    className={classNames({
+      [spacing({ s: 1 }, { margin: ['top'] })]: true,
+      [spacing({ s: 1 }, { margin: ['right'] })]: true,
+      [spacing({ s: 0 }, { margin: ['bottom'] })]: true,
+      [font({ s: 'HNL4' })]: true,
+    })}
+  >
     <span>By </span>
     {contributors.map(({ agent }, i, arr) => (
       <Fragment key={agent.label}>
-        <span className={classNames({
-          'border-color-black': true,
-          [font({s: 'HNM4'})]: true,
-          'border-left-width-1': i !== 0,
-          [spacing({ s: 1 }, { margin: ['left'], padding: ['left'] })]: i !== 0
-        })}>{agent.label}</span>
+        <span
+          className={classNames({
+            'border-color-black': true,
+            [font({ s: 'HNM4' })]: true,
+            'border-left-width-1': i !== 0,
+            [spacing({ s: 1 }, { margin: ['left'], padding: ['left'] })]:
+              i !== 0,
+          })}
+        >
+          {agent.label}
+        </span>
       </Fragment>
     ))}
   </p>

--- a/common/views/components/GifVideo/GifVideo.js
+++ b/common/views/components/GifVideo/GifVideo.js
@@ -30,7 +30,7 @@ class GifVideo extends Component<Props, State> {
     computedVideoWidth: null,
   };
 
-  videoRef = createRef<HTMLVideoElement>();
+  videoRef: { current: HTMLVideoElement | null } = createRef();
 
   inViewport = (video: HTMLElement) => {
     const rect = video.getBoundingClientRect();

--- a/common/views/components/Iframe/Iframe.js
+++ b/common/views/components/Iframe/Iframe.js
@@ -20,7 +20,7 @@ class Iframe extends Component<Props, State> {
     iframeShowing: false,
   };
 
-  iframeRef = createRef<HTMLIFrameElement>();
+  iframeRef: { current: HTMLIFrameElement | null } = createRef();
 
   toggleIframeDisplay = () => {
     if (!this.state.iframeShowing) {

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -83,7 +83,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
     isLazyLoaded: false,
   };
 
-  imgRef = createRef<HTMLImageElement>();
+  imgRef: { current: HTMLImageElement | null } = createRef();
 
   getImageSize = () => {
     this.state.imgRef &&

--- a/common/views/components/InfoBanner/InfoBanner.js
+++ b/common/views/components/InfoBanner/InfoBanner.js
@@ -48,7 +48,6 @@ class InfoBanner extends React.Component<Props, State> {
   }
 
   render() {
-    const { text } = this.props;
     if (this.state.showInfoBanner) {
       return (
         <div

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -35,7 +35,7 @@ type Props = {
 };
 
 // $FlowFixMe (forwardRef)
-const TextInput = React.forwardRef(({ label, ...inputProps }: Props, ref) => (
+const TextInput = React.forwardRef(({ label, ...inputProps }: Props, ref) => ( // eslint-disable-line
   <label className="flex flex--v-center">
     <StyledInput
       ref={ref}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^5.11.1",
     "eslint-config-prettier": "^4.0.0",
     "eslint-config-standard": "^11.0.0-beta.0",
-    "eslint-plugin-flowtype": "^3.2.0",
+    "eslint-plugin-flowtype": "^3.2.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-node": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react": "^7.12.2",
     "eslint-plugin-standard": "^3.0.1",
     "flow-typed": "^2.5.1",
+    "husky": "^1.3.1",
     "lint-staged": "^7.0.0",
     "pa11y": "^5.1.0",
     "pa11y-reporter-html": "^1.0.0",
@@ -47,5 +48,13 @@
     "catalogue/webapp",
     "content/webapp",
     "common"
-  ]
+  ],
+  "lint-staged": {
+    "*.js": ["eslint --fix", "git add"]
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,6 +2503,11 @@ ci-info@^1.5.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
 
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
@@ -2863,7 +2868,7 @@ cosmiconfig@^4.0.0:
     parse-json "^4.0.0"
     require-from-string "^2.0.1"
 
-cosmiconfig@^5.0.2:
+cosmiconfig@^5.0.2, cosmiconfig@^5.0.7:
   version "5.0.7"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.7.tgz#39826b292ee0d78eda137dfa3173bd1c21a43b04"
   integrity sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==
@@ -3887,6 +3892,19 @@ execa@^0.9.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
+  integrity sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^4.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -4460,6 +4478,13 @@ get-stream@^3.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
   integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
+get-stream@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+  dependencies:
+    pump "^3.0.0"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -4899,6 +4924,22 @@ https-proxy-agent@^2.2.0, https-proxy-agent@^2.2.1:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
+husky@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-1.3.1.tgz#26823e399300388ca2afff11cfa8a86b0033fae0"
+  integrity sha512-86U6sVVVf4b5NYSZ0yvv88dRgBSSXXmHaiq5pP4KDj5JVzdwKgBjEtUPOm8hcoytezFwbU+7gotXNhpHdystlg==
+  dependencies:
+    cosmiconfig "^5.0.7"
+    execa "^1.0.0"
+    find-up "^3.0.0"
+    get-stdin "^6.0.0"
+    is-ci "^2.0.0"
+    pkg-dir "^3.0.0"
+    please-upgrade-node "^3.1.1"
+    read-pkg "^4.0.1"
+    run-node "^1.0.0"
+    slash "^2.0.0"
+
 iconv-lite@0.4.23:
   version "0.4.23"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
@@ -5150,6 +5191,13 @@ is-ci@^1.0.10, is-ci@^1.1.0:
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -7759,7 +7807,7 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-please-upgrade-node@^3.0.2:
+please-upgrade-node@^3.0.2, please-upgrade-node@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz#ed320051dfcc5024fae696712c8288993595e8ac"
   integrity sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==
@@ -8555,6 +8603,15 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+read-pkg@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-4.0.1.tgz#963625378f3e1c4d48c85872b5a6ec7d5d093237"
+  integrity sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+
 "readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -8964,6 +9021,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/run-node/-/run-node-1.0.0.tgz#46b50b946a2aa2d4947ae1d886e9856fd9cabe5e"
+  integrity sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==
+
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
@@ -9257,6 +9319,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@0.0.4:
   version "0.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3631,10 +3631,10 @@ eslint-plugin-es@^1.3.1:
     eslint-utils "^1.3.0"
     regexpp "^2.0.1"
 
-eslint-plugin-flowtype@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.0.tgz#824364ed5940a404b91326fdb5a313a2a74760df"
-  integrity sha512-baJmzngM6UKbEkJ5OY3aGw2zjXBt5L2QKZvTsOlXX7yHKIjNRrlJx2ods8Rng6EdqPR9rVNIQNYHpTs0qfn2qA==
+eslint-plugin-flowtype@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.2.1.tgz#45e032aee54e695dfc41a891e92b7afedfc62c77"
+  integrity sha512-1lymqM8Cawxu5xsS8TaCrLWJYUmUdoG4hCfa7yWOhCf0qZn/CvI8FxqkhdOP6bAosBn5zeYxKe3Q/4rfKN8a+A==
   dependencies:
     lodash "^4.17.10"
 


### PR DESCRIPTION
Using an appropriate eslint config for the tech we use.

For now, I've turned off the `flowtype/no-types-missing-file-annotation` setting, so we can incrementally fix flow in our files without breaking linting.

And we've got `lint-staged` back in to check (and autofix if possible) anything that doesn't meet our requirements.