### PR TITLE
add e-books and don't filter out non-digitised works

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -190,7 +190,7 @@ const SearchForm = ({
                     })}
                     style={{ marginTop: '3px' }}
                   >
-                    Filter by:
+                    Include:
                   </div>
                   <SelectableTags
                     tags={[
@@ -200,12 +200,17 @@ const SearchForm = ({
                           query,
                           workType:
                             workType.indexOf('a') !== -1
-                              ? workType.filter(workType => workType !== 'a')
-                              : [...workType, 'a'],
+                              ? workType.filter(
+                                  workType =>
+                                    !(workType === 'a' || workType === 'v')
+                                )
+                              : [...workType, 'a', 'v'],
                           itemsLocationsLocationType,
                           page: 1,
                         }),
-                        selected: workType.indexOf('a') !== -1,
+                        selected:
+                          workType.indexOf('a') !== -1 &&
+                          workType.indexOf('v') !== -1,
                       },
                       {
                         textParts: ['Digital images'],

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -387,7 +387,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
     'items.locations.locationType' in ctx.query
       ? ctx.query['items.locations.locationType'].split(',')
       : showCatalogueSearchFilters
-      ? ['iiif-image', 'iiif-presentation']
+      ? []
       : ['iiif-image'];
 
   const filters = {

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -387,7 +387,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
     'items.locations.locationType' in ctx.query
       ? ctx.query['items.locations.locationType'].split(',')
       : showCatalogueSearchFilters
-      ? []
+      ? ['iiif-image', 'iiif-presentation']
       : ['iiif-image'];
 
   const filters = {


### PR DESCRIPTION
Fixes #4198 

* Add E-Books under books filter
* ~Add non-digitised works (remove filter to return only items with `iiif-presentation` or `iiif-image` item locations)~ we are only returning digitised content.

