### PR TITLE
Work header and details toggle

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
@@ -15,7 +15,7 @@ import License from '@weco/common/views/components/License/License';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
-import MetaUnit2 from '@weco/common/views/components/MetaUnit/MetaUnit2';
+import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit2';
 
 const StyledWorkDetailsSection = styled.div`
   /* TODO: variables/functions/mixins/linting */
@@ -189,7 +189,7 @@ const WorkDetails = ({
       <WorkDetailsSection headingText={`About this ${singularWorkTypeLabel}`}>
         <div className="spaced-text">
           {work.description && (
-            <MetaUnit2
+            <MetaUnit
               headingLevel={3}
               headingText="Description"
               text={[work.description]}
@@ -197,7 +197,7 @@ const WorkDetails = ({
           )}
 
           {work.production.length > 0 && (
-            <MetaUnit2
+            <MetaUnit
               headingLevel={3}
               headingText="Publication/Creation"
               text={work.production.map(
@@ -207,7 +207,7 @@ const WorkDetails = ({
           )}
 
           {(work.physicalDescription || work.extent || work.dimensions) && (
-            <MetaUnit2
+            <MetaUnit
               headingLevel={3}
               headingText="Physical description"
               text={[
@@ -219,7 +219,7 @@ const WorkDetails = ({
           )}
 
           {work.lettering && (
-            <MetaUnit2
+            <MetaUnit
               headingLevel={3}
               headingText="Lettering"
               text={[work.lettering]}
@@ -227,7 +227,7 @@ const WorkDetails = ({
           )}
 
           {work.genres.length > 0 && (
-            <MetaUnit2
+            <MetaUnit
               headingLevel={3}
               headingText="Type"
               links={work.genres.map(genre => {
@@ -245,7 +245,7 @@ const WorkDetails = ({
           )}
 
           {work.language && (
-            <MetaUnit2
+            <MetaUnit
               headingLevel={3}
               headingText="Language"
               links={[work.language.label]}
@@ -271,30 +271,30 @@ const WorkDetails = ({
     <WorkDetailsSection headingText="Identifiers">
       {isbnIdentifiers.length > 0 && (
         <div className="spaced-text" style={{ marginBottom: '1.6em' }}>
-          <MetaUnit2
+          <MetaUnit
             headingText="ISBN"
             list={isbnIdentifiers.map(id => id.value)}
           />
         </div>
       )}
-      <MetaUnit2 headingText="Share">
+      <MetaUnit headingText="Share">
         <CopyUrl
           id={work.id}
           url={`https://wellcomecollection.org/works/${work.id}`}
         />
-      </MetaUnit2>
+      </MetaUnit>
     </WorkDetailsSection>
   );
   if (licenseInfo) {
     WorkDetailsSections.push(
       <WorkDetailsSection headingText="License information">
         <div className="spaced-text">
-          <MetaUnit2
+          <MetaUnit
             headingLevel={3}
             headingText="License information"
             text={licenseInfo.humanReadableText}
           />
-          <MetaUnit2
+          <MetaUnit
             headingLevel={3}
             headingText="Credit"
             text={[

--- a/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
@@ -15,7 +15,7 @@ import License from '@weco/common/views/components/License/License';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
-import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
+import MetaUnit2 from '@weco/common/views/components/MetaUnit/MetaUnit2';
 
 const StyledWorkDetailsSection = styled.div`
   /* TODO: variables/functions/mixins/linting */
@@ -189,7 +189,7 @@ const WorkDetails = ({
       <WorkDetailsSection headingText={`About this ${singularWorkTypeLabel}`}>
         <div className="spaced-text">
           {work.description && (
-            <MetaUnit
+            <MetaUnit2
               headingLevel={3}
               headingText="Description"
               text={[work.description]}
@@ -197,7 +197,7 @@ const WorkDetails = ({
           )}
 
           {work.production.length > 0 && (
-            <MetaUnit
+            <MetaUnit2
               headingLevel={3}
               headingText="Publication/Creation"
               text={work.production.map(
@@ -207,7 +207,7 @@ const WorkDetails = ({
           )}
 
           {(work.physicalDescription || work.extent || work.dimensions) && (
-            <MetaUnit
+            <MetaUnit2
               headingLevel={3}
               headingText="Physical description"
               text={[
@@ -219,7 +219,7 @@ const WorkDetails = ({
           )}
 
           {work.lettering && (
-            <MetaUnit
+            <MetaUnit2
               headingLevel={3}
               headingText="Lettering"
               text={[work.lettering]}
@@ -227,7 +227,7 @@ const WorkDetails = ({
           )}
 
           {work.genres.length > 0 && (
-            <MetaUnit
+            <MetaUnit2
               headingLevel={3}
               headingText="Type"
               links={work.genres.map(genre => {
@@ -245,7 +245,7 @@ const WorkDetails = ({
           )}
 
           {work.language && (
-            <MetaUnit
+            <MetaUnit2
               headingLevel={3}
               headingText="Language"
               links={[work.language.label]}
@@ -271,30 +271,30 @@ const WorkDetails = ({
     <WorkDetailsSection headingText="Identifiers">
       {isbnIdentifiers.length > 0 && (
         <div className="spaced-text" style={{ marginBottom: '1.6em' }}>
-          <MetaUnit
+          <MetaUnit2
             headingText="ISBN"
             list={isbnIdentifiers.map(id => id.value)}
           />
         </div>
       )}
-      <MetaUnit headingText="Share">
+      <MetaUnit2 headingText="Share">
         <CopyUrl
           id={work.id}
           url={`https://wellcomecollection.org/works/${work.id}`}
         />
-      </MetaUnit>
+      </MetaUnit2>
     </WorkDetailsSection>
   );
   if (licenseInfo) {
     WorkDetailsSections.push(
       <WorkDetailsSection headingText="License information">
         <div className="spaced-text">
-          <MetaUnit
+          <MetaUnit2
             headingLevel={3}
             headingText="License information"
             text={licenseInfo.humanReadableText}
           />
-          <MetaUnit
+          <MetaUnit2
             headingLevel={3}
             headingText="Credit"
             text={[

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -38,8 +38,7 @@ type Props = {|
   query: ?string,
   page: ?number,
   itemsLocationsLocationType: string[],
-  showNewMetaDataGrouping: boolean,
-  showWorkHeader: boolean,
+  showWorkPageChanges: boolean,
   showCatalogueSearchFilters: boolean,
 |};
 
@@ -49,8 +48,7 @@ export const WorkPage = ({
   page,
   workType,
   itemsLocationsLocationType,
-  showNewMetaDataGrouping,
-  showWorkHeader,
+  showWorkPageChanges,
   showCatalogueSearchFilters,
 }: Props) => {
   if (work.type === 'Error') {
@@ -169,7 +167,7 @@ export const WorkPage = ({
         </div>
       </div>
 
-      {showWorkHeader && (
+      {showWorkPageChanges && (
         <div
           className={classNames({
             row: true,
@@ -198,7 +196,7 @@ export const WorkPage = ({
           />
         )}
 
-        {showNewMetaDataGrouping ? (
+        {showWorkPageChanges ? (
           <WorkDetailsNewDataGrouping
             work={work}
             iiifImageLocationUrl={iiifImageLocationUrl}
@@ -215,7 +213,7 @@ export const WorkPage = ({
             iiifImageLocationCredit={iiifImageLocationCredit}
             iiifImageLocationLicenseId={iiifImageLocationLicenseId}
             encoreLink={encoreLink}
-            excludeTitle={showWorkHeader}
+            excludeTitle={showWorkPageChanges}
           />
         )}
       </Fragment>
@@ -239,10 +237,7 @@ WorkPage.getInitialProps = async (
 
   const { id, query, page } = ctx.query;
   const workOrError = await getWork({ id });
-  const showNewMetaDataGrouping = Boolean(
-    ctx.query.toggles.showWorkMetaDataGrouping
-  );
-  const showWorkHeader = Boolean(ctx.query.toggles.showWorkHeader);
+  const showWorkPageChanges = Boolean(ctx.query.toggles.showWorkPageChanges);
   const showCatalogueSearchFilters = Boolean(
     ctx.query.toggles.showCatalogueSearchFilters
   );
@@ -265,8 +260,7 @@ WorkPage.getInitialProps = async (
       page: page ? parseInt(page, 10) : null,
       workType,
       itemsLocationsLocationType,
-      showNewMetaDataGrouping,
-      showWorkHeader,
+      showWorkPageChanges,
       showCatalogueSearchFilters,
     };
   }

--- a/common/views/components/MetaUnit/MetaUnit2.js
+++ b/common/views/components/MetaUnit/MetaUnit2.js
@@ -1,17 +1,17 @@
 // @flow
+import type { Node } from 'react';
 import { spacing, font } from '../../../utils/classnames';
 import NextLink from 'next/link';
-import Divider from '../Divider/Divider';
 
 type HeadingProps = {
   headingLevel: ?number,
   headingText: string,
 };
 const Heading = ({ headingLevel, headingText }: HeadingProps) => {
-  const classes = `${font({ s: 'HNM5', m: 'HNM4' })} ${spacing(
+  const classes = `${font({ s: 'HNM4', m: 'HNM3' })} ${spacing(
     { s: 0 },
     { margin: ['top'] }
-  )} ${spacing({ s: 1 }, { margin: ['bottom'] })}`;
+  )} ${spacing({ s: 0 }, { margin: ['bottom'] })}`;
   const smallClasses = `${font({ s: 'HNM6', m: 'HNM5' })} ${spacing(
     { s: 0 },
     { margin: ['top'] }
@@ -22,7 +22,7 @@ const Heading = ({ headingLevel, headingText }: HeadingProps) => {
     case 2:
       return <h2 className={classes}>{headingText}</h2>;
     case 3:
-      return <h3 className={smallClasses}>{headingText}</h3>;
+      return <h3 className={classes}>{headingText}</h3>;
     case 4:
       return <h4 className={smallClasses}>{headingText}</h4>;
     case 5:
@@ -38,16 +38,7 @@ const Paragraphs = ({ text }) => {
   return (
     text.length > 0 &&
     text.map((para, i) => {
-      return (
-        <p
-          key={i}
-          className={`${font({ s: 'HNL5', m: 'HNL4' })} ${spacing(
-            { s: 2 },
-            { margin: ['bottom'] }
-          )}`}
-          dangerouslySetInnerHTML={{ __html: para }}
-        />
-      );
+      return <p key={i} dangerouslySetInnerHTML={{ __html: para }} />;
     })
   );
 };
@@ -56,7 +47,10 @@ const LinksList = ({ links }) => {
   return (
     links.length > 0 && (
       <ul
-        className={`${spacing({ s: 2 }, { margin: ['bottom'] })} ${spacing(
+        className={`plain-list ${spacing(
+          { s: 2 },
+          { margin: ['bottom'] }
+        )} ${spacing(
           { s: 0 },
           {
             margin: ['top', 'left', 'right'],
@@ -65,7 +59,7 @@ const LinksList = ({ links }) => {
         )}`}
       >
         {links.map((link, i, arr) => (
-          <li key={i} className={`inline ${font({ s: 'HNL5', m: 'HNL4' })}`}>
+          <li key={i} className="inline">
             {link.url && <NextLink href={link.url}>{link.text}</NextLink>}
             {!link.url && link}
             {arr.length - 1 !== i && ' '}
@@ -80,7 +74,10 @@ const List = ({ list }) => {
   return (
     list.length > 0 && (
       <ul
-        className={`${spacing({ s: 2 }, { margin: ['bottom'] })} ${spacing(
+        className={`plain-list ${spacing(
+          { s: 2 },
+          { margin: ['bottom'] }
+        )} ${spacing(
           { s: 0 },
           {
             margin: ['top', 'left', 'right'],
@@ -89,11 +86,7 @@ const List = ({ list }) => {
         )}`}
       >
         {list.map((item, i, arr) => (
-          <li
-            key={i}
-            className={font({ s: 'HNL5', m: 'HNL4' })}
-            style={{ listStylePosition: 'inside' }}
-          >
+          <li key={i} style={{ listStylePosition: 'inside' }}>
             {item}
           </li>
         ))}
@@ -101,13 +94,14 @@ const List = ({ list }) => {
     )
   );
 };
+
 type MetaUnitProps = {|
   headingLevel?: number,
   headingText?: string,
   links?: any[], // TODO replace with React.Element<'NextLink'>[], once moved to V2
   text?: string[],
   list?: string[],
-  includeDivider?: boolean,
+  children?: Node,
 |};
 
 const MetaUnit = ({
@@ -116,24 +110,17 @@ const MetaUnit = ({
   text = [],
   links = [],
   list = [],
-  includeDivider,
+  children,
 }: MetaUnitProps) => {
   return (
-    <div className={spacing({ s: 2 }, { margin: ['bottom'] })}>
+    <div className={`${font({ s: 'HNL4', m: 'HNL3' })}`}>
       {headingText && (
         <Heading headingLevel={headingLevel} headingText={headingText} />
       )}
       <Paragraphs text={text} />
       <LinksList links={links} />
       <List list={list} />
-      {includeDivider && (
-        <Divider
-          extraClasses={`divider--pumice divider--keyline ${spacing(
-            { s: 1 },
-            { margin: ['top', 'bottom'] }
-          )}`}
-        />
-      )}
+      {children}
     </div>
   );
 };

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -39,16 +39,12 @@ const featureToggles = [
       'This will show unfilter those results, and allow for filtering.',
   },
   {
-    id: 'showWorkMetaDataGrouping',
-    title: 'Show work metadata grouped in a new way',
+    id: 'showWorkPageChanges',
+    title: 'Show work page changes',
     description:
-      'Shows the work metadata grouped together and ordered based on usability testing and workshops.',
-  },
-  {
-    id: 'showWorkHeader',
-    title: 'Show the header on individual work pages',
-    description:
-      'The header on the works page should hopefully give a summary at a glance on what the work is about.',
+      'Adds a header to the page which should hopefully summarise, at a glance, what the work is about.' + 
+      ' Changes the layout/styling of the work details section and' +
+      ' labels and groups the data in an attempt to make it easier to comprehend.'
   },
 ];
 


### PR DESCRIPTION
Puts the Work page header and new layout/groupings of the details behind the same toggle.

It doesn't make sense to show the new work details without the header since the header contains data now missing from this version of the work details section.

I've also put the original MetaUnit component back for now, as it was changing the original page, and made a new one for the redesigned page
