### PR TITLE
Work type filters as a segmented control

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -188,7 +188,7 @@ const SearchForm = ({
                       ),
                     },
                     {
-                      text: 'Visuals',
+                      text: 'Pictures',
                       link: worksUrl({
                         query,
                         workType: ['k', 'q'],

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -7,6 +7,7 @@ import TextInput from '@weco/common/views/components/TextInput/TextInput';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import SelectableTags from '@weco/common/views/components/SelectableTags/SelectableTags';
+import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import { classNames, font, spacing } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { worksUrl } from '@weco/common/services/catalogue/urls';
@@ -151,13 +152,58 @@ const SearchForm = ({
         )}
       </form>
       <TogglesContext.Consumer>
-        {({ showCatalogueSearchFilters, feedback }) =>
-          (showCatalogueSearchFilters || feedback) && (
+        {({ showCatalogueSearchFilters, feedback, tabbedNavOnSearchForm }) =>
+          (showCatalogueSearchFilters || feedback || tabbedNavOnSearchForm) && (
             <div
               className={classNames({
                 [spacing({ s: 1 }, { margin: ['top'] })]: true,
               })}
             >
+              {tabbedNavOnSearchForm && works && (
+                <TabNav
+                  large={false}
+                  items={[
+                    {
+                      text: 'All',
+                      link: worksUrl({
+                        query,
+                        workType: undefined,
+                        itemsLocationsLocationType,
+                        page: 1,
+                      }),
+                      selected: !workType,
+                    },
+                    {
+                      text: 'Books',
+                      link: worksUrl({
+                        query,
+                        workType: ['a', 'v'],
+                        itemsLocationsLocationType,
+                        page: 1,
+                      }),
+                      selected: !!(
+                        workType &&
+                        (workType.indexOf('a') !== -1 &&
+                          workType.indexOf('v') !== -1)
+                      ),
+                    },
+                    {
+                      text: 'Visuals',
+                      link: worksUrl({
+                        query,
+                        workType: ['k', 'q'],
+                        itemsLocationsLocationType,
+                        page: 1,
+                      }),
+                      selected: !!(
+                        workType &&
+                        (workType.indexOf('k') !== -1 &&
+                          workType.indexOf('q') !== -1)
+                      ),
+                    },
+                  ]}
+                />
+              )}
               {feedback && (
                 <p
                   className={classNames({

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -23,6 +23,7 @@ import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
 import WorkCard from '../components/WorkCard/WorkCard';
 import BetaBar from '@weco/common/views/components/BetaBar/BetaBar';
+import TabNav from '@weco/common/views/components/TabNav/TabNav';
 
 type Props = {|
   query: ?string,
@@ -203,6 +204,59 @@ export const Works = ({
         </div>
 
         {!works && <StaticWorksContent />}
+
+        <TogglesContext.Consumer>
+          {({ tabbedNavOnResults }) =>
+            tabbedNavOnResults &&
+            works && (
+              <Layout12>
+                <TabNav
+                  large={true}
+                  items={[
+                    {
+                      text: 'All',
+                      link: worksUrl({
+                        query,
+                        workType: undefined,
+                        itemsLocationsLocationType,
+                        page: 1,
+                      }),
+                      selected: !workType,
+                    },
+                    {
+                      text: 'Books',
+                      link: worksUrl({
+                        query,
+                        workType: ['a', 'v'],
+                        itemsLocationsLocationType,
+                        page: 1,
+                      }),
+                      selected: !!(
+                        workType &&
+                        (workType.indexOf('a') !== -1 &&
+                          workType.indexOf('v') !== -1)
+                      ),
+                    },
+                    {
+                      text: 'Visuals',
+                      link: worksUrl({
+                        query,
+                        workType: ['k', 'q'],
+                        itemsLocationsLocationType,
+                        page: 1,
+                      }),
+                      selected: !!(
+                        workType &&
+                        (workType.indexOf('k') !== -1 &&
+                          workType.indexOf('q') !== -1)
+                      ),
+                    },
+                  ]}
+                />
+              </Layout12>
+            )
+          }
+        </TogglesContext.Consumer>
 
         {works && works.results.length > 0 && (
           <Fragment>

--- a/common/model/text-links.js
+++ b/common/model/text-links.js
@@ -1,0 +1,3 @@
+// @flow
+import { type NextLinkType } from './next-link-type';
+export type TextLink = {| text: string, link: NextLinkType |};

--- a/common/views/components/TabNav/README.md
+++ b/common/views/components/TabNav/README.md
@@ -1,0 +1,3 @@
+## Purpose
+
+To navigate through categorisations within a set of results.

--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -1,0 +1,112 @@
+// @flow
+
+import styled from 'styled-components';
+import NextLink from 'next/link';
+import { type TextLink } from '../../../model/text-links';
+import { spacing, font, classNames } from '../../../utils/classnames';
+
+type SelectableTextLink = {| ...TextLink, selected: boolean |};
+
+// TODO: This large property is a bit silly but okay for while we're testing
+type Props = {
+  items: SelectableTextLink[],
+  large: boolean,
+};
+
+const NavItemInner = styled(({ className, selected, children, large }) => (
+  <span
+    className={classNames({
+      selected,
+      block: true,
+      relative: true,
+      [className]: true,
+      [spacing({ s: 3 }, { margin: ['right'] })]: large,
+    })}
+  >
+    {children}
+  </span>
+))`
+  padding: ${props => (props.large ? '1rem 0.3rem' : '0 0.3rem 1rem')};
+  z-index: 1;
+
+  &:after {
+    content: '';
+    position: absolute;
+    bottom: 1rem;
+    height: 0.6rem;
+    left: 0;
+    width: 0;
+    background: ${props => props.theme.colors.yellow};
+    z-index: -1;
+    transition: width 200ms ease;
+  }
+
+  &.selected,
+  &:hover,
+  &:focus {
+    &:after {
+      width: 100%;
+      // Prevent iOS double-tap link issue
+      // https://css-tricks.com/annoying-mobile-double-tap-link-issue/
+      @media (pointer: coarse) {
+        width: 0;
+      }
+    }
+  }
+`;
+
+const NavItem = ({
+  link,
+  text,
+  selected,
+  large,
+}: {|
+  ...SelectableTextLink,
+  large: boolean,
+|}) => (
+  <NextLink {...link}>
+    <a
+      className={classNames({
+        'plain-link': true,
+        block: true,
+      })}
+    >
+      <NavItemInner selected={selected} large={large}>
+        {text}
+      </NavItemInner>
+    </a>
+  </NextLink>
+);
+
+const TabNav = ({ items, large }: Props) => {
+  return (
+    <div
+      className={classNames({
+        // Cancel out space below individual tags
+        [font({ s: large ? 'HNM3' : 'HNM4' })]: true,
+        [spacing({ s: -2 }, { margin: ['bottom'] })]: true,
+      })}
+    >
+      <ul
+        className={classNames({
+          'plain-list': true,
+          flex: true,
+          [spacing({ s: 0 }, { padding: ['left'], margin: ['top'] })]: true,
+        })}
+      >
+        {items.map(item => (
+          <li
+            key={item.text}
+            style={{
+              marginRight: '1vw',
+            }}
+          >
+            <NavItem {...item} large={large} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TabNav;

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -74,6 +74,18 @@ const featureToggles = [
       'Letting people know that the service is being worked on, how they might ' +
       "find out about what's going on, and let us know what they think.",
   },
+  {
+    id: 'tabbedNavOnSearchForm',
+    title: 'Tabbed work type navigation on search results',
+    description:
+      'Tabbed navigation on search form to allow people to select between books and visuals',
+  },
+  {
+    id: 'tabbedNavOnResults',
+    title: 'Tabbed work type navigation on search form',
+    description:
+      'Tabbed navigation on search results to allow people to select between books and visuals',
+  },
 ];
 
 const IndexPage = () => {


### PR DESCRIPTION
Creates two types of Tabbed nav for the work type filters.

One associated with the search bar (as discussed) and another with results as it's something that feels worth mucking around with.

The filters are Books (Books & E-Books) and Visuals (Images & Pictures).

![screencast-localhost-3000-2019 03 06-16-42-06](https://user-images.githubusercontent.com/31692/53898041-3e0a1700-402f-11e9-9e44-10283ef9a807.gif)
