### PR TITLE
Add outbound link tracking

### DIFF
--- a/common/utils/domain.js
+++ b/common/utils/domain.js
@@ -1,0 +1,10 @@
+export function getDomain(url: string): string {
+  return url
+    .replace('http://', '')
+    .replace('https://', '')
+    .split('/')[0];
+}
+
+export function isExternal(url: string): boolean {
+  return getDomain(document.location.href) !== getDomain(url);
+}

--- a/common/utils/ga.js
+++ b/common/utils/ga.js
@@ -1,19 +1,6 @@
 // @flow
 import ReactGA from 'react-ga';
 
-export function trackIfOutboundLink(url: string) {
-  const isExternal = new window.URL(url).host !== window.location.host;
-
-  if (isExternal) {
-    ReactGA.event({
-      category: 'outbound',
-      action: 'click',
-      label: url,
-      transport: 'beacon',
-    });
-  }
-}
-
 export type GaEvent = {|
   category: string,
   action: string,

--- a/common/views/components/Links/MoreLink/MoreLink.js
+++ b/common/views/components/Links/MoreLink/MoreLink.js
@@ -1,7 +1,7 @@
 // @flow
 import { font, conditionalClassNames } from '../../../../utils/classnames';
 import Icon from '../../Icon/Icon';
-import { trackIfOutboundLink, trackEvent } from '../../../../utils/ga';
+import { trackEvent } from '../../../../utils/ga';
 import type { GaEvent } from '../../../../utils/ga';
 
 type Props = {|
@@ -20,7 +20,6 @@ const MoreLink = ({
   trackingEvent,
 }: Props) => {
   function handleClick(event) {
-    trackIfOutboundLink(event.currentTarget.href);
     if (trackingEvent) {
       trackEvent({
         category: 'MoreLink',

--- a/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
+++ b/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
@@ -3,23 +3,13 @@
 import React, { useEffect } from 'react';
 import ReactGA from 'react-ga';
 import type { Node } from 'react';
+import { isExternal } from '../../../utils/domain';
 
 type Props = {|
   children: Node,
 |};
 
 const OutboundLinkTracker = ({ children }: Props) => {
-  function getDomain(url: string): string {
-    return url
-      .replace('http://', '')
-      .replace('https://', '')
-      .split('/')[0];
-  }
-
-  function isExternal(url: string): boolean {
-    return getDomain(document.location.href) !== getDomain(url);
-  }
-
   function handleClick(event: { target: any }) {
     const url = event.target.href;
 

--- a/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
+++ b/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
@@ -1,0 +1,47 @@
+// @flow
+
+import React, { useEffect } from 'react';
+import ReactGA from 'react-ga';
+import type { Node } from 'react';
+
+type Props = {|
+  children: Node,
+|};
+
+const OutboundLinkTracker = ({ children }: Props) => {
+  function getDomain(url: string): string {
+    return url
+      .replace('http://', '')
+      .replace('https://', '')
+      .split('/')[0];
+  }
+
+  function isExternal(url: string): boolean {
+    return getDomain(document.location.href) !== getDomain(url);
+  }
+
+  function handleClick(event) {
+    const href = event.target.href;
+
+    if (href && isExternal(href)) {
+      ReactGA.outboundLink(
+        {
+          label: href,
+        },
+        () => {} // ReactGA requires the hitCallback arg
+      );
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('click', handleClick);
+
+    return () => {
+      document.removeEventListener('click', handleClick);
+    };
+  });
+
+  return <>{children}</>;
+};
+
+export default OutboundLinkTracker;

--- a/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
+++ b/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
@@ -26,6 +26,7 @@ const OutboundLinkTracker = ({ children }: Props) => {
   }
 
   useEffect(() => {
+    // TODO:decouple this from the document for testing
     document.addEventListener('click', handleClick);
 
     return () => {

--- a/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
+++ b/common/views/components/OutboundLinkTracker/OutboundLinkTracker.js
@@ -20,13 +20,15 @@ const OutboundLinkTracker = ({ children }: Props) => {
     return getDomain(document.location.href) !== getDomain(url);
   }
 
-  function handleClick(event) {
-    const href = event.target.href;
+  function handleClick(event: { target: any }) {
+    const url = event.target.href;
 
-    if (href && isExternal(href)) {
+    if (url && isExternal(url)) {
       ReactGA.outboundLink(
         {
-          label: href,
+          category: 'outbound',
+          action: 'click',
+          label: url,
         },
         () => {} // ReactGA requires the hitCallback arg
       );

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -11,6 +11,7 @@ import theme from '../../views/themes/default';
 import { parseOpeningTimesFromCollectionVenues } from '../../services/prismic/opening-times';
 import ErrorPage from '../../views/components/ErrorPage/ErrorPage';
 import TogglesContext from '../../views/components/TogglesContext/TogglesContext';
+import OutboundLinkTracker from '../../views/components/OutboundLinkTracker/OutboundLinkTracker';
 import OpeningTimesContext from '../../views/components/OpeningTimesContext/OpeningTimesContext';
 import GlobalAlertContext from '../../views/components/GlobalAlertContext/GlobalAlertContext';
 import { trackEvent } from '../../utils/ga';
@@ -344,12 +345,14 @@ export default class WecoApp extends App {
           <OpeningTimesContext.Provider value={parsedOpeningTimes}>
             <GlobalAlertContext.Provider value={globalAlert.text}>
               <ThemeProvider theme={theme}>
-                <Fragment>
-                  {!pageProps.statusCode && <Component {...pageProps} />}
-                  {pageProps.statusCode && pageProps.statusCode !== 200 && (
-                    <ErrorPage statusCode={pageProps.statusCode} />
-                  )}
-                </Fragment>
+                <OutboundLinkTracker>
+                  <Fragment>
+                    {!pageProps.statusCode && <Component {...pageProps} />}
+                    {pageProps.statusCode && pageProps.statusCode !== 200 && (
+                      <ErrorPage statusCode={pageProps.statusCode} />
+                    )}
+                  </Fragment>
+                </OutboundLinkTracker>
               </ThemeProvider>
             </GlobalAlertContext.Provider>
           </OpeningTimesContext.Provider>


### PR DESCRIPTION
Closes #3970

Wraps the `_app` in a component that listens for clicks, tests if those clicks are on things with `href`s at external domains, and fires an event to GA if so: 
```
{
  category: 'outbound',
  action: 'click',
  label: url,
}
```

Took the outbound link tracking off the `MoreLink` component to prevent duplication.  
