### PR TITLE
Playing with pagination

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -186,17 +186,6 @@ export const Works = ({
                   historical library materials and museum objects to
                   contemporary digital photographs.
                 </p>
-                {works && (
-                  <p
-                    className={classNames([
-                      spacing({ s: 2 }, { margin: ['top', 'bottom'] }),
-                      font({ s: 'LR3', m: 'LR2' }),
-                    ])}
-                  >
-                    {works.totalResults !== 0 ? works.totalResults : 'No'}{' '}
-                    results for &apos;{query}&apos;
-                  </p>
-                )}
               </div>
             </div>
           </div>
@@ -212,8 +201,23 @@ export const Works = ({
               <div className="container">
                 <div className="grid">
                   <div className="grid__cell">
-                    <div className="flex flex--h-space-between flex--v-center">
+                    <div className="flex flex--h-space-between flex--v-center flex--wrap">
                       <Fragment>
+                        {works && (
+                          <p
+                            className={classNames([
+                              'font-pewter',
+                              'flex__grow',
+                              spacing({ s: 2 }, { margin: ['top', 'bottom'] }),
+                              font({ s: 'LR3', m: 'LR2' }),
+                            ])}
+                          >
+                            {works.totalResults !== 0
+                              ? works.totalResults
+                              : 'No'}{' '}
+                            results for &apos;{query}&apos;
+                          </p>
+                        )}
                         <Paginator
                           currentPage={page || 1}
                           pageSize={works.pageSize}

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -189,6 +189,10 @@
   justify-content: space-between;
 }
 
+.flex__grow {
+  flex-grow: 1;
+}
+
 .flex-end {
   justify-content: flex-end;
 }
@@ -458,6 +462,10 @@
 
 .opacity-0 {
   opacity: 0;
+}
+
+.opacity-disabled {
+  opacity: 0.3;
 }
 
 .hidden {

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -81,12 +81,13 @@ const Paginator = ({
   return (
     <Fragment>
       <div
-        className={`flex flex--v-center font-pewter ${font({
-          s: 'LR3',
-          m: 'LR2',
-        })}`}
+        className={classNames({
+          'flex flex--v-center font-pewter': true,
+          [spacing({ s: 2 }, { margin: ['right'] })]: true,
+          [font({ s: 'LR3', m: 'LR2' })]: true,
+        })}
       >
-        Showing {rangeStart} - {rangeEnd}
+        {rangeStart} - {rangeEnd} |{' '}
       </div>
       <div
         className={classNames({
@@ -117,6 +118,17 @@ const Paginator = ({
             </a>
           </NextLink>
         )}
+        {!prev && (
+          <Control
+            type="light"
+            extraClasses={`opacity-disabled icon--180 ${spacing(
+              { s: 2 },
+              { margin: ['right'] }
+            )}`}
+            icon="arrow"
+            text={`No previous page`}
+          />
+        )}
 
         <span>
           Page {currentPage} of {totalPages}
@@ -137,6 +149,17 @@ const Paginator = ({
               />
             </a>
           </NextLink>
+        )}
+        {!next && (
+          <Control
+            type="light"
+            extraClasses={`opacity-disabled ${spacing(
+              { s: 2 },
+              { margin: ['left'] }
+            )} `}
+            icon="arrow"
+            text={`No next page`}
+          />
         )}
       </div>
     </Fragment>


### PR DESCRIPTION
Ref #1447 

I got annoyed with the pagination bouncing around dependant on whether there is pages or no pages. 

This is more pronounced because we're changing the results with more than just the query, but feels like we could think of a way to fix this without being part of the adding-books works. 

This addresses ☝️ by making the controls permanently visible, and also take a poke at moving the amount of results closer to where they should be. Ping @Heesoomoon for 👈 

# First pass
![screencast-localhost-3000-2019 03 06-17-01-07](https://user-images.githubusercontent.com/31692/53899551-59c2ec80-4032-11e9-8c00-e30b3a293fc2.gif)
