### PR TITLE
show all dates/times on event compact card

### DIFF
--- a/cardigan/stories/components/EventDateRange.js
+++ b/cardigan/stories/components/EventDateRange.js
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import { Fragment } from 'react';
 import moment from 'moment';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, date } from '@storybook/addon-knobs/react';
@@ -11,32 +11,50 @@ function dateKnob(name, defaultValue) {
 }
 
 const stories = storiesOf('Components', module);
-stories
-  .addDecorator(withKnobs)
-  .add('Event date range', () => {
-    const firstDate = moment().subtract(2, 'day').toDate();
-    const secondDate = moment().add(1, 'minute').toDate();
-    const thirdDate = moment().add(1, 'day').toDate();
+stories.addDecorator(withKnobs).add(
+  'Event date range',
+  () => {
+    const firstDate = moment()
+      .subtract(2, 'day')
+      .toDate();
+    const secondDate = moment()
+      .add(1, 'minute')
+      .toDate();
+    const thirdDate = moment()
+      .add(1, 'day')
+      .toDate();
 
-    const times = [{
-      range: {
-        startDateTime: dateKnob('First date', firstDate),
-        endDateTime: moment(firstDate).add(1, 'day').toDate()
-      }
-    }, {
-      range: {
-        startDateTime: dateKnob('Second date', secondDate),
-        endDateTime: moment(secondDate).add(1, 'day').toDate()
-      }
-    }, {
-      range: {
-        startDateTime: dateKnob('Third date', thirdDate),
-        endDateTime: moment(thirdDate).add(1, 'day').toDate()
-      }
-    }];
+    const times = [
+      {
+        range: {
+          startDateTime: dateKnob('First date', firstDate),
+          endDateTime: moment(firstDate)
+            .add(1, 'day')
+            .toDate(),
+        },
+      },
+      {
+        range: {
+          startDateTime: dateKnob('Second date', secondDate),
+          endDateTime: moment(secondDate)
+            .add(1, 'day')
+            .toDate(),
+        },
+      },
+      {
+        range: {
+          startDateTime: dateKnob('Third date', thirdDate),
+          endDateTime: moment(thirdDate)
+            .add(1, 'day')
+            .toDate(),
+        },
+      },
+    ];
     return (
       <Fragment>
         <EventDateRange event={{ times }} />
       </Fragment>
     );
-  }, {info: Readme});
+  },
+  { info: Readme }
+);

--- a/common/views/components/CompactCard/CompactCard.js
+++ b/common/views/components/CompactCard/CompactCard.js
@@ -1,6 +1,5 @@
 // @flow
-import type { Element, ElementProps } from 'react';
-
+import { type Element, type ElementProps, type Node } from 'react';
 import {
   grid,
   font,
@@ -10,12 +9,13 @@ import {
 } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import DateRange from '../DateRange/DateRange';
+import EventDateRange from '../EventDateRange/EventDateRange';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
 import LabelsList from '../LabelsList/LabelsList';
 import ImagePlaceholder from '../ImagePlaceholder/ImagePlaceholder';
 import PartNumberIndicator from '../PartNumberIndicator/PartNumberIndicator';
 import { default as ImageType } from '../Image/Image';
-import type { ColorSelection } from '../../../model/color-selections';
+import { type ColorSelection } from '../../../model/color-selections';
 
 type Props = {|
   url: ?string,
@@ -27,8 +27,9 @@ type Props = {|
   partNumber: ?number,
   color: ?ColorSelection,
   Image: ?Element<typeof ImageType | typeof ImagePlaceholder>,
-  DateInfo: ?Element<typeof DateRange>,
+  DateInfo: ?(Element<typeof DateRange> | Element<typeof EventDateRange>),
   StatusIndicator: ?Element<typeof StatusIndicator>,
+  ExtraInfo?: ?Node,
 |};
 
 const CompactCard = ({
@@ -43,6 +44,7 @@ const CompactCard = ({
   Image,
   DateInfo,
   StatusIndicator,
+  ExtraInfo,
 }: Props) => {
   const textGridSizes = Image
     ? { s: 7, m: 7, l: 8, xl: 8 }
@@ -92,8 +94,9 @@ const CompactCard = ({
         >
           {title}
         </div>
-        {DateRange && <div>{DateInfo}</div>}
+        {DateInfo}
         {StatusIndicator}
+        {ExtraInfo}
         {description && (
           <div className="spaced-text">
             <p className={font({ s: 'HNL4' })}>{description}</p>

--- a/common/views/components/EventCard/EventCard.js
+++ b/common/views/components/EventCard/EventCard.js
@@ -1,16 +1,17 @@
 // @flow
+import { type UiEvent } from '../../../model/events';
 import CompactCard from '../CompactCard/CompactCard';
 import Image from '../Image/Image';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
 import EventDateRange from '../EventDateRange/EventDateRange';
-import type { UiEvent } from '../../../model/events';
+import { classNames, font } from '../../../utils/classnames';
 
 type Props = {|
   event: UiEvent,
 |};
 
 const EventCard = ({ event }: Props) => {
-  const DateRangeComponent = EventDateRange({ event });
+  const DateRangeComponent = <EventDateRange event={event} />;
   const ImageComponent = event.promo && event.promo.image && (
     <Image {...event.promo.image} />
   );
@@ -36,6 +37,18 @@ const EventCard = ({ event }: Props) => {
       Image={ImageComponent}
       DateInfo={DateRangeComponent}
       StatusIndicator={StatusIndicatorComponent}
+      ExtraInfo={
+        !event.isPast &&
+        event.times.length > 1 && (
+          <p
+            className={classNames({
+              [font({ s: 'HNM5' })]: true,
+            })}
+          >
+            See all dates/times
+          </p>
+        )
+      }
     />
   );
 };


### PR DESCRIPTION
Ref #4101 

Probably need to revisit the structure of the compact card.
It would be nice to codify this idea of the card & header being relatively the same.

Some linting happened too.

![screenshot 2019-02-11 at 16 10 34](https://user-images.githubusercontent.com/31692/52576379-d8ec4880-2e17-11e9-9bad-7be65e8cb153.png)
