### PR TITLE
Prevent touch-actions on a and button elements in Openseadragon viewer

### DIFF
--- a/common/styles/components/_image_viewer.scss
+++ b/common/styles/components/_image_viewer.scss
@@ -20,7 +20,12 @@
 .image-viewer__controls {
   // TODO: keep an eye on https://github.com/openseadragon/openseadragon/issues/1586
   // for a less heavy handed solution to Openseadragon breaking on touch events
-  touch-action: none;
+  &,
+  button,
+  a {
+    touch-action: none;
+  }
+
   height: 3em;
 
   .icon {


### PR DESCRIPTION
A bit of a punt to reduce the noise we're getting in Sentry along the lines of `Cannot read property 'minus' of undefined`. The problem is with Openseadragon, and seems to have to do with touch events.

Preventing touch actions on the element that contains the controls for the viewer didn't prevent the errors, so this PR adds them to the `Control` elements within that area as well. This seems to be the approach taken on the example at the top of the [Openseadragon homepage](https://openseadragon.github.io/).