### PR TITLE
always return a flat array

### DIFF
--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -40,13 +40,16 @@ export function getProductionDates(work: Work) {
 export function getDownloadOptionsFromManifest(
   iiifManifest: IIIFManifest
 ): IIIFRendering[] {
-  const sequence =
-    iiifManifest.sequences &&
-    iiifManifest.sequences.find(
-      sequence => sequence['@type'] === 'sc:Sequence'
-    );
-  // $FlowFixMe
-  return sequence && sequence.rendering ? [sequence.rendering] : [];
+  const sequence = iiifManifest.sequences.find(
+    sequence => sequence['@type'] === 'sc:Sequence'
+  );
+  const sequenceRendering = sequence && sequence.rendering;
+
+  return sequenceRendering
+    ? Array.isArray(sequenceRendering)
+      ? sequenceRendering
+      : [sequenceRendering]
+    : [];
 }
 
 export function getDownloadOptionsFromImageUrl(


### PR DESCRIPTION
when we're creating the download options from the iiif Presentation Manifest using sequence.rendering we sometimes get an object and sometimes an array of objects. We always wan't to return an array