### PR TITLE
Don’t display :before pseudo element when gallery is active

### DIFF
--- a/common/styles/components/_image_gallery_v2.scss
+++ b/common/styles/components/_image_gallery_v2.scss
@@ -26,6 +26,9 @@ $image-gallery-v2-transition-properties: 400ms ease;
 
     .captioned-image__image-container {
       background: color('charcoal');
+      &:before {
+        display: none;
+      }
       &:hover:before {
         opacity: 0;
       }


### PR DESCRIPTION
The pseudo element we use to create the hover effect on the first item of an inline gallery, is preventing the correct context menu from showing if the user right clicks above any image in the gallery.

No 'Save Image as...', 'Copy Image' etc.
![right-click-image](https://user-images.githubusercontent.com/6051896/52873199-5b417900-3146-11e9-9fca-ea32a6d4e121.jpg)

This fixes that
