### PR TITLE
don’t always have sequences and some aren’t valid

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -284,20 +284,22 @@ const ItemPage = ({
   workType,
   query,
 }: Props) => {
-  const canvases = manifest.sequences[0].canvases;
-  const currentCanvas = canvases[canvasIndex];
+  const canvases = manifest.sequences && manifest.sequences[0].canvases;
+  const currentCanvas = canvases && canvases[canvasIndex];
   const title = manifest.label;
   const mainImageService = {
-    '@id': currentCanvas.images[0].resource.service['@id'],
+    '@id': currentCanvas ? currentCanvas.images[0].resource.service['@id'] : '',
   };
 
-  const navigationCanvases = [...Array(pageSize)]
-    .map((_, i) => pageSize * pageIndex + i)
-    .map(i => canvases[i])
-    .filter(Boolean);
+  const navigationCanvases =
+    canvases &&
+    [...Array(pageSize)]
+      .map((_, i) => pageSize * pageIndex + i)
+      .map(i => canvases[i])
+      .filter(Boolean);
 
   const sharedPaginatorProps = {
-    totalResults: canvases.length,
+    totalResults: canvases && canvases.length,
     link: itemUrl({
       workId,
       query,
@@ -376,8 +378,8 @@ const ItemPage = ({
           <Paginator {...mainPaginatorProps} render={XOfY} />
 
           <IIIFResponsiveImage
-            width={currentCanvas.width}
-            height={currentCanvas.height}
+            width={currentCanvas ? currentCanvas.width : 0}
+            height={currentCanvas ? currentCanvas.height : 0}
             imageService={mainImageService}
             sizes={`(min-width: 860px) 800px, 100vw)`}
             extraClasses={classNames({
@@ -397,44 +399,45 @@ const ItemPage = ({
         </IIIFViewerMain>
 
         <IIIFViewerThumbs>
-          {navigationCanvases.map((canvas, i) => (
-            <IIIFViewerThumb key={canvas['@id']}>
-              <Paginator
-                {...thumbsPaginatorProps}
-                render={({ rangeStart }) => (
-                  <NextLink
-                    {...itemUrl({
-                      workId,
-                      query,
-                      workType,
-                      itemsLocationsLocationType,
-                      page: pageIndex + 1,
-                      sierraId,
-                      langCode,
-                      canvas: pageSize * pageIndex + (i + 1),
-                    })}
-                    scroll={false}
-                    replace
-                    passHref
-                  >
-                    <IIIFViewerThumbLink
-                      isActive={canvasIndex === rangeStart + i - 1}
+          {navigationCanvases &&
+            navigationCanvases.map((canvas, i) => (
+              <IIIFViewerThumb key={canvas['@id']}>
+                <Paginator
+                  {...thumbsPaginatorProps}
+                  render={({ rangeStart }) => (
+                    <NextLink
+                      {...itemUrl({
+                        workId,
+                        query,
+                        workType,
+                        itemsLocationsLocationType,
+                        page: pageIndex + 1,
+                        sierraId,
+                        langCode,
+                        canvas: pageSize * pageIndex + (i + 1),
+                      })}
+                      scroll={false}
+                      replace
+                      passHref
                     >
-                      <IIIFViewerThumbNumber>
-                        <span className="visually-hidden">image </span>
-                        {rangeStart + i}
-                      </IIIFViewerThumbNumber>
-                      <IIIFCanvasThumbnail
-                        canvas={canvas}
-                        maxWidth={300}
-                        lang={langCode}
-                      />
-                    </IIIFViewerThumbLink>
-                  </NextLink>
-                )}
-              />
-            </IIIFViewerThumb>
-          ))}
+                      <IIIFViewerThumbLink
+                        isActive={canvasIndex === rangeStart + i - 1}
+                      >
+                        <IIIFViewerThumbNumber>
+                          <span className="visually-hidden">image </span>
+                          {rangeStart + i}
+                        </IIIFViewerThumbNumber>
+                        <IIIFCanvasThumbnail
+                          canvas={canvas}
+                          maxWidth={300}
+                          lang={langCode}
+                        />
+                      </IIIFViewerThumbLink>
+                    </NextLink>
+                  )}
+                />
+              </IIIFViewerThumb>
+            ))}
           <IIIFViewerPaginatorButtons isThumbs={true}>
             <Paginator {...thumbsPaginatorProps} render={PaginatorButtons} />
           </IIIFViewerPaginatorButtons>

--- a/common/model/iiif.js
+++ b/common/model/iiif.js
@@ -32,6 +32,7 @@ export type IIIFImage = {|
 export type IIIFCanvas = {|
   '@id': string,
   thumbnail: IIIFThumbnail,
+  label: string,
   images: IIIFImage[],
   width: number,
   height: number,
@@ -46,6 +47,7 @@ export type IIIFRendering = {|
 export type IIIFSequence = {|
   '@id': string,
   '@type': string,
+  compatibilityHint: string,
   canvases: IIIFCanvas[],
   rendering: IIIFRendering[],
 |};
@@ -65,6 +67,6 @@ export type IIIFManifest = {|
   '@id': string,
   label: string,
   metadata: IIIFMetadata[],
-  sequences: IIIFSequence[],
-  structures: IIIFStructure[],
+  sequences?: IIIFSequence[],
+  structures?: IIIFStructure[],
 |};

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -40,9 +40,11 @@ export function getProductionDates(work: Work) {
 export function getDownloadOptionsFromManifest(
   iiifManifest: IIIFManifest
 ): IIIFRendering[] {
-  const sequence = iiifManifest.sequences.find(
-    sequence => sequence['@type'] === 'sc:Sequence'
-  );
+  const sequence =
+    iiifManifest.sequences &&
+    iiifManifest.sequences.find(
+      sequence => sequence['@type'] === 'sc:Sequence'
+    );
   const sequenceRendering = sequence && sequence.rendering;
 
   return sequenceRendering


### PR DESCRIPTION
Work type v, i.e. E-books can include multi volume works, which is causing errors on the work and item pages because the iiif manifest doesn't have any sequences, but links to other manifests.

There are also works which have sequences for non iiif content, such as PDFs

We need to work out what to do with these but in the meantime, this prevents the work page from breaking and suppresses the link to the viewer under those circumstances.
