### PR TITLE
move results count to pagination

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -216,18 +216,6 @@ export const Works = ({
                     )
                   }
                 </TogglesContext.Consumer>
-
-                {works && (
-                  <p
-                    className={classNames([
-                      spacing({ s: 2 }, { margin: ['top', 'bottom'] }),
-                      font({ s: 'LR3', m: 'LR2' }),
-                    ])}
-                  >
-                    {works.totalResults !== 0 ? works.totalResults : 'No'}{' '}
-                    results for &apos;{query}&apos;
-                  </p>
-                )}
               </div>
             </div>
           </div>

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -34,11 +34,6 @@ const Paginator = ({
   const totalPages = Math.ceil(totalResults / pageSize);
   const next = currentPage < totalPages ? currentPage + 1 : null;
   const prev = currentPage > 1 ? currentPage - 1 : null;
-  const rangeStart = pageSize * currentPage - (pageSize - 1);
-  const rangeEnd =
-    pageSize * currentPage > totalResults
-      ? totalResults
-      : pageSize * currentPage;
 
   const prevLink = prev
     ? {
@@ -86,7 +81,7 @@ const Paginator = ({
           m: 'LR2',
         })}`}
       >
-        Showing {rangeStart} - {rangeEnd}
+        {totalResults} results
       </div>
       <div
         className={classNames({

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -81,7 +81,7 @@ const Paginator = ({
           m: 'LR2',
         })}`}
       >
-        {totalResults} results
+        {totalResults} result{totalResults !== 1 ? 's' : ''}
       </div>
       <div
         className={classNames({


### PR DESCRIPTION

<img width="1127" alt="Screenshot 2019-03-11 at 11 45 39" src="https://user-images.githubusercontent.com/31692/54121776-382b8180-43f3-11e9-9bdd-2d0a23a807c1.png">


As discussed with @Heesoomoon, this seems clearer, and be more based on the segmenting of the page into Beta, Search, Filter, Nav, Results.