### PR TITLE
Move tag links from header to work details

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -121,11 +121,15 @@ const WorkDetails = ({
           <MetaUnit
             headingLevel={3}
             headingText="Contributors"
-            text={[
-              work.contributors
-                .map(contributor => contributor.agent.label)
-                .join(' | '),
-            ]}
+            tags={work.contributors.map(({ agent }) => {
+              return {
+                textParts: [agent.label],
+                linkAttributes: worksUrl({
+                  query: `"${agent.label}"`,
+                  page: 1,
+                }),
+              };
+            })}
           />
         )}
 

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -11,8 +11,6 @@ import Icon from '../Icon/Icon';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import LinkLabels from '../LinkLabels/LinkLabels';
 import TogglesContext from '../TogglesContext/TogglesContext';
-import Tags from '../Tags/Tags';
-import { worksUrl } from '../../../services/catalogue/urls';
 
 type Props = {|
   work: Work,
@@ -69,20 +67,33 @@ const WorkHeader = ({ work }: Props) => {
             {work.contributors.length > 0 && (
               <div
                 className={classNames({
+                  'flex flex--wrap': true,
                   [spacing({ s: 2 }, { margin: ['right'] })]: true,
                 })}
               >
-                <Tags
-                  tags={work.contributors.map(({ agent }) => {
-                    return {
-                      textParts: [agent.label],
-                      linkAttributes: worksUrl({
-                        query: `"${agent.label}"`,
-                        page: 1,
-                      }),
-                    };
-                  })}
-                />
+                {work.contributors.map(({ agent }, i, arr) => (
+                  <span
+                    className={classNames({
+                      [font({ s: 'HNL4' })]: true,
+                    })}
+                    key={agent.label}
+                  >
+                    {agent.label}
+                    {i < arr.length - 1 && (
+                      <span
+                        className={classNames({
+                          'inline-block': true,
+                          [spacing(
+                            { s: 1 },
+                            { margin: ['left', 'right'] }
+                          )]: true,
+                        })}
+                      >
+                        |
+                      </span>
+                    )}
+                  </span>
+                ))}
               </div>
             )}
 


### PR DESCRIPTION
Making contributors plain text when displayed in the header, and tags when in the work details section.

![Screenshot 2019-03-13 at 17 38 47](https://user-images.githubusercontent.com/1394592/54301523-07944500-45b7-11e9-9f84-5946420c3d2a.png)

![Screenshot 2019-03-13 at 17 38 59](https://user-images.githubusercontent.com/1394592/54301509-0105cd80-45b7-11e9-8b18-3800cbbc53f7.png)

