### PR TITLE
create new cache behaviour for /works

### DIFF
--- a/cache/cloudfront_dev.tf
+++ b/cache/cloudfront_dev.tf
@@ -35,15 +35,54 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
       query_string_cache_keys = [
         "page",
         "current",
-        "query",
         "uri",
-        "MIROPAC",                      # Wellcome Images redirect
-        "MIRO",                         # Wellcome Images redirect
+        "MIROPAC", # Wellcome Images redirect
+        "MIRO",    # Wellcome Images redirect
 
         # dotmailer gives us a 'result' (if we run out of params,
         # consider making new urls for newsletter pages instead)
         "result",
+      ]
 
+      cookies {
+        forward = "whitelist"
+
+        whitelisted_names = [
+          "toggles",  # feature toggles
+          "toggle_*", # feature toggles
+        ]
+      }
+    }
+
+    lambda_function_association {
+      event_type = "origin-request"
+      lambda_arn = "${aws_lambda_function.edge_lambda_request.qualified_arn}"
+    }
+
+    lambda_function_association {
+      event_type = "origin-response"
+      lambda_arn = "${aws_lambda_function.edge_lambda_response.qualified_arn}"
+    }
+  }
+
+  ordered_cache_behavior {
+    allowed_methods        = ["HEAD", "GET", "OPTIONS"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id       = "origin"
+    path_pattern           = "/works*"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      headers      = ["Host"]
+      query_string = true
+
+      query_string_cache_keys = [
+        "page",
+        "current",
+        "query",
         "workType",
         "sierraId",
         "canvas",

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -52,15 +52,55 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
       query_string_cache_keys = [
         "page",
         "current",
-        "query",
         "uri",
-        "MIROPAC",                      # Wellcome Images redirect
-        "MIRO",                         # Wellcome Images redirect
+        "MIROPAC", # Wellcome Images redirect
+        "MIRO",    # Wellcome Images redirect
 
         # dotmailer gives us a 'result' (if we run out of params,
         # consider making new urls for newsletter pages instead)
         "result",
+      ]
 
+      cookies {
+        forward = "whitelist"
+
+        whitelisted_names = [
+          "toggles",  # feature toggles
+          "toggle_*", # feature toggles
+        ]
+      }
+    }
+
+    lambda_function_association {
+      event_type = "origin-request"
+      lambda_arn = "${data.aws_lambda_function.versioned_edge_lambda_request.arn}"
+    }
+
+    lambda_function_association {
+      event_type = "origin-response"
+      lambda_arn = "${data.aws_lambda_function.versioned_edge_lambda_response.arn}"
+    }
+  }
+
+  # Works
+  ordered_cache_behavior {
+    allowed_methods        = ["HEAD", "GET", "OPTIONS"]
+    cached_methods         = ["HEAD", "GET", "OPTIONS"]
+    viewer_protocol_policy = "redirect-to-https"
+    target_origin_id       = "origin"
+    path_pattern           = "/works*"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      headers      = ["Host"]
+      query_string = true
+
+      query_string_cache_keys = [
+        "page",
+        "current",
+        "query",
         "workType",
         "sierraId",
         "canvas",

--- a/cache/terraform.tf
+++ b/cache/terraform.tf
@@ -1,6 +1,6 @@
 locals {
-  edge_lambda_request_version  = 10
-  edge_lambda_response_version = 11
+  edge_lambda_request_version  = 11
+  edge_lambda_response_version = 12
 }
 
 # Setup terraform for this service


### PR DESCRIPTION
We had too many query parameters, so we now have a new ✨ cache behaviour.

This is probably better in the long run as it feels like we'll have different requirements for `/works` anyway.