### PR TITLE
add contributors back to work details

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetailsNewDataGrouping.js
@@ -195,6 +195,18 @@ const WorkDetails = ({
             />
           )}
 
+          {work.contributors.length > 0 && (
+            <MetaUnit
+              headingLevel={3}
+              headingText="Contributors"
+              text={[
+                work.contributors
+                  .map(contributor => contributor.agent.label)
+                  .join(' | '),
+              ]}
+            />
+          )}
+
           {work.production.length > 0 && (
             <MetaUnit
               headingLevel={3}


### PR DESCRIPTION
As per our discussion, just because something is in the header, doesn't mean it needs to be removed from the details.

The point of the head is to give an overview, and allow quick scanning of what might be important to a specific type of thing, the details below can replicate this.

This will avoid having inconsistent details across the different works if the decision is to have different overview structure.

e.g. we might pull contributors out as really important on books, but not ephemera.

![screenshot 2019-02-11 at 15 43 54](https://user-images.githubusercontent.com/31692/52574499-5c0b9f80-2e14-11e9-881a-ae48f826db0b.png)


[Ordering taken from here](https://github.com/wellcometrust/wellcomecollection.org/issues/3954#issuecomment-456986989)