### PR TITLE
set img widths to auto inside metaUnit text

### DIFF
--- a/common/views/components/MetaUnit/MetaUnit.js
+++ b/common/views/components/MetaUnit/MetaUnit.js
@@ -2,6 +2,8 @@
 import type { Node } from 'react';
 import { spacing, font } from '../../../utils/classnames';
 import NextLink from 'next/link';
+import styled from 'styled-components';
+import { classNames } from '@weco/common/utils/classnames';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Tags, { type TagType } from '../Tags/Tags';
 
@@ -36,13 +38,23 @@ const Heading = ({ headingLevel, headingText }: HeadingProps) => {
   }
 };
 
+const ParagraphContainer = styled.div.attrs(props => ({
+  className: classNames({
+    'spaced-text': true,
+  }),
+}))`
+  img {
+    width: auto;
+  }
+`;
+
 const Paragraphs = ({ text }: { text: string[] }) => {
   return (
-    <div className="spaced-text">
+    <ParagraphContainer>
       {text.map((para, i) => {
         return <p key={i} dangerouslySetInnerHTML={{ __html: para }} />;
       })}
-    </div>
+    </ParagraphContainer>
   );
 };
 


### PR DESCRIPTION
repository info from the iiif presentation manifest can contain images, which get stretch to 100%. This makes sure that their width is set to auto.

before: 
![Screen Shot 2019-03-20 at 17 39 06](https://user-images.githubusercontent.com/6051896/54706547-19399780-4b37-11e9-8f63-adc348f7c29c.png)

after: 
![Screen Shot 2019-03-20 at 17 38 54](https://user-images.githubusercontent.com/6051896/54706560-1e96e200-4b37-11e9-94b9-a4a5eee00c56.png)
