### PR TITLE
add new work locations toggle

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -5,41 +5,15 @@ import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import { classNames, font, spacing } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { worksUrl } from '../../services/catalogue/urls';
-
-const workTypes = [
-  { id: 'a', label: 'Books' },
-  { id: 'b', label: 'Manuscripts, Asian' },
-  { id: 'c', label: 'Music' },
-  { id: 'd', label: 'Journals' },
-  { id: 'e', label: 'Maps' },
-  { id: 'f', label: 'E-videos' },
-  { id: 'g', label: 'Videorecordings' },
-  { id: 'h', label: 'Archives and manuscripts' },
-  { id: 'i', label: 'Sound' },
-  { id: 'j', label: 'E-journals' },
-  { id: 'k', label: 'Pictures' },
-  { id: 'l', label: 'Ephemera' },
-  { id: 'm', label: 'CD-Roms' },
-  { id: 'n', label: 'Cinefilm' },
-  { id: 'p', label: 'Mixed materials' },
-  { id: 'q', label: 'Digital images' },
-  { id: 'r', label: '3-D Objects' },
-  { id: 's', label: 'E-sound' },
-  { id: 'u', label: 'Standing order' },
-  { id: 'v', label: 'E-books' },
-  { id: 'w', label: 'Student dissertations' },
-  { id: 'x', label: 'E-manuscripts, Asian' },
-  { id: 'z', label: 'Web sites ' },
-];
 
 type Props = {|
   initialQuery: string,
   initialWorkType: string[],
   initialItemsLocationsLocationType: string[],
-  showFilters: boolean,
   ariaDescribedBy: string,
 |};
 
@@ -113,7 +87,6 @@ const SearchForm = ({
   initialQuery = '',
   initialWorkType = [],
   initialItemsLocationsLocationType = [],
-  showFilters,
   ariaDescribedBy,
 }: Props) => {
   const [query, setQuery] = useState(initialQuery);
@@ -199,74 +172,79 @@ const SearchForm = ({
         </SearchButtonWrapper>
       </div>
 
-      {showFilters && (
-        <Fragment>
-          <fieldset
-            className={classNames({
-              [spacing({ s: 1 }, { margin: ['top'] })]: true,
-            })}
-          >
-            <legend
-              className={classNames({
-                'float-l': true,
-                [spacing({ s: 1 }, { margin: ['right'] })]: true,
-                [font({ s: 'HNL4' })]: true,
-              })}
-              style={{ marginTop: '3px' }}
-            >
-              Filter by:
-            </legend>
-            <SearchTag
-              name={'workType'}
-              label="Images"
-              value="k,q"
-              checked={
-                workType.indexOf('k') !== -1 && workType.indexOf('q') !== -1
-              }
-              onChange={event => {
-                const input = event.currentTarget;
-                const newWorkType = input.checked
-                  ? [...workType, 'k', 'q']
-                  : workType.filter(val => val !== 'k' && val !== 'q');
-                setWorkType(newWorkType);
-              }}
-            />
-            <SearchTag
-              name={'workType'}
-              label="Books"
-              value="a"
-              checked={workType.indexOf('a') !== -1}
-              onChange={event => {
-                const input = event.currentTarget;
-                const newWorkType = input.checked
-                  ? [...workType, 'a']
-                  : workType.filter(val => val !== 'a');
-                setWorkType(newWorkType);
-              }}
-            />
-            <SearchTag
-              name={'items.locations.locationType'}
-              label="Online"
-              value="iiif-image,iiif-presentation"
-              checked={
-                itemsLocationsLocationType.indexOf('iiif-image') !== -1 &&
-                itemsLocationsLocationType.indexOf('iiif-presentation') !== -1
-              }
-              onChange={event => {
-                const input = event.currentTarget;
-                if (input.checked) {
-                  setItemsLocationsLocationType([
-                    'iiif-image',
-                    'iiif-presentation',
-                  ]);
-                } else {
-                  setItemsLocationsLocationType([]);
-                }
-              }}
-            />
-          </fieldset>
-        </Fragment>
-      )}
+      <TogglesContext.Consumer>
+        {({ showCatalogueSearchFilters }) =>
+          showCatalogueSearchFilters && (
+            <Fragment>
+              <fieldset
+                className={classNames({
+                  [spacing({ s: 1 }, { margin: ['top'] })]: true,
+                })}
+              >
+                <legend
+                  className={classNames({
+                    'float-l': true,
+                    [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                    [font({ s: 'HNL4' })]: true,
+                  })}
+                  style={{ marginTop: '3px' }}
+                >
+                  Filter by:
+                </legend>
+                <SearchTag
+                  name={'workType'}
+                  label="Images"
+                  value="k,q"
+                  checked={
+                    workType.indexOf('k') !== -1 && workType.indexOf('q') !== -1
+                  }
+                  onChange={event => {
+                    const input = event.currentTarget;
+                    const newWorkType = input.checked
+                      ? [...workType, 'k', 'q']
+                      : workType.filter(val => val !== 'k' && val !== 'q');
+                    setWorkType(newWorkType);
+                  }}
+                />
+                <SearchTag
+                  name={'workType'}
+                  label="Books"
+                  value="a"
+                  checked={workType.indexOf('a') !== -1}
+                  onChange={event => {
+                    const input = event.currentTarget;
+                    const newWorkType = input.checked
+                      ? [...workType, 'a']
+                      : workType.filter(val => val !== 'a');
+                    setWorkType(newWorkType);
+                  }}
+                />
+                <SearchTag
+                  name={'items.locations.locationType'}
+                  label="Online"
+                  value="iiif-image,iiif-presentation"
+                  checked={
+                    itemsLocationsLocationType.indexOf('iiif-image') !== -1 &&
+                    itemsLocationsLocationType.indexOf('iiif-presentation') !==
+                      -1
+                  }
+                  onChange={event => {
+                    const input = event.currentTarget;
+                    if (input.checked) {
+                      setItemsLocationsLocationType([
+                        'iiif-image',
+                        'iiif-presentation',
+                      ]);
+                    } else {
+                      setItemsLocationsLocationType([]);
+                    }
+                  }}
+                />
+              </fieldset>
+            </Fragment>
+          )
+        }
+      </TogglesContext.Consumer>
     </form>
   );
 };

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -30,7 +30,6 @@ type Props = {|
   page: ?number,
   itemsLocationsLocationType: string[],
   showWorkPageChanges: boolean,
-  showCatalogueSearchFilters: boolean,
 |};
 
 export const WorkPage = ({
@@ -40,7 +39,6 @@ export const WorkPage = ({
   workType,
   itemsLocationsLocationType,
   showWorkPageChanges,
-  showCatalogueSearchFilters,
 }: Props) => {
   if (work.type === 'Error') {
     return (
@@ -130,7 +128,6 @@ export const WorkPage = ({
                 initialQuery={query || ''}
                 initialWorkType={workType}
                 initialItemsLocationsLocationType={itemsLocationsLocationType}
-                showFilters={showCatalogueSearchFilters}
                 ariaDescribedBy="search-form-description"
               />
             </div>
@@ -228,10 +225,8 @@ WorkPage.getInitialProps = async (
 
   const { id, query, page } = ctx.query;
   const workOrError = await getWork({ id });
-  const showWorkPageChanges = Boolean(ctx.query.toggles.showWorkPageChanges);
-  const showCatalogueSearchFilters = Boolean(
-    ctx.query.toggles.showCatalogueSearchFilters
-  );
+
+  const { showWorkPageChanges = false } = ctx.query.toggles;
 
   if (workOrError && workOrError.type === 'Redirect') {
     const { res } = ctx;
@@ -252,7 +247,6 @@ WorkPage.getInitialProps = async (
       workType,
       itemsLocationsLocationType,
       showWorkPageChanges,
-      showCatalogueSearchFilters,
     };
   }
 };

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -147,7 +147,6 @@ export const Works = ({
                   initialQuery={query || ''}
                   initialWorkType={workType}
                   initialItemsLocationsLocationType={itemsLocationsLocationType}
-                  showFilters={showCatalogueSearchFilters}
                   ariaDescribedBy="search-form-description"
                 />
                 <p

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -10,6 +10,7 @@ import {
 import Icon from '../Icon/Icon';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import LinkLabels from '../LinkLabels/LinkLabels';
+import TogglesContext from '../TogglesContext/TogglesContext';
 
 type Props = {|
   work: Work,
@@ -90,33 +91,37 @@ const WorkHeader = ({ work }: Props) => {
             )}
           </div>
         )}
-
-        {(digitalLocations.length > 0 || physicalLocations.length > 0) && (
-          <div
-            className={classNames({
-              [spacing({ s: 2 }, { margin: ['top'] })]: true,
-            })}
-          >
-            <LinkLabels
-              heading={'See it'}
-              icon={'eye'}
-              items={[
-                digitalLocations.length > 0
-                  ? {
-                      text: 'Online',
-                      url: null,
-                    }
-                  : null,
-                physicalLocations.length > 0
-                  ? {
-                      text: 'Wellcome Library',
-                      url: null,
-                    }
-                  : null,
-              ].filter(Boolean)}
-            />
-          </div>
-        )}
+        <TogglesContext.Consumer>
+          {toggles =>
+            toggles.showWorkLocations &&
+            (digitalLocations.length > 0 || physicalLocations.length > 0) && (
+              <div
+                className={classNames({
+                  [spacing({ s: 2 }, { margin: ['top'] })]: true,
+                })}
+              >
+                <LinkLabels
+                  heading={'See it'}
+                  icon={'eye'}
+                  items={[
+                    digitalLocations.length > 0
+                      ? {
+                          text: 'Online',
+                          url: null,
+                        }
+                      : null,
+                    physicalLocations.length > 0
+                      ? {
+                          text: 'Wellcome Library',
+                          url: null,
+                        }
+                      : null,
+                  ].filter(Boolean)}
+                />
+              </div>
+            )
+          }
+        </TogglesContext.Consumer>
       </SpacingComponent>
     </div>
   );

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -45,6 +45,12 @@ const featureToggles = [
       ' Changes the layout/styling of the work details section and' +
       ' labels and groups the data in an attempt to make it easier to comprehend.',
   },
+  {
+    id: 'showWorkLocations',
+    title: 'Show the locations of a work in the header',
+    description:
+      'These can be either physical or digital locations. We need to do a little bt of work figuring out what all the codes mean to get the messaging right.',
+  },
 ];
 
 const IndexPage = () => {


### PR DESCRIPTION
Adding the work locations toggle to the header.

The discussion we had was that the header and the new metadata ordering is good to go.
One piece that potentially needs work is the work's locations #4043.

Instead of holding this up any more, we can release the header and metadata by removing the current `WorkPagesChanges` toggle.

