### PR TITLE
Add license information

### DIFF
--- a/common/utils/get-license-info.js
+++ b/common/utils/get-license-info.js
@@ -65,6 +65,17 @@ export const licenseMap = {
       'Creative Commons Attribution Non-Commercial No-Derivatives (CC BY-NC-ND 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">https://creativecommons.org/licenses/by-nc-nd/4.0/</a>',
     ],
   },
+  'open-government-licence-for-public-sector-information': {
+    url:
+      'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/',
+    text: 'Open Government Licence for public sector information',
+    icons: [],
+    description: 'Free to use with attribution.',
+    humanReadableText: [
+      'You can use this work for any purpose, including commercial uses, without restriction under copyright law. You should also provide attribution to the original work, source and licence.',
+      '<a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/">Open Government Licence for public sector information terms and conditions</a>',
+    ],
+  },
 };
 
 export default function(licenseIdentifier: string): ?LicenseData {

--- a/common/utils/get-license-info.js
+++ b/common/utils/get-license-info.js
@@ -65,15 +65,35 @@ export const licenseMap = {
       'Creative Commons Attribution Non-Commercial No-Derivatives (CC BY-NC-ND 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">https://creativecommons.org/licenses/by-nc-nd/4.0/</a>',
     ],
   },
-  'open-government-licence-for-public-sector-information': {
+  inc: {
+    url: 'http://rightsstatements.org/vocab/InC/1.0/',
+    text: 'In copyright',
+    description:
+      'Free to use as permitted by the copyright and rights legislation that applies to your use.',
+    humanReadableText: [
+      'It is possible this Item is protected by copyright and/or related rights. You are free to use this Item in any way that is permitted by the copyright and related rights legislation that applies to your use. For other uses you need to obtain permission from the rights-holder(s).',
+    ],
+  },
+  OGL: {
     url:
-      'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/',
-    text: 'Open Government Licence for public sector information',
-    icons: [],
+      'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
+    text: 'Open Government Licence',
     description: 'Free to use with attribution.',
     humanReadableText: [
       'You can use this work for any purpose, including commercial uses, without restriction under copyright law. You should also provide attribution to the original work, source and licence.',
-      '<a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/">Open Government Licence for public sector information terms and conditions</a>',
+
+      'Open Government Licence terms and conditions <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/</a>',
+    ],
+  },
+  OPL: {
+    url:
+      'https://www.parliament.uk/site-information/copyright/open-parliament-licence/',
+    text: 'Open Parliament Licence',
+    description: 'Free to use with attribution.',
+    humanReadableText: [
+      'You can use this work for any purpose, including commercial uses, without restriction under copyright law. You should also provide attribution to the original work, source and licence.',
+
+      'Open Parliament Licence terms and conditions <a href="https://www.parliament.uk/site-information/copyright/open-parliament-licence/">https://www.parliament.uk/site-information/copyright/open-parliament-licence/</a>',
     ],
   },
 };


### PR DESCRIPTION
- Some works are licensed under Open Government Licence V2, as  specified in the iiif presentation manifest for the work.
- The licenseMap object, we use for our license information, doesn't account for this.
- This PR adds information to the object, so that license information will be displayed to the user.
- Open Government Licence V2 is directly compatible with the Creative Commons Attribution License 4.0, so I'm using the same wording, but linking to the Open Government Licence.

![Screen Shot 2019-03-25 at 14 00 15 1](https://user-images.githubusercontent.com/6051896/54926281-e3fec200-4f07-11e9-8a30-fdd841afc2c8.png)
