### PR TITLE
use max in main image in item viewer

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -300,7 +300,7 @@ const ItemPage = ({
             width={largestSize.width}
             height={largestSize.height}
             src={urlTemplate({
-              size: `${largestSize.width},${largestSize.height}`,
+              size: `max`,
             })}
           />
           <IIIFViewerPaginatorButtons>


### PR DESCRIPTION
Fixes the broken thumbs being used as the main image in the main preview.

Tl;DR; some image max bounding size is actually 1000x1000.
This is something that has just been lingering as it hasn't caused problems before.

The longer explanation can be found on slack.

This uses the `max` size in the IIIF Image API, which, on the thumbs service, can be `1000`, but will select `1024` if available.

As a point it's the `1000` images that are in the minority (6%).