### PR TITLE
add feedback message to search

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -62,8 +62,10 @@ const SearchTag = ({
         'flex-inline': true,
         'flex--v-center': true,
         pointer: true,
-        [spacing({ s: 1 }, { padding: ['left', 'right'] })]: true,
-        [spacing({ s: 1 }, { margin: ['left'] })]: true,
+        [spacing(
+          { s: 1 },
+          { padding: ['left', 'right'], margin: ['left'] }
+        )]: true,
         [font({ s: 'HNL3' })]: true,
       })}
       style={{ borderRadius: '3px' }}

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -237,19 +237,14 @@ const SearchForm = ({
                 <SearchTag
                   name={'items.locations.locationType'}
                   label="Online"
-                  value="iiif-image,iiif-presentation"
+                  value="iiif-image"
                   checked={
-                    itemsLocationsLocationType.indexOf('iiif-image') !== -1 &&
-                    itemsLocationsLocationType.indexOf('iiif-presentation') !==
-                      -1
+                    itemsLocationsLocationType.indexOf('iiif-image') !== -1
                   }
                   onChange={event => {
                     const input = event.currentTarget;
                     if (input.checked) {
-                      setItemsLocationsLocationType([
-                        'iiif-image',
-                        'iiif-presentation',
-                      ]);
+                      setItemsLocationsLocationType(['iiif-image']);
                     } else {
                       setItemsLocationsLocationType([]);
                     }

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -1,5 +1,5 @@
 // @flow
-import { Fragment, useState, useRef } from 'react';
+import { useState, useRef } from 'react';
 import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
@@ -63,7 +63,7 @@ const SearchTag = ({
         'flex--v-center': true,
         pointer: true,
         [spacing({ s: 1 }, { padding: ['left', 'right'] })]: true,
-        [spacing({ s: 1 }, { margin: ['right'] })]: true,
+        [spacing({ s: 1 }, { margin: ['left'] })]: true,
         [font({ s: 'HNL3' })]: true,
       })}
       style={{ borderRadius: '3px' }}
@@ -180,16 +180,26 @@ const SearchForm = ({
       <TogglesContext.Consumer>
         {({ showCatalogueSearchFilters }) =>
           showCatalogueSearchFilters && (
-            <Fragment>
+            <div
+              className={classNames({
+                flex: true,
+                'flex--wrap': true,
+                'flex--v-center': true,
+                [spacing({ s: 1 }, { margin: ['top'] })]: true,
+              })}
+            >
               <fieldset
                 className={classNames({
-                  [spacing({ s: 1 }, { margin: ['top'] })]: true,
+                  relative: true,
+                  [spacing({ s: 2 }, { margin: ['right'] })]: true,
                 })}
+                style={{
+                  left: '1px',
+                }}
               >
                 <legend
                   className={classNames({
                     'float-l': true,
-                    [spacing({ s: 1 }, { margin: ['right'] })]: true,
                     [font({ s: 'HNL4' })]: true,
                   })}
                   style={{ marginTop: '3px' }}
@@ -246,7 +256,23 @@ const SearchForm = ({
                   }}
                 />
               </fieldset>
-            </Fragment>
+              <p
+                className={classNames({
+                  [font({ s: 'HNL4' })]: true,
+                  'no-margin': true,
+                  relative: true,
+                })}
+                style={{
+                  left: '1px',
+                  flexGrow: 1,
+                }}
+              >
+                Our search is currently in beta.{' '}
+                <a href="https://www.surveymonkey.co.uk/r/W3NBWV2">
+                  Let us know what you think
+                </a>
+              </p>
+            </div>
           )
         }
       </TogglesContext.Consumer>

--- a/catalogue/webapp/components/WorkCompactCard.js/WorkCompactCard.js
+++ b/catalogue/webapp/components/WorkCompactCard.js/WorkCompactCard.js
@@ -4,6 +4,7 @@ import { type Work } from '@weco/common/model/work';
 import { classNames, spacing, font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import {
   getPhysicalLocations,
   getDigitalLocations,
@@ -115,11 +116,11 @@ const WorkCompactCard = ({
               <LinkLabels
                 items={work.contributors.map(({ agent }) => ({
                   text: agent.label,
-                  url: `/works?query="${agent.label}"`,
+                  url: null,
                 }))}
               />
             )}
-            {productionDates && (
+            {productionDates.length > 0 && (
               <div
                 className={classNames({
                   [spacing({ s: 2 }, { margin: ['left'] })]: true,
@@ -135,33 +136,37 @@ const WorkCompactCard = ({
               </div>
             )}
           </div>
-
-          {(digitalLocations.length > 0 || physicalLocations.length > 0) && (
-            <div
-              className={classNames({
-                [spacing({ s: 2 }, { margin: ['top'] })]: true,
-              })}
-            >
-              <LinkLabels
-                heading={'See it'}
-                icon={'eye'}
-                items={[
-                  digitalLocations.length > 0
-                    ? {
-                        text: 'Online',
-                        url: null,
-                      }
-                    : null,
-                  physicalLocations.length > 0
-                    ? {
-                        text: 'Wellcome Library',
-                        url: null,
-                      }
-                    : null,
-                ].filter(Boolean)}
-              />
-            </div>
-          )}
+          <TogglesContext.Consumer>
+            {({ showWorkLocations }) =>
+              showWorkLocations &&
+              (digitalLocations.length > 0 || physicalLocations.length > 0) && (
+                <div
+                  className={classNames({
+                    [spacing({ s: 2 }, { margin: ['top'] })]: true,
+                  })}
+                >
+                  <LinkLabels
+                    heading={'See it'}
+                    icon={'eye'}
+                    items={[
+                      digitalLocations.length > 0
+                        ? {
+                            text: 'Online',
+                            url: null,
+                          }
+                        : null,
+                      physicalLocations.length > 0
+                        ? {
+                            text: 'Wellcome Library',
+                            url: null,
+                          }
+                        : null,
+                    ].filter(Boolean)}
+                  />
+                </div>
+              )
+            }
+          </TogglesContext.Consumer>
         </a>
       </NextLink>
     </div>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -68,6 +68,16 @@ export const Works = ({
     );
   }
 
+  // This is very convoluted, but you can't do arry equality because, JavaScript
+  // e.g. itemsLocationsLocationType === ['iiif-image'] is always false.
+  const useImagelessResult =
+    showCatalogueSearchFilters &&
+    !(
+      workType.toString() === 'k,q' &&
+      itemsLocationsLocationType.length === 1 &&
+      itemsLocationsLocationType[0] === 'iiif-image'
+    );
+
   return (
     <Fragment>
       <Head>
@@ -228,7 +238,7 @@ export const Works = ({
             >
               <div className="container">
                 <div className="grid">
-                  {showCatalogueSearchFilters &&
+                  {useImagelessResult &&
                     works.results.map(result => (
                       <div
                         className={classNames({
@@ -247,7 +257,7 @@ export const Works = ({
                         />
                       </div>
                     ))}
-                  {!showCatalogueSearchFilters &&
+                  {!useImagelessResult &&
                     works.results.map(result => (
                       <div
                         key={result.id}
@@ -372,7 +382,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
     'items.locations.locationType' in ctx.query
       ? ctx.query['items.locations.locationType'].split(',')
       : showCatalogueSearchFilters
-      ? ['iiif-image', 'iiif-presentation']
+      ? ['iiif-image']
       : ['iiif-image'];
 
   const filters = {

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -56,7 +56,7 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
     )}
     {items.map(({ url, text }, i) => (
       <dd
-        key={url || text}
+        key={`${url || text}-${i}`}
         className={classNames({
           'no-margin': true,
         })}


### PR DESCRIPTION
Adds a message to the search to say we're in beta.
<img width="1260" alt="screenshot 2019-02-15 at 10 00 57" src="https://user-images.githubusercontent.com/31692/52850898-9c1c9c00-310c-11e9-8421-8c42e832ce2d.png">

---

When looking around at other `beta`s, there are quite a few that aren't opt in, they just have clear messaging to let people know things are in testing. Similar to [how gov.uk use beta](https://www.gov.uk/help/beta), and other services just label them as such (Github for example).
[e.g.](http://beta.charitycommission.gov.uk/charity-details/?regid=210183&subid=0)

In our case, if the person doesn't want to use the extra filters, they don't have to, and leaving the `Images` and `Online` filters checked (default) allows it to stay as it currently is. 

[I have created a not-for-release version of a feedback survey in Survey monkey](https://www.surveymonkey.co.uk/r/W3NBWV2). [Seems a pretty common pattern to just link off to another service](https://www.smartsurvey.co.uk/s/gov_uk?c=/&gcl=2029946722.1550227701). Survey Monkey is a tool we already use and can contibue to use from a GDPR perspective, but it needs to be the Wellcome account.

The two new checkboxes offer:
* Adding books to the results
* Searching for things that we don't have have a way of visually representing i.e. isn't a `iiif-image`.

---

The results look a little different to to account for works without thumbnails, I've run this past @GarethOrmerod, and we were happy, but could maybe do with some more work?
<img width="831" alt="screenshot 2019-02-15 at 10 15 03" src="https://user-images.githubusercontent.com/31692/52850088-9625bb80-310a-11e9-8543-b6773110a692.png">

TODO:
* tracking, [potentially this](https://github.com/wellcometrust/wellcomecollection.org/issues/4110#issuecomment-463963056)?
