### PR TITLE
get the naming right on iiifPresentationLocation

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -6,10 +6,7 @@ import {
   type CatalogueApiRedirect,
 } from '@weco/common/model/catalogue';
 import { spacing, grid, classNames } from '@weco/common/utils/classnames';
-import {
-  type iiifPresentationLocation,
-  getIiifPresentationLocation,
-} from '@weco/common/utils/works';
+import { getIIIFPresentationLocation } from '@weco/common/utils/works';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
@@ -30,7 +27,6 @@ import IIIFImagePreview from '@weco/common/views/components/IIIFImagePreview/III
 
 type Props = {|
   work: Work | CatalogueApiError,
-  iiifPresentationLocation: iiifPresentationLocation,
   workType: string[],
   query: ?string,
   page: ?number,
@@ -39,7 +35,6 @@ type Props = {|
 
 export const WorkPage = ({
   work,
-  iiifPresentationLocation,
   query,
   page,
   workType,
@@ -79,11 +74,10 @@ export const WorkPage = ({
     ) || {}
   ).value;
 
-  const iiifPresentationLocation = (getIiifPresentationLocation(work) || {})
-    .url;
+  const iiifPresentationLocation = getIIIFPresentationLocation(work);
   const sierraIdFromPresentationManifestUrl =
     iiifPresentationLocation &&
-    iiifPresentationLocation.match(/iiif\/(.*)\/manifest/)[1];
+    (iiifPresentationLocation.url.match(/iiif\/(.*)\/manifest/) || [])[1];
 
   // We strip the last character as that's what Wellcome library expect
   const encoreLink =
@@ -231,7 +225,6 @@ WorkPage.getInitialProps = async (
 
   const { id, query, page } = ctx.query;
   const workOrError = await getWork({ id });
-  const iiifPresentationLocation = getIiifPresentationLocation(workOrError);
 
   if (workOrError && workOrError.type === 'Redirect') {
     const { res } = ctx;
@@ -248,7 +241,6 @@ WorkPage.getInitialProps = async (
     return {
       query,
       work: workOrError,
-      iiifPresentationLocation,
       page: page ? parseInt(page, 10) : null,
       workType: workTypeQuery && workTypeQuery.split(',').filter(Boolean),
       itemsLocationsLocationType:

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -23,7 +23,7 @@ export function getProductionDates(work: Work) {
     .reduce((a, b) => a.concat(b), []);
 }
 
-export type iiifPresentationLocation = {|
+export type IIIFPresentationLocation = {|
   locationType: {
     id: 'iiif-presentation',
     label: 'IIIF Presentation API',
@@ -33,9 +33,9 @@ export type iiifPresentationLocation = {|
   type: 'DigitalLocation',
 |};
 
-export function getIiifPresentationLocation(
+export function getIIIFPresentationLocation(
   work: Work
-): iiifPresentationLocation {
+): IIIFPresentationLocation {
   return work.items
     .map(item =>
       item.locations.find(

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -1,6 +1,6 @@
 // @flow
 import { type IIIFManifest, type IIIFCanvas } from '@weco/common/model/iiif';
-import { type iiifPresentationLocation } from '@weco/common/utils/works';
+import { type IIIFPresentationLocation } from '@weco/common/utils/works';
 import fetch from 'isomorphic-unfetch';
 import NextLink from 'next/link';
 import styled from 'styled-components';
@@ -229,7 +229,7 @@ function previewThumbnails(
 }
 
 type Props = {|
-  iiifPresentationLocation: iiifPresentationLocation,
+  iiifPresentationLocation: IIIFPresentationLocation,
   itemUrl: any,
 |};
 


### PR DESCRIPTION
Not sure how this past the build, I'd like to look into it.

For now I guess we think about how we name IIIF things as we have a mixture of caps and small, the pattern seeming like if it's:
* `camelCase` and starts with `IIIF`, we leave it small e.g. `iiifImageThings`
* `camelCase` and has it in between it's large e.g. `thingsThatHaveIIIFInIt`
* `PascalCase` and starts = large `IIIFImageLocation`
* `PascalCase` and in between = large `ThingsIIIFImageLocation`

Either way, we had `type`s and `const`s named the same, which should never really be the case.