### PR TITLE
add shortTitle to exhibitions

### DIFF
--- a/common/model/exhibitions.js
+++ b/common/model/exhibitions.js
@@ -17,6 +17,7 @@ export type ExhibitionFormat = {|
 
 export type Exhibition = {|
   ...GenericContentFields,
+  shortTitle: ?string,
   type: 'exhibitions',
   format: ?ExhibitionFormat,
   start: Date,

--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -189,6 +189,7 @@ export function parseExhibitionDoc(document: PrismicDocument): UiExhibition {
   const exhibition = {
     ...genericFields,
     type: 'exhibitions',
+    shortTitle: data.shortTitle && asText(data.shortTitle),
     format: format,
     description: description,
     intro: intro,

--- a/content/webapp/components/Installation/Installation.js
+++ b/content/webapp/components/Installation/Installation.js
@@ -56,7 +56,7 @@ const Installation = ({ installation }: Props) => {
       },
       partOf && {
         url: `/exhibitions/${partOf.id}`,
-        text: partOf.title,
+        text: partOf.shortTitle || partOf.title,
         prefix: 'Part of',
       },
       {

--- a/prismic-model/js/exhibitions.js
+++ b/prismic-model/js/exhibitions.js
@@ -11,11 +11,13 @@ import structuredText from './parts/structured-text';
 import contributorsWithTitle from './parts/contributorsWithTitle';
 import body from './parts/body';
 import boolean from './parts/boolean';
+import singleLineText from './parts/single-line-text';
 
 const Exhibitions = {
   Exhibition: {
     format: link('Format', 'document', ['exhibition-formats']),
     title,
+    shortTitle: singleLineText('Short title', 'heading1'),
     body,
     start: timestamp('Start date'),
     end: timestamp('End date'),

--- a/prismic-model/js/parts/single-line-text.js
+++ b/prismic-model/js/parts/single-line-text.js
@@ -1,10 +1,13 @@
 // @flow
-export default function heading(label: string = 'Title') {
+export default function heading(
+  label: string = 'Title',
+  type: ?string = 'paragraph'
+) {
   return {
     type: 'StructuredText',
     config: {
       label: label,
-      single: 'paragraph',
+      single: type,
     },
   };
 }

--- a/prismic-model/json/exhibitions.json
+++ b/prismic-model/json/exhibitions.json
@@ -18,6 +18,13 @@
         "useAsTitle": true
       }
     },
+    "shortTitle": {
+      "type": "StructuredText",
+      "config": {
+        "label": "Short title",
+        "single": "heading1"
+      }
+    },
     "body": {
       "fieldset": "Body content",
       "type": "Slices",


### PR DESCRIPTION
Fixes #1716

We've decided this piece of metadata is predominantly, if not exclusively, for display purposes.

The title of the exhibitions works similar to a `Work` where is has _a_ title.

<img width="1080" alt="screenshot 2019-02-21 at 12 04 38" src="https://user-images.githubusercontent.com/31692/53167952-53b02300-35d1-11e9-88e0-545490fc5be0.png">
