### PR TITLE
spread initialState over defaultState to allow for null values

### DIFF
--- a/catalogue/webapp/components/SearchContext/SearchContext.js
+++ b/catalogue/webapp/components/SearchContext/SearchContext.js
@@ -43,18 +43,17 @@ type SearchProviderProps = {
 };
 
 const SearchProvider = ({ initialState, children }: SearchProviderProps) => {
-  const [query, setQuery] = useState(initialState.query || defaultState.query);
-  const [page, setPage] = useState(initialState.page || defaultState.page);
-  const [workType, setWorkType] = useState(
-    initialState.workType || defaultState.workType
-  );
+  const state = {
+    ...defaultState,
+    ...initialState,
+  };
+  const [query, setQuery] = useState(state.query);
+  const [page, setPage] = useState(state.page);
+  const [workType, setWorkType] = useState(state.workType);
   const [itemsLocationsLocationType, setItemsLocationsLocationType] = useState(
-    initialState.itemsLocationsLocationType ||
-      defaultState.itemsLocationsLocationType
+    state.itemsLocationsLocationType
   );
-  const [queryType, setQueryType] = useState(
-    initialState.queryType || defaultState.queryType
-  );
+  const [queryType, setQueryType] = useState(state.queryType);
 
   const value = {
     query,


### PR DESCRIPTION
This allows us to use `null` values where `null` values are valid.
e.g. 
```JS
let state = {};
const defaultState = { workType: ['k', 'q'] };
const initialState = { workType: null };
state = { workType: initialState.workType || defaultState.workType};
// state = { workType: ['k', 'q'] } <= wrong!
state = { ...defaultState, ...initialState };
// state = { workType: null } <= right!
const newInitialState = { otherProp: 'value' };
state = { ..defaultState, ...newInitialState };
// state = { workType: ['k', 'q'], otherProp: 'value' } <= right!
```