### PR TITLE
Make work types more obviously (de)selectable

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -1,13 +1,12 @@
 // @flow
 import { type CatalogueResultsList } from '@weco/common/model/catalogue';
-import { type NextLinkType } from '@weco/common/model/next-link-type';
 import { useState, useRef } from 'react';
 import Router from 'next/router';
-import NextLink from 'next/link';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import SelectableTags from '@weco/common/views/components/SelectableTags/SelectableTags';
 import { classNames, font, spacing } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { worksUrl } from '@weco/common/services/catalogue/urls';
@@ -44,33 +43,6 @@ const SearchButtonWrapper = styled.div`
 const ClearSearch = styled.button`
   right: 12px;
 `;
-
-type SearchTagProps = {
-  link: NextLinkType,
-  label: string,
-  selected: boolean,
-};
-const SearchTag = ({ link, label, selected }: SearchTagProps) => {
-  return (
-    <NextLink {...link}>
-      <a
-        className={classNames({
-          'font-teal': selected,
-          'flex-inline': true,
-          'flex--v-center': true,
-          pointer: true,
-          [spacing(
-            { s: 1 },
-            { padding: ['left', 'right'], margin: ['left'] }
-          )]: true,
-          [font({ s: 'HNL4' })]: true,
-        })}
-      >
-        {label}
-      </a>
-    </NextLink>
-  );
-};
 
 const SearchForm = ({
   initialQuery = '',
@@ -179,9 +151,6 @@ const SearchForm = ({
           (showCatalogueSearchFilters || feedback) && (
             <div
               className={classNames({
-                flex: true,
-                'flex--wrap': true,
-                'flex--v-center': true,
                 [spacing({ s: 1 }, { margin: ['top'] })]: true,
               })}
             >
@@ -205,7 +174,7 @@ const SearchForm = ({
                 </p>
               )}
               {showCatalogueSearchFilters && works && (
-                <fieldset
+                <div
                   className={classNames({
                     relative: true,
                   })}
@@ -213,61 +182,60 @@ const SearchForm = ({
                     left: '1px',
                   }}
                 >
-                  <legend
+                  <div
                     className={classNames({
                       'float-l': true,
                       [font({ s: 'HNM4' })]: true,
+                      [spacing({ s: 1 }, { margin: ['right'] })]: true,
                     })}
                     style={{ marginTop: '3px' }}
                   >
                     Filter by:
-                  </legend>
-                  <SearchTag
-                    name={'workType'}
-                    label="Books"
-                    value="a"
-                    selected={workType.indexOf('a') !== -1}
-                    link={worksUrl({
-                      query,
-                      workType:
-                        workType.indexOf('a') !== -1
-                          ? workType.filter(workType => workType !== 'a')
-                          : [...workType, 'a'],
-                      itemsLocationsLocationType,
-                      page: 1,
-                    })}
+                  </div>
+                  <SelectableTags
+                    tags={[
+                      {
+                        textParts: ['Books'],
+                        linkAttributes: worksUrl({
+                          query,
+                          workType:
+                            workType.indexOf('a') !== -1
+                              ? workType.filter(workType => workType !== 'a')
+                              : [...workType, 'a'],
+                          itemsLocationsLocationType,
+                          page: 1,
+                        }),
+                        selected: workType.indexOf('a') !== -1,
+                      },
+                      {
+                        textParts: ['Digital images'],
+                        linkAttributes: worksUrl({
+                          query,
+                          workType:
+                            workType.indexOf('q') !== -1
+                              ? workType.filter(workType => workType !== 'q')
+                              : [...workType, 'q'],
+                          itemsLocationsLocationType,
+                          page: 1,
+                        }),
+                        selected: workType.indexOf('q') !== -1,
+                      },
+                      {
+                        textParts: ['Pictures'],
+                        linkAttributes: worksUrl({
+                          query,
+                          workType:
+                            workType.indexOf('k') !== -1
+                              ? workType.filter(workType => workType !== 'k')
+                              : [...workType, 'k'],
+                          itemsLocationsLocationType,
+                          page: 1,
+                        }),
+                        selected: workType.indexOf('k') !== -1,
+                      },
+                    ]}
                   />
-                  <SearchTag
-                    name={'workType'}
-                    label="Digital images"
-                    value="q"
-                    selected={workType.indexOf('q') !== -1}
-                    link={worksUrl({
-                      query,
-                      workType:
-                        workType.indexOf('q') !== -1
-                          ? workType.filter(workType => workType !== 'q')
-                          : [...workType, 'q'],
-                      itemsLocationsLocationType,
-                      page: 1,
-                    })}
-                  />
-                  <SearchTag
-                    name={'workType'}
-                    label="Pictures"
-                    value="k"
-                    selected={workType.indexOf('k') !== -1}
-                    link={worksUrl({
-                      query,
-                      workType:
-                        workType.indexOf('k') !== -1
-                          ? workType.filter(workType => workType !== 'k')
-                          : [...workType, 'k'],
-                      itemsLocationsLocationType,
-                      page: 1,
-                    })}
-                  />
-                </fieldset>
+                </div>
               )}
             </div>
           )

--- a/common/styles/base/_icons.scss
+++ b/common/styles/base/_icons.scss
@@ -44,6 +44,10 @@
   transform: rotate(270deg);
 }
 
+.icon--18 {
+  height: 18px;
+}
+
 .icon-rounder {
   border: 2px solid color('currentColor');
   border-radius: 50%;

--- a/common/views/components/SelectableTags/README.md
+++ b/common/views/components/SelectableTags/README.md
@@ -1,0 +1,3 @@
+## Purpose
+
+To indicate the links that will trigger a search.

--- a/common/views/components/SelectableTags/SelectableTags.js
+++ b/common/views/components/SelectableTags/SelectableTags.js
@@ -1,0 +1,115 @@
+// @flow
+
+import styled from 'styled-components';
+import NextLink from 'next/link';
+import type { NextLinkType } from '@weco/common/model/next-link-type';
+import { spacing, font, classNames } from '../../../utils/classnames';
+import Icon from '@weco/common/views/components/Icon/Icon';
+
+export type TagType = {|
+  textParts: string[],
+  linkAttributes: NextLinkType,
+  selected: boolean,
+|};
+
+const Tag = styled.div`
+  border-radius: 3px;
+  text-decoration: none;
+  padding: ${props =>
+    props.selected ? '0.2em 0.5em' : '0.2em calc(0.5em + 12px)'};
+  transition: color 250ms ease, background 250ms ease;
+`;
+
+type Props = {
+  tags: TagType[],
+};
+
+const SelectableTags = ({ tags }: Props) => {
+  return (
+    <div
+      className={classNames({
+        // Cancel out space below individual tags
+        [spacing({ s: -2 }, { margin: ['bottom'] })]: true,
+      })}
+    >
+      <ul
+        className={classNames({
+          'plain-list': true,
+          [spacing({ s: 0 }, { padding: ['left'], margin: ['top'] })]: true,
+        })}
+      >
+        {tags.map(({ textParts, linkAttributes, selected }) => {
+          return (
+            <li
+              key={textParts.join('-')}
+              className={classNames({
+                'inline-block': true,
+              })}
+            >
+              <NextLink {...linkAttributes}>
+                <a>
+                  <Tag
+                    selected={selected}
+                    className={classNames({
+                      [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                      [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
+                      'line-height-1': true,
+                      'inline-block': true,
+                      'bg-hover-green font-hover-white': !selected,
+                      'bg-green font-white': selected,
+                      'border-color-green border-width-1': true,
+                    })}
+                  >
+                    {textParts.map((part, i, arr) => (
+                      <span
+                        key={part}
+                        className={classNames({
+                          [font({ s: 'HNM5', m: 'HNM4' })]: i === 0,
+                          [font({ s: 'HNL5', m: 'HNL4' })]: i !== 0,
+                          [spacing({ s: 1 }, { margin: ['right'] })]:
+                            i !== arr.length - 1,
+                          'inline-block': true,
+                        })}
+                      >
+                        {selected && (
+                          <span
+                            className={classNames({
+                              flex: true,
+                              'flex--v-center': true,
+                            })}
+                          >
+                            {part}
+                            <Icon
+                              name="cross"
+                              extraClasses={classNames({
+                                'icon--18': true,
+                                [spacing({ s: 1 }, { margin: ['left'] })]: true,
+                              })}
+                            />
+                          </span>
+                        )}
+                        {!selected && part}
+                        {i !== arr.length - 1 && (
+                          <span
+                            className={classNames({
+                              [font({ s: 'HNL4' })]: true,
+                            })}
+                          >
+                            {' '}
+                            {i === 0 ? '|' : '–'}
+                          </span>
+                        )}
+                      </span>
+                    ))}
+                  </Tag>
+                </a>
+              </NextLink>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};
+
+export default SelectableTags;


### PR DESCRIPTION
To allow users to know they can, and also to not be so linky, but more selectable (similar to a segmented control).

As our design system is growing and becoming more robust, it felt good practise to follow this lifecycle, especially for testing (hence the copy/paste from `Tags`, although the follow the purpose of taking you to a new search).
<img width="911" alt="screen shot 2017-06-30 at 17 53 24" src="https://user-images.githubusercontent.com/31692/53507190-54ecbe80-3aaf-11e9-8b72-14f3705cbd7e.png">

![filters 2](https://user-images.githubusercontent.com/31692/53507039-11925000-3aaf-11e9-9820-cd8a608c340c.gif)

