### PR TITLE
Remove scroll to

### DIFF
--- a/common/styles/components/_image_viewer.scss
+++ b/common/styles/components/_image_viewer.scss
@@ -50,13 +50,8 @@
 .image-viewer__launch-button {
   position: absolute;
   bottom: 0;
-  right: $container-padding-s;
-  transform: translateX(-120%) translateY(50%);
-
-  @include respond-to('medium') {
-    right: 50%;
-    transform: translateX(50%) translateY(50%);
-  }
+  right: 50%;
+  transform: translateX(50%) translateY(50%);
 
   .icon {
     margin: 0;
@@ -70,20 +65,12 @@
 // react-transition-group classes
 .slideup-viewer-btn {
   opacity: 0;
-  transform: translateX(-120%) translateY(250%);
+  transform: translateX(50%) translateY(250%);
   transition: transform 700ms;
-
-  @include respond-to('medium') {
-    transform: translateX(50%) translateY(250%);
-  }
 }
 
 .slideup-viewer-btn-entered {
   opacity: 1;
-  transform: translateX(-120%) translateY(50%);
+  transform: translateX(50%) translateY(50%);
   transition: transform 700ms, opacity 700ms;
-
-  @include respond-to('medium') {
-    transform: translateX(50%) translateY(50%);
-  }
 }

--- a/common/views/components/WorkMedia/WorkMedia.js
+++ b/common/views/components/WorkMedia/WorkMedia.js
@@ -1,5 +1,4 @@
 // @flow
-import Control from '../Buttons/Control/Control';
 import {
   iiifImageTemplate,
   convertImageUri,
@@ -37,18 +36,6 @@ const WorkMedia = ({
           'bg-black': !isV2,
         })}
       >
-        <Control
-          type="dark"
-          extraClasses="scroll-to-info js-scroll-to-info js-work-media-control flush-container-right"
-          url="#work-info"
-          trackingEvent={{
-            category: 'Control',
-            action: 'scroll to work info',
-            label: id,
-          }}
-          icon="chevron"
-          text="Scroll to info"
-        />
         {/*  TODO pass <Image> here rather than pass props down? */}
         <ImageViewer
           infoUrl={imageInfoUrl}


### PR DESCRIPTION
We currently have a 'scroll to' control button on work pages (mobile view). However, it doesn't work well now we have the header on works.

Rather than apply a fix, this PR removes the control, as we're likely to be exploring in-page navigation that will supersede it and it's rarely used:

<img width="1142" alt="screenshot 2019-02-07 at 15 02 49" src="https://user-images.githubusercontent.com/6051896/52726781-c145c900-2fab-11e9-9102-64b348d53d2f.png">

Before:
<img width="525" alt="screen shot 2019-02-13 at 16 15 05" src="https://user-images.githubusercontent.com/6051896/52727243-b63f6880-2fac-11e9-9105-2c46689098f5.png">

After: 
<img width="510" alt="screen shot 2019-02-13 at 16 20 52" src="https://user-images.githubusercontent.com/6051896/52727284-c9523880-2fac-11e9-95ea-b5a6524f3a8b.png">


