### PR TITLE
More link position

### DIFF
--- a/cardigan/stories/components/SectionHeader.js
+++ b/cardigan/stories/components/SectionHeader.js
@@ -7,13 +7,9 @@ const stories = storiesOf('Components', module);
 
 const SectionHeaderExample = () => {
   const title = text('Title', 'You may have missed');
-  const linkText = text('Link text', 'More articles');
-  return (
-    <SectionHeader title={title} linkUrl='#' linkText={linkText} />
-  );
+  return <SectionHeader title={title} />;
 };
 
-stories
-  .add('Section header', SectionHeaderExample, {
-    info: Readme
-  });
+stories.add('Section header', SectionHeaderExample, {
+  info: Readme,
+});

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -18,7 +18,7 @@ type ContentTypes = UiEvent | UiExhibition | Book | Article;
 type Props = {|
   items: $ReadOnlyArray<ContentTypes>,
   hidePromoText?: boolean,
-  children: Node,
+  children?: Node,
 |};
 
 const CardGrid = ({ items, hidePromoText, children }: Props) => {

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -1,5 +1,4 @@
 // @flow
-import { type Node } from 'react';
 import { classNames, cssGrid, spacing } from '../../../utils/classnames';
 import ExhibitionPromo from '../ExhibitionPromo/ExhibitionPromo';
 import EventPromo from '../EventPromo/EventPromo';
@@ -7,6 +6,8 @@ import DailyTourPromo from '../DailyTourPromo/DailyTourPromo';
 import BookPromo from '../BookPromo/BookPromo';
 import Layout12 from '../Layout12/Layout12';
 import StoryPromo from '../StoryPromo/StoryPromo';
+import MoreLink from '../Links/MoreLink/MoreLink';
+import { type Link } from '../../../model/link';
 import { type UiExhibition } from '../../../model/exhibitions';
 import { type UiEvent } from '../../../model/events';
 import { type Book } from '../../../model/books';
@@ -18,9 +19,9 @@ type ContentTypes = UiEvent | UiExhibition | Book | Article;
 type Props = {|
   items: $ReadOnlyArray<ContentTypes>,
   hidePromoText?: boolean,
-  children?: Node,
   itemsPerRow: number,
   itemsHaveTransparentBackground?: boolean,
+  links?: Link[],
 |};
 
 const CardGrid = ({
@@ -28,7 +29,7 @@ const CardGrid = ({
   hidePromoText,
   itemsPerRow,
   itemsHaveTransparentBackground = false,
-  children,
+  links,
 }: Props) => {
   const gridColumns = itemsPerRow === 4 ? 3 : 4;
 
@@ -91,16 +92,22 @@ const CardGrid = ({
           ))}
         </div>
       </div>
-      <Layout12>
-        <div
-          className={classNames({
-            // TODO: update with inter-component spacing when it's formalised
-            [spacing({ s: 3 }, { margin: ['top'] })]: true,
-          })}
-        >
-          {children}
-        </div>
-      </Layout12>
+      {links && links.length > 0 && (
+        <Layout12>
+          <div
+            className={classNames({
+              // TODO: update with inter-component spacing when it's formalised
+              [spacing({ s: 3 }, { margin: ['top'] })]: true,
+            })}
+          >
+            {links.map(link => (
+              <div key={link.url}>
+                <MoreLink url={link.url} name={link.text} />
+              </div>
+            ))}
+          </div>
+        </Layout12>
+      )}
     </div>
   );
 };

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -94,6 +94,7 @@ const CardGrid = ({
       <Layout12>
         <div
           className={classNames({
+            // TODO: update with inter-component spacing when it's formalised
             [spacing({ s: 3 }, { margin: ['top'] })]: true,
           })}
         >

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -1,9 +1,11 @@
 // @flow
-import { classNames, cssGrid } from '../../../utils/classnames';
+import { type Node } from 'react';
+import { classNames, cssGrid, spacing } from '../../../utils/classnames';
 import ExhibitionPromo from '../ExhibitionPromo/ExhibitionPromo';
 import EventPromo from '../EventPromo/EventPromo';
 import DailyTourPromo from '../DailyTourPromo/DailyTourPromo';
 import BookPromo from '../BookPromo/BookPromo';
+import Layout12 from '../Layout12/Layout12';
 import StoryPromo from '../StoryPromo/StoryPromo';
 import { type UiExhibition } from '../../../model/exhibitions';
 import { type UiEvent } from '../../../model/events';
@@ -16,60 +18,72 @@ type ContentTypes = UiEvent | UiExhibition | Book | Article;
 type Props = {|
   items: $ReadOnlyArray<ContentTypes>,
   hidePromoText?: boolean,
+  children: Node,
 |};
 
-const CardGrid = ({ items, hidePromoText }: Props) => {
+const CardGrid = ({ items, hidePromoText, children }: Props) => {
   return (
-    <div className="css-grid__container">
-      <div className="css-grid">
-        {items.map((item, i) => (
-          <div
-            key={item.id}
-            className={classNames({
-              [cssGrid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
-            })}
-          >
-            {item.id === 'tours' && <DailyTourPromo />}
+    <div>
+      <div className="css-grid__container">
+        <div className="css-grid">
+          {items.map((item, i) => (
+            <div
+              key={item.id}
+              className={classNames({
+                [cssGrid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
+              })}
+            >
+              {item.id === 'tours' && <DailyTourPromo />}
 
-            {item.type === 'exhibitions' && (
-              // TODO: (remove Picture type)
-              // $FlowFixMe
-              <ExhibitionPromo
-                id={item.id}
-                url={`/exhibitions/${item.id}`}
-                title={item.title}
-                format={item.format}
+              {item.type === 'exhibitions' && (
                 // TODO: (remove Picture type)
                 // $FlowFixMe
-                image={item.promoImage}
-                start={!item.isPermanent ? item.start : null}
-                end={!item.isPermanent ? item.end : null}
-                statusOverride={item.statusOverride}
-                position={i}
-              />
-            )}
-            {item.id !== 'tours' && item.type === 'events' && (
-              <EventPromo event={item} position={i} />
-            )}
-            {item.type === 'articles' && (
-              <StoryPromo
-                item={item}
-                position={i}
-                hidePromoText={hidePromoText}
-              />
-            )}
-            {item.type === 'books' && (
-              <BookPromo
-                url={`/books/${item.id}`}
-                title={item.title}
-                subtitle={item.subtitle}
-                description={item.promoText}
-                image={item.cover}
-              />
-            )}
-          </div>
-        ))}
+                <ExhibitionPromo
+                  id={item.id}
+                  url={`/exhibitions/${item.id}`}
+                  title={item.title}
+                  format={item.format}
+                  // TODO: (remove Picture type)
+                  // $FlowFixMe
+                  image={item.promoImage}
+                  start={!item.isPermanent ? item.start : null}
+                  end={!item.isPermanent ? item.end : null}
+                  statusOverride={item.statusOverride}
+                  position={i}
+                />
+              )}
+              {item.id !== 'tours' && item.type === 'events' && (
+                <EventPromo event={item} position={i} />
+              )}
+              {item.type === 'articles' && (
+                <StoryPromo
+                  item={item}
+                  position={i}
+                  hidePromoText={hidePromoText}
+                />
+              )}
+              {item.type === 'books' && (
+                <BookPromo
+                  url={`/books/${item.id}`}
+                  title={item.title}
+                  subtitle={item.subtitle}
+                  description={item.promoText}
+                  image={item.cover}
+                />
+              )}
+            </div>
+          ))}
+        </div>
       </div>
+      <Layout12>
+        <div
+          className={classNames({
+            [spacing({ s: 3 }, { margin: ['top'] })]: true,
+          })}
+        >
+          {children}
+        </div>
+      </Layout12>
     </div>
   );
 };

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -19,9 +19,19 @@ type Props = {|
   items: $ReadOnlyArray<ContentTypes>,
   hidePromoText?: boolean,
   children?: Node,
+  itemsPerRow: number,
+  itemsHaveTransparentBackground?: boolean,
 |};
 
-const CardGrid = ({ items, hidePromoText, children }: Props) => {
+const CardGrid = ({
+  items,
+  hidePromoText,
+  itemsPerRow,
+  itemsHaveTransparentBackground = false,
+  children,
+}: Props) => {
+  const gridColumns = itemsPerRow === 4 ? 3 : 4;
+
   return (
     <div>
       <div className="css-grid__container">
@@ -30,7 +40,12 @@ const CardGrid = ({ items, hidePromoText, children }: Props) => {
             <div
               key={item.id}
               className={classNames({
-                [cssGrid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
+                [cssGrid({
+                  s: 12,
+                  m: 6,
+                  l: gridColumns,
+                  xl: gridColumns,
+                })]: true,
               })}
             >
               {item.id === 'tours' && <DailyTourPromo />}
@@ -60,6 +75,7 @@ const CardGrid = ({ items, hidePromoText, children }: Props) => {
                   item={item}
                   position={i}
                   hidePromoText={hidePromoText}
+                  hasTransparentBackground={itemsHaveTransparentBackground}
                 />
               )}
               {item.type === 'books' && (

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -183,7 +183,10 @@ class EventsByMonth extends Component<Props, State> {
                 </h2>
               </div>
             </div>
-            <CardGrid items={eventsInMonths[month.id].concat(dailyTourPromo)}>
+            <CardGrid
+              items={eventsInMonths[month.id].concat(dailyTourPromo)}
+              itemsPerRow={3}
+            >
               {this.props.children}
             </CardGrid>
           </div>

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -1,5 +1,6 @@
 // @flow
-import { type Node, Component } from 'react';
+
+import { Component } from 'react';
 import sortBy from 'lodash.sortby';
 import { london } from '../../../utils/format-date';
 import { getEarliestFutureDateRange } from '../../../utils/dates';
@@ -7,11 +8,12 @@ import { classNames, cssGrid, spacing } from '../../../utils/classnames';
 import SegmentedControl from '../SegmentedControl/SegmentedControl';
 import CardGrid from '../CardGrid/CardGrid';
 import { data as dailyTourPromo } from '../DailyTourPromo/DailyTourPromo';
-import type { UiEvent } from '../../../model/events';
+import { type UiEvent } from '../../../model/events';
+import { type Link } from '../../../model/link';
 
 type Props = {|
   events: UiEvent[],
-  children: Node,
+  links?: Link[],
 |};
 
 type State = {|
@@ -34,7 +36,7 @@ class EventsByMonth extends Component<Props, State> {
     activeId: null,
   };
   render() {
-    const { events } = this.props;
+    const { events, links } = this.props;
     const { activeId } = this.state;
 
     const monthsIndex = {
@@ -186,9 +188,8 @@ class EventsByMonth extends Component<Props, State> {
             <CardGrid
               items={eventsInMonths[month.id].concat(dailyTourPromo)}
               itemsPerRow={3}
-            >
-              {this.props.children}
-            </CardGrid>
+              links={links}
+            />
           </div>
         ))}
       </div>

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -1,17 +1,17 @@
 // @flow
-
+import { type Node, Component } from 'react';
 import sortBy from 'lodash.sortby';
-import { Component } from 'react';
 import { london } from '../../../utils/format-date';
 import { getEarliestFutureDateRange } from '../../../utils/dates';
 import { classNames, cssGrid, spacing } from '../../../utils/classnames';
 import SegmentedControl from '../SegmentedControl/SegmentedControl';
-import EventPromo from '../EventPromo/EventPromo';
-import DailyTourPromo from '../DailyTourPromo/DailyTourPromo';
+import CardGrid from '../CardGrid/CardGrid';
+import { data as dailyTourPromo } from '../DailyTourPromo/DailyTourPromo';
 import type { UiEvent } from '../../../model/events';
 
 type Props = {|
   events: UiEvent[],
+  children: Node,
 |};
 
 type State = {|
@@ -129,7 +129,7 @@ class EventsByMonth extends Component<Props, State> {
     });
 
     return (
-      <div className={classNames({})}>
+      <div>
         <div
           className={classNames({
             [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
@@ -183,32 +183,9 @@ class EventsByMonth extends Component<Props, State> {
                 </h2>
               </div>
             </div>
-            <div className="css-grid__container">
-              <div className="css-grid">
-                {eventsInMonths[month.id].map((event, i) => (
-                  <div
-                    key={event.id}
-                    className={classNames({
-                      [cssGrid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
-                    })}
-                  >
-                    <EventPromo
-                      event={event}
-                      position={i}
-                      fromDate={london({ M: monthsIndex[month.text] })}
-                    />
-                  </div>
-                ))}
-                <div
-                  key={`${month.id}-daily-tour`}
-                  className={classNames({
-                    [cssGrid({ s: 12, m: 6, l: 4, xl: 4 })]: true,
-                  })}
-                >
-                  <DailyTourPromo />
-                </div>
-              </div>
-            </div>
+            <CardGrid items={eventsInMonths[month.id].concat(dailyTourPromo)}>
+              {this.props.children}
+            </CardGrid>
           </div>
         ))}
       </div>

--- a/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents.js
+++ b/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents.js
@@ -31,6 +31,10 @@ const ExhibitionsAndEvents = ({
     extras
   );
 
-  return <CardGrid items={items}>{children}</CardGrid>;
+  return (
+    <CardGrid items={items} itemsPerRow={3}>
+      {children}
+    </CardGrid>
+  );
 };
 export default ExhibitionsAndEvents;

--- a/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents.js
+++ b/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents.js
@@ -1,22 +1,23 @@
 // @flow
-import { type Node } from 'react';
+
 import CardGrid from '../CardGrid/CardGrid';
 import { data as dailyTourPromoData } from '../DailyTourPromo/DailyTourPromo';
 import type { UiExhibition } from '../../../model/exhibitions';
-import type { UiEvent } from '../../../model/events';
+import { type UiEvent } from '../../../model/events';
+import { type Link } from '../../../model/link';
 
 type Props = {|
   exhibitions: UiExhibition[],
   events: UiEvent[],
   extras?: (UiExhibition | UiEvent)[],
-  children: Node,
+  links?: Link[],
 |};
 
 const ExhibitionsAndEvents = ({
   exhibitions,
   events,
   extras = [],
-  children,
+  links,
 }: Props) => {
   const permanentExhibitions = exhibitions.filter(
     exhibition => exhibition.isPermanent
@@ -31,10 +32,6 @@ const ExhibitionsAndEvents = ({
     extras
   );
 
-  return (
-    <CardGrid items={items} itemsPerRow={3}>
-      {children}
-    </CardGrid>
-  );
+  return <CardGrid items={items} itemsPerRow={3} links={links} />;
 };
 export default ExhibitionsAndEvents;

--- a/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents.js
+++ b/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents.js
@@ -1,4 +1,5 @@
 // @flow
+import { type Node } from 'react';
 import CardGrid from '../CardGrid/CardGrid';
 import { data as dailyTourPromoData } from '../DailyTourPromo/DailyTourPromo';
 import type { UiExhibition } from '../../../model/exhibitions';
@@ -8,9 +9,15 @@ type Props = {|
   exhibitions: UiExhibition[],
   events: UiEvent[],
   extras?: (UiExhibition | UiEvent)[],
+  children: Node,
 |};
 
-const ExhibitionsAndEvents = ({ exhibitions, events, extras = [] }: Props) => {
+const ExhibitionsAndEvents = ({
+  exhibitions,
+  events,
+  extras = [],
+  children,
+}: Props) => {
   const permanentExhibitions = exhibitions.filter(
     exhibition => exhibition.isPermanent
   );
@@ -24,6 +31,6 @@ const ExhibitionsAndEvents = ({ exhibitions, events, extras = [] }: Props) => {
     extras
   );
 
-  return <CardGrid items={items} />;
+  return <CardGrid items={items}>{children}</CardGrid>;
 };
 export default ExhibitionsAndEvents;

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -121,7 +121,7 @@ const LayoutPaginatedResults = ({
       )}
 
       <div className={spacing({ s: 4 }, { margin: ['top'] })}>
-        <CardGrid items={paginatedResults.results} />
+        <CardGrid items={paginatedResults.results} itemsPerRow={3} />
       </div>
 
       {paginatedResults.totalPages > 1 && (

--- a/common/views/components/SectionHeader/README.md
+++ b/common/views/components/SectionHeader/README.md
@@ -1,3 +1,3 @@
-A `SectionHeader` is visually comprised of a dashed divider above a title and an optional `MoreLink`.
+## Purpose
 
-It should be used to separate sections of promos, where the `MoreLink` would link to more of the type of promos listed.
+To separate page sections.

--- a/common/views/components/SectionHeader/SectionHeader.js
+++ b/common/views/components/SectionHeader/SectionHeader.js
@@ -1,20 +1,17 @@
 // @flow
-import { spacing, grid, font, classNames } from '../../../utils/classnames';
+import { spacing, grid, font } from '../../../utils/classnames';
 import Divider from '../Divider/Divider';
-import MoreLink from '../Links/MoreLink/MoreLink';
 
 type Props = {|
   title: string,
-  linkText?: string,
-  linkUrl?: string,
 |};
 
 // TODO: Allow the component to take a MoreLink as a prop
 // (not possible while we're using it in Nunjucks land).
 
-const SectionHeader = ({ title, linkText, linkUrl }: Props) => {
+const SectionHeader = ({ title }: Props) => {
   return (
-    <div className={`row ${spacing({ s: 6 }, { margin: ['bottom'] })}`}>
+    <div className={`row`}>
       <div className="container">
         <div className="grid">
           <div
@@ -26,35 +23,10 @@ const SectionHeader = ({ title, linkText, linkUrl }: Props) => {
             <Divider extraClasses="divider--dashed" />
           </div>
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div
-              className={`${spacing(
-                { s: 1, l: 4 },
-                { margin: ['bottom'] }
-              )} flex-l-up flex--v-end flex--h-space-between`}
-            >
-              <h2
-                className={`${font({ s: 'WB5', m: 'WB4' })} ${spacing(
-                  { l: 1 },
-                  { padding: ['right'] }
-                )} ${spacing({ s: 0 }, { margin: ['top'] })} ${spacing(
-                  { s: 0 },
-                  { margin: ['bottom'] }
-                )}`}
-              >
+            <div>
+              <h2 className={`no-margin ${font({ s: 'WB5', m: 'WB4' })}`}>
                 {title}
               </h2>
-              {linkText && linkUrl && (
-                <MoreLink name={linkText} url={linkUrl} />
-              )}
-              {linkText && !linkUrl && (
-                <span
-                  className={classNames({
-                    [font({ s: 'HNM5', m: 'HNM4' })]: true,
-                  })}
-                >
-                  {linkText}
-                </span>
-              )}
             </div>
           </div>
         </div>

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -19,12 +19,15 @@ import { exhibitionLd, eventLd, articleLd } from '@weco/common/utils/json-ld';
 import StoryPromo from '@weco/common/views/components/StoryPromo/StoryPromo';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import ExhibitionsAndEvents from '@weco/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents';
+import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
+import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import type { UiExhibition } from '@weco/common/model/exhibitions';
-import type { UiEvent } from '@weco/common/model/events';
-import type { Article } from '@weco/common/model/articles';
-import type { PaginatedResults } from '@weco/common/services/prismic/types';
+import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import { type UiExhibition } from '@weco/common/model/exhibitions';
+import { type UiEvent } from '@weco/common/model/events';
+import { type Article } from '@weco/common/model/articles';
+import { type PaginatedResults } from '@weco/common/services/prismic/types';
 
 type Props = {|
   exhibitions: PaginatedResults<UiExhibition>,
@@ -111,45 +114,51 @@ export class HomePage extends Component<Props> {
         </SpacingSection>
 
         <SpacingSection>
-          <SectionHeader
-            title="This week at Wellcome Collection"
-            linkText="All exhibitions and events"
-            linkUrl="/whats-on"
-          />
-          <ExhibitionsAndEvents
-            exhibitions={exhibitions}
-            events={orderEventsByNextAvailableDate(
-              filterEventsForNext7Days(events)
-            )}
-          />
+          <SpacingComponent>
+            <SectionHeader title="This week at Wellcome Collection" />
+          </SpacingComponent>
+          <SpacingComponent>
+            <ExhibitionsAndEvents
+              exhibitions={exhibitions}
+              events={orderEventsByNextAvailableDate(
+                filterEventsForNext7Days(events)
+              )}
+            />
+            <Layout12>
+              <MoreLink name={`All exhibitions and events`} url={`/whats-on`} />
+            </Layout12>
+          </SpacingComponent>
         </SpacingSection>
 
         <SpacingSection>
-          <SectionHeader
-            title="Latest articles, comics and more"
-            linkText="All stories"
-            linkUrl="/stories"
-          />
-          <div className="css-grid__container">
-            <div className="css-grid">
-              {articles.results.map((article, i) => {
-                return (
-                  <div
-                    key={article.id}
-                    className={classNames({
-                      [cssGrid({ s: 12, m: 6, l: 3, xl: 3 })]: true,
-                    })}
-                  >
-                    <StoryPromo
-                      item={article}
-                      position={i}
-                      hasTransparentBackground={true}
-                    />
-                  </div>
-                );
-              })}
+          <SpacingComponent>
+            <SectionHeader title="Latest articles, comics and more" />
+          </SpacingComponent>
+          <SpacingComponent>
+            <div className="css-grid__container">
+              <div className="css-grid">
+                {articles.results.map((article, i) => {
+                  return (
+                    <div
+                      key={article.id}
+                      className={classNames({
+                        [cssGrid({ s: 12, m: 6, l: 3, xl: 3 })]: true,
+                      })}
+                    >
+                      <StoryPromo
+                        item={article}
+                        position={i}
+                        hasTransparentBackground={true}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
             </div>
-          </div>
+            <Layout12>
+              <MoreLink name={`All stories`} url={`/stories`} />
+            </Layout12>
+          </SpacingComponent>
         </SpacingSection>
       </PageLayout>
     );

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -19,7 +19,6 @@ import { exhibitionLd, eventLd, articleLd } from '@weco/common/utils/json-ld';
 import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import ExhibitionsAndEvents from '@weco/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents';
-import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
@@ -122,9 +121,8 @@ export class HomePage extends Component<Props> {
               events={orderEventsByNextAvailableDate(
                 filterEventsForNext7Days(events)
               )}
-            >
-              <MoreLink name={`All exhibitions and events`} url={`/whats-on`} />
-            </ExhibitionsAndEvents>
+              links={[{ text: 'All exhibitions and events', url: '/whats-on' }]}
+            />
           </SpacingComponent>
         </SpacingSection>
 
@@ -137,9 +135,8 @@ export class HomePage extends Component<Props> {
               items={articles.results}
               itemsPerRow={4}
               itemsHaveTransparentBackground={true}
-            >
-              <MoreLink name={`All stories`} url={`/stories`} />
-            </CardGrid>
+              links={[{ text: 'All stories', url: '/stories' }]}
+            />
           </SpacingComponent>
         </SpacingSection>
       </PageLayout>

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -16,14 +16,13 @@ import {
 import { getArticles } from '@weco/common/services/prismic/articles';
 import { convertJsonToDates } from './event';
 import { exhibitionLd, eventLd, articleLd } from '@weco/common/utils/json-ld';
-import StoryPromo from '@weco/common/views/components/StoryPromo/StoryPromo';
+import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
 import ExhibitionsAndEvents from '@weco/common/views/components/ExhibitionsAndEvents/ExhibitionsAndEvents';
 import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { type UiExhibition } from '@weco/common/model/exhibitions';
 import { type UiEvent } from '@weco/common/model/events';
 import { type Article } from '@weco/common/model/articles';
@@ -130,34 +129,17 @@ export class HomePage extends Component<Props> {
         </SpacingSection>
 
         <SpacingSection>
-          {/* TODO: use card grid? */}
           <SpacingComponent>
             <SectionHeader title="Latest articles, comics and more" />
           </SpacingComponent>
           <SpacingComponent>
-            <div className="css-grid__container">
-              <div className="css-grid">
-                {articles.results.map((article, i) => {
-                  return (
-                    <div
-                      key={article.id}
-                      className={classNames({
-                        [cssGrid({ s: 12, m: 6, l: 3, xl: 3 })]: true,
-                      })}
-                    >
-                      <StoryPromo
-                        item={article}
-                        position={i}
-                        hasTransparentBackground={true}
-                      />
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-            <Layout12>
+            <CardGrid
+              items={articles.results}
+              itemsPerRow={4}
+              itemsHaveTransparentBackground={true}
+            >
               <MoreLink name={`All stories`} url={`/stories`} />
-            </Layout12>
+            </CardGrid>
           </SpacingComponent>
         </SpacingSection>
       </PageLayout>

--- a/content/webapp/pages/homepage.js
+++ b/content/webapp/pages/homepage.js
@@ -123,14 +123,14 @@ export class HomePage extends Component<Props> {
               events={orderEventsByNextAvailableDate(
                 filterEventsForNext7Days(events)
               )}
-            />
-            <Layout12>
+            >
               <MoreLink name={`All exhibitions and events`} url={`/whats-on`} />
-            </Layout12>
+            </ExhibitionsAndEvents>
           </SpacingComponent>
         </SpacingSection>
 
         <SpacingSection>
+          {/* TODO: use card grid? */}
           <SpacingComponent>
             <SectionHeader title="Latest articles, comics and more" />
           </SpacingComponent>

--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -229,11 +229,10 @@ export class StoriesPage extends Component<Props> {
             <SectionHeader title="You may have missed" />
           </SpacingComponent>
           <SpacingComponent>
-            <CardGrid items={articles.slice(5, 11)} />
+            <CardGrid items={articles.slice(5, 11)}>
+              <MoreLink name={`More articles`} url={`/articles`} />
+            </CardGrid>
           </SpacingComponent>
-          <Layout12>
-            <MoreLink name={`More articles`} url={`/articles`} />
-          </Layout12>
         </SpacingSection>
       </PageLayout>
     );

--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -8,6 +8,7 @@ import { articleLd } from '@weco/common/utils/json-ld';
 import { classNames, spacing, grid, font } from '@weco/common/utils/classnames';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import StoryPromoFeatured from '@weco/common/views/components/StoryPromoFeatured/StoryPromoFeatured';
+import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
 import StoryPromo from '@weco/common/views/components/StoryPromo/StoryPromo';
 import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -17,6 +18,7 @@ import type { Article } from '@weco/common/model/articles';
 import type { ArticleSeries } from '@weco/common/model/article-series';
 import type { PaginatedResults } from '@weco/common/services/prismic/types';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
+import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 type Props = {|
   articles: PaginatedResults<Article>,
   series: ArticleSeries,
@@ -223,13 +225,15 @@ export class StoriesPage extends Component<Props> {
         </SpacingSection>
 
         <SpacingSection>
-          <SectionHeader
-            title="You may have missed"
-            linkText="More articles"
-            linkUrl="/articles"
-          />
-
-          <CardGrid items={articles.slice(5, 11)} />
+          <SpacingComponent>
+            <SectionHeader title="You may have missed" />
+          </SpacingComponent>
+          <SpacingComponent>
+            <CardGrid items={articles.slice(5, 11)} />
+          </SpacingComponent>
+          <Layout12>
+            <MoreLink name={`More articles`} url={`/articles`} />
+          </Layout12>
         </SpacingSection>
       </PageLayout>
     );

--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -8,7 +8,6 @@ import { articleLd } from '@weco/common/utils/json-ld';
 import { classNames, spacing, grid, font } from '@weco/common/utils/classnames';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import StoryPromoFeatured from '@weco/common/views/components/StoryPromoFeatured/StoryPromoFeatured';
-import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
 import StoryPromo from '@weco/common/views/components/StoryPromo/StoryPromo';
 import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -229,9 +228,11 @@ export class StoriesPage extends Component<Props> {
             <SectionHeader title="You may have missed" />
           </SpacingComponent>
           <SpacingComponent>
-            <CardGrid items={articles.slice(5, 11)} itemsPerRow={3}>
-              <MoreLink name={`More articles`} url={`/articles`} />
-            </CardGrid>
+            <CardGrid
+              items={articles.slice(5, 11)}
+              itemsPerRow={3}
+              links={[{ text: 'More articles', url: '/articles' }]}
+            />
           </SpacingComponent>
         </SpacingSection>
       </PageLayout>

--- a/content/webapp/pages/stories.js
+++ b/content/webapp/pages/stories.js
@@ -68,7 +68,7 @@ const SerialisedSeries = ({ series }: any) => {
           </div>
         </div>
       </Layout12>
-      <CardGrid items={series.items} hidePromoText={true} />
+      <CardGrid items={series.items} hidePromoText={true} itemsPerRow={3} />
     </div>
   );
 };
@@ -229,7 +229,7 @@ export class StoriesPage extends Component<Props> {
             <SectionHeader title="You may have missed" />
           </SpacingComponent>
           <SpacingComponent>
-            <CardGrid items={articles.slice(5, 11)}>
+            <CardGrid items={articles.slice(5, 11)} itemsPerRow={3}>
               <MoreLink name={`More articles`} url={`/articles`} />
             </CardGrid>
           </SpacingComponent>

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -38,12 +38,13 @@ import ExhibitionsAndEvents from '@weco/common/views/components/ExhibitionsAndEv
 import FacilityPromo from '@weco/common/views/components/FacilityPromo/FacilityPromo';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import OpeningTimesContext from '@weco/common/views/components/OpeningTimesContext/OpeningTimesContext';
+import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import { exhibitionLd, eventLd } from '@weco/common/utils/json-ld';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
-import type { UiExhibition } from '@weco/common/model/exhibitions';
-import type { UiEvent } from '@weco/common/model/events';
-import type { Period } from '@weco/common/model/periods';
-import type { PaginatedResults } from '@weco/common/services/prismic/types';
+import { type UiExhibition } from '@weco/common/model/exhibitions';
+import { type UiEvent } from '@weco/common/model/events';
+import { type Period } from '@weco/common/model/periods';
+import { type PaginatedResults } from '@weco/common/services/prismic/types';
 
 type Props = {|
   exhibitions: PaginatedResults<UiExhibition>,
@@ -399,33 +400,26 @@ export class WhatsOnPage extends Component<Props> {
                         <CardGrid items={exhibitions} />
 
                         <Layout12>
-                          <div
-                            className={spacing({ s: 3 }, { margin: ['top'] })}
-                          >
-                            <MoreLink
-                              name={'View all exhibitions'}
-                              url={'/exhibitions'}
-                            />
-                          </div>
+                          <MoreLink
+                            name={'View all exhibitions'}
+                            url={'/exhibitions'}
+                          />
                         </Layout12>
                       </SpacingSection>
 
                       <SpacingSection>
-                        <SectionHeader
-                          title={'Events'}
-                          linkText={'Free admission'}
-                        />
-                        <EventsByMonth events={events} />
-                        <Layout12>
-                          <div
-                            className={spacing({ s: 3 }, { margin: ['top'] })}
-                          >
+                        <SpacingComponent>
+                          <SectionHeader title={'Events'} />
+                        </SpacingComponent>
+                        <SpacingComponent>
+                          <EventsByMonth events={events} />
+                          <Layout12>
                             <MoreLink
                               name={'View all events'}
                               url={'/events'}
                             />
-                          </div>
-                        </Layout12>
+                          </Layout12>
+                        </SpacingComponent>
                       </SpacingSection>
                     </div>
                   </Fragment>
@@ -495,41 +489,51 @@ export class WhatsOnPage extends Component<Props> {
               </div>
 
               <SpacingSection>
-                <SectionHeader title="Try these too" />
-
-                <div className="css-grid__container">
-                  <div
-                    className={classNames({
-                      'css-grid': true,
-                    })}
-                  >
+                <SpacingComponent>
+                  <SectionHeader title="Try these too" />
+                </SpacingComponent>
+                <SpacingComponent>
+                  <div className="css-grid__container">
                     <div
                       className={classNames({
-                        'css-grid__scroll-container container--scroll touch-scroll': true,
-                        [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
+                        'css-grid': true,
                       })}
                     >
-                      <div className="css-grid grid--scroll">
-                        {tryTheseTooPromos.concat(eatShopPromos).map(promo => (
-                          <div
-                            key={promo.id}
-                            className={cssGrid({ s: 12, m: 6, l: 3, xl: 3 })}
-                          >
-                            <FacilityPromo
-                              id={promo.id}
-                              title={promo.title}
-                              url={promo.url}
-                              description={promo.description}
-                              imageProps={promo.image}
-                              metaText={promo.metaText}
-                              metaIcon={promo.metaIcon}
-                            />
-                          </div>
-                        ))}
+                      <div
+                        className={classNames({
+                          'css-grid__scroll-container container--scroll touch-scroll': true,
+                          [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
+                        })}
+                      >
+                        <div className="css-grid grid--scroll">
+                          {tryTheseTooPromos
+                            .concat(eatShopPromos)
+                            .map(promo => (
+                              <div
+                                key={promo.id}
+                                className={cssGrid({
+                                  s: 12,
+                                  m: 6,
+                                  l: 3,
+                                  xl: 3,
+                                })}
+                              >
+                                <FacilityPromo
+                                  id={promo.id}
+                                  title={promo.title}
+                                  url={promo.url}
+                                  description={promo.description}
+                                  imageProps={promo.image}
+                                  metaText={promo.metaText}
+                                  metaIcon={promo.metaIcon}
+                                />
+                              </div>
+                            ))}
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
+                </SpacingComponent>
               </SpacingSection>
             </Fragment>
           )}

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -397,14 +397,12 @@ export class WhatsOnPage extends Component<Props> {
                           </div>
                         </Layout12>
 
-                        <CardGrid items={exhibitions} />
-
-                        <Layout12>
+                        <CardGrid items={exhibitions}>
                           <MoreLink
                             name={'View all exhibitions'}
                             url={'/exhibitions'}
                           />
-                        </Layout12>
+                        </CardGrid>
                       </SpacingSection>
 
                       <SpacingSection>
@@ -412,13 +410,12 @@ export class WhatsOnPage extends Component<Props> {
                           <SectionHeader title={'Events'} />
                         </SpacingComponent>
                         <SpacingComponent>
-                          <EventsByMonth events={events} />
-                          <Layout12>
+                          <EventsByMonth events={events}>
                             <MoreLink
                               name={'View all events'}
                               url={'/events'}
                             />
-                          </Layout12>
+                          </EventsByMonth>
                         </SpacingComponent>
                       </SpacingSection>
                     </div>
@@ -469,21 +466,14 @@ export class WhatsOnPage extends Component<Props> {
                           ? filterEventsForWeekend(events)
                           : events
                       }
-                    />
-                    <div
-                      className={classNames({
-                        [spacing({ s: 4 }, { margin: ['top'] })]: true,
-                      })}
                     >
-                      <Layout12>
-                        <MoreLink
-                          name={'View all exhibitions'}
-                          url={'/exhibitions'}
-                        />
-                        <br />
-                        <MoreLink name={'View all events'} url={'/events'} />
-                      </Layout12>
-                    </div>
+                      <MoreLink
+                        name={'View all exhibitions'}
+                        url={'/exhibitions'}
+                      />
+                      <br />
+                      <MoreLink name={'View all events'} url={'/events'} />
+                    </ExhibitionsAndEvents>
                   </Fragment>
                 )}
               </div>

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -27,7 +27,6 @@ import {
 } from '@weco/common/data/facility-promos';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import SegmentedControl from '@weco/common/views/components/SegmentedControl/SegmentedControl';
-import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
 import CardGrid from '@weco/common/views/components/CardGrid/CardGrid';
 import EventsByMonth from '@weco/common/views/components/EventsByMonth/EventsByMonth';
 import SectionHeader from '@weco/common/views/components/SectionHeader/SectionHeader';
@@ -397,12 +396,16 @@ export class WhatsOnPage extends Component<Props> {
                           </div>
                         </Layout12>
 
-                        <CardGrid items={exhibitions} itemsPerRow={3}>
-                          <MoreLink
-                            name={'View all exhibitions'}
-                            url={'/exhibitions'}
-                          />
-                        </CardGrid>
+                        <CardGrid
+                          items={exhibitions}
+                          itemsPerRow={3}
+                          links={[
+                            {
+                              text: 'View all exhibitions',
+                              url: '/exhibitions',
+                            },
+                          ]}
+                        />
                       </SpacingSection>
 
                       <SpacingSection>
@@ -410,19 +413,19 @@ export class WhatsOnPage extends Component<Props> {
                           <SectionHeader title={'Events'} />
                         </SpacingComponent>
                         <SpacingComponent>
-                          <EventsByMonth events={events}>
-                            <MoreLink
-                              name={'View all events'}
-                              url={'/events'}
-                            />
-                          </EventsByMonth>
+                          <EventsByMonth
+                            events={events}
+                            links={[
+                              { text: 'View all events', url: '/events' },
+                            ]}
+                          />
                         </SpacingComponent>
                       </SpacingSection>
                     </div>
                   </Fragment>
                 )}
                 {period !== 'current-and-coming-up' && (
-                  <Fragment>
+                  <SpacingSection>
                     <div
                       className={classNames({
                         [spacing(
@@ -466,15 +469,12 @@ export class WhatsOnPage extends Component<Props> {
                           ? filterEventsForWeekend(events)
                           : events
                       }
-                    >
-                      <MoreLink
-                        name={'View all exhibitions'}
-                        url={'/exhibitions'}
-                      />
-                      <br />
-                      <MoreLink name={'View all events'} url={'/events'} />
-                    </ExhibitionsAndEvents>
-                  </Fragment>
+                      links={[
+                        { text: 'View all exhibitions', url: '/exhibitions' },
+                        { text: 'View all events', url: '/events' },
+                      ]}
+                    />
+                  </SpacingSection>
                 )}
               </div>
 

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -397,7 +397,7 @@ export class WhatsOnPage extends Component<Props> {
                           </div>
                         </Layout12>
 
-                        <CardGrid items={exhibitions}>
+                        <CardGrid items={exhibitions} itemsPerRow={3}>
                           <MoreLink
                             name={'View all exhibitions'}
                             url={'/exhibitions'}


### PR DESCRIPTION
Move `MoreLink`s out of `SectionHeader`s to be below the block of promos that follows.

Rationalising more of our inter-/intra-component spacing in the process.

![screenshot 2019-02-15 at 11 13 33](https://user-images.githubusercontent.com/1394592/52853441-8e1e4980-3113-11e9-99f9-39bdebc8e943.png)
