### PR TITLE
Add book download

### DIFF
--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -69,7 +69,6 @@ const DownloadOptions = styled.div`
 type Work = Object;
 type Props = {|
   work: Work,
-  iiifImageLocationUrl: string,
   licenseInfo: ?LicenseData,
   iiifImageLocationCredit: ?string,
   iiifImageLocationLicenseId: ?LicenseType,
@@ -78,7 +77,6 @@ type Props = {|
 
 const Download = ({
   work,
-  iiifImageLocationUrl,
   licenseInfo,
   iiifImageLocationCredit,
   iiifImageLocationLicenseId,

--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -1,9 +1,9 @@
 // @flow
 import type { LicenseData } from '@weco/common/utils/get-license-info';
 import type { LicenseType } from '@weco/common/model/license';
+import { type IIIFRendering } from '@weco/common/model/iiif';
 import { trackEvent } from '@weco/common/utils/ga';
 import { useState, useEffect } from 'react';
-import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import styled from 'styled-components';
 import { font, spacing, classNames } from '@weco/common/utils/classnames';
 import License from '@weco/common/views/components/License/License';
@@ -73,6 +73,7 @@ type Props = {|
   licenseInfo: ?LicenseData,
   iiifImageLocationCredit: ?string,
   iiifImageLocationLicenseId: ?LicenseType,
+  downloadOptions: IIIFRendering[],
 |};
 
 const Download = ({
@@ -81,6 +82,7 @@ const Download = ({
   licenseInfo,
   iiifImageLocationCredit,
   iiifImageLocationLicenseId,
+  downloadOptions,
 }: Props) => {
   const [showDownloads, setShowDownloads] = useState(true);
   const [useJavascriptControl, setUseJavascriptControl] = useState(false);
@@ -116,7 +118,7 @@ const Download = ({
                     [spacing({ s: 1 }, { margin: ['right'] })]: true,
                   })}
                 >
-                  Download this image
+                  Download
                 </span>
                 <Icon name="chevron" />
               </span>
@@ -129,7 +131,7 @@ const Download = ({
               'work-details-heading': true,
             })}
           >
-            Download this image
+            Download
           </h2>
         )}
         <DownloadOptions
@@ -140,69 +142,56 @@ const Download = ({
             show: showDownloads,
           })}
         >
-          <ul className="plain-list no-margin no-padding">
-            <li>
-              <a
-                tabIndex={showDownloads ? null : -1}
-                target="_blank"
-                rel="noopener noreferrer"
-                href={convertImageUri(iiifImageLocationUrl, 'full')}
-                onClick={() => {
-                  trackEvent({
-                    category: 'Button',
-                    action: 'download large work image',
-                    label: work.id,
-                  });
-                }}
-              >
-                <span className="flex-inline flex--v-center">
-                  <Icon name="download" />
-                  <span className="underline-on-hover">Download full size</span>
-                  <span
-                    className={classNames({
-                      'font-pewter': true,
-                      [font({ s: 'HNM5' })]: true,
-                      [spacing({ s: 2 }, { margin: ['left'] })]: true,
-                    })}
-                  >
-                    JPG
-                  </span>
-                </span>
-              </a>
-            </li>
-            <li>
-              <a
-                tabIndex={showDownloads ? null : -1}
-                target="_blank"
-                rel="noopener noreferrer"
-                href={convertImageUri(iiifImageLocationUrl, 760)}
-                onClick={() => {
-                  trackEvent({
-                    category: 'Button',
-                    action: 'download small work image',
-                    label: work.id,
-                  });
-                }}
-              >
-                <span className="flex-inline flex--v-center">
-                  <Icon name="download" />
-                  <span className="underline-on-hover">
-                    Download small (760px)
-                  </span>
-                  <span
-                    className={classNames({
-                      'font-pewter': true,
-                      [font({ s: 'HNM5' })]: true,
-                      [spacing({ s: 2 }, { margin: ['left'] })]: true,
-                    })}
-                  >
-                    JPG
-                  </span>
-                </span>
-              </a>
-            </li>
-          </ul>
+          {downloadOptions && (
+            <ul className="plain-list no-margin no-padding">
+              {downloadOptions.map(option => {
+                // Doing this for the action so analytics is constant, speak to Hayley about removeing this
+                const action =
+                  option.label === 'Download full size'
+                    ? 'download large work image'
+                    : option.label === 'Download small (760px)'
+                    ? 'download small work image'
+                    : option.label;
+                const format = option.format.split('/')[1].toUpperCase();
+
+                return (
+                  <li key={option.label}>
+                    <a
+                      tabIndex={showDownloads ? null : -1}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      href={option['@id']}
+                      onClick={() => {
+                        trackEvent({
+                          category: 'Button',
+                          action: action,
+                          label: work.id,
+                        });
+                      }}
+                    >
+                      <span className="flex-inline flex--v-center">
+                        <Icon name="download" />
+                        <span className="underline-on-hover">
+                          {option.label}
+                        </span>
+                        <span
+                          className={classNames({
+                            'font-pewter': true,
+                            [font({ s: 'HNM5' })]: true,
+                            [spacing({ s: 2 }, { margin: ['left'] })]: true,
+                          })}
+                        >
+                          {format}
+                        </span>
+                      </span>
+                    </a>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
         </DownloadOptions>
+
         <div className="flex-inline flex--v-center">
           {iiifImageLocationLicenseId && (
             <span

--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -144,50 +144,52 @@ const Download = ({
         >
           {downloadOptions && (
             <ul className="plain-list no-margin no-padding">
-              {downloadOptions.map(option => {
-                // Doing this for the action so analytics is constant, speak to Hayley about removeing this
-                const action =
-                  option.label === 'Download full size'
-                    ? 'download large work image'
-                    : option.label === 'Download small (760px)'
-                    ? 'download small work image'
-                    : option.label;
-                const format = option.format.split('/')[1].toUpperCase();
+              {downloadOptions
+                .filter(option => option.format !== 'text/plain') // We're taking out raw text for now
+                .map(option => {
+                  // Doing this for the action so analytics is constant, speak to Hayley about removing this
+                  const action =
+                    option.label === 'Download full size'
+                      ? 'download large work image'
+                      : option.label === 'Download small (760px)'
+                      ? 'download small work image'
+                      : option.label;
+                  const format = option.format.split('/')[1].toUpperCase();
 
-                return (
-                  <li key={option.label}>
-                    <a
-                      tabIndex={showDownloads ? null : -1}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      href={option['@id']}
-                      onClick={() => {
-                        trackEvent({
-                          category: 'Button',
-                          action: action,
-                          label: work.id,
-                        });
-                      }}
-                    >
-                      <span className="flex-inline flex--v-center">
-                        <Icon name="download" />
-                        <span className="underline-on-hover">
-                          {option.label}
+                  return (
+                    <li key={option.label}>
+                      <a
+                        tabIndex={showDownloads ? null : -1}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        href={option['@id']}
+                        onClick={() => {
+                          trackEvent({
+                            category: 'Button',
+                            action: action,
+                            label: work.id,
+                          });
+                        }}
+                      >
+                        <span className="flex-inline flex--v-center">
+                          <Icon name="download" />
+                          <span className="underline-on-hover">
+                            {option.label}
+                          </span>
+                          <span
+                            className={classNames({
+                              'font-pewter': true,
+                              [font({ s: 'HNM5' })]: true,
+                              [spacing({ s: 2 }, { margin: ['left'] })]: true,
+                            })}
+                          >
+                            {format}
+                          </span>
                         </span>
-                        <span
-                          className={classNames({
-                            'font-pewter': true,
-                            [font({ s: 'HNM5' })]: true,
-                            [spacing({ s: 2 }, { margin: ['left'] })]: true,
-                          })}
-                        >
-                          {format}
-                        </span>
-                      </span>
-                    </a>
-                  </li>
-                );
-              })}
+                      </a>
+                    </li>
+                  );
+                })}
             </ul>
           )}
         </DownloadOptions>

--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -66,6 +66,17 @@ const DownloadOptions = styled.div`
   }
 `;
 
+function getFormatString(format) {
+  switch (format) {
+    case 'application/pdf':
+      return 'PDF';
+    case 'text/plain':
+      return 'PLAIN';
+    case 'image/jpeg':
+      return 'JPG';
+  }
+}
+
 type Work = Object;
 type Props = {|
   work: Work,
@@ -152,7 +163,7 @@ const Download = ({
                       : option.label === 'Download small (760px)'
                       ? 'download small work image'
                       : option.label;
-                  const format = option.format.split('/')[1].toUpperCase();
+                  const format = getFormatString(option.format);
 
                   return (
                     <li key={option.label}>
@@ -174,15 +185,17 @@ const Download = ({
                           <span className="underline-on-hover">
                             {option.label}
                           </span>
-                          <span
-                            className={classNames({
-                              'font-pewter': true,
-                              [font({ s: 'HNM5' })]: true,
-                              [spacing({ s: 2 }, { margin: ['left'] })]: true,
-                            })}
-                          >
-                            {format}
-                          </span>
+                          {format && (
+                            <span
+                              className={classNames({
+                                'font-pewter': true,
+                                [font({ s: 'HNM5' })]: true,
+                                [spacing({ s: 2 }, { margin: ['left'] })]: true,
+                              })}
+                            >
+                              {format}
+                            </span>
+                          )}
                         </span>
                       </a>
                     </li>

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -2,6 +2,7 @@
 import type { Node } from 'react';
 import type { LicenseData } from '@weco/common/utils/get-license-info';
 import type { LicenseType } from '@weco/common/model/license';
+import { type IIIFRendering } from '@weco/common/model/iiif';
 import { font, spacing, grid, classNames } from '@weco/common/utils/classnames';
 import { worksUrl } from '@weco/common/services/catalogue/urls';
 import { Fragment } from 'react';
@@ -12,7 +13,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
-// import Download from '../Download/Download';
+import Download from '../Download/Download';
 
 type WorkDetailsSectionProps = {|
   headingText?: string,
@@ -64,6 +65,7 @@ type Props = {|
   licenseInfo: ?LicenseData,
   iiifImageLocationCredit: ?string,
   iiifImageLocationLicenseId: ?LicenseType,
+  downloadOptions: IIIFRendering[],
   encoreLink: ?string,
 |};
 
@@ -72,6 +74,7 @@ const WorkDetails = ({
   licenseInfo,
   iiifImageLocationCredit,
   iiifImageLocationLicenseId,
+  downloadOptions,
   encoreLink,
 }: Props) => {
   const singularWorkTypeLabel = work.workType.label
@@ -83,6 +86,19 @@ const WorkDetails = ({
 
   const WorkDetailsSections = [];
 
+  if (downloadOptions) {
+    WorkDetailsSections.push(
+      <WorkDetailsSection>
+        <Download
+          work={work}
+          licenseInfo={licenseInfo}
+          iiifImageLocationCredit={iiifImageLocationCredit}
+          iiifImageLocationLicenseId={iiifImageLocationLicenseId}
+          downloadOptions={downloadOptions}
+        />
+      </WorkDetailsSection>
+    );
+  }
   if (
     work.description ||
     work.production.length > 0 ||

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -12,7 +12,7 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
-import Download from '../Download/Download';
+// import Download from '../Download/Download';
 
 type WorkDetailsSectionProps = {|
   headingText?: string,
@@ -61,7 +61,6 @@ type Work = Object;
 
 type Props = {|
   work: Work,
-  iiifImageLocationUrl: ?string,
   licenseInfo: ?LicenseData,
   iiifImageLocationCredit: ?string,
   iiifImageLocationLicenseId: ?LicenseType,
@@ -70,7 +69,6 @@ type Props = {|
 
 const WorkDetails = ({
   work,
-  iiifImageLocationUrl,
   licenseInfo,
   iiifImageLocationCredit,
   iiifImageLocationLicenseId,
@@ -84,19 +82,7 @@ const WorkDetails = ({
   });
 
   const WorkDetailsSections = [];
-  if (iiifImageLocationUrl) {
-    WorkDetailsSections.push(
-      <WorkDetailsSection>
-        <Download
-          work={work}
-          iiifImageLocationUrl={iiifImageLocationUrl}
-          licenseInfo={licenseInfo}
-          iiifImageLocationCredit={iiifImageLocationCredit}
-          iiifImageLocationLicenseId={iiifImageLocationLicenseId}
-        />
-      </WorkDetailsSection>
-    );
-  }
+
   if (
     work.description ||
     work.production.length > 0 ||

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -10,6 +10,7 @@ import fetch from 'isomorphic-unfetch';
 import { spacing, grid, classNames } from '@weco/common/utils/classnames';
 import {
   getIIIFPresentationLocation,
+  getDownloadOptionsFromImageUrl,
   getDownloadOptionsFromManifest,
 } from '@weco/common/utils/works';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
@@ -85,6 +86,13 @@ export const WorkPage = ({
   const sierraIdFromPresentationManifestUrl =
     iiifPresentationLocation &&
     (iiifPresentationLocation.url.match(/iiif\/(.*)\/manifest/) || [])[1];
+
+  const downloadOptions =
+    iiifPresentationDownloadOptions.length > 0
+      ? iiifPresentationDownloadOptions
+      : iiifImageLocationUrl
+      ? getDownloadOptionsFromImageUrl(iiifImageLocationUrl)
+      : [];
 
   // We strip the last character as that's what Wellcome library expect
   const encoreLink =
@@ -215,7 +223,7 @@ export const WorkPage = ({
         iiifImageLocationCredit={iiifImageLocationCredit}
         iiifImageLocationLicenseId={iiifImageLocationLicenseId}
         encoreLink={encoreLink}
-        downloadOptions={iiifPresentationDownloadOptions}
+        downloadOptions={downloadOptions}
       />
     </PageLayout>
   );

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -218,7 +218,6 @@ export const WorkPage = ({
 
       <WorkDetails
         work={work}
-        iiifImageLocationUrl={iiifImageLocationUrl}
         licenseInfo={licenseInfo}
         iiifImageLocationCredit={iiifImageLocationCredit}
         iiifImageLocationLicenseId={iiifImageLocationLicenseId}

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -10,7 +10,7 @@ import fetch from 'isomorphic-unfetch';
 import { spacing, grid, classNames } from '@weco/common/utils/classnames';
 import {
   getIIIFPresentationLocation,
-  getSequenceRendering,
+  getDownloadOptionsFromManifest,
 } from '@weco/common/utils/works';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
@@ -36,7 +36,7 @@ type Props = {|
   query: ?string,
   page: ?number,
   itemsLocationsLocationType: string[],
-  rendering: IIIFRendering[],
+  iiifPresentationDownloadOptions: IIIFRendering[],
 |};
 
 export const WorkPage = ({
@@ -45,7 +45,7 @@ export const WorkPage = ({
   page,
   workType,
   itemsLocationsLocationType,
-  rendering,
+  iiifPresentationDownloadOptions,
 }: Props) => {
   if (work.type === 'Error') {
     return (
@@ -215,7 +215,7 @@ export const WorkPage = ({
         iiifImageLocationCredit={iiifImageLocationCredit}
         iiifImageLocationLicenseId={iiifImageLocationLicenseId}
         encoreLink={encoreLink}
-        rendering={rendering}
+        downloadOptions={iiifPresentationDownloadOptions}
       />
     </PageLayout>
   );
@@ -231,12 +231,15 @@ WorkPage.getInitialProps = async (
   const { id, query, page } = ctx.query;
   const workOrError = await getWork({ id });
   const iiifPresentationLocation = getIIIFPresentationLocation(workOrError);
-  let rendering = [];
+
+  let iiifPresentationDownloadOptions = [];
   if (iiifPresentationLocation) {
     try {
       const iiifManifest = await fetch(iiifPresentationLocation.url);
       const manifestData = await iiifManifest.json();
-      rendering = getSequenceRendering(manifestData);
+      iiifPresentationDownloadOptions = getDownloadOptionsFromManifest(
+        manifestData
+      );
     } catch (e) {}
   }
   if (workOrError && workOrError.type === 'Redirect') {
@@ -259,7 +262,7 @@ WorkPage.getInitialProps = async (
       itemsLocationsLocationType:
         itemsLocationsLocationTypeQuery &&
         itemsLocationsLocationTypeQuery.split(',').filter(Boolean),
-      rendering,
+      iiifPresentationDownloadOptions,
     };
   }
 };

--- a/common/model/iiif.js
+++ b/common/model/iiif.js
@@ -31,10 +31,17 @@ export type IIIFCanvas = {|
   images: IIIFImage[],
 |};
 
+export type IIIFRendering = {|
+  '@id': string,
+  format: string,
+  label: string,
+|};
+
 export type IIIFSequence = {|
   '@id': string,
   '@type': string,
   canvases: IIIFCanvas[],
+  rendering: IIIFRendering[],
 |};
 type IIIFStructure = {|
   '@id': string,

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -1,5 +1,6 @@
 // @flow
 import { type Work } from '../model/work';
+import { type IIIFManifest, type IIIFRendering } from '../model/iiif';
 
 export function getPhysicalLocations(work: Work) {
   return work.items
@@ -21,6 +22,15 @@ export function getProductionDates(work: Work) {
   return work.production
     .map(productionEvent => productionEvent.dates.map(date => date.label))
     .reduce((a, b) => a.concat(b), []);
+}
+
+export function getSequenceRendering(
+  iiifManifest: IIIFManifest
+): IIIFRendering[] {
+  const sequence = iiifManifest.sequences.find(
+    sequence => sequence['@type'] === 'sc:Sequence'
+  );
+  return (sequence && sequence.rendering) || [];
 }
 
 export type IIIFPresentationLocation = {|

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -1,6 +1,7 @@
 // @flow
 import { type Work } from '../model/work';
 import { type IIIFManifest, type IIIFRendering } from '../model/iiif';
+import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 
 export function getPhysicalLocations(work: Work) {
   return work.items
@@ -31,6 +32,23 @@ export function getDownloadOptionsFromManifest(
     sequence => sequence['@type'] === 'sc:Sequence'
   );
   return (sequence && sequence.rendering) || [];
+}
+
+export function getDownloadOptionsFromImageUrl(
+  imageUrl: string
+): IIIFRendering[] {
+  return [
+    {
+      '@id': convertImageUri(imageUrl, 'full'),
+      format: 'image/jpeg',
+      label: 'Download full size',
+    },
+    {
+      '@id': convertImageUri(imageUrl, 760),
+      format: 'image/jpeg',
+      label: 'Download small (760px)',
+    },
+  ];
 }
 
 export type IIIFPresentationLocation = {|

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -24,7 +24,7 @@ export function getProductionDates(work: Work) {
     .reduce((a, b) => a.concat(b), []);
 }
 
-export function getSequenceRendering(
+export function getDownloadOptionsFromManifest(
   iiifManifest: IIIFManifest
 ): IIIFRendering[] {
   const sequence = iiifManifest.sequences.find(

--- a/common/views/components/Tags/Tags.js
+++ b/common/views/components/Tags/Tags.js
@@ -33,10 +33,10 @@ const Tags = ({ tags }: Props) => {
           [spacing({ s: 0 }, { padding: ['left'], margin: ['top'] })]: true,
         })}
       >
-        {tags.map(({ textParts, linkAttributes }) => {
+        {tags.map(({ textParts, linkAttributes }, i) => {
           return (
             <li
-              key={textParts.join('-')}
+              key={textParts.concat(i).join('-')}
               className={classNames({
                 'inline-block': true,
               })}


### PR DESCRIPTION
References #4228

- Adds PDF download option for books
- Instead of passing a iiif image url to the Download component we now pass an array of download options
- The download options come from the iiifPresentationManifest if we have one, else they are generate from the iiif imageUrl if we have that
- N.B. this does mean making a second API call for the manifest, but can't see a way around that
(but since we're doing this we should send if down the pipe, then the IIIFPresentationPreview won't need to request it again - will do this in separate PR)

<img width="548" alt="Screen Shot 2019-03-12 at 16 58 38" src="https://user-images.githubusercontent.com/6051896/54219888-2bd52080-44e8-11e9-9e83-75451419869e.png">


Next PR: 
- getting the appropriate licensing information
- maybe using context for the download props?

