### PR TITLE
get pdf url from mediaSequences if it’s available

### DIFF
--- a/common/model/iiif.js
+++ b/common/model/iiif.js
@@ -44,6 +44,15 @@ export type IIIFRendering = {|
   label: string,
 |};
 
+type IIIFMediaSequence = {|
+  '@id': string,
+  '@type': string,
+  elements: {
+    '@id': string,
+    format: string,
+  }[],
+|};
+
 export type IIIFSequence = {|
   '@id': string,
   '@type': string,
@@ -67,6 +76,7 @@ export type IIIFManifest = {|
   '@id': string,
   label: string,
   metadata: IIIFMetadata[],
+  mediaSequences?: IIIFMediaSequence[],
   sequences?: IIIFSequence[],
   structures?: IIIFStructure[],
 |};

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -46,12 +46,25 @@ export function getDownloadOptionsFromManifest(
       sequence => sequence['@type'] === 'sc:Sequence'
     );
   const sequenceRendering = sequence && sequence.rendering;
+  const sequenceRenderingArray = Array.isArray(sequenceRendering)
+    ? sequenceRendering
+    : [sequenceRendering];
 
-  return sequenceRendering
-    ? Array.isArray(sequenceRendering)
-      ? sequenceRendering
-      : [sequenceRendering]
+  const pdfRenderingArray = iiifManifest.mediaSequences
+    ? iiifManifest.mediaSequences.reduce((acc, sequence) => {
+        sequence.elements.forEach(element => {
+          if (element.format === 'application/pdf') {
+            acc.push({
+              '@id': element['@id'],
+              format: element.format,
+              label: 'Download PDF',
+            });
+          }
+        });
+        return acc;
+      }, [])
     : [];
+  return [...sequenceRenderingArray, ...pdfRenderingArray].filter(Boolean);
 }
 
 export function getDownloadOptionsFromImageUrl(

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -52,16 +52,19 @@ export function getDownloadOptionsFromManifest(
 
   const pdfRenderingArray = iiifManifest.mediaSequences
     ? iiifManifest.mediaSequences.reduce((acc, sequence) => {
-        sequence.elements.forEach(element => {
-          if (element.format === 'application/pdf') {
-            acc.push({
-              '@id': element['@id'],
-              format: element.format,
-              label: 'Download PDF',
-            });
-          }
-        });
-        return acc;
+        return acc.concat(
+          sequence.elements
+            .map(element => {
+              if (element.format === 'application/pdf') {
+                return {
+                  '@id': element['@id'],
+                  format: element.format,
+                  label: 'Download PDF',
+                };
+              }
+            })
+            .filter(Boolean)
+        );
       }, [])
     : [];
   return [...sequenceRenderingArray, ...pdfRenderingArray].filter(Boolean);


### PR DESCRIPTION
If we have a work, that only has a iiif presentation manifest wrapping a pdf, there is currently no way for a user to get hold of the pdf.

This uses gets the url of the pdf, from the manifest mediaSequences, and adds it to the download options.

![Screen Shot 2019-03-25 at 12 25 02](https://user-images.githubusercontent.com/6051896/54919576-0e954e80-4ef9-11e9-8398-5ac5668117ad.png)
