### PR TITLE
run edge lambda deploy on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,5 +295,4 @@ workflows:
           filters:
             branches:
               only:
-                - edge_lambda_deploy
-                - move_edge_lambdas
+                - master


### PR DESCRIPTION
Make sure we actually copy the edge@lambda file over to S3.
Hence the versions weren't being bumped when we were trying to deploy earlier.
