### PR TITLE
Gallery close a11y

### DIFF
--- a/common/styles/components/_image_gallery_v2.scss
+++ b/common/styles/components/_image_gallery_v2.scss
@@ -78,13 +78,18 @@ $image-gallery-v2-transition-properties: 400ms ease;
 }
 
 .image-gallery-v2__close-wrapper {
-  top: $image-gallery-v2-clip-height-s;
-  bottom: 0;
-  width: 100%;
-  pointer-events: none;
+  display: none;
 
-  @include respond-to('medium') {
-    top: $image-gallery-v2-clip-height-m;
+  .enhanced & {
+    display: inherit;
+    top: $image-gallery-v2-clip-height-s;
+    bottom: 0;
+    width: 100%;
+    pointer-events: none;
+
+    @include respond-to('medium') {
+      top: $image-gallery-v2-clip-height-m;
+    }
   }
 }
 

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -452,6 +452,10 @@
   @include visually-hidden;
 }
 
+.opacity-0 {
+  opacity: 0;
+}
+
 .hidden {
   visibility: hidden;
 }

--- a/common/views/components/Buttons/Button/Button.js
+++ b/common/views/components/Buttons/Button/Button.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { forwardRef } from 'react';
 import type { GaEvent } from '../../../../utils/ga';
 import { trackEvent } from '../../../../utils/ga';
 import { font } from '../../../../utils/classnames';
@@ -17,55 +18,71 @@ type Props = {|
   target?: string,
   download?: string,
   rel?: string,
+  ariaControls?: string,
+  ariaExpanded?: boolean,
   clickHandler?: (event: Event) => void,
 |};
 
-const Button = ({
-  url,
-  type,
-  id,
-  extraClasses,
-  icon,
-  text,
-  trackingEvent,
-  disabled,
-  target,
-  download,
-  rel,
-  clickHandler,
-}: Props) => {
-  const HtmlTag = url ? 'a' : 'button';
-  const fontClasses =
-    extraClasses && extraClasses.indexOf('btn--tertiary') > -1
-      ? { s: 'HNM5' }
-      : { s: 'HNM4' };
-  function handleClick(e) {
-    if (clickHandler) {
-      clickHandler(e);
+// $FlowFixMe (forwardRef)
+const Button = forwardRef(
+  (
+    {
+      url,
+      type,
+      id,
+      extraClasses,
+      icon,
+      text,
+      trackingEvent,
+      disabled,
+      target,
+      download,
+      rel,
+      clickHandler,
+      ariaControls,
+      ariaExpanded,
+    }: Props,
+    ref
+  ) => {
+    const HtmlTag = url ? 'a' : 'button';
+    const fontClasses =
+      extraClasses && extraClasses.indexOf('btn--tertiary') > -1
+        ? { s: 'HNM5' }
+        : { s: 'HNM4' };
+    function handleClick(e) {
+      if (clickHandler) {
+        clickHandler(e);
+      }
+      if (trackingEvent) {
+        trackEvent(trackingEvent);
+      }
     }
-    if (trackingEvent) {
-      trackEvent(trackingEvent);
-    }
+
+    return (
+      <HtmlTag
+        ref={ref}
+        aria-controls={ariaControls}
+        aria-expanded={ariaExpanded}
+        href={url}
+        target={target}
+        download={download}
+        rel={rel}
+        id={id}
+        className={`btn btn--${type} ${extraClasses || ''} ${font(
+          fontClasses
+        )} flex-inline flex--v-center`}
+        onClick={handleClick}
+        disabled={disabled}
+      >
+        <span className="flex-inline flex--v-center">
+          {icon && <Icon name={icon} />}
+          <span className="btn__text">{text}</span>
+        </span>
+      </HtmlTag>
+    );
   }
-  return (
-    <HtmlTag
-      href={url}
-      target={target}
-      download={download}
-      rel={rel}
-      id={id}
-      className={`btn btn--${type} ${extraClasses || ''} ${font(
-        fontClasses
-      )} flex-inline flex--v-center`}
-      onClick={handleClick}
-      disabled={disabled}
-    >
-      <span className="flex-inline flex--v-center">
-        {icon && <Icon name={icon} />}
-        <span className="btn__text">{text}</span>
-      </span>
-    </HtmlTag>
-  );
-};
+);
+
+Button.displayName = 'Button';
 
 export default Button;

--- a/common/views/components/Buttons/Button/Button.js
+++ b/common/views/components/Buttons/Button/Button.js
@@ -7,6 +7,7 @@ import { font } from '../../../../utils/classnames';
 import Icon from '../../Icon/Icon';
 
 type Props = {|
+  tabIndex?: string,
   url?: string,
   type: 'primary' | 'secondary' | 'tertiary',
   extraClasses?: string,

--- a/common/views/components/Buttons/Button/Button.js
+++ b/common/views/components/Buttons/Button/Button.js
@@ -60,6 +60,7 @@ const Button = forwardRef(
     }
 
     return (
+      // $FlowFixMe (conditional JSX tag)
       <HtmlTag
         ref={ref}
         aria-controls={ariaControls}

--- a/common/views/components/Buttons/Control/Control.js
+++ b/common/views/components/Buttons/Control/Control.js
@@ -6,6 +6,7 @@ import type { GaEvent } from '../../../../utils/ga';
 import { trackEvent } from '../../../../utils/ga';
 
 type Props = {|
+  tabIndex?: string,
   url?: string,
   id?: string,
   type: 'light' | 'dark',
@@ -31,6 +32,7 @@ const InnerControl = ({ text, icon }: InnerControlProps) => (
 const Control = forwardRef(
   (
     {
+      tabIndex,
       url,
       id,
       type,
@@ -48,6 +50,7 @@ const Control = forwardRef(
     const attrs = {
       'aria-controls': ariaControls || undefined,
       'aria-expanded': ariaExpanded || undefined,
+      tabIndex: tabIndex || undefined,
       id: id,
       href: url,
       className: `control control--${type} ${extraClasses || ''}`,

--- a/common/views/components/Buttons/Control/Control.js
+++ b/common/views/components/Buttons/Control/Control.js
@@ -47,6 +47,7 @@ const Control = forwardRef(
     }: Props,
     ref
   ) => {
+    const HtmlTag = url ? 'a' : 'button';
     const attrs = {
       'aria-controls': ariaControls || undefined,
       'aria-expanded': ariaExpanded || undefined,
@@ -68,14 +69,11 @@ const Control = forwardRef(
       }
     }
 
-    return url ? (
-      <a ref={ref} {...attrs}>
+    return (
+      // $FlowFixMe (conditional JSX tag)
+      <HtmlTag ref={ref} {...attrs}>
         <InnerControl text={text} icon={icon} />
-      </a>
-    ) : (
-      <button ref={ref} {...attrs}>
-        <InnerControl text={text} icon={icon} />
-      </button>
+      </HtmlTag>
     );
   }
 );

--- a/common/views/components/Buttons/Control/Control.js
+++ b/common/views/components/Buttons/Control/Control.js
@@ -1,4 +1,6 @@
 // @flow
+
+import { forwardRef } from 'react';
 import Icon from '../../Icon/Icon';
 import type { GaEvent } from '../../../../utils/ga';
 import { trackEvent } from '../../../../utils/ga';
@@ -12,6 +14,8 @@ type Props = {|
   text: string,
   trackingEvent?: GaEvent,
   disabled?: boolean,
+  ariaControls?: string,
+  ariaExpanded?: boolean,
   clickHandler?: (event: Event) => void,
 |};
 
@@ -23,44 +27,56 @@ const InnerControl = ({ text, icon }: InnerControlProps) => (
   </span>
 );
 
-const Control = ({
-  url,
-  id,
-  type,
-  extraClasses,
-  icon,
-  text,
-  disabled,
-  clickHandler,
-  trackingEvent,
-}: Props) => {
-  const attrs = {
-    id: id,
-    href: url,
-    className: `control control--${type} ${extraClasses || ''}`,
-    disabled: disabled,
-    onClick: handleClick,
-  };
+// $FlowFixMe (forwardRef)
+const Control = forwardRef(
+  (
+    {
+      url,
+      id,
+      type,
+      extraClasses,
+      icon,
+      text,
+      disabled,
+      clickHandler,
+      trackingEvent,
+      ariaControls,
+      ariaExpanded,
+    }: Props,
+    ref
+  ) => {
+    const attrs = {
+      'aria-controls': ariaControls || undefined,
+      'aria-expanded': ariaExpanded || undefined,
+      id: id,
+      href: url,
+      className: `control control--${type} ${extraClasses || ''}`,
+      disabled: disabled,
+      onClick: handleClick,
+    };
 
-  function handleClick(event) {
-    if (trackingEvent) {
-      trackEvent(trackingEvent);
+    function handleClick(event) {
+      if (trackingEvent) {
+        trackEvent(trackingEvent);
+      }
+
+      if (clickHandler) {
+        clickHandler(event);
+      }
     }
 
-    if (clickHandler) {
-      clickHandler(event);
-    }
+    return url ? (
+      <a ref={ref} {...attrs}>
+        <InnerControl text={text} icon={icon} />
+      </a>
+    ) : (
+      <button ref={ref} {...attrs}>
+        <InnerControl text={text} icon={icon} />
+      </button>
+    );
   }
+);
 
-  return url ? (
-    <a {...attrs}>
-      <InnerControl text={text} icon={icon} />
-    </a>
-  ) : (
-    <button {...attrs}>
-      <InnerControl text={text} icon={icon} />
-    </button>
-  );
-};
+Control.displayName = 'Control';
 
 export default Control;

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -33,7 +33,7 @@ class ImageGallery extends Component<Props, State> {
   };
 
   openButtonRef: {
-    current: HTMLAnchorElement | HTMLButtonElement | null,
+    current: HTMLButtonElement | HTMLAnchorElement | null,
   } = createRef();
 
   closeButtonRef: {
@@ -42,9 +42,9 @@ class ImageGallery extends Component<Props, State> {
 
   handleOpenClicked() {
     if (this.closeButtonRef.current) {
-      this.showAllImages(true);
-      this.closeButtonRef.current.focus();
       this.closeButtonRef.current.tabIndex = 0;
+      this.closeButtonRef.current.focus();
+      this.showAllImages(true);
     }
 
     if (this.openButtonRef.current) {
@@ -54,14 +54,18 @@ class ImageGallery extends Component<Props, State> {
 
   handleCloseClicked() {
     if (this.openButtonRef.current) {
+      this.setState({ isActive: false });
+
       trackEvent({
         category: `Control`,
         action: 'close ImageGallery',
         label: this.props.id,
       });
-      this.setState({ isActive: false });
-      this.openButtonRef.current.focus();
+    }
+
+    if (this.openButtonRef.current) {
       this.openButtonRef.current.tabIndex = 0;
+      this.openButtonRef.current.focus();
     }
 
     if (this.closeButtonRef.current) {

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -40,6 +40,14 @@ class ImageGallery extends Component<Props, State> {
     current: HTMLAnchorElement | HTMLButtonElement | null,
   } = createRef();
 
+  focusOpenButton = () => {
+    this.openButtonRef.current && this.openButtonRef.current.focus();
+  };
+
+  focusCloseButton = () => {
+    this.closeButtonRef.current && this.closeButtonRef.current.focus();
+  };
+
   showAllImages = (isButton?: boolean) => {
     trackEvent({
       category: `${isButton ? 'Button' : 'CaptionedImage'}`,
@@ -155,14 +163,12 @@ class ImageGallery extends Component<Props, State> {
                         className={classNames({
                           'flex flex-end': true,
                           'image-gallery-v2__close': true,
+                          hidden: !isActive,
                           [spacing(
                             { s: 3 },
                             { padding: ['right', 'bottom'] }
                           )]: true,
                         })}
-                        style={{
-                          visibility: isActive ? 'visible' : 'hidden',
-                        }}
                       >
                         <Control
                           ariaControls={`image-gallery-${id}`}
@@ -178,13 +184,8 @@ class ImageGallery extends Component<Props, State> {
                               action: 'close ImageGallery',
                               label: this.props.id,
                             });
-
                             this.setState({ isActive: false });
-
-                            setTimeout(() => {
-                              this.openButtonRef.current &&
-                                this.openButtonRef.current.focus();
-                            }, 0);
+                            this.focusOpenButton();
                           }}
                         />
                       </div>
@@ -195,11 +196,7 @@ class ImageGallery extends Component<Props, State> {
                       onClick={() => {
                         if (!isActive) {
                           this.showAllImages();
-
-                          setTimeout(() => {
-                            this.closeButtonRef.current &&
-                              this.closeButtonRef.current.focus();
-                          }, 0);
+                          this.focusCloseButton();
                         }
                       }}
                       className={classNames({
@@ -249,15 +246,11 @@ class ImageGallery extends Component<Props, State> {
                       icon="gallery"
                       clickHandler={() => {
                         this.showAllImages(true);
-
-                        setTimeout(() => {
-                          this.closeButtonRef.current &&
-                            this.closeButtonRef.current.focus();
-                        }, 0);
+                        this.focusCloseButton();
                       }}
                       extraClasses={classNames({
                         'image-gallery-v2__button absolute': true,
-                        'is-hidden': isActive,
+                        hidden: isActive,
                       })}
                       text={`${items.length} images`}
                     />

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -54,6 +54,7 @@ class ImageGallery extends Component<Props, State> {
 
   handleCloseClicked() {
     if (this.openButtonRef.current) {
+      this.openButtonRef.current.tabIndex = 0;
       this.setState({ isActive: false });
 
       trackEvent({
@@ -61,11 +62,6 @@ class ImageGallery extends Component<Props, State> {
         action: 'close ImageGallery',
         label: this.props.id,
       });
-    }
-
-    if (this.openButtonRef.current) {
-      this.openButtonRef.current.tabIndex = 0;
-      this.openButtonRef.current.focus();
     }
 
     if (this.closeButtonRef.current) {
@@ -204,12 +200,8 @@ class ImageGallery extends Component<Props, State> {
                           type={`light`}
                           text={`close`}
                           icon={`cross`}
-                          clickHandler={event => {
-                            // Closing the gallery links back to the gallery heading.
-                            // We have to move the keyboard focus away after this happens.
-                            setTimeout(() => {
-                              this.handleCloseClicked();
-                            }, 0);
+                          clickHandler={() => {
+                            this.handleCloseClicked();
                           }}
                         />
                       </div>

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -40,13 +40,34 @@ class ImageGallery extends Component<Props, State> {
     current: HTMLAnchorElement | HTMLButtonElement | null,
   } = createRef();
 
-  focusOpenButton = () => {
-    this.openButtonRef.current && this.openButtonRef.current.focus();
-  };
+  handleOpenClicked() {
+    if (this.closeButtonRef.current) {
+      this.showAllImages(true);
+      this.closeButtonRef.current.focus();
+      this.closeButtonRef.current.tabIndex = 0;
+    }
 
-  focusCloseButton = () => {
-    this.closeButtonRef.current && this.closeButtonRef.current.focus();
-  };
+    if (this.openButtonRef.current) {
+      this.openButtonRef.current.tabIndex = -1;
+    }
+  }
+
+  handleCloseClicked() {
+    if (this.openButtonRef.current) {
+      trackEvent({
+        category: `Control`,
+        action: 'close ImageGallery',
+        label: this.props.id,
+      });
+      this.setState({ isActive: false });
+      this.openButtonRef.current.focus();
+      this.openButtonRef.current.tabIndex = 0;
+    }
+
+    if (this.closeButtonRef.current) {
+      this.closeButtonRef.current.tabIndex = -1;
+    }
+  }
 
   showAllImages = (isButton?: boolean) => {
     trackEvent({
@@ -163,7 +184,7 @@ class ImageGallery extends Component<Props, State> {
                         className={classNames({
                           'flex flex-end': true,
                           'image-gallery-v2__close': true,
-                          hidden: !isActive,
+                          'opacity-0': !isActive,
                           [spacing(
                             { s: 3 },
                             { padding: ['right', 'bottom'] }
@@ -171,6 +192,7 @@ class ImageGallery extends Component<Props, State> {
                         })}
                       >
                         <Control
+                          tabIndex={`-1`}
                           ariaControls={`image-gallery-${id}`}
                           ariaExpanded={isActive}
                           ref={this.closeButtonRef}
@@ -179,13 +201,11 @@ class ImageGallery extends Component<Props, State> {
                           text={`close`}
                           icon={`cross`}
                           clickHandler={event => {
-                            trackEvent({
-                              category: `Control`,
-                              action: 'close ImageGallery',
-                              label: this.props.id,
-                            });
-                            this.setState({ isActive: false });
-                            this.focusOpenButton();
+                            // Closing the gallery links back to the gallery heading.
+                            // We have to move the keyboard focus away after this happens.
+                            setTimeout(() => {
+                              this.handleCloseClicked();
+                            }, 0);
                           }}
                         />
                       </div>
@@ -195,8 +215,7 @@ class ImageGallery extends Component<Props, State> {
                     <div
                       onClick={() => {
                         if (!isActive) {
-                          this.showAllImages();
-                          this.focusCloseButton();
+                          this.handleOpenClicked();
                         }
                       }}
                       className={classNames({
@@ -245,12 +264,11 @@ class ImageGallery extends Component<Props, State> {
                       type="primary"
                       icon="gallery"
                       clickHandler={() => {
-                        this.showAllImages(true);
-                        this.focusCloseButton();
+                        this.handleOpenClicked();
                       }}
                       extraClasses={classNames({
                         'image-gallery-v2__button absolute': true,
-                        hidden: isActive,
+                        'opacity-0': isActive,
                       })}
                       text={`${items.length} images`}
                     />

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -1,6 +1,6 @@
 // @flow
 // TODO: use styled components
-import { Fragment, Component } from 'react';
+import { Fragment, Component, createRef } from 'react';
 import { font, spacing, classNames } from '../../../utils/classnames';
 import { CaptionedImage } from '../Images/Images';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
@@ -31,6 +31,14 @@ class ImageGallery extends Component<Props, State> {
     isActive: true,
     titleStyle: null,
   };
+
+  openButtonRef: {
+    current: HTMLAnchorElement | HTMLButtonElement | null,
+  } = createRef();
+
+  closeButtonRef: {
+    current: HTMLAnchorElement | HTMLButtonElement | null,
+  } = createRef();
 
   showAllImages = (isButton?: boolean) => {
     trackEvent({
@@ -92,6 +100,7 @@ class ImageGallery extends Component<Props, State> {
               </span>
             )}
             <div
+              id={`image-gallery-${id}`}
               className={classNames({
                 'image-gallery-v2--standalone': isStandalone,
                 'image-gallery-v2 row relative': true,
@@ -156,6 +165,9 @@ class ImageGallery extends Component<Props, State> {
                         }}
                       >
                         <Control
+                          ariaControls={`image-gallery-${id}`}
+                          ariaExpanded={isActive}
+                          ref={this.closeButtonRef}
                           url={`#gallery-${id}`}
                           type={`light`}
                           text={`close`}
@@ -168,6 +180,11 @@ class ImageGallery extends Component<Props, State> {
                             });
 
                             this.setState({ isActive: false });
+
+                            setTimeout(() => {
+                              this.openButtonRef.current &&
+                                this.openButtonRef.current.focus();
+                            }, 0);
                           }}
                         />
                       </div>
@@ -175,7 +192,16 @@ class ImageGallery extends Component<Props, State> {
                   )}
                   {this.itemsToShow().map((captionedImage, i) => (
                     <div
-                      onClick={!isActive ? this.showAllImages : undefined}
+                      onClick={() => {
+                        if (!isActive) {
+                          this.showAllImages();
+
+                          setTimeout(() => {
+                            this.closeButtonRef.current &&
+                              this.closeButtonRef.current.focus();
+                          }, 0);
+                        }
+                      }}
                       className={classNames({
                         [spacing({ s: 10 }, { margin: ['bottom'] })]: isActive,
                       })}
@@ -214,14 +240,25 @@ class ImageGallery extends Component<Props, State> {
                     </div>
                   ))}
 
-                  {!isActive && titleStyle && (
+                  {titleStyle && (
                     <Button
+                      ref={this.openButtonRef}
+                      ariaControls={`image-gallery-${id}`}
+                      ariaExpanded={isActive}
                       type="primary"
                       icon="gallery"
                       clickHandler={() => {
                         this.showAllImages(true);
+
+                        setTimeout(() => {
+                          this.closeButtonRef.current &&
+                            this.closeButtonRef.current.focus();
+                        }, 0);
                       }}
-                      extraClasses="image-gallery-v2__button absolute"
+                      extraClasses={classNames({
+                        'image-gallery-v2__button absolute': true,
+                        'is-hidden': isActive,
+                      })}
                       text={`${items.length} images`}
                     />
                   )}


### PR DESCRIPTION
Screenreader users should be alerted to the fact that the gallery will expand when they click the open-gallery button, and that it is expanded when they do. Focus should be moved to the close button once the open button is clicked.

__TODO__
- [x] Flow
- [x] Work out how to do this without `setTimout`s