### PR TITLE
add thumbnails for navigation to item page (no JS)

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -117,7 +117,7 @@ const ItemPage = ({
           />
         </div>
 
-        <div className={classNames({ flex: true })}>
+        <div className={classNames({ flex: true })} style={{ clear: 'both' }}>
           {navigationCanvases.map((canvas, i) => (
             <div key={canvas['@id']}>
               <NextLink

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -7,7 +7,9 @@ import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { itemUrl, workUrl } from '@weco/common/services/catalogue/urls';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
-import Paginator from '@weco/common/views/components/RenderlessPaginator/RenderlessPaginator';
+import Paginator, {
+  type PaginatorRenderFunctionProps,
+} from '@weco/common/views/components/RenderlessPaginator/RenderlessPaginator';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import { classNames, spacing, font } from '@weco/common/utils/classnames';
 
@@ -45,6 +47,45 @@ const IIIFCanvasThumbnail = ({
         size: `${size.width},${size.height}`,
       })}
     />
+  );
+};
+
+const Pagination = ({
+  currentPage,
+  totalPages,
+  prevLink,
+  nextLink,
+}: PaginatorRenderFunctionProps) => {
+  return (
+    <div
+      className={classNames({
+        'flex flex--v-center flex--h-center': true,
+        [spacing({ s: 1 }, { margin: ['top', 'bottom'] })]: true,
+      })}
+    >
+      {prevLink && (
+        <NextLink {...prevLink} prefetch scroll={false}>
+          <a>
+            <Control type="light" icon="arrow" extraClasses="icon--180" />
+          </a>
+        </NextLink>
+      )}
+      <span
+        className={classNames({
+          [spacing({ s: 1 }, { margin: ['left', 'right'] })]: true,
+          [font({ s: 'LR3' })]: true,
+        })}
+      >
+        {currentPage} of {totalPages}
+      </span>
+      {nextLink && (
+        <NextLink {...nextLink} prefetch scroll={false}>
+          <a>
+            <Control type="light" icon="arrow" extraClasses="icon" />
+          </a>
+        </NextLink>
+      )}
+    </div>
   );
 };
 
@@ -97,43 +138,7 @@ const ItemPage = ({
             itemsLocationsLocationType,
             sierraId,
           })}
-          render={({ currentPage, totalPages, prevLink, nextLink }) => {
-            return (
-              <div
-                className={classNames({
-                  'flex flex--v-center flex--h-center': true,
-                  [spacing({ s: 1 }, { margin: ['top', 'bottom'] })]: true,
-                })}
-              >
-                {prevLink && (
-                  <NextLink {...prevLink} prefetch>
-                    <a>
-                      <Control
-                        type="light"
-                        icon="arrow"
-                        extraClasses="icon--180"
-                      />
-                    </a>
-                  </NextLink>
-                )}
-                <span
-                  className={classNames({
-                    [spacing({ s: 1 }, { margin: ['left', 'right'] })]: true,
-                    [font({ s: 'LR3' })]: true,
-                  })}
-                >
-                  {currentPage} of {totalPages}
-                </span>
-                {nextLink && (
-                  <NextLink {...nextLink} prefetch>
-                    <a>
-                      <Control type="light" icon="arrow" extraClasses="icon" />
-                    </a>
-                  </NextLink>
-                )}
-              </div>
-            );
-          }}
+          render={Pagination}
         />
       </Layout12>
       <Layout12>
@@ -151,6 +156,22 @@ const ItemPage = ({
           src={urlTemplate({
             size: `${largestSize.width},${largestSize.height}`,
           })}
+        />
+        <Paginator
+          currentPage={pageIndex + 1}
+          pageSize={5}
+          totalResults={canvases.length}
+          linkKey={'page'}
+          link={itemUrl({
+            workId,
+            query,
+            page: pageIndex + 1,
+            canvas: canvasIndex + 1,
+            workType,
+            itemsLocationsLocationType,
+            sierraId,
+          })}
+          render={Pagination}
         />
         <div className={classNames({ flex: true })}>
           {navigationCanvases.map((canvas, i) => (

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -2,6 +2,7 @@
 import { type Context } from 'next';
 import Router from 'next/router';
 import fetch from 'isomorphic-unfetch';
+import NextLink from 'next/link';
 import { type IIIFManifest, type IIIFCanvas } from '@weco/common/model/iiif';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { itemUrl } from '@weco/common/services/catalogue/urls';
@@ -83,42 +84,58 @@ const ItemPage = ({
     >
       <Layout12>
         <h1>{title}</h1>
-
-        <Paginator
-          currentPage={pageIndex + 1}
-          pageSize={pageSize}
-          totalResults={canvases.length}
-          link={itemUrl({
-            workId,
-            query,
-            page: pageIndex - 1,
-            workType,
-            itemsLocationsLocationType,
-            sierraId,
-          })}
-          onPageChange={async (event, newPage) => {
-            event.preventDefault();
-
-            const link = itemUrl({
+        {/* TODO: this div is here as it's annoyingly floating to the right */}
+        <div>
+          <Paginator
+            currentPage={pageIndex + 1}
+            pageSize={pageSize}
+            totalResults={canvases.length}
+            link={itemUrl({
               workId,
               query,
+              page: pageIndex - 1,
               workType,
               itemsLocationsLocationType,
-              page: newPage,
               sierraId,
-            });
+              canvas: canvasIndex + 1,
+            })}
+            onPageChange={async (event, newPage) => {
+              event.preventDefault();
 
-            Router.push(link.href, link.as).then(() => window.scrollTo(0, 0));
-          }}
-        />
+              const link = itemUrl({
+                workId,
+                query,
+                workType,
+                itemsLocationsLocationType,
+                page: newPage,
+                sierraId,
+                canvas: canvasIndex + 1,
+              });
+
+              Router.push(link.href, link.as).then(() => window.scrollTo(0, 0));
+            }}
+          />
+        </div>
 
         <div className={classNames({ flex: true })}>
-          {navigationCanvases.map(canvas => (
-            <IIIFCanvasThumbnail
-              key={canvas['@id']}
-              canvas={canvas}
-              maxWidth={300}
-            />
+          {navigationCanvases.map((canvas, i) => (
+            <div key={canvas['@id']}>
+              <NextLink
+                {...itemUrl({
+                  workId,
+                  query,
+                  workType,
+                  itemsLocationsLocationType,
+                  page: pageIndex + 1,
+                  sierraId,
+                  canvas: pageSize * pageIndex + (i + 1),
+                })}
+              >
+                <a>
+                  <IIIFCanvasThumbnail canvas={canvas} maxWidth={300} />
+                </a>
+              </NextLink>
+            </div>
           ))}
         </div>
 

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -183,10 +183,11 @@ export const WorkPage = ({
             {...itemUrl({
               workId: work.id,
               query,
-              page,
               workType,
               itemsLocationsLocationType,
               sierraId,
+              page: 1,
+              canvas: 1,
             })}
           >
             <a>View item</a>

--- a/common/model/iiif.js
+++ b/common/model/iiif.js
@@ -26,6 +26,7 @@ export type IIIFImage = {|
 |};
 
 export type IIIFCanvas = {|
+  '@id': string,
   thumbnail: IIIFThumbnail,
   images: IIIFImage[],
 |};

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -17,6 +17,7 @@ type ItemUrlProps = {|
   ...WorksUrlProps,
   workId: string,
   sierraId: string,
+  canvas: number,
 |};
 
 function removeEmpty(obj: Object): Object {
@@ -98,6 +99,7 @@ export function itemUrl({
   workType,
   itemsLocationsLocationType,
   sierraId,
+  canvas,
 }: ItemUrlProps): NextLinkType {
   return {
     href: {
@@ -107,6 +109,7 @@ export function itemUrl({
         ...removeEmpty({
           query: query || undefined,
           page: page && page > 1 ? page : undefined,
+          canvas: canvas && canvas > 1 ? canvas : undefined,
           sierraId: sierraId,
           ...workTypeAndItemsLocationType(workType, itemsLocationsLocationType),
         }),
@@ -117,6 +120,7 @@ export function itemUrl({
       query: removeEmpty({
         query: query || undefined,
         page: page && page > 1 ? page : undefined,
+        canvas: canvas && canvas > 1 ? canvas : undefined,
         sierraId: sierraId,
         ...workTypeAndItemsLocationType(workType, itemsLocationsLocationType),
       }),

--- a/common/views/components/RenderlessPaginator/RenderlessPaginator.js
+++ b/common/views/components/RenderlessPaginator/RenderlessPaginator.js
@@ -2,7 +2,7 @@
 import { Fragment, type Node } from 'react';
 import { type NextLinkType } from '@weco/common/model/next-link-type';
 
-type PaginatorRenderFunctionProps = {|
+export type PaginatorRenderFunctionProps = {|
   currentPage: number,
   totalPages: number,
   prevLink: ?NextLinkType,


### PR DESCRIPTION
Ref #4147 

Thinking we could restructure the URLs, more specifically the query string, to be:
`/works/{id}/items?sierraId={sierraId}&page={3}&canvas=12`.

Assuming `pageSize` is `5`, and we _aren't_ `zeroIndexing` here, we could then show canvases `11` - `15`, with `12` in the main focus.

__Next up__ Layout

![screencast-localhost-3000-2019 03 07-08-15-10](https://user-images.githubusercontent.com/31692/53941885-38551580-40b1-11e9-8545-32f796f275eb.gif)
