### PR TITLE
be hyper conservative with event parsing

### DIFF
--- a/common/services/prismic/articles.js
+++ b/common/services/prismic/articles.js
@@ -99,7 +99,7 @@ const graphQuery = `{
     }
     outroResearchItem {
       ... on events {
-        title
+        ...eventsFields
       }
       ... on exhibitions {
         title
@@ -125,7 +125,7 @@ const graphQuery = `{
     }
     outroReadItem {
       ... on events {
-        title
+        ...eventsFields
       }
       ... on exhibitions {
         title
@@ -151,7 +151,7 @@ const graphQuery = `{
     }
     outroVisitItem {
       ... on events {
-        title
+        ...eventsFields
       }
       ... on exhibitions {
         title

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -94,6 +94,8 @@ export function parseEventDoc(
   scheduleDocs: ?PrismicApiSearchResponse
 ): UiEvent {
   const data = document.data;
+  console.info('=+++++++++++++++++++++++++++++++++');
+  console.info(data.schedule);
   const scheduleLength = isDocumentLink(data.schedule.map(s => s.event)[0])
     ? data.schedule.length
     : 0;
@@ -121,11 +123,12 @@ export function parseEventDoc(
     )
     .filter(Boolean);
 
-  const matchedId = /\/e\/([0-9]+)/.exec(data.eventbriteEvent.url);
+  const matchedId =
+    data.eventbriteEvent && /\/e\/([0-9]+)/.exec(data.eventbriteEvent.url);
   const eventbriteId =
     data.eventbriteEvent && matchedId !== null ? matchedId[1] : '';
 
-  const audiences = document.data.audiences
+  const audiences = data.audiences
     .map(audience =>
       isDocumentLink(audience.audience)
         ? {
@@ -137,7 +140,8 @@ export function parseEventDoc(
     .filter(Boolean);
 
   const bookingEnquiryTeam =
-    document.data.bookingEnquiryTeam.data &&
+    data.bookingEnquiryTeam &&
+    data.bookingEnquiryTeam.data &&
     ({
       id: data.bookingEnquiryTeam.id,
       title: asText(data.bookingEnquiryTeam.data.title) || '',
@@ -146,7 +150,7 @@ export function parseEventDoc(
       url: data.bookingEnquiryTeam.data.url,
     }: Team);
 
-  const thirdPartyBooking = {
+  const thirdPartyBooking = data.thirdPartyBookingName && {
     name: data.thirdPartyBookingName,
     url: data.thirdPartyBookingUrl.url,
   };
@@ -194,9 +198,11 @@ export function parseEventDoc(
     place: isDocumentLink(data.place) ? parsePlace(data.place) : null,
     audiences,
     bookingEnquiryTeam,
-    thirdPartyBooking: data.thirdPartyBookingUrl.url ? thirdPartyBooking : null,
+    thirdPartyBooking: thirdPartyBooking,
     bookingInformation:
-      data.bookingInformation.length > 1 ? data.bookingInformation : null,
+      data.bookingInformation && data.bookingInformation.length > 1
+        ? data.bookingInformation
+        : null,
     bookingType: parseEventBookingType(document),
     cost: data.cost,
     format: data.format && parseEventFormat(data.format),
@@ -209,7 +215,9 @@ export function parseEventDoc(
     scheduleLength,
     schedule,
     backgroundTexture:
-      data.backgroundTexture.data && data.backgroundTexture.data.image.url,
+      data.backgroundTexture &&
+      data.backgroundTexture.data &&
+      data.backgroundTexture.data.image.url,
     eventbriteId,
     isCompletelySoldOut:
       data.times && data.times.filter(time => !time.isFullyBooked).length === 0,

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -94,8 +94,6 @@ export function parseEventDoc(
   scheduleDocs: ?PrismicApiSearchResponse
 ): UiEvent {
   const data = document.data;
-  console.info('=+++++++++++++++++++++++++++++++++');
-  console.info(data.schedule);
   const scheduleLength = isDocumentLink(data.schedule.map(s => s.event)[0])
     ? data.schedule.length
     : 0;

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -446,7 +446,7 @@ export function isStructuredText(structuredTextObject: HTMLString): boolean {
 // If a link is non-existant, it can either be returned as `null`, or as an
 // empty link object, which is why we use this
 export function isDocumentLink(fragment: ?PrismicFragment): boolean {
-  return Boolean(fragment && fragment.isBroken === false);
+  return Boolean(fragment && fragment.isBroken === false && fragment.data);
 }
 
 // when images have crops, event if the image isn't attached, we get e.g.


### PR DESCRIPTION
Event parsing on the outro doesn't work as we don't always get linked docs etc.
This hopefully deals with that, but adds really rubbish null checking in our parsers.
It'd be nice to move to GraphQL completely... 
