### PR TITLE
add partof to exhibitions

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -437,14 +437,18 @@ export async function getExhibitionExhibits(
 }
 
 export async function getExhibitExhibition(
-  req: Request,
+  req: ?Request,
   exhibitId: string
 ): Promise<?UiExhibition> {
   const predicates = [
     Prismic.Predicates.at('my.exhibitions.exhibits.item', exhibitId),
   ];
   const apiResponse = await getDocuments(req, predicates, {
-    fetchLinks: peopleFields.concat(contributorsFields, placesFields),
+    fetchLinks: peopleFields.concat(
+      exhibitionFields,
+      contributorsFields,
+      placesFields
+    ),
   });
 
   if (apiResponse.results.length > 0) {

--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -1,4 +1,5 @@
 // @flow
+import { useEffect, useState } from 'react';
 import { exhibitionLd } from '@weco/common/utils/json-ld';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
@@ -15,12 +16,22 @@ import { getInfoItems } from '../Exhibition/Exhibition';
 import InfoBox from '@weco/common/views/components/InfoBox/InfoBox';
 import { font } from '@weco/common/utils/classnames';
 import { isPast } from '@weco/common/utils/dates';
+import { getExhibitExhibition } from '@weco/common/services/prismic/exhibitions';
 
 type Props = {|
   installation: UiExhibition,
 |};
 
 const Installation = ({ installation }: Props) => {
+  const [partOf, setPartOf] = useState(null);
+  useEffect(() => {
+    getExhibitExhibition(null, installation.id).then(partOf => {
+      if (partOf) {
+        setPartOf(partOf);
+      }
+    });
+  }, []);
+
   const FeaturedMedia = getFeaturedMedia({
     id: installation.id,
     title: installation.title,
@@ -43,12 +54,16 @@ const Installation = ({ installation }: Props) => {
       {
         text: 'Installations',
       },
+      partOf && {
+        url: `/exhibitions/${partOf.id}`,
+        text: partOf.title,
+      },
       {
         url: `/exhibitions/${installation.id}`,
         text: installation.title,
         isHidden: true,
       },
-    ],
+    ].filter(Boolean),
   };
 
   const Header = (

--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -57,6 +57,7 @@ const Installation = ({ installation }: Props) => {
       partOf && {
         url: `/exhibitions/${partOf.id}`,
         text: partOf.title,
+        prefix: 'Part of',
       },
       {
         url: `/exhibitions/${installation.id}`,


### PR DESCRIPTION
Alternative for #4120 

To be clear, the reason for not having to async calls for non-integral information on a page is latency. It's one of the least performant things, so even when calling to the same service, we double the latency, which feels like bloat that we can avoid with the common pattern of loading other content in asynchronously.

![screenshot 2019-02-13 at 08 41 25](https://user-images.githubusercontent.com/31692/52698330-2fb66700-2f6b-11e9-962c-162190782ced.png)

