### PR TITLE
Fix TabNav highlight for iOS

### DIFF
--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -36,7 +36,6 @@ const NavItemInner = styled.span.attrs(props => ({
     transition: width 200ms ease;
   }
 
-  &.selected,
   &:hover,
   &:focus {
     &:after {
@@ -47,6 +46,10 @@ const NavItemInner = styled.span.attrs(props => ({
         width: 0;
       }
     }
+  }
+
+  &.selected:after {
+    width: 100%;
   }
 `;
 


### PR DESCRIPTION
Fixes #4312

We have a line that stops the need for double-tapping links on iOS using [this technique](https://css-tricks.com/annoying-mobile-double-tap-link-issue/), but the style was also preventing filter highlight on ~iOS~ touchscreen devices.

This PR splits the relevant style pieces out so the yellow highlight can still be visible without affecting the double-tap stuff.