### PR TITLE
add installation label to exhibition results

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -241,6 +241,13 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
           url: null,
         },
       ]
+    : exhibition.format
+    ? [
+        {
+          text: exhibition.format.title,
+          url: null,
+        },
+      ]
     : [{ url: null, text: 'Exhibition' }];
 
   return { ...exhibition, labels };
@@ -386,7 +393,8 @@ export async function getExhibitionRelatedContent(
     eventPoliciesFields,
     contributorsFields,
     articleSeriesFields,
-    articleFormatsFields
+    articleFormatsFields,
+    exhibitionFields
   );
   const types = ['exhibitions', 'events', 'installations', 'articles', 'books'];
   const extraContent = await getTypeByIds(req, types, ids, { fetchLinks });

--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -17,6 +17,7 @@ import {
   eventPoliciesFields,
   audiencesFields,
   articleSeriesFields,
+  exhibitionFields,
 } from './fetch-links';
 import { parseArticleSeries } from './article-series';
 import type { MultiContent } from '../../model/multi-content';


### PR DESCRIPTION
Adds the installation label to exhibition results.
![label](https://user-images.githubusercontent.com/31692/52560509-7fbcee80-2df0-11e9-92b7-91f54391191b.png)
