### PR TITLE
remove images and whitespace from repository value

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -247,7 +247,10 @@ const WorkDetails = ({
   if (encoreLink || iiifPresentationRepository) {
     const textArray = [
       encoreLink && `<a href="${encoreLink}">Wellcome library</a>`,
-      iiifPresentationRepository && iiifPresentationRepository.value,
+      iiifPresentationRepository &&
+        iiifPresentationRepository.value
+          .replace(/<img[^>]*>/g, '')
+          .replace(/<br\s*\/?>/g, ''),
     ].filter(Boolean);
     WorkDetailsSections.push(
       <WorkDetailsSection headingText="Where to find it">


### PR DESCRIPTION
references  #4290

repository information from the iiif presentation manifest can contain images, we don't want to display them