### PR TITLE
Add enough padding for close cross

### DIFF
--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -16,7 +16,7 @@ const VisuallyHidden = styled.div`
 
 const StyledInput = styled.input`
   width: 100%;
-  padding: 0.4em;
+  padding: 0.4em 40px 0.4em 0.4em;
   border: 1px solid ${props => props.theme.colors.pumice};
 
   &:focus {


### PR DESCRIPTION
__Before__
![screenshot 2019-02-26 at 12 23 54](https://user-images.githubusercontent.com/1394592/53419678-31a01180-39d2-11e9-89f7-c3abd5b220b8.png)

__After__
![screenshot 2019-02-26 at 12 23 32](https://user-images.githubusercontent.com/1394592/53419864-8a6faa00-39d2-11e9-88eb-ec08da214be9.png)

I suppose this could mean we over-pad the right end of the input if we use  the `StyledInput` component without the close cross, but I figure that shouldn't be a serious issue