### PR TITLE
put museum and library LD on the pages

### DIFF
--- a/common/model/opening-hours.js
+++ b/common/model/opening-hours.js
@@ -107,6 +107,25 @@ export const galleryOpeningHours: OpeningHours = {
   ],
 };
 
+export const libraryOpeningHours: OpeningHours = {
+  // TODO remove these once organization.js is using the gallery data from prismic github issue #2476
+  regular: [
+    { dayOfWeek: 'Monday', opens: '10:00', closes: '18:00' },
+    { dayOfWeek: 'Tuesday', opens: '10:00', closes: '18:00' },
+    { dayOfWeek: 'Wednesday', opens: '10:00', closes: '18:00' },
+    { dayOfWeek: 'Thursday', opens: '10:00', closes: '20:00' },
+    { dayOfWeek: 'Friday', opens: '10:00', closes: '18:00' },
+    { dayOfWeek: 'Saturday', opens: '10:00', closes: '18:00' },
+    { dayOfWeek: 'Sunday' },
+  ],
+  exceptional: [
+    { overrideDate: moment('2018-04-02'), opens: '10:00', closes: '18:00' },
+    { overrideDate: moment('2018-05-07'), opens: '10:00', closes: '18:00' },
+    { overrideDate: moment('2018-05-28'), opens: '10:00', closes: '18:00' },
+    { overrideDate: moment('2018-08-27'), opens: '10:00', closes: '18:00' },
+  ],
+};
+
 // http://schema.org/specialOpeningHoursSpecification
 export type SpecialOpeningHours = {|
   opens: string,

--- a/common/model/organization.js
+++ b/common/model/organization.js
@@ -1,6 +1,6 @@
 // @flow
 import type { OpeningHoursDay, SpecialOpeningHours } from './opening-hours';
-import { galleryOpeningHours } from './opening-hours';
+import { galleryOpeningHours, libraryOpeningHours } from './opening-hours';
 import { objToJsonLd } from '../utils/json-ld';
 import moment from 'moment';
 
@@ -33,7 +33,7 @@ export const wellcomeCollectionAddress = {
   addressCountry: 'UK',
 };
 
-export const wellcomeCollection: Organization = {
+export const wellcomeCollectionGallery: Organization = {
   name: 'Wellcome Collection',
   url: 'https://wellcomecollection.org',
   logo: {
@@ -78,4 +78,32 @@ export const wellcomeCollection: Organization = {
   isAccessibleForFree: true,
   publicAccess: true,
   telephone: '+4420 7611 2222',
+};
+
+export const wellcomeCollectionLibrary: Organization = {
+  ...wellcomeCollectionGallery,
+  openingHoursSpecification: libraryOpeningHours.regular.map(
+    openingHoursDay => {
+      const specObject = objToJsonLd(
+        openingHoursDay,
+        'OpeningHoursSpecification',
+        false
+      );
+      delete specObject.note;
+      return specObject;
+    }
+  ),
+  specialOpeningHoursSpecification:
+    libraryOpeningHours.exceptional &&
+    libraryOpeningHours.exceptional.map(openingHoursDate => {
+      const specObject = {
+        opens: openingHoursDate.opens,
+        closes: openingHoursDate.closes,
+        validFrom: moment(openingHoursDate.overrideDate).format('DD MMMM YYYY'),
+        validThrough: moment(openingHoursDate.overrideDate).format(
+          'DD MMMM YYYY'
+        ),
+      };
+      return objToJsonLd(specObject, 'OpeningHoursSpecification', false);
+    }),
 };

--- a/common/utils/json-ld.js
+++ b/common/utils/json-ld.js
@@ -1,6 +1,6 @@
 import type { EventPromo, Event } from '../model/events';
 import {
-  wellcomeCollection,
+  wellcomeCollectionGallery,
   wellcomeCollectionAddress,
 } from '../model/organization';
 import { convertImageUri } from './convert-image-uri';
@@ -26,7 +26,7 @@ export function contentLd(content) {
       image: content.promo && imageLd(content.promo.image),
       datePublished: content.datePublished,
       dateModified: content.datePublished,
-      publisher: orgLd(wellcomeCollection),
+      publisher: orgLd(wellcomeCollectionGallery),
       mainEntityOfPage: `https://wellcomecollection.org${content.url}`,
     },
     'Article'
@@ -73,7 +73,7 @@ export function articleLd(article) {
         ),
       image: article.promoImage && article.promoImage.contentUrl,
       // TODO: isPartOf
-      publisher: orgLd(wellcomeCollection),
+      publisher: orgLd(wellcomeCollectionGallery),
       url: `https://wellcomecollection.org/articles/${article.id}`,
     },
     'Article'
@@ -175,6 +175,13 @@ export function museumLd(museum) {
   const newMuseum = Object.assign({}, museum, { logo });
   delete newMuseum.twitterHandle;
   return objToJsonLd(newMuseum, 'Museum');
+}
+
+export function libraryLd(museum) {
+  const logo = imageLd(museum.logo);
+  const newMuseum = Object.assign({}, museum, { logo, image: logo });
+  delete newMuseum.twitterHandle;
+  return objToJsonLd(newMuseum, 'Library');
 }
 
 export function eventLd(event: Event) {

--- a/common/views/components/FindUs/FindUs.js
+++ b/common/views/components/FindUs/FindUs.js
@@ -4,7 +4,7 @@ import { spacing, font, classNames } from '../../../utils/classnames';
 import { convertImageUri } from '../../../utils/convert-image-uri';
 import Icon from '../Icon/Icon';
 import {
-  wellcomeCollection,
+  wellcomeCollectionGallery,
   wellcomeCollectionAddress,
 } from '../../../model/organization';
 
@@ -56,7 +56,10 @@ const FindUs = () => (
       })}
     >
       <abbr title="telephone number">T</abbr>:{' '}
-      <a className="find-us__link" href={`tel:${wellcomeCollection.telephone}`}>
+      <a
+        className="find-us__link"
+        href={`tel:${wellcomeCollectionGallery.telephone}`}
+      >
         +44 (0)20 7611 2222
       </a>
     </p>

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -15,6 +15,7 @@ import OutboundLinkTracker from '../../views/components/OutboundLinkTracker/Outb
 import OpeningTimesContext from '../../views/components/OpeningTimesContext/OpeningTimesContext';
 import GlobalAlertContext from '../../views/components/GlobalAlertContext/GlobalAlertContext';
 import { trackEvent } from '../../utils/ga';
+
 const isServer = typeof window === 'undefined';
 const isClient = !isServer;
 

--- a/common/views/pages/_document.js
+++ b/common/views/pages/_document.js
@@ -1,6 +1,12 @@
 // @flow
 import Document, { Head, Main, NextScript } from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
+import JsonLd from '../../views/components/JsonLd/JsonLd';
+import { museumLd, libraryLd } from '../../utils/json-ld';
+import {
+  wellcomeCollectionGallery,
+  wellcomeCollectionLibrary,
+} from '../../model/organization';
 
 export default function WeDoc(css: string) {
   return class WecoDoc extends Document {
@@ -29,6 +35,8 @@ export default function WeDoc(css: string) {
             />
             {this.props.styleTags}
             <style dangerouslySetInnerHTML={{ __html: css }} />
+            <JsonLd data={museumLd(wellcomeCollectionGallery)} />
+            <JsonLd data={libraryLd(wellcomeCollectionLibrary)} />
           </Head>
           <body>
             {/* Google Tag Manager (noscript) */}


### PR DESCRIPTION
No idea how we missed this off.

The two tests we had on for this were incredibly brittle (using Yandex didn't always work, and the Google API rate limits you).

Might be worth sticking in some structural page analysis.

The warnings below are about adding performers and offers.
![screenshot 2019-02-26 at 16 07 02](https://user-images.githubusercontent.com/31692/53427398-c447ad00-39e0-11e9-86ca-d90c4e65974b.png)
