### PR TITLE
don't show date label when there are no dates on work card

### DIFF
--- a/catalogue/webapp/components/WorkCompactCard.js/WorkCompactCard.js
+++ b/catalogue/webapp/components/WorkCompactCard.js/WorkCompactCard.js
@@ -119,7 +119,7 @@ const WorkCompactCard = ({
                 }))}
               />
             )}
-            {productionDates && (
+            {productionDates.length > 0 && (
               <div
                 className={classNames({
                   [spacing({ s: 2 }, { margin: ['left'] })]: true,


### PR DESCRIPTION
Fixed in #4133 
But waiting for that might take too long.

Removes the `Date` label from the work compact card if there are no production dates.