### PR TITLE
use moment to create dates on pharamacy of colour

### DIFF
--- a/common/data/the-pharmacy-of-colour.js
+++ b/common/data/the-pharmacy-of-colour.js
@@ -1,13 +1,14 @@
 // @flow
 import { type UiExhibition } from '../model/exhibitions';
+import { london } from '../utils/format-date';
 
 const data = ({
   type: 'exhibitions',
   id: 'XFximBAAAPkAioW7',
   title: 'The Pharmacy of Colour',
   description: [],
-  start: new Date('2018-07-23T23:00:00+0000'),
-  end: new Date('2019-02-17T23:00:00+0000'),
+  start: london('2018-07-23T23:00:00+0000').toDate(),
+  end: london('2019-02-17T23:00:00+0000').toDate(),
   body: [],
   standfirst: null,
   contributors: [],


### PR DESCRIPTION
We need to remember that not all browsers are equal when coming to dates, especially Safari.
This is why we use moment.

Having a strategy for this, and applying it universally would be nice.

Fixes this 👇 
![screenshot 2019-02-12 at 09 07 55](https://user-images.githubusercontent.com/31692/52624041-bacd2980-2ea5-11e9-9a44-f397351e27f6.png)
