### PR TITLE
make search query logic simpler by making parameters nullable

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -13,8 +13,8 @@ import { worksUrl } from '@weco/common/services/catalogue/urls';
 
 type Props = {|
   initialQuery: string,
-  initialWorkType: string[],
-  initialItemsLocationsLocationType: string[],
+  initialWorkType: ?(string[]),
+  initialItemsLocationsLocationType: ?(string[]),
   ariaDescribedBy: string,
   compact: boolean,
   works: ?CatalogueResultsList,
@@ -46,8 +46,8 @@ const ClearSearch = styled.button`
 
 const SearchForm = ({
   initialQuery = '',
-  initialWorkType = [],
-  initialItemsLocationsLocationType = [],
+  initialWorkType,
+  initialItemsLocationsLocationType,
   ariaDescribedBy,
   compact,
   works,
@@ -139,12 +139,16 @@ const SearchForm = ({
             </button>
           </SearchButtonWrapper>
         </div>
-        <input
-          type="hidden"
-          name="items.locations.locationType"
-          value={itemsLocationsLocationType}
-        />
-        <input type="hidden" name="workType" value={workType.join(',')} />
+        {itemsLocationsLocationType && (
+          <input
+            type="hidden"
+            name="items.locations.locationType"
+            value={itemsLocationsLocationType.join(',')}
+          />
+        )}
+        {workType && (
+          <input type="hidden" name="workType" value={workType.join(',')} />
+        )}
       </form>
       <TogglesContext.Consumer>
         {({ showCatalogueSearchFilters, feedback }) =>
@@ -190,7 +194,7 @@ const SearchForm = ({
                     })}
                     style={{ marginTop: '3px' }}
                   >
-                    Include:
+                    Show:
                   </div>
                   <SelectableTags
                     tags={[
@@ -198,45 +202,39 @@ const SearchForm = ({
                         textParts: ['Books'],
                         linkAttributes: worksUrl({
                           query,
-                          workType:
-                            workType.indexOf('a') !== -1
-                              ? workType.filter(
-                                  workType =>
-                                    !(workType === 'a' || workType === 'v')
-                                )
-                              : [...workType, 'a', 'v'],
+                          workType: workType
+                            ? workType.indexOf('a') !== -1 ||
+                              workType.indexOf('v') !== -1
+                              ? workType.filter(v => !(v === 'a' || v === 'v'))
+                              : [...workType, 'a', 'v']
+                            : ['a', 'v'],
                           itemsLocationsLocationType,
                           page: 1,
                         }),
-                        selected:
-                          workType.indexOf('a') !== -1 &&
-                          workType.indexOf('v') !== -1,
+                        selected: !!(
+                          workType &&
+                          (workType.indexOf('a') !== -1 &&
+                            workType.indexOf('v') !== -1)
+                        ),
                       },
                       {
-                        textParts: ['Digital images'],
+                        textParts: ['Visual'],
                         linkAttributes: worksUrl({
                           query,
-                          workType:
-                            workType.indexOf('q') !== -1
-                              ? workType.filter(workType => workType !== 'q')
-                              : [...workType, 'q'],
+                          workType: workType
+                            ? workType.indexOf('k') !== -1 ||
+                              workType.indexOf('q') !== -1
+                              ? workType.filter(v => !(v === 'k' || v === 'q'))
+                              : [...workType, 'k', 'q']
+                            : ['k', 'q'],
                           itemsLocationsLocationType,
                           page: 1,
                         }),
-                        selected: workType.indexOf('q') !== -1,
-                      },
-                      {
-                        textParts: ['Pictures'],
-                        linkAttributes: worksUrl({
-                          query,
-                          workType:
-                            workType.indexOf('k') !== -1
-                              ? workType.filter(workType => workType !== 'k')
-                              : [...workType, 'k'],
-                          itemsLocationsLocationType,
-                          page: 1,
-                        }),
-                        selected: workType.indexOf('k') !== -1,
+                        selected: !!(
+                          workType &&
+                          (workType.indexOf('k') !== -1 &&
+                            workType.indexOf('q') !== -1)
+                        ),
                       },
                     ]}
                   />

--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -19,8 +19,8 @@ type Props = {|
   work: Work,
   query: ?string,
   page: ?number,
-  workType: string[],
-  itemsLocationsLocationType: string[],
+  workType: ?(string[]),
+  itemsLocationsLocationType: ?(string[]),
 |};
 
 const Container = styled.div`

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -227,15 +227,8 @@ WorkPage.getInitialProps = async (
   ctx
 ): Promise<Props | CatalogueApiRedirect> => {
   const workTypeQuery = ctx.query.workType;
-  const workType = Array.isArray(workTypeQuery)
-    ? workTypeQuery
-    : typeof workTypeQuery === 'string'
-    ? workTypeQuery.split(',')
-    : ['k', 'q'];
-  const itemsLocationsLocationType =
-    'items.locations.locationType' in ctx.query
-      ? ctx.query['items.locations.locationType'].split(',')
-      : ['iiif-image'];
+  const itemsLocationsLocationTypeQuery =
+    ctx.query['items.locations.locationType'];
 
   const { id, query, page } = ctx.query;
   const workOrError = await getWork({ id });
@@ -264,8 +257,10 @@ WorkPage.getInitialProps = async (
       work: workOrError,
       iiifManifest: iiifManifest ? await iiifManifest.json() : null,
       page: page ? parseInt(page, 10) : null,
-      workType,
-      itemsLocationsLocationType,
+      workType: workTypeQuery && workTypeQuery.split(',').filter(Boolean),
+      itemsLocationsLocationType:
+        itemsLocationsLocationTypeQuery &&
+        itemsLocationsLocationTypeQuery.split(',').filter(Boolean),
     };
   }
 };

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -4,8 +4,8 @@ import type { NextLinkType } from '@weco/common/model/next-link-type';
 type WorksUrlProps = {|
   query: ?string,
   page: ?number,
-  workType?: string[],
-  itemsLocationsLocationType?: string[],
+  workType?: ?(string[]),
+  itemsLocationsLocationType?: ?(string[]),
 |};
 
 type WorkUrlProps = {|
@@ -23,19 +23,15 @@ function removeEmpty(obj: Object): Object {
   return JSON.parse(JSON.stringify(obj));
 }
 
-function workTypeAndItemsLocationType(workType, itemsLocationsLocationType) {
-  const isDefaultWorkType =
-    JSON.stringify(workType) === JSON.stringify(['k', 'q']);
-  const isDefaultItemsLocationsLocationType =
-    JSON.stringify(itemsLocationsLocationType) ===
-    JSON.stringify(['iiif-image']);
-
+function workTypeAndItemsLocationType(
+  workType: ?(string[]),
+  itemsLocationsLocationType: ?(string[])
+) {
   return {
-    workType: workType && !isDefaultWorkType ? workType.join(',') : undefined,
-    'items.locations.locationType':
-      itemsLocationsLocationType && !isDefaultItemsLocationsLocationType
-        ? itemsLocationsLocationType.join(',')
-        : undefined,
+    workType: workType ? workType.join(',') : undefined,
+    'items.locations.locationType': itemsLocationsLocationType
+      ? itemsLocationsLocationType.join(',')
+      : undefined,
   };
 }
 


### PR DESCRIPTION
Hopefully simplified the logic of how we construct and use the query parameters down the way.
`QS` = `QueryString`

This allows us to group filters by Books / Visual.

* If there is no `QS`, filter is set to `null`
* If this is set to `null`, we send a default array to the API dependant on the toggle, but the interface still gets `null`

This means we can still send and read a `QS` like `['k', 'v']` that doesn't get picked up further down the line  as default, and removes it, making it really hard for the interface to respond to the `QS`, i.e. the `SelectableTags`.