### PR TITLE
Filters attached to query or not

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -16,6 +16,7 @@ type Props = {|
   ariaDescribedBy: string,
   compact: boolean,
   showFilters: boolean,
+  reactiveFilters: boolean,
 |};
 
 const SearchInputWrapper = styled.div`
@@ -67,21 +68,42 @@ const SearchTag = ({
           { s: 1 },
           { padding: ['left', 'right'], margin: ['left'] }
         )]: true,
-        [font({ s: 'HNL4' })]: true,
       })}
       style={{ borderRadius: '3px', textDecoration: 'underline' }}
     >
-      <input
+      <div
         className={classNames({
-          [spacing({ s: 1 }, { margin: ['right'] })]: true,
+          flex: true,
+          'flex--v-center': true,
         })}
-        type="checkbox"
-        name={name}
-        value={value}
-        checked={checked}
-        onChange={onChange}
-      />
-      {label}
+      >
+        <input
+          className={classNames({
+            input: true,
+            'input--checkbox': true,
+            [font({ s: 'HNL3' })]: true,
+          })}
+          type="checkbox"
+          name={name}
+          value={value}
+          checked={checked}
+          onChange={onChange}
+        />
+        <span
+          className={classNames({
+            'input__control-indicator': true,
+            'input__control-indicator--checkbox': true,
+            [spacing({ s: 1 }, { margin: ['right'] })]: true,
+          })}
+        />
+        <span
+          className={classNames({
+            [font({ s: 'HNL4' })]: true,
+          })}
+        >
+          {label}
+        </span>
+      </div>
     </label>
   );
 };
@@ -94,6 +116,7 @@ const SearchForm = ({
   compact,
   // This only works in conjunction with the toggle
   showFilters,
+  reactiveFilters,
 }: Props) => {
   const [query, setQuery] = useState(initialQuery);
   const [workType, setWorkType] = useState(initialWorkType);
@@ -194,9 +217,6 @@ const SearchForm = ({
               (showCatalogueSearchFilters || feedback) && (
                 <div
                   className={classNames({
-                    flex: true,
-                    'flex--wrap': true,
-                    'flex--v-center': true,
                     [spacing({ s: 1 }, { margin: ['top'] })]: true,
                   })}
                 >
@@ -228,87 +248,99 @@ const SearchForm = ({
                         left: '1px',
                       }}
                     >
-                      <legend
-                        className={classNames({
-                          'float-l': true,
-                          [font({ s: 'HNM4' })]: true,
-                        })}
-                        style={{ marginTop: '3px' }}
-                      >
-                        Filter by
-                      </legend>
-                      <SearchTag
-                        name={'workType'}
-                        label="Books"
-                        value="a"
-                        checked={workType.indexOf('a') !== -1}
-                        onChange={event => {
-                          const input = event.currentTarget;
-                          const newWorkType = input.checked
-                            ? [...workType, 'a']
-                            : workType.filter(val => val !== 'a');
-                          setWorkType(newWorkType);
+                      <div className={classNames({ flex: true })}>
+                        <legend
+                          className={classNames({
+                            'float-l': true,
+                            [font({ s: 'HNM4' })]: true,
+                          })}
+                        >
+                          Filter by
+                        </legend>
+                        <div>
+                          <SearchTag
+                            name={'workType'}
+                            label="Books"
+                            value="a"
+                            checked={workType.indexOf('a') !== -1}
+                            onChange={event => {
+                              const input = event.currentTarget;
+                              const newWorkType = input.checked
+                                ? [...workType, 'a']
+                                : workType.filter(val => val !== 'a');
 
-                          const link = worksUrl({
-                            query,
-                            workType: showCatalogueSearchFacets
-                              ? []
-                              : newWorkType,
-                            itemsLocationsLocationType,
-                            page: 1,
-                          });
+                              setWorkType(newWorkType);
 
-                          Router.push(link.href, link.as);
-                        }}
-                      />
-                      <SearchTag
-                        name={'workType'}
-                        label="Pictures"
-                        value="k"
-                        checked={workType.indexOf('k') !== -1}
-                        onChange={event => {
-                          const input = event.currentTarget;
-                          const newWorkType = input.checked
-                            ? [...workType, 'k']
-                            : workType.filter(val => val !== 'k');
-                          setWorkType(newWorkType);
+                              if (reactiveFilters && query !== '') {
+                                const link = worksUrl({
+                                  query,
+                                  workType: showCatalogueSearchFacets
+                                    ? []
+                                    : newWorkType,
+                                  itemsLocationsLocationType,
+                                  page: 1,
+                                });
 
-                          const link = worksUrl({
-                            query,
-                            workType: showCatalogueSearchFacets
-                              ? []
-                              : newWorkType,
-                            itemsLocationsLocationType,
-                            page: 1,
-                          });
+                                Router.push(link.href, link.as);
+                              }
+                            }}
+                          />
+                          <SearchTag
+                            name={'workType'}
+                            label="Pictures"
+                            value="k"
+                            checked={workType.indexOf('k') !== -1}
+                            onChange={event => {
+                              const input = event.currentTarget;
+                              const newWorkType = input.checked
+                                ? [...workType, 'k']
+                                : workType.filter(val => val !== 'k');
 
-                          Router.push(link.href, link.as);
-                        }}
-                      />
-                      <SearchTag
-                        name={'workType'}
-                        label="Digital images"
-                        value="q"
-                        checked={workType.indexOf('q') !== -1}
-                        onChange={event => {
-                          const input = event.currentTarget;
-                          const newWorkType = input.checked
-                            ? [...workType, 'q']
-                            : workType.filter(val => val !== 'q');
-                          setWorkType(newWorkType);
+                              setWorkType(newWorkType);
 
-                          const link = worksUrl({
-                            query,
-                            workType: showCatalogueSearchFacets
-                              ? []
-                              : newWorkType,
-                            itemsLocationsLocationType,
-                            page: 1,
-                          });
+                              if (reactiveFilters && query !== '') {
+                                const link = worksUrl({
+                                  query,
+                                  workType: showCatalogueSearchFacets
+                                    ? []
+                                    : newWorkType,
+                                  itemsLocationsLocationType,
+                                  page: 1,
+                                });
 
-                          Router.push(link.href, link.as);
-                        }}
-                      />
+                                Router.push(link.href, link.as);
+                              }
+                            }}
+                          />
+                          <SearchTag
+                            name={'workType'}
+                            label="Digital images"
+                            value="q"
+                            checked={workType.indexOf('q') !== -1}
+                            onChange={event => {
+                              const input = event.currentTarget;
+                              const newWorkType = input.checked
+                                ? [...workType, 'q']
+                                : workType.filter(val => val !== 'q');
+
+                              setWorkType(newWorkType);
+
+                              if (reactiveFilters && query !== '') {
+                                const link = worksUrl({
+                                  query,
+                                  workType: showCatalogueSearchFacets
+                                    ? []
+                                    : newWorkType,
+                                  itemsLocationsLocationType,
+                                  page: 1,
+                                });
+
+                                Router.push(link.href, link.as);
+                              }
+                            }}
+                          />
+                        </div>
+                      </div>
                     </fieldset>
                   )}
                 </div>

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -70,7 +70,7 @@ const SearchTag = ({
         )]: true,
         [font({ s: 'HNL4' })]: true,
       })}
-      style={{ borderRadius: '3px' }}
+      style={{ borderRadius: '3px', textDecoration: 'underline' }}
     >
       <input
         className={classNames({
@@ -248,6 +248,17 @@ const SearchForm = ({
                             ? [...workType, 'a']
                             : workType.filter(val => val !== 'a');
                           setWorkType(newWorkType);
+
+                          const link = worksUrl({
+                            query,
+                            workType: showCatalogueSearchFacets
+                              ? []
+                              : newWorkType,
+                            itemsLocationsLocationType,
+                            page: 1,
+                          });
+
+                          Router.push(link.href, link.as);
                         }}
                       />
                       <SearchTag
@@ -261,6 +272,17 @@ const SearchForm = ({
                             ? [...workType, 'k']
                             : workType.filter(val => val !== 'k');
                           setWorkType(newWorkType);
+
+                          const link = worksUrl({
+                            query,
+                            workType: showCatalogueSearchFacets
+                              ? []
+                              : newWorkType,
+                            itemsLocationsLocationType,
+                            page: 1,
+                          });
+
+                          Router.push(link.href, link.as);
                         }}
                       />
                       <SearchTag
@@ -274,6 +296,17 @@ const SearchForm = ({
                             ? [...workType, 'q']
                             : workType.filter(val => val !== 'q');
                           setWorkType(newWorkType);
+
+                          const link = worksUrl({
+                            query,
+                            workType: showCatalogueSearchFacets
+                              ? []
+                              : newWorkType,
+                            itemsLocationsLocationType,
+                            page: 1,
+                          });
+
+                          Router.push(link.href, link.as);
                         }}
                       />
                     </fieldset>

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -1,9 +1,7 @@
 // @flow
 import { type CatalogueResultsList } from '@weco/common/model/catalogue';
-import { type NextLinkType } from '@weco/common/model/next-link-type';
 import { useState, useRef } from 'react';
 import Router from 'next/router';
-import NextLink from 'next/link';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -46,37 +44,46 @@ const ClearSearch = styled.button`
 `;
 
 type SearchTagProps = {
-  link: NextLinkType,
   label: string,
+  name: string,
+  value: string,
   checked: boolean,
+  onChange: (event: SyntheticEvent<HTMLInputElement>) => void,
 };
-const SearchTag = ({ link, label, checked }: SearchTagProps) => {
+
+const SearchTag = ({
+  label,
+  name,
+  value,
+  checked,
+  onChange,
+}: SearchTagProps) => {
   return (
-    <NextLink {...link}>
-      <a
+    <label
+      className={classNames({
+        'flex-inline': true,
+        'flex--v-center': true,
+        pointer: true,
+        [spacing(
+          { s: 1 },
+          { padding: ['left', 'right'], margin: ['left'] }
+        )]: true,
+        [font({ s: 'HNL4' })]: true,
+      })}
+      style={{ borderRadius: '3px' }}
+    >
+      <input
         className={classNames({
-          // 'bg-pumice': true,
-          'flex-inline': true,
-          'flex--v-center': true,
-          pointer: true,
-          [spacing(
-            { s: 1 },
-            { padding: ['left', 'right'], margin: ['left'] }
-          )]: true,
-          [font({ s: 'HNL4' })]: true,
+          [spacing({ s: 1 }, { margin: ['right'] })]: true,
         })}
-        style={{ borderRadius: '3px', textDecoration: 'underline' }}
-      >
-        <input
-          className={classNames({
-            [spacing({ s: 1 }, { margin: ['right'] })]: true,
-          })}
-          type="checkbox"
-          checked={checked}
-        />
-        {label}
-      </a>
-    </NextLink>
+        type="checkbox"
+        name={name}
+        value={value}
+        checked={checked}
+        onChange={onChange}
+      />
+      {label}
+    </label>
   );
 };
 
@@ -89,7 +96,7 @@ const SearchForm = ({
   works,
 }: Props) => {
   const [query, setQuery] = useState(initialQuery);
-  const workType = initialWorkType;
+  const [workType, setWorkType] = useState(initialWorkType);
   const [itemsLocationsLocationType] = useState(
     initialItemsLocationsLocationType
   );
@@ -222,52 +229,46 @@ const SearchForm = ({
                     })}
                     style={{ marginTop: '3px' }}
                   >
-                    Filter by:
+                    Filter by
                   </legend>
                   <SearchTag
                     name={'workType'}
-                    label="Digital images"
-                    value="q"
-                    checked={workType.indexOf('q') !== -1}
-                    link={worksUrl({
-                      query,
-                      workType:
-                        workType.indexOf('q') !== -1
-                          ? workType.filter(workType => workType !== 'q')
-                          : [...workType, 'q'],
-                      itemsLocationsLocationType,
-                      page: 1,
-                    })}
+                    label="Books"
+                    value="a"
+                    checked={workType.indexOf('a') !== -1}
+                    onChange={event => {
+                      const input = event.currentTarget;
+                      const newWorkType = input.checked
+                        ? [...workType, 'a']
+                        : workType.filter(val => val !== 'a');
+                      setWorkType(newWorkType);
+                    }}
                   />
                   <SearchTag
                     name={'workType'}
                     label="Pictures"
                     value="k"
                     checked={workType.indexOf('k') !== -1}
-                    link={worksUrl({
-                      query,
-                      workType:
-                        workType.indexOf('k') !== -1
-                          ? workType.filter(workType => workType !== 'k')
-                          : [...workType, 'k'],
-                      itemsLocationsLocationType,
-                      page: 1,
-                    })}
+                    onChange={event => {
+                      const input = event.currentTarget;
+                      const newWorkType = input.checked
+                        ? [...workType, 'k']
+                        : workType.filter(val => val !== 'k');
+                      setWorkType(newWorkType);
+                    }}
                   />
                   <SearchTag
                     name={'workType'}
-                    label="Books"
-                    value="a"
-                    checked={workType.indexOf('a') !== -1}
-                    link={worksUrl({
-                      query,
-                      workType:
-                        workType.indexOf('a') !== -1
-                          ? workType.filter(workType => workType !== 'a')
-                          : [...workType, 'a'],
-                      itemsLocationsLocationType,
-                      page: 1,
-                    })}
+                    label="Digital images"
+                    value="q"
+                    checked={workType.indexOf('q') !== -1}
+                    onChange={event => {
+                      const input = event.currentTarget;
+                      const newWorkType = input.checked
+                        ? [...workType, 'q']
+                        : workType.filter(val => val !== 'q');
+                      setWorkType(newWorkType);
+                    }}
                   />
                 </fieldset>
               )}

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -1,5 +1,4 @@
 // @flow
-import { type CatalogueResultsList } from '@weco/common/model/catalogue';
 import { useState, useRef } from 'react';
 import Router from 'next/router';
 import styled from 'styled-components';
@@ -16,7 +15,7 @@ type Props = {|
   initialItemsLocationsLocationType: string[],
   ariaDescribedBy: string,
   compact: boolean,
-  works: ?CatalogueResultsList,
+  showFilters: boolean,
 |};
 
 const SearchInputWrapper = styled.div`
@@ -93,7 +92,8 @@ const SearchForm = ({
   initialItemsLocationsLocationType = [],
   ariaDescribedBy,
   compact,
-  works,
+  // This only works in conjunction with the toggle
+  showFilters,
 }: Props) => {
   const [query, setQuery] = useState(initialQuery);
   const [workType, setWorkType] = useState(initialWorkType);
@@ -219,7 +219,7 @@ const SearchForm = ({
                       </a>
                     </p>
                   )}
-                  {showCatalogueSearchFilters && works && (
+                  {showCatalogueSearchFilters && showFilters && (
                     <fieldset
                       className={classNames({
                         relative: true,

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -103,180 +103,188 @@ const SearchForm = ({
   const searchInput = useRef(null);
 
   return (
-    <>
-      <form
-        action="/works"
-        aria-describedby={ariaDescribedBy}
-        onSubmit={event => {
-          event.preventDefault();
+    <TogglesContext.Consumer>
+      {({ showCatalogueSearchFacets }) => (
+        <>
+          <form
+            action="/works"
+            aria-describedby={ariaDescribedBy}
+            onSubmit={event => {
+              event.preventDefault();
 
-          trackEvent({
-            category: 'SearchForm',
-            action: 'submit search',
-            label: query,
-          });
+              trackEvent({
+                category: 'SearchForm',
+                action: 'submit search',
+                label: query,
+              });
 
-          const link = worksUrl({
-            query,
-            workType,
-            itemsLocationsLocationType,
-            page: 1,
-          });
+              const link = worksUrl({
+                query,
+                workType: showCatalogueSearchFacets ? [] : workType,
+                itemsLocationsLocationType,
+                page: 1,
+              });
 
-          Router.push(link.href, link.as);
+              Router.push(link.href, link.as);
 
-          return false;
-        }}
-      >
-        <div className="relative">
-          <SearchInputWrapper className="relative">
-            <TextInput
-              label={'Search the catalogue'}
-              placeholder={'Search for artworks, photos and more'}
-              name="query"
-              value={query}
-              autoFocus={query === ''}
-              onChange={event => setQuery(event.currentTarget.value)}
-              ref={searchInput}
-              className={font({
-                s: compact ? 'HNL4' : 'HNL3',
-                m: compact ? 'HNL3' : 'HNL2',
-              })}
-            />
-
-            {query && (
-              <ClearSearch
-                className="absolute line-height-1 plain-button v-center no-padding"
-                onClick={() => {
-                  trackEvent({
-                    category: 'SearchForm',
-                    action: 'clear search',
-                    label: 'works-search',
-                  });
-
-                  setQuery('');
-
-                  searchInput.current && searchInput.current.focus();
-                }}
-                type="button"
-              >
-                <Icon name="clear" title="Clear" />
-              </ClearSearch>
-            )}
-          </SearchInputWrapper>
-
-          <SearchButtonWrapper className="absolute bg-green">
-            <button
-              className={classNames({
-                'full-width': true,
-                'full-height': true,
-                'line-height-1': true,
-                'plain-button no-padding': true,
-                [font({ s: 'HNL3', m: 'HNL2' })]: true,
-              })}
-            >
-              <span className="visually-hidden">Search</span>
-              <span className="flex flex--v-center flex--h-center">
-                <Icon name="search" title="Search" extraClasses="icon--white" />
-              </span>
-            </button>
-          </SearchButtonWrapper>
-        </div>
-      </form>
-      <TogglesContext.Consumer>
-        {({ showCatalogueSearchFilters, feedback }) =>
-          (showCatalogueSearchFilters || feedback) && (
-            <div
-              className={classNames({
-                flex: true,
-                'flex--wrap': true,
-                'flex--v-center': true,
-                [spacing({ s: 1 }, { margin: ['top'] })]: true,
-              })}
-            >
-              {feedback && (
-                <p
-                  className={classNames({
-                    [font({ s: 'HNL4' })]: true,
-                    relative: true,
-                    [spacing({ s: 2 }, { margin: ['right'] })]: true,
-                    [spacing({ s: 0 }, { margin: ['bottom'] })]: true,
+              return false;
+            }}
+          >
+            <div className="relative">
+              <SearchInputWrapper className="relative">
+                <TextInput
+                  label={'Search the catalogue'}
+                  placeholder={'Search for artworks, photos and more'}
+                  name="query"
+                  value={query}
+                  autoFocus={query === ''}
+                  onChange={event => setQuery(event.currentTarget.value)}
+                  ref={searchInput}
+                  className={font({
+                    s: compact ? 'HNL4' : 'HNL3',
+                    m: compact ? 'HNL3' : 'HNL2',
                   })}
-                  style={{
-                    left: '1px',
-                    flexGrow: 1,
-                  }}
-                >
-                  Our search is currently in beta.{' '}
-                  <a href="https://www.surveymonkey.co.uk/r/W3NBWV2">
-                    Let us know what you think
-                  </a>
-                </p>
-              )}
-              {showCatalogueSearchFilters && works && (
-                <fieldset
-                  className={classNames({
-                    relative: true,
-                  })}
-                  style={{
-                    left: '1px',
-                  }}
-                >
-                  <legend
-                    className={classNames({
-                      'float-l': true,
-                      [font({ s: 'HNM4' })]: true,
-                    })}
-                    style={{ marginTop: '3px' }}
+                />
+
+                {query && (
+                  <ClearSearch
+                    className="absolute line-height-1 plain-button v-center no-padding"
+                    onClick={() => {
+                      trackEvent({
+                        category: 'SearchForm',
+                        action: 'clear search',
+                        label: 'works-search',
+                      });
+
+                      setQuery('');
+
+                      searchInput.current && searchInput.current.focus();
+                    }}
+                    type="button"
                   >
-                    Filter by
-                  </legend>
-                  <SearchTag
-                    name={'workType'}
-                    label="Books"
-                    value="a"
-                    checked={workType.indexOf('a') !== -1}
-                    onChange={event => {
-                      const input = event.currentTarget;
-                      const newWorkType = input.checked
-                        ? [...workType, 'a']
-                        : workType.filter(val => val !== 'a');
-                      setWorkType(newWorkType);
-                    }}
-                  />
-                  <SearchTag
-                    name={'workType'}
-                    label="Pictures"
-                    value="k"
-                    checked={workType.indexOf('k') !== -1}
-                    onChange={event => {
-                      const input = event.currentTarget;
-                      const newWorkType = input.checked
-                        ? [...workType, 'k']
-                        : workType.filter(val => val !== 'k');
-                      setWorkType(newWorkType);
-                    }}
-                  />
-                  <SearchTag
-                    name={'workType'}
-                    label="Digital images"
-                    value="q"
-                    checked={workType.indexOf('q') !== -1}
-                    onChange={event => {
-                      const input = event.currentTarget;
-                      const newWorkType = input.checked
-                        ? [...workType, 'q']
-                        : workType.filter(val => val !== 'q');
-                      setWorkType(newWorkType);
-                    }}
-                  />
-                </fieldset>
-              )}
+                    <Icon name="clear" title="Clear" />
+                  </ClearSearch>
+                )}
+              </SearchInputWrapper>
+
+              <SearchButtonWrapper className="absolute bg-green">
+                <button
+                  className={classNames({
+                    'full-width': true,
+                    'full-height': true,
+                    'line-height-1': true,
+                    'plain-button no-padding': true,
+                    [font({ s: 'HNL3', m: 'HNL2' })]: true,
+                  })}
+                >
+                  <span className="visually-hidden">Search</span>
+                  <span className="flex flex--v-center flex--h-center">
+                    <Icon
+                      name="search"
+                      title="Search"
+                      extraClasses="icon--white"
+                    />
+                  </span>
+                </button>
+              </SearchButtonWrapper>
             </div>
-          )
-        }
-      </TogglesContext.Consumer>
-    </>
+          </form>
+          <TogglesContext.Consumer>
+            {({ showCatalogueSearchFilters, feedback }) =>
+              (showCatalogueSearchFilters || feedback) && (
+                <div
+                  className={classNames({
+                    flex: true,
+                    'flex--wrap': true,
+                    'flex--v-center': true,
+                    [spacing({ s: 1 }, { margin: ['top'] })]: true,
+                  })}
+                >
+                  {feedback && (
+                    <p
+                      className={classNames({
+                        [font({ s: 'HNL4' })]: true,
+                        relative: true,
+                        [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                        [spacing({ s: 0 }, { margin: ['bottom'] })]: true,
+                      })}
+                      style={{
+                        left: '1px',
+                        flexGrow: 1,
+                      }}
+                    >
+                      Our search is currently in beta.{' '}
+                      <a href="https://www.surveymonkey.co.uk/r/W3NBWV2">
+                        Let us know what you think
+                      </a>
+                    </p>
+                  )}
+                  {showCatalogueSearchFilters && works && (
+                    <fieldset
+                      className={classNames({
+                        relative: true,
+                      })}
+                      style={{
+                        left: '1px',
+                      }}
+                    >
+                      <legend
+                        className={classNames({
+                          'float-l': true,
+                          [font({ s: 'HNM4' })]: true,
+                        })}
+                        style={{ marginTop: '3px' }}
+                      >
+                        Filter by
+                      </legend>
+                      <SearchTag
+                        name={'workType'}
+                        label="Books"
+                        value="a"
+                        checked={workType.indexOf('a') !== -1}
+                        onChange={event => {
+                          const input = event.currentTarget;
+                          const newWorkType = input.checked
+                            ? [...workType, 'a']
+                            : workType.filter(val => val !== 'a');
+                          setWorkType(newWorkType);
+                        }}
+                      />
+                      <SearchTag
+                        name={'workType'}
+                        label="Pictures"
+                        value="k"
+                        checked={workType.indexOf('k') !== -1}
+                        onChange={event => {
+                          const input = event.currentTarget;
+                          const newWorkType = input.checked
+                            ? [...workType, 'k']
+                            : workType.filter(val => val !== 'k');
+                          setWorkType(newWorkType);
+                        }}
+                      />
+                      <SearchTag
+                        name={'workType'}
+                        label="Digital images"
+                        value="q"
+                        checked={workType.indexOf('q') !== -1}
+                        onChange={event => {
+                          const input = event.currentTarget;
+                          const newWorkType = input.checked
+                            ? [...workType, 'q']
+                            : workType.filter(val => val !== 'q');
+                          setWorkType(newWorkType);
+                        }}
+                      />
+                    </fieldset>
+                  )}
+                </div>
+              )
+            }
+          </TogglesContext.Consumer>
+        </>
+      )}
+    </TogglesContext.Consumer>
   );
 };
 export default SearchForm;

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -122,7 +122,7 @@ export const WorkPage = ({
                 ariaDescribedBy="search-form-description"
                 compact={true}
                 showFilters={true}
-                reactiveFilter={false}
+                reactiveFilters={false}
               />
             </div>
           </div>

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -122,6 +122,7 @@ export const WorkPage = ({
                 ariaDescribedBy="search-form-description"
                 compact={true}
                 showFilters={true}
+                reactiveFilter={false}
               />
             </div>
           </div>

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -121,7 +121,7 @@ export const WorkPage = ({
                 initialItemsLocationsLocationType={itemsLocationsLocationType}
                 ariaDescribedBy="search-form-description"
                 compact={true}
-                works={null}
+                showFilters={true}
               />
             </div>
           </div>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -154,6 +154,7 @@ export const Works = ({
                   ariaDescribedBy="search-form-description"
                   compact={false}
                   showFilters={Boolean(works)}
+                  reactiveFilters={query !== ''}
                 />
                 <p
                   className={classNames({

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -153,7 +153,7 @@ export const Works = ({
                   initialItemsLocationsLocationType={itemsLocationsLocationType}
                   ariaDescribedBy="search-form-description"
                   compact={false}
-                  works={works}
+                  showFilters={Boolean(works)}
                 />
                 <p
                   className={classNames({

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -225,62 +225,77 @@ export const Works = ({
               </div>
             </div>
 
-            <div
-              className={`row ${spacing({ s: 3, m: 5 }, { padding: ['top'] })}`}
-            >
-              <div className="container">
-                <div className="grid">
-                  <div className="grid__cell">
-                    <WorkTags
-                      tags={[
-                        {
-                          query: 'Books',
-                          textParts: ['Books'],
-                          selected: workType.indexOf('a') !== -1,
-                          linkAttributes: worksUrl({
-                            query,
-                            itemsLocationsLocationType,
-                            page,
-                            workType:
-                              workType.indexOf('a') !== -1
-                                ? workType.filter(workType => workType !== 'a')
-                                : [...workType, 'a'],
-                          }),
-                        },
-                        {
-                          query: 'Pictures',
-                          textParts: ['Pictures'],
-                          selected: workType.indexOf('k') !== -1,
-                          linkAttributes: worksUrl({
-                            query,
-                            itemsLocationsLocationType,
-                            page,
-                            workType:
-                              workType.indexOf('k') !== -1
-                                ? workType.filter(workType => workType !== 'k')
-                                : [...workType, 'k'],
-                          }),
-                        },
-                        {
-                          query: 'Digital images',
-                          textParts: ['Digital images'],
-                          selected: workType.indexOf('q') !== -1,
-                          linkAttributes: worksUrl({
-                            query,
-                            itemsLocationsLocationType,
-                            page,
-                            workType:
-                              workType.indexOf('q') !== -1
-                                ? workType.filter(workType => workType !== 'q')
-                                : [...workType, 'q'],
-                          }),
-                        },
-                      ]}
-                    />
+            <TogglesContext.Consumer>
+              {({ showCatalogueSearchFacets }) =>
+                showCatalogueSearchFacets && (
+                  <div
+                    className={`row ${spacing(
+                      { s: 3, m: 5 },
+                      { padding: ['top'] }
+                    )}`}
+                  >
+                    <div className="container">
+                      <div className="grid">
+                        <div className="grid__cell">
+                          <WorkTags
+                            tags={[
+                              {
+                                query: 'Books',
+                                textParts: ['Books'],
+                                selected: workType.indexOf('a') !== -1,
+                                linkAttributes: worksUrl({
+                                  query,
+                                  itemsLocationsLocationType,
+                                  page,
+                                  workType:
+                                    workType.indexOf('a') !== -1
+                                      ? workType.filter(
+                                          workType => workType !== 'a'
+                                        )
+                                      : [...workType, 'a'],
+                                }),
+                              },
+                              {
+                                query: 'Pictures',
+                                textParts: ['Pictures'],
+                                selected: workType.indexOf('k') !== -1,
+                                linkAttributes: worksUrl({
+                                  query,
+                                  itemsLocationsLocationType,
+                                  page,
+                                  workType:
+                                    workType.indexOf('k') !== -1
+                                      ? workType.filter(
+                                          workType => workType !== 'k'
+                                        )
+                                      : [...workType, 'k'],
+                                }),
+                              },
+                              {
+                                query: 'Digital images',
+                                textParts: ['Digital images'],
+                                selected: workType.indexOf('q') !== -1,
+                                linkAttributes: worksUrl({
+                                  query,
+                                  itemsLocationsLocationType,
+                                  page,
+                                  workType:
+                                    workType.indexOf('q') !== -1
+                                      ? workType.filter(
+                                          workType => workType !== 'q'
+                                        )
+                                      : [...workType, 'q'],
+                                }),
+                              },
+                            ]}
+                          />
+                        </div>
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-            </div>
+                )
+              }
+            </TogglesContext.Consumer>
 
             <div
               className={`row ${spacing({ s: 4 }, { padding: ['top'] })}`}
@@ -411,10 +426,14 @@ export const Works = ({
 Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
-  const { showCatalogueSearchFilters = false } = ctx.query.toggles;
+  const {
+    showCatalogueSearchFilters = false,
+    showCatalogueSearchFacets = false,
+  } = ctx.query.toggles;
+  const isShowy = showCatalogueSearchFilters || showCatalogueSearchFacets;
 
   const workTypeQuery = ctx.query.workType;
-  const workType = !showCatalogueSearchFilters
+  const workType = !isShowy
     ? ['k', 'q']
     : !workTypeQuery
     ? []
@@ -423,13 +442,13 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const itemsLocationsLocationType =
     'items.locations.locationType' in ctx.query
       ? ctx.query['items.locations.locationType'].split(',')
-      : showCatalogueSearchFilters
+      : isShowy
       ? ['iiif-image', 'iiif-presentation']
       : ['iiif-image'];
 
   const filters = {
     'items.locations.locationType': itemsLocationsLocationType,
-    workType: !showCatalogueSearchFilters
+    workType: !isShowy
       ? workType
       : workType.length === 0
       ? ['a', 'k', 'q']

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -8,14 +8,15 @@ import {
   type CatalogueResultsList,
 } from '@weco/common/model/catalogue';
 import { font, grid, spacing, classNames } from '@weco/common/utils/classnames';
+import { workUrl, worksUrl } from '@weco/common/services/catalogue/urls';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import WorkPromo from '@weco/common/views/components/WorkPromo/WorkPromo';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
+import WorkTags from '@weco/common/views/components/WorkTags/WorkTags';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
-import { workUrl, worksUrl } from '@weco/common/services/catalogue/urls';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
@@ -225,6 +226,63 @@ export const Works = ({
             </div>
 
             <div
+              className={`row ${spacing({ s: 3, m: 5 }, { padding: ['top'] })}`}
+            >
+              <div className="container">
+                <div className="grid">
+                  <div className="grid__cell">
+                    <WorkTags
+                      tags={[
+                        {
+                          query: 'Books',
+                          textParts: ['Books'],
+                          selected: workType.indexOf('a') !== -1,
+                          linkAttributes: worksUrl({
+                            query,
+                            itemsLocationsLocationType,
+                            page,
+                            workType:
+                              workType.indexOf('a') !== -1
+                                ? workType.filter(workType => workType !== 'a')
+                                : [...workType, 'a'],
+                          }),
+                        },
+                        {
+                          query: 'Pictures',
+                          textParts: ['Pictures'],
+                          selected: workType.indexOf('k') !== -1,
+                          linkAttributes: worksUrl({
+                            query,
+                            itemsLocationsLocationType,
+                            page,
+                            workType:
+                              workType.indexOf('k') !== -1
+                                ? workType.filter(workType => workType !== 'k')
+                                : [...workType, 'k'],
+                          }),
+                        },
+                        {
+                          query: 'Digital images',
+                          textParts: ['Digital images'],
+                          selected: workType.indexOf('q') !== -1,
+                          linkAttributes: worksUrl({
+                            query,
+                            itemsLocationsLocationType,
+                            page,
+                            workType:
+                              workType.indexOf('q') !== -1
+                                ? workType.filter(workType => workType !== 'q')
+                                : [...workType, 'q'],
+                          }),
+                        },
+                      ]}
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div
               className={`row ${spacing({ s: 4 }, { padding: ['top'] })}`}
               style={{ opacity: loading ? 0 : 1 }}
             >
@@ -356,23 +414,11 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const { showCatalogueSearchFilters = false } = ctx.query.toggles;
 
   const workTypeQuery = ctx.query.workType;
-  // We sometimes get workType=k%2Cq&workType=a as some checkboxes are
-  // considered multiple workTypes
-  const workType = Array.isArray(workTypeQuery)
-    ? workTypeQuery
-        .map(workType => workType.split(','))
-        .reduce(
-          (workTypes, workTypeStringArray) => [
-            ...workTypes,
-            ...workTypeStringArray,
-          ],
-          []
-        )
-    : typeof workTypeQuery === 'string'
-    ? workTypeQuery.split(',')
-    : showCatalogueSearchFilters
+  const workType = !showCatalogueSearchFilters
+    ? ['k', 'q']
+    : !workTypeQuery
     ? []
-    : ['k', 'q'];
+    : workTypeQuery.split(',').filter(Boolean);
 
   const itemsLocationsLocationType =
     'items.locations.locationType' in ctx.query
@@ -383,7 +429,11 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
 
   const filters = {
     'items.locations.locationType': itemsLocationsLocationType,
-    workType,
+    workType: !showCatalogueSearchFilters
+      ? workType
+      : workType.length === 0
+      ? ['a', 'k', 'q']
+      : workType,
   };
 
   const worksOrError =

--- a/common/styles/base/_icons.scss
+++ b/common/styles/base/_icons.scss
@@ -32,6 +32,10 @@
   }
 }
 
+.icon--24 {
+  height: 24px;
+}
+
 .icon--90 {
   transform: rotate(90deg);
 }

--- a/common/styles/components/_input.scss
+++ b/common/styles/components/_input.scss
@@ -89,6 +89,7 @@
 }
 
 .input__control-indicator--checkbox {
+  background: color('white');
   &:after {
     transition: opacity 400ms ease;
   }

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -117,6 +117,18 @@ const Paginator = ({
             </a>
           </NextLink>
         )}
+        {!prev && (
+          <div style={{ opacity: 0.25 }}>
+            <Control
+              type="light"
+              extraClasses={`icon--180 ${spacing(
+                { s: 2 },
+                { margin: ['right'] }
+              )}`}
+              icon="arrow"
+            />
+          </div>
+        )}
 
         <span>
           Page {currentPage} of {totalPages}
@@ -137,6 +149,15 @@ const Paginator = ({
               />
             </a>
           </NextLink>
+        )}
+        {!next && (
+          <div style={{ opacity: 0.25 }}>
+            <Control
+              type="light"
+              extraClasses={`${spacing({ s: 2 }, { margin: ['left'] })}`}
+              icon="arrow"
+            />
+          </div>
         )}
       </div>
     </Fragment>

--- a/common/views/components/WorkTags/WorkTags.js
+++ b/common/views/components/WorkTags/WorkTags.js
@@ -1,12 +1,15 @@
+// @flow
+import type { NextLinkType } from '@weco/common/model/next-link-type';
 import styled from 'styled-components';
 import { spacing, font, classNames } from '../../../utils/classnames';
 import NextLink from 'next/link';
-import type { NextLinkType } from '@weco/common/model/next-link-type';
+import Icon from '@weco/common/views/components/Icon/Icon';
 
 export type WorkTagType = {|
   query: string,
   textParts: string[],
   linkAttributes: NextLinkType,
+  selected?: boolean,
 |};
 
 const WorkTag = styled.div`
@@ -34,7 +37,7 @@ const WorkTags = ({ tags }: Props) => {
           [spacing({ s: 0 }, { padding: ['left'], margin: ['top'] })]: true,
         })}
       >
-        {tags.map(({ query, textParts, linkAttributes }) => {
+        {tags.map(({ query, textParts, linkAttributes, selected }) => {
           return (
             <li
               key={query}
@@ -49,7 +52,9 @@ const WorkTags = ({ tags }: Props) => {
                       [spacing({ s: 1 }, { margin: ['right'] })]: true,
                       [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
                       'line-height-1': true,
-                      'inline-block bg-hover-green font-hover-white': true,
+                      'inline-block': true,
+                      'bg-hover-green font-hover-white': !selected,
+                      'bg-green font-white': selected,
                       'border-color-green border-width-1': true,
                     })}
                   >
@@ -64,7 +69,12 @@ const WorkTags = ({ tags }: Props) => {
                           'inline-block': true,
                         })}
                       >
-                        {part}
+                        <div className="flex">
+                          {part}
+                          {selected && (
+                            <Icon name="cross" extraClasses="icon--24" />
+                          )}
+                        </div>
                         {i !== arr.length - 1 && (
                           <span
                             className={classNames({


### PR DESCRIPTION
_I had previously seen this as filters V facets, it's not, it's just a different interface for a (lightly) faceted search._

The difference between these versions is whether the filters are attached to the query, or to the results. 

Another thing being testing here after talking to @GarethOrmerod was whether they act as link style filters act as link, or you select them and hit search. This is a bit of a hybrid that I would like to simplify if we go with it.

__Attached to query (filters)__
* great for refining searches as they are part of the search itself 
* generally apply across the whole range of your data
* persist with the search query
* because of ☝️ are often bundled with the search term
* often selected pre-search, or just after search term

__Attached to results (aggregations)__
* great to apply relevant categorisations of fetched data. a.k.a. Aggregations
* often created from aggregations of the results
* because of ☝️ often reset when the search query resets
* because of ☝️ are often bundled with the results
* often selected as options post search

Google search is a good example. 

__Note__
* `Search type: Images` and the type of `Image type: GIF` are filters, and persist through the search
* `Horn` and `Train` are aggregations

![screencast-www google com-2019 02 26-18-56-01](https://user-images.githubusercontent.com/31692/53438917-cb7ab500-39f8-11e9-929e-9c03d221cc91.gif)

---

Here's two versions.

## Filters
![facets](https://user-images.githubusercontent.com/31692/53438984-f49b4580-39f8-11e9-9570-30da4383b2e0.gif)

## Aggregations(-sh, they're not really)
![filters](https://user-images.githubusercontent.com/31692/53438997-fbc25380-39f8-11e9-8d5f-229a340e6731.gif)

---

Fun experiment, but my conclusion, following this logic, is that `workType` feels like it's attached to the query, rather than the results?

Definitely up to explore more, but need to see what we want for testing on Thursday.