### PR TITLE
add sierraId to canonical href of items

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -332,7 +332,7 @@ const ItemPage = ({
     <PageLayout
       title={''}
       description={''}
-      url={{ pathname: `/works/${workId}/items` }}
+      url={{ pathname: `/works/${workId}/items`, query: { sierraId } }}
       openGraphType={'website'}
       jsonLd={{ '@type': 'WebPage' }}
       siteSection={'works'}


### PR DESCRIPTION
Appends the sierraId onto the canonical url for the items of a work.