### PR TITLE
use b number from manifest file for viewing items

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -77,6 +77,13 @@ export const WorkPage = ({
       identifier => identifier.identifierType.id === 'sierra-system-number'
     ) || {}
   ).value;
+
+  const iiifPresentationLocation = (getIiifPresentationLocation(work) || {})
+    .url;
+  const sierraIdForPresentationManifest =
+    iiifPresentationLocation &&
+    iiifPresentationLocation.match(/iiif\/(.*)\/manifest/)[1];
+
   // We strip the last character as that's what Wellcome library expect
   const encoreLink =
     sierraId &&
@@ -185,7 +192,7 @@ export const WorkPage = ({
               query,
               workType,
               itemsLocationsLocationType,
-              sierraId,
+              sierraId: sierraIdForPresentationManifest,
               page: 1,
               canvas: 1,
             })}

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -80,7 +80,7 @@ export const WorkPage = ({
 
   const iiifPresentationLocation = (getIiifPresentationLocation(work) || {})
     .url;
-  const sierraIdForPresentationManifest =
+  const sierraIdFromPresentationManifestUrl =
     iiifPresentationLocation &&
     iiifPresentationLocation.match(/iiif\/(.*)\/manifest/)[1];
 
@@ -192,7 +192,7 @@ export const WorkPage = ({
               query,
               workType,
               itemsLocationsLocationType,
-              sierraId: sierraIdForPresentationManifest,
+              sierraId: sierraIdFromPresentationManifestUrl,
               page: 1,
               canvas: 1,
             })}


### PR DESCRIPTION
Some works have 2 sierra records, these are works that have been merged.
https://api.wellcomecollection.org/catalogue/v2/works/v6zxz262?include=items,identifiers

The manifest is only related to one of those IDs, so we make sure we pull it from the actual manifest URL.

Interestingly, the manifest B number doesn't have a corresponding library record. e.g. 
__exists:__ https://search.wellcomelibrary.org/iii/encore/record/C__Rb1298367?lang=eng
__doesn't exist:__ https://search.wellcomelibrary.org/iii/encore/record/C__Rb22021814?lang=eng

It might be worth getting to the bottom of this.