### PR TITLE
remove checkboxes from filters to be explicit about how they work

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -48,14 +48,14 @@ const ClearSearch = styled.button`
 type SearchTagProps = {
   link: NextLinkType,
   label: string,
-  checked: boolean,
+  selected: boolean,
 };
-const SearchTag = ({ link, label, checked }: SearchTagProps) => {
+const SearchTag = ({ link, label, selected }: SearchTagProps) => {
   return (
     <NextLink {...link}>
       <a
         className={classNames({
-          // 'bg-pumice': true,
+          'font-teal': selected,
           'flex-inline': true,
           'flex--v-center': true,
           pointer: true,
@@ -65,15 +65,7 @@ const SearchTag = ({ link, label, checked }: SearchTagProps) => {
           )]: true,
           [font({ s: 'HNL4' })]: true,
         })}
-        style={{ borderRadius: '3px', textDecoration: 'underline' }}
       >
-        <input
-          className={classNames({
-            [spacing({ s: 1 }, { margin: ['right'] })]: true,
-          })}
-          type="checkbox"
-          checked={checked}
-        />
         {label}
       </a>
     </NextLink>
@@ -228,7 +220,7 @@ const SearchForm = ({
                     name={'workType'}
                     label="Digital images"
                     value="q"
-                    checked={workType.indexOf('q') !== -1}
+                    selected={workType.indexOf('q') !== -1}
                     link={worksUrl({
                       query,
                       workType:
@@ -243,7 +235,7 @@ const SearchForm = ({
                     name={'workType'}
                     label="Pictures"
                     value="k"
-                    checked={workType.indexOf('k') !== -1}
+                    selected={workType.indexOf('k') !== -1}
                     link={worksUrl({
                       query,
                       workType:
@@ -258,7 +250,7 @@ const SearchForm = ({
                     name={'workType'}
                     label="Books"
                     value="a"
-                    checked={workType.indexOf('a') !== -1}
+                    selected={workType.indexOf('a') !== -1}
                     link={worksUrl({
                       query,
                       workType:

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -167,6 +167,12 @@ const SearchForm = ({
             </button>
           </SearchButtonWrapper>
         </div>
+        <input
+          type="hidden"
+          name="items.locations.locationType"
+          value={itemsLocationsLocationType}
+        />
+        <input type="hidden" name="workType" value={workType.join(',')} />
       </form>
       <TogglesContext.Consumer>
         {({ showCatalogueSearchFilters, feedback }) =>

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -218,6 +218,21 @@ const SearchForm = ({
                   </legend>
                   <SearchTag
                     name={'workType'}
+                    label="Books"
+                    value="a"
+                    selected={workType.indexOf('a') !== -1}
+                    link={worksUrl({
+                      query,
+                      workType:
+                        workType.indexOf('a') !== -1
+                          ? workType.filter(workType => workType !== 'a')
+                          : [...workType, 'a'],
+                      itemsLocationsLocationType,
+                      page: 1,
+                    })}
+                  />
+                  <SearchTag
+                    name={'workType'}
                     label="Digital images"
                     value="q"
                     selected={workType.indexOf('q') !== -1}
@@ -242,21 +257,6 @@ const SearchForm = ({
                         workType.indexOf('k') !== -1
                           ? workType.filter(workType => workType !== 'k')
                           : [...workType, 'k'],
-                      itemsLocationsLocationType,
-                      page: 1,
-                    })}
-                  />
-                  <SearchTag
-                    name={'workType'}
-                    label="Books"
-                    value="a"
-                    selected={workType.indexOf('a') !== -1}
-                    link={worksUrl({
-                      query,
-                      workType:
-                        workType.indexOf('a') !== -1
-                          ? workType.filter(workType => workType !== 'a')
-                          : [...workType, 'a'],
                       itemsLocationsLocationType,
                       page: 1,
                     })}

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -355,24 +355,13 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
   const { showCatalogueSearchFilters = false } = ctx.query.toggles;
 
+  const defaultWorkType = ['k', 'q'];
   const workTypeQuery = ctx.query.workType;
-  // We sometimes get workType=k%2Cq&workType=a as some checkboxes are
-  // considered multiple workTypes
-  const workType = Array.isArray(workTypeQuery)
-    ? workTypeQuery
-        .map(workType => workType.split(','))
-        .reduce(
-          (workTypes, workTypeStringArray) => [
-            ...workTypes,
-            ...workTypeStringArray,
-          ],
-          []
-        )
-    : typeof workTypeQuery === 'string'
-    ? workTypeQuery.split(',')
-    : showCatalogueSearchFilters
+  const workType = !showCatalogueSearchFilters
+    ? defaultWorkType
+    : !workTypeQuery
     ? []
-    : ['k', 'q'];
+    : workTypeQuery.split(',').filter(Boolean);
 
   const itemsLocationsLocationType =
     'items.locations.locationType' in ctx.query
@@ -380,12 +369,17 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
       : showCatalogueSearchFilters
       ? ['iiif-image', 'iiif-presentation']
       : ['iiif-image'];
-
+  console.info(workType);
   const filters = {
     'items.locations.locationType': itemsLocationsLocationType,
-    workType,
+    workType: !showCatalogueSearchFilters
+      ? defaultWorkType
+      : workType.length === 0
+      ? ['a', 'k', 'q']
+      : workType,
   };
 
+  console.info(filters);
   const worksOrError =
     query && query !== '' ? await getWorks({ query, page, filters }) : null;
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -369,7 +369,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
       : showCatalogueSearchFilters
       ? ['iiif-image', 'iiif-presentation']
       : ['iiif-image'];
-  console.info(workType);
+
   const filters = {
     'items.locations.locationType': itemsLocationsLocationType,
     workType: !showCatalogueSearchFilters
@@ -379,7 +379,6 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
       : workType,
   };
 
-  console.info(filters);
   const worksOrError =
     query && query !== '' ? await getWorks({ query, page, filters }) : null;
 


### PR DESCRIPTION
Ref #4134

TL;DR
* ✨ Clears up confusion around filter function
* 🐛 Makes sure we're not searching the whole catalogue as noticed by @hthair 

From the exploratory work done on #4181 and working with @GarethOrmerod, there were a couple of things that were confusing the matter:

* Are the filters tied to the results or search term? In this case it seems to be the search term as the `workType`s are not tied to any aggregation data on the results themselves and can be applied Google example in #4181). 
* Are these link style filters, or checkboxes, i.e. do you apply them pre-search, or post-search. As per discussion with @Heesoomoon, they are to act like links and affect the results immediately.

All in all feels quite nice, I'm sure some things will come out in the wash during testing.

For the design the only selected states we could find on the site were on the newsletter signup and main navigation. The main navigation didn't feel applicable, so maybe something to start thinking about.

![screencast-localhost-3000-2019 02 27-08-32-11](https://user-images.githubusercontent.com/31692/53476425-49c36f80-3a6a-11e9-8948-ceb9e51e769c.gif)
