### PR TITLE
maintain worktype state

### DIFF
--- a/catalogue/webapp/components/SearchContext/SearchContext.js
+++ b/catalogue/webapp/components/SearchContext/SearchContext.js
@@ -47,6 +47,7 @@ const SearchProvider = ({ initialState, children }: SearchProviderProps) => {
     ...defaultState,
     ...initialState,
   };
+
   const [query, setQuery] = useState(state.query);
   const [page, setPage] = useState(state.page);
   const [workType, setWorkType] = useState(state.workType);

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Context } from 'next';
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useState, useContext } from 'react';
 import Router from 'next/router';
 import Head from 'next/head';
 import {
@@ -19,7 +19,9 @@ import { worksUrl } from '@weco/common/services/catalogue/urls';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import BetaBar from '@weco/common/views/components/BetaBar/BetaBar';
 import TabNav from '@weco/common/views/components/TabNav/TabNav';
-import { SearchProvider } from '../components/SearchContext/SearchContext';
+import SearchContext, {
+  SearchProvider,
+} from '../components/SearchContext/SearchContext';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
@@ -66,6 +68,7 @@ const Works = ({
   itemsLocationsLocationType,
 }: Props) => {
   const [loading, setLoading] = useState(false);
+  const { setWorkType } = useContext(SearchContext);
 
   useEffect(() => {
     function routeChangeStart(url: string) {
@@ -276,6 +279,7 @@ const Works = ({
                         page: 1,
                       }),
                       selected: !workType,
+                      onClick: event => setWorkType(undefined),
                     },
                     {
                       text: 'Books',
@@ -290,6 +294,7 @@ const Works = ({
                         (workType.indexOf('a') !== -1 &&
                           workType.indexOf('v') !== -1)
                       ),
+                      onClick: event => setWorkType(['a', 'v']),
                     },
                     {
                       text: 'Pictures',
@@ -304,6 +309,7 @@ const Works = ({
                         (workType.indexOf('k') !== -1 &&
                           workType.indexOf('q') !== -1)
                       ),
+                      onClick: event => setWorkType(['k', 'q']),
                     },
                   ]}
                 />

--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -5,7 +5,11 @@ import NextLink from 'next/link';
 import { type TextLink } from '../../../model/text-links';
 import { spacing, font, classNames } from '../../../utils/classnames';
 
-type SelectableTextLink = {| ...TextLink, selected: boolean |};
+type SelectableTextLink = {|
+  ...TextLink,
+  selected: boolean,
+  onClick?: (SyntheticEvent<HTMLAnchorElement>) => void,
+|};
 
 // TODO: This large property is a bit silly but okay for while we're testing
 type Props = {


### PR DESCRIPTION
When you use a context, you need to remember to update things as you have an initialState that you need to make sure you update for effects to be used elsewhere.

I don't think this is the solution to it, and would like to maybe tie the router to the context so that you don't need to remember to do this every time.