### PR TITLE
Use search context

### DIFF
--- a/catalogue/webapp/components/SearchContext/SearchContext.js
+++ b/catalogue/webapp/components/SearchContext/SearchContext.js
@@ -6,8 +6,8 @@ import { worksUrl } from '@weco/common/services/catalogue/urls';
 export type CatalogueQuery = {|
   query: string,
   page: number,
-  workType: string[],
-  itemsLocationsLocationType: string[],
+  workType: ?(string[]),
+  itemsLocationsLocationType: ?(string[]),
   queryType: ?string,
 |};
 
@@ -15,8 +15,8 @@ type ContextProps = {|
   ...CatalogueQuery,
   setQuery: (value: string) => void,
   setPage: (value: number) => void,
-  setWorkType: (value: string[]) => void,
-  setItemsLocationsLocationType: (value: string[]) => void,
+  setWorkType: (value: ?(string[])) => void,
+  setItemsLocationsLocationType: (value: ?(string[])) => void,
   setQueryType: (value: ?string) => void,
 |};
 

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -1,6 +1,6 @@
 // @flow
 import { type CatalogueResultsList } from '@weco/common/model/catalogue';
-import { useState, useRef, useContext } from 'react';
+import { useRef, useContext } from 'react';
 import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
@@ -14,8 +14,6 @@ import { worksUrl } from '@weco/common/services/catalogue/urls';
 import SearchContext from '../SearchContext/SearchContext';
 
 type Props = {|
-  initialWorkType: ?(string[]),
-  initialItemsLocationsLocationType: ?(string[]),
   ariaDescribedBy: string,
   compact: boolean,
   works: ?CatalogueResultsList,
@@ -45,17 +43,9 @@ const ClearSearch = styled.button`
   right: 12px;
 `;
 
-const SearchForm = ({
-  initialWorkType,
-  initialItemsLocationsLocationType,
-  ariaDescribedBy,
-  compact,
-  works,
-}: Props) => {
-  const { query, setQuery } = useContext(SearchContext);
-  const workType = initialWorkType;
-  const [itemsLocationsLocationType] = useState(
-    initialItemsLocationsLocationType
+const SearchForm = ({ ariaDescribedBy, compact, works }: Props) => {
+  const { query, setQuery, itemsLocationsLocationType, workType } = useContext(
+    SearchContext
   );
   const searchInput = useRef(null);
 

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -1,6 +1,6 @@
 // @flow
 import { type CatalogueResultsList } from '@weco/common/model/catalogue';
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext } from 'react';
 import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
@@ -11,9 +11,9 @@ import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import { classNames, font, spacing } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { worksUrl } from '@weco/common/services/catalogue/urls';
+import SearchContext from '../SearchContext/SearchContext';
 
 type Props = {|
-  initialQuery: string,
   initialWorkType: ?(string[]),
   initialItemsLocationsLocationType: ?(string[]),
   ariaDescribedBy: string,
@@ -46,14 +46,13 @@ const ClearSearch = styled.button`
 `;
 
 const SearchForm = ({
-  initialQuery = '',
   initialWorkType,
   initialItemsLocationsLocationType,
   ariaDescribedBy,
   compact,
   works,
 }: Props) => {
-  const [query, setQuery] = useState(initialQuery);
+  const { query, setQuery } = useContext(SearchContext);
   const workType = initialWorkType;
   const [itemsLocationsLocationType] = useState(
     initialItemsLocationsLocationType

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -132,7 +132,6 @@ export const WorkPage = ({
               })}
             >
               <SearchForm
-                initialQuery={query || ''}
                 initialWorkType={workType}
                 initialItemsLocationsLocationType={itemsLocationsLocationType}
                 ariaDescribedBy="search-form-description"

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -132,8 +132,6 @@ export const WorkPage = ({
               })}
             >
               <SearchForm
-                initialWorkType={workType}
-                initialItemsLocationsLocationType={itemsLocationsLocationType}
                 ariaDescribedBy="search-form-description"
                 compact={true}
                 works={null}

--- a/catalogue/webapp/pages/works-context.js
+++ b/catalogue/webapp/pages/works-context.js
@@ -75,7 +75,7 @@ const Search = () => {
       <fieldset>
         <Checkboxes
           name="workType"
-          values={workType}
+          values={workType || []}
           setter={setWorkType}
           options={[
             {
@@ -97,7 +97,7 @@ const Search = () => {
       <fieldset>
         <Checkboxes
           name="items.locations.locationType"
-          values={itemsLocationsLocationType}
+          values={itemsLocationsLocationType || []}
           setter={setItemsLocationsLocationType}
           options={[
             {

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -217,8 +217,6 @@ const Works = ({
                 </TogglesContext.Consumer>
 
                 <SearchForm
-                  initialWorkType={workType}
-                  initialItemsLocationsLocationType={itemsLocationsLocationType}
                   ariaDescribedBy="search-form-description"
                   compact={false}
                   works={works}

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -18,12 +18,13 @@ import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import { workUrl, worksUrl } from '@weco/common/services/catalogue/urls';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import BetaBar from '@weco/common/views/components/BetaBar/BetaBar';
+import TabNav from '@weco/common/views/components/TabNav/TabNav';
+import { SearchProvider } from '../components/SearchContext/SearchContext';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
 import WorkCard from '../components/WorkCard/WorkCard';
-import BetaBar from '@weco/common/views/components/BetaBar/BetaBar';
-import TabNav from '@weco/common/views/components/TabNav/TabNav';
 
 type Props = {|
   query: ?string,
@@ -33,7 +34,32 @@ type Props = {|
   itemsLocationsLocationType: ?(string[]),
 |};
 
-export const Works = ({
+const WorksSearchProvider = ({
+  works,
+  query,
+  page,
+  workType,
+  itemsLocationsLocationType,
+}: Props) => (
+  <SearchProvider
+    initialState={{
+      query: query || '',
+      page: page || 1,
+      workType,
+      itemsLocationsLocationType,
+    }}
+  >
+    <Works
+      works={works}
+      query={query}
+      page={page}
+      workType={workType}
+      itemsLocationsLocationType={itemsLocationsLocationType}
+    />
+  </SearchProvider>
+);
+
+const Works = ({
   works,
   query,
   page,
@@ -41,6 +67,7 @@ export const Works = ({
   itemsLocationsLocationType,
 }: Props) => {
   const [loading, setLoading] = useState(false);
+
   useEffect(() => {
     function routeChangeStart(url: string) {
       setLoading(true);
@@ -190,7 +217,6 @@ export const Works = ({
                 </TogglesContext.Consumer>
 
                 <SearchForm
-                  initialQuery={query || ''}
                   initialWorkType={workType}
                   initialItemsLocationsLocationType={itemsLocationsLocationType}
                   ariaDescribedBy="search-form-description"
@@ -460,7 +486,7 @@ export const Works = ({
   );
 };
 
-Works.getInitialProps = async (ctx: Context): Promise<Props> => {
+WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
@@ -516,4 +542,4 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   };
 };
 
-export default Works;
+export default WorksSearchProvider;


### PR DESCRIPTION
In a bid to simplify the search routing, we're using a combo of state hooks and next's router.
This will maintain the state of the search in a context that is provided at the root of the application.

[You can read more about it here](https://github.com/wellcometrust/wellcomecollection.org/pull/4196).

__Next:__ add query type