### PR TITLE
Ignore touch events on ImageViewer controls

### DIFF
--- a/common/styles/components/_image_viewer.scss
+++ b/common/styles/components/_image_viewer.scss
@@ -18,6 +18,9 @@
 }
 
 .image-viewer__controls {
+  // TODO: keep an eye on https://github.com/openseadragon/openseadragon/issues/1586
+  // for a less heavy handed solution to Openseadragon breaking on touch events
+  touch-action: none;
   height: 3em;
 
   .icon {


### PR DESCRIPTION
Should keep some of the noise in the explosions channel down a bit.