### PR TITLE
Add RenderlessPaginator

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -4,10 +4,10 @@ import NextLink from 'next/link';
 import fetch from 'isomorphic-unfetch';
 import { type IIIFManifest } from '@weco/common/model/iiif';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
-import { itemUrl } from '@weco/common/services/catalogue/urls';
+import { itemUrl, workUrl } from '@weco/common/services/catalogue/urls';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import RenderlessPaginator from '@weco/common/views/components/RenderlessPaginator/RenderlessPaginator';
+import Paginator from '@weco/common/views/components/RenderlessPaginator/RenderlessPaginator';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import { classNames, spacing, font } from '@weco/common/utils/classnames';
 
@@ -32,6 +32,7 @@ const ItemPage = ({
 }: Props) => {
   const canvases = manifest.sequences[0].canvases;
   const currentCanvas = canvases[pageIndex];
+  const title = manifest.label;
   const service = currentCanvas.thumbnail.service;
   const urlTemplate = iiifImageTemplate(service['@id']);
   const largestSize = service.sizes[service.sizes.length - 1];
@@ -49,7 +50,7 @@ const ItemPage = ({
       hideNewsletterPromo={true}
     >
       <Layout12>
-        <RenderlessPaginator
+        <Paginator
           currentPage={pageIndex + 1}
           pageSize={1}
           totalResults={canvases.length}
@@ -61,8 +62,7 @@ const ItemPage = ({
             itemsLocationsLocationType,
             sierraId,
           })}
-        >
-          {({ currentPage, totalPages, prevLink, nextLink }) => {
+          render={({ currentPage, totalPages, prevLink, nextLink }) => {
             return (
               <div
                 className={classNames({
@@ -70,36 +70,43 @@ const ItemPage = ({
                   [spacing({ s: 1 }, { margin: ['top', 'bottom'] })]: true,
                 })}
               >
-                <NextLink {...prevLink} prefetch>
-                  <a>
-                    <Control
-                      type="light"
-                      icon="arrow"
-                      extraClasses="icon--180"
-                    />
-                  </a>
-                </NextLink>
+                {prevLink && (
+                  <NextLink {...prevLink} prefetch>
+                    <a>
+                      <Control
+                        type="light"
+                        icon="arrow"
+                        extraClasses="icon--180"
+                      />
+                    </a>
+                  </NextLink>
+                )}
                 <span
                   className={classNames({
                     [spacing({ s: 1 }, { margin: ['left', 'right'] })]: true,
                     [font({ s: 'LR3' })]: true,
                   })}
                 >
-                  Page {currentPage} of {totalPages}
+                  {currentPage} of {totalPages}
                 </span>
-                <NextLink {...nextLink} prefetch>
-                  <a>
-                    <Control type="light" icon="arrow" extraClasses="icon" />
-                  </a>
-                </NextLink>
+                {nextLink && (
+                  <NextLink {...nextLink} prefetch>
+                    <a>
+                      <Control type="light" icon="arrow" extraClasses="icon" />
+                    </a>
+                  </NextLink>
+                )}
               </div>
             );
           }}
-        </RenderlessPaginator>
+        />
       </Layout12>
       <Layout12>
         <img
-          className="block h-center"
+          className={classNames({
+            'block h-center': true,
+            [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
+          })}
           style={{
             maxHeight: '80vh',
             width: 'auto',
@@ -110,6 +117,22 @@ const ItemPage = ({
             size: `${largestSize.width},${largestSize.height}`,
           })}
         />
+        <h1
+          className={classNames({
+            [font({ s: 'HNM3', m: 'HNM2', l: 'HNM1' })]: true,
+          })}
+        >
+          {title}
+        </h1>
+        <NextLink
+          {...workUrl({
+            id: workId,
+            page: null,
+            query: null,
+          })}
+        >
+          <a>View overview</a>
+        </NextLink>
       </Layout12>
     </PageLayout>
   );

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -1,13 +1,15 @@
 // @flow
 import { type Context } from 'next';
-import Router from 'next/router';
+import NextLink from 'next/link';
 import fetch from 'isomorphic-unfetch';
 import { type IIIFManifest } from '@weco/common/model/iiif';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { itemUrl } from '@weco/common/services/catalogue/urls';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import Paginator from '@weco/common/views/components/Paginator/Paginator';
+import RenderlessPaginator from '@weco/common/views/components/RenderlessPaginator/RenderlessPaginator';
+import Control from '@weco/common/views/components/Buttons/Control/Control';
+import { classNames, spacing, font } from '@weco/common/utils/classnames';
 
 type Props = {|
   workId: string,
@@ -32,7 +34,6 @@ const ItemPage = ({
   const currentCanvas = canvases[pageIndex];
   const service = currentCanvas.thumbnail.service;
   const urlTemplate = iiifImageTemplate(service['@id']);
-  const title = manifest.label;
   const largestSize = service.sizes[service.sizes.length - 1];
 
   return (
@@ -48,9 +49,7 @@ const ItemPage = ({
       hideNewsletterPromo={true}
     >
       <Layout12>
-        <h1>{title}</h1>
-
-        <Paginator
+        <RenderlessPaginator
           currentPage={pageIndex + 1}
           pageSize={1}
           totalResults={canvases.length}
@@ -62,22 +61,49 @@ const ItemPage = ({
             itemsLocationsLocationType,
             sierraId,
           })}
-          onPageChange={async (event, newPage) => {
-            event.preventDefault();
-
-            const link = itemUrl({
-              workId,
-              query,
-              workType,
-              itemsLocationsLocationType,
-              page: newPage,
-              sierraId,
-            });
-
-            Router.push(link.href, link.as).then(() => window.scrollTo(0, 0));
+        >
+          {({ currentPage, totalPages, prevLink, nextLink }) => {
+            return (
+              <div
+                className={classNames({
+                  'flex flex--v-center flex--h-center': true,
+                  [spacing({ s: 1 }, { margin: ['top', 'bottom'] })]: true,
+                })}
+              >
+                <NextLink {...prevLink} prefetch>
+                  <a>
+                    <Control
+                      type="light"
+                      icon="arrow"
+                      extraClasses="icon--180"
+                    />
+                  </a>
+                </NextLink>
+                <span
+                  className={classNames({
+                    [spacing({ s: 1 }, { margin: ['left', 'right'] })]: true,
+                    [font({ s: 'LR3' })]: true,
+                  })}
+                >
+                  Page {currentPage} of {totalPages}
+                </span>
+                <NextLink {...nextLink} prefetch>
+                  <a>
+                    <Control type="light" icon="arrow" extraClasses="icon" />
+                  </a>
+                </NextLink>
+              </div>
+            );
           }}
-        />
+        </RenderlessPaginator>
+      </Layout12>
+      <Layout12>
         <img
+          className="block h-center"
+          style={{
+            maxHeight: '80vh',
+            width: 'auto',
+          }}
           width={largestSize.width}
           height={largestSize.height}
           src={urlTemplate({

--- a/common/views/components/RenderlessPaginator/RenderlessPaginator.js
+++ b/common/views/components/RenderlessPaginator/RenderlessPaginator.js
@@ -1,37 +1,30 @@
 // @flow
-import { Fragment, type Node as ReactNode } from 'react';
+import { Fragment, type Node } from 'react';
+import { type NextLinkType } from '@weco/common/model/next-link-type';
 
-type Link = {|
-  +pathname: string,
-  +query: Object,
-|};
-
-type LinkProps = {|
-  href: Link,
-  as: Link,
+type PaginatorRenderFunctionProps = {|
+  currentPage: number,
+  totalPages: number,
+  prevLink: ?NextLinkType,
+  nextLink: ?NextLinkType,
+  rangeStart: number,
+  rangeEnd: number,
 |};
 
 type Props = {|
   currentPage: number,
   pageSize: number,
   totalResults: number,
-  link: LinkProps,
-  children: ({|
-    currentPage: number,
-    totalPages: number,
-    prevLink: any, // FIXME: ?Link
-    nextLink: any, // FIXME: ?Link
-    rangeStart: number,
-    rangeEnd: number,
-  |}) => ReactNode,
+  link: NextLinkType,
+  render: (data: PaginatorRenderFunctionProps) => Node,
 |};
 
-const RenderlessPaginator = ({
+const Paginator = ({
   currentPage,
   pageSize,
   totalResults,
   link,
-  children,
+  render,
 }: Props) => {
   const totalPages = Math.ceil(totalResults / pageSize);
   const next = currentPage < totalPages ? currentPage + 1 : null;
@@ -82,7 +75,7 @@ const RenderlessPaginator = ({
 
   return (
     <Fragment>
-      {children({
+      {render({
         currentPage,
         totalPages,
         prevLink,
@@ -93,4 +86,4 @@ const RenderlessPaginator = ({
     </Fragment>
   );
 };
-export default RenderlessPaginator;
+export default Paginator;

--- a/common/views/components/RenderlessPaginator/RenderlessPaginator.js
+++ b/common/views/components/RenderlessPaginator/RenderlessPaginator.js
@@ -1,0 +1,96 @@
+// @flow
+import { Fragment, type Node as ReactNode } from 'react';
+
+type Link = {|
+  +pathname: string,
+  +query: Object,
+|};
+
+type LinkProps = {|
+  href: Link,
+  as: Link,
+|};
+
+type Props = {|
+  currentPage: number,
+  pageSize: number,
+  totalResults: number,
+  link: LinkProps,
+  children: ({|
+    currentPage: number,
+    totalPages: number,
+    prevLink: any, // FIXME: ?Link
+    nextLink: any, // FIXME: ?Link
+    rangeStart: number,
+    rangeEnd: number,
+  |}) => ReactNode,
+|};
+
+const RenderlessPaginator = ({
+  currentPage,
+  pageSize,
+  totalResults,
+  link,
+  children,
+}: Props) => {
+  const totalPages = Math.ceil(totalResults / pageSize);
+  const next = currentPage < totalPages ? currentPage + 1 : null;
+  const prev = currentPage > 1 ? currentPage - 1 : null;
+  const rangeStart = pageSize * currentPage - (pageSize - 1);
+  const rangeEnd =
+    pageSize * currentPage > totalResults
+      ? totalResults
+      : pageSize * currentPage;
+
+  const prevLink = prev
+    ? {
+        href: {
+          ...link.href,
+          query: {
+            ...link.href.query,
+            page: prev,
+          },
+        },
+        as: {
+          ...link.as,
+          query: {
+            ...link.as.query,
+            page: prev,
+          },
+        },
+      }
+    : null;
+
+  const nextLink = next
+    ? {
+        href: {
+          ...link.href,
+          query: {
+            ...link.href.query,
+            page: next,
+          },
+        },
+        as: {
+          ...link.as,
+          query: {
+            ...link.as.query,
+            page: next,
+          },
+        },
+      }
+    : null;
+
+  return (
+    <Fragment>
+      {children({
+        currentPage,
+        totalPages,
+        prevLink,
+        nextLink,
+        rangeStart,
+        rangeEnd,
+      })}
+    </Fragment>
+  );
+};
+export default RenderlessPaginator;


### PR DESCRIPTION
Making the pagination a bit more reusable(/customisable) and giving the individual item pages some very basic styling.

<img width="928" alt="screenshot 2019-03-06 at 17 45 10" src="https://user-images.githubusercontent.com/1394592/53901782-a52bc980-4037-11e9-9b00-00ce2b9d9f3c.png">

__TODO:__
- [ ] Add loader to indicate page change (e.g. [NProgress](http://ricostacruz.com/nprogress/))
- [ ] Make current `Paginator` use the `RenderlessPaginator`