### PR TITLE
add imagelesssearchresult toggl

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -28,6 +28,7 @@ type Props = {|
   workType: string[],
   itemsLocationsLocationType: string[],
   showCatalogueSearchFilters: boolean,
+  imagelessSearchResult: boolean,
 |};
 
 export const Works = ({
@@ -37,6 +38,7 @@ export const Works = ({
   workType,
   itemsLocationsLocationType,
   showCatalogueSearchFilters,
+  imagelessSearchResult,
 }: Props) => {
   const [loading, setLoading] = useState(false);
   useEffect(() => {
@@ -71,12 +73,13 @@ export const Works = ({
   // This is very convoluted, but you can't do arry equality because, JavaScript
   // e.g. itemsLocationsLocationType === ['iiif-image'] is always false.
   const useImagelessResult =
-    showCatalogueSearchFilters &&
-    !(
-      workType.toString() === 'k,q' &&
-      itemsLocationsLocationType.length === 1 &&
-      itemsLocationsLocationType[0] === 'iiif-image'
-    );
+    imagelessSearchResult ||
+    (showCatalogueSearchFilters &&
+      !(
+        workType.toString() === 'k,q' &&
+        itemsLocationsLocationType.length === 1 &&
+        itemsLocationsLocationType[0] === 'iiif-image'
+      ));
 
   return (
     <Fragment>
@@ -376,7 +379,10 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
     ? workTypeQuery.split(',')
     : ['k', 'q'];
 
-  const { showCatalogueSearchFilters } = ctx.query.toggles;
+  const {
+    showCatalogueSearchFilters = false,
+    imagelessSearchResult = false,
+  } = ctx.query.toggles;
 
   const itemsLocationsLocationType =
     'items.locations.locationType' in ctx.query
@@ -400,6 +406,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
     workType,
     itemsLocationsLocationType,
     showCatalogueSearchFilters,
+    imagelessSearchResult,
   };
 };
 

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -47,6 +47,13 @@ const featureToggles = [
       'This will show unfilter those results, and allow for filtering.',
   },
   {
+    id: 'imagelessSearchResult',
+    title: 'Imageless search results',
+    description:
+      "Uses a search results that doesn't need to have an image, but, if " +
+      'need be, can',
+  },
+  {
     id: 'showWorkLocations',
     title: 'Show the locations of a work in the header',
     description:


### PR DESCRIPTION
As we can work on this in parallel and release it without blocking the work going on in getting the works search out, a switch has been added for this.

This means we could A/B it too.