### PR TITLE
add item page

### DIFF
--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -1,4 +1,3 @@
-const { parse } = require('url');
 const Koa = require('koa');
 const Router = require('koa-router');
 const next = require('next');
@@ -26,6 +25,7 @@ module.exports = app
     route('/works/progress', '/progress', router, app);
     route('/works/:id', '/work', router, app);
     route('/works', '/works', router, app);
+    route('/works/:workId/items/:id', '/item', router, app);
 
     router.get('/works/management/healthcheck', async ctx => {
       ctx.status = 200;

--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -25,7 +25,7 @@ module.exports = app
     route('/works/progress', '/progress', router, app);
     route('/works/:id', '/work', router, app);
     route('/works', '/works', router, app);
-    route('/works/:workId/items/:id', '/item', router, app);
+    route('/works/:workId/items', '/item', router, app);
 
     router.get('/works/management/healthcheck', async ctx => {
       ctx.status = 200;

--- a/catalogue/webapp/package.json
+++ b/catalogue/webapp/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "@weco/catalogue",
   "version": "1.0.0",

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -3,14 +3,13 @@ import { type Context } from 'next';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 type Props = {|
   workId: string,
-  id: string,
 |};
 
-const ItemPage = ({ workId, id }: Props) => (
+const ItemPage = ({ workId }: Props) => (
   <PageLayout
     title={''}
     description={''}
-    url={{ pathname: `/works/${workId}/items/${id}` }}
+    url={{ pathname: `/works/${workId}/items` }}
     openGraphType={'website'}
     jsonLd={{ '@type': 'WebPage' }}
     siteSection={'works'}
@@ -18,13 +17,13 @@ const ItemPage = ({ workId, id }: Props) => (
     imageAltText={''}
     hideNewsletterPromo={true}
   >
-    <h1>{id}</h1>
+    <h1>{workId}</h1>
   </PageLayout>
 );
 
 ItemPage.getInitialProps = async (ctx: Context): Promise<Props> => {
-  const { id, workId } = ctx.query;
-  return { id, workId };
+  const { workId } = ctx.query;
+  return { workId };
 };
 
 export default ItemPage;

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -1,0 +1,30 @@
+// @flow
+import { type Context } from 'next';
+import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
+type Props = {|
+  workId: string,
+  id: string,
+|};
+
+const ItemPage = ({ workId, id }: Props) => (
+  <PageLayout
+    title={''}
+    description={''}
+    url={{ pathname: `/works/${workId}/items/${id}` }}
+    openGraphType={'website'}
+    jsonLd={{ '@type': 'WebPage' }}
+    siteSection={'works'}
+    imageUrl={'imageContentUrl'}
+    imageAltText={''}
+    hideNewsletterPromo={true}
+  >
+    <h1>{id}</h1>
+  </PageLayout>
+);
+
+ItemPage.getInitialProps = async (ctx: Context): Promise<Props> => {
+  const { id, workId } = ctx.query;
+  return { id, workId };
+};
+
+export default ItemPage;

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -9,10 +9,7 @@ import {
   type CatalogueApiRedirect,
 } from '@weco/common/model/catalogue';
 import { spacing, grid, classNames } from '@weco/common/utils/classnames';
-import {
-  getIiifPresentationLocation,
-  getIiifPresentationItemId,
-} from '@weco/common/utils/works';
+import { getIiifPresentationLocation } from '@weco/common/utils/works';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
@@ -91,8 +88,6 @@ export const WorkPage = ({
   const imageContentUrl =
     iiifImageLocationUrl &&
     iiifImageTemplate(iiifImageLocationUrl)({ size: `800,` });
-
-  const iiifPresentationItemId = getIiifPresentationItemId(work);
 
   return (
     <PageLayout
@@ -182,24 +177,21 @@ export const WorkPage = ({
         </div>
       </div>
 
-      <Layout12>
-        <>
-          {iiifPresentationItemId && (
-            <NextLink
-              {...itemUrl({
-                id: iiifPresentationItemId,
-                workId: work.id,
-                query,
-                page,
-                workType,
-                itemsLocationsLocationType,
-              })}
-            >
-              <a>View item</a>
-            </NextLink>
-          )}
-        </>
-      </Layout12>
+      {iiifManifest && (
+        <Layout12>
+          <NextLink
+            {...itemUrl({
+              workId: work.id,
+              query,
+              page,
+              workType,
+              itemsLocationsLocationType,
+            })}
+          >
+            <a>View item</a>
+          </NextLink>
+        </Layout12>
+      )}
 
       <TogglesContext.Consumer>
         {({ showWorkPreview, showMultiImageWorkPreview }) => (

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -1,6 +1,7 @@
 // @flow
 import { Fragment } from 'react';
 import Router from 'next/router';
+import NextLink from 'next/link';
 import fetch from 'isomorphic-unfetch';
 import {
   type Work,
@@ -8,7 +9,10 @@ import {
   type CatalogueApiRedirect,
 } from '@weco/common/model/catalogue';
 import { spacing, grid, classNames } from '@weco/common/utils/classnames';
-import { getIiifPresentationLocation } from '@weco/common/utils/works';
+import {
+  getIiifPresentationLocation,
+  getIiifPresentationItemId,
+} from '@weco/common/utils/works';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
@@ -20,7 +24,7 @@ import BackToResults from '@weco/common/views/components/BackToResults/BackToRes
 import WorkHeader from '@weco/common/views/components/WorkHeader/WorkHeader';
 import BetaBar from '@weco/common/views/components/BetaBar/BetaBar';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
-import { worksUrl } from '@weco/common/services/catalogue/urls';
+import { worksUrl, itemUrl } from '@weco/common/services/catalogue/urls';
 import WorkDetails from '../components/WorkDetails/WorkDetails';
 import SearchForm from '../components/SearchForm/SearchForm';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
@@ -87,6 +91,8 @@ export const WorkPage = ({
   const imageContentUrl =
     iiifImageLocationUrl &&
     iiifImageTemplate(iiifImageLocationUrl)({ size: `800,` });
+
+  const iiifPresentationItemId = getIiifPresentationItemId(work);
 
   return (
     <PageLayout
@@ -175,6 +181,25 @@ export const WorkPage = ({
           </div>
         </div>
       </div>
+
+      <Layout12>
+        <>
+          {iiifPresentationItemId && (
+            <NextLink
+              {...itemUrl({
+                id: iiifPresentationItemId,
+                workId: work.id,
+                query,
+                page,
+                workType,
+                itemsLocationsLocationType,
+              })}
+            >
+              <a>View item</a>
+            </NextLink>
+          )}
+        </>
+      </Layout12>
 
       <TogglesContext.Consumer>
         {({ showWorkPreview, showMultiImageWorkPreview }) => (

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -1,19 +1,22 @@
 // @flow
 import type { NextLinkType } from '@weco/common/model/next-link-type';
 
-type WorkUrlProps = {|
-  id: string,
+type WorksUrlProps = {|
   query: ?string,
   page: ?number,
   workType?: string[],
   itemsLocationsLocationType?: string[],
 |};
 
-type WorksUrlProps = {|
-  query: ?string,
-  page: ?number,
-  workType?: string[],
-  itemsLocationsLocationType?: string[],
+type WorkUrlProps = {|
+  ...WorksUrlProps,
+  id: string,
+|};
+
+type ItemUrlProps = {|
+  ...WorksUrlProps,
+  id: string,
+  workId: string,
 |};
 
 function removeEmpty(obj: Object): Object {
@@ -83,6 +86,38 @@ export function worksUrl({
     },
     as: {
       pathname: `/works`,
+      query: removeEmpty({
+        query: query || undefined,
+        page: page && page > 1 ? page : undefined,
+        ...workTypeAndItemsLocationType(workType, itemsLocationsLocationType),
+      }),
+    },
+  };
+}
+
+export function itemUrl({
+  id,
+  workId,
+  query,
+  page,
+  workType,
+  itemsLocationsLocationType,
+}: ItemUrlProps): NextLinkType {
+  return {
+    href: {
+      pathname: `/item`,
+      query: {
+        id,
+        workId,
+        ...removeEmpty({
+          query: query || undefined,
+          page: page && page > 1 ? page : undefined,
+          ...workTypeAndItemsLocationType(workType, itemsLocationsLocationType),
+        }),
+      },
+    },
+    as: {
+      pathname: `/works/${workId}/items/${id}`,
       query: removeEmpty({
         query: query || undefined,
         page: page && page > 1 ? page : undefined,

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -15,7 +15,6 @@ type WorkUrlProps = {|
 
 type ItemUrlProps = {|
   ...WorksUrlProps,
-  id: string,
   workId: string,
 |};
 
@@ -96,7 +95,6 @@ export function worksUrl({
 }
 
 export function itemUrl({
-  id,
   workId,
   query,
   page,
@@ -107,7 +105,6 @@ export function itemUrl({
     href: {
       pathname: `/item`,
       query: {
-        id,
         workId,
         ...removeEmpty({
           query: query || undefined,
@@ -117,7 +114,7 @@ export function itemUrl({
       },
     },
     as: {
-      pathname: `/works/${workId}/items/${id}`,
+      pathname: `/works/${workId}/items`,
       query: removeEmpty({
         query: query || undefined,
         page: page && page > 1 ? page : undefined,

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -24,13 +24,23 @@ export function getProductionDates(work: Work) {
 }
 
 export function getIiifPresentationLocation(work: Work) {
-  return work.items
-    .map(item =>
-      item.locations.find(
-        location => location.locationType.id === 'iiif-presentation'
-      )
-    )
-    .filter(Boolean)[0];
+  return work.items.find(item => {
+    const iiifPresentationLocation = item.locations.find(
+      location => location.locationType.id === 'iiif-presentation'
+    );
+    return iiifPresentationLocation || null;
+  });
+}
+
+export function getIiifPresentationItemId(work: Work): ?string {
+  const iiifPresentationItem = work.items.find(item => {
+    const iiifPresentationLocation = item.locations.find(
+      location => location.locationType.id === 'iiif-presentation'
+    );
+    return Boolean(iiifPresentationLocation);
+  });
+
+  return iiifPresentationItem && iiifPresentationItem.id;
 }
 
 const workTypeIcons = {

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -24,23 +24,13 @@ export function getProductionDates(work: Work) {
 }
 
 export function getIiifPresentationLocation(work: Work) {
-  return work.items.find(item => {
-    const iiifPresentationLocation = item.locations.find(
-      location => location.locationType.id === 'iiif-presentation'
-    );
-    return iiifPresentationLocation || null;
-  });
-}
-
-export function getIiifPresentationItemId(work: Work): ?string {
-  const iiifPresentationItem = work.items.find(item => {
-    const iiifPresentationLocation = item.locations.find(
-      location => location.locationType.id === 'iiif-presentation'
-    );
-    return Boolean(iiifPresentationLocation);
-  });
-
-  return iiifPresentationItem && iiifPresentationItem.id;
+  return work.items
+    .map(item =>
+      item.locations.find(
+        location => location.locationType.id === 'iiif-presentation'
+      )
+    )
+    .filter(Boolean)[0];
 }
 
 const workTypeIcons = {


### PR DESCRIPTION
Ref: #4147

Adds a link to, for example, `/works/fwquzvcf/items` which will then render the `DigitalLocation` of the first item.

Not all items have IDs due to the fact that the ID is based on Sierra's Item ID, and we only have this for items with `PhysicalLocation`s.