### PR TITLE
remove share heading

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -217,7 +217,7 @@ const WorkDetails = ({
           list={isbnIdentifiers.map(id => id.value)}
         />
       )}
-      <MetaUnit headingText="Share">
+      <MetaUnit>
         <CopyUrl
           id={work.id}
           url={`https://wellcomecollection.org/works/${work.id}`}


### PR DESCRIPTION
As there are many other uses, we are removing the share heading from the link copy component.
![Screenshot 2019-03-18 at 12 38 15](https://user-images.githubusercontent.com/31692/54530518-e5197780-497a-11e9-97d4-2a328292424b.png)
