### PR TITLE
add updown / uptimerobot to dash index

### DIFF
--- a/dash/webapp/pages/index.js
+++ b/dash/webapp/pages/index.js
@@ -76,6 +76,26 @@ const IndexPage = () => {
             </a>
           </li>
           <li>
+            <a href="https://updown.io/2cep" rel="uptime">
+              Uptime: Homepage
+            </a>
+          </li>
+          <li>
+            <a href="https://updown.io/5t1q" rel="uptime">
+              Uptime: Stories
+            </a>
+          </li>
+          <li>
+            <a href="https://updown.io/bhef" rel="uptime">
+              Uptime: Works
+            </a>
+          </li>
+          <li>
+            <a href="https://stats.uptimerobot.com/x6RyoIGYR" rel="uptime">
+              Uptime: Whole site, no cache
+            </a>
+          </li>
+          <li>
             <a
               href="https://wellcomecollection.org/works/progress"
               rel="progress"


### PR DESCRIPTION
Annoyed that I have to keep looking them up.
This adds the updown / uptmie robot stats to the dash index.