### PR TITLE
add error handling to IIIF images

### DIFF
--- a/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage.js
+++ b/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage.js
@@ -1,12 +1,12 @@
 // @flow
-
+import Raven from 'raven-js';
 import { classNames } from '../../../utils/classnames';
 import { imageSizes } from '../../../utils/image-sizes';
 import {
   type IIIFImageService,
   type IIIFThumbnailService,
 } from '../../../model/iiif';
-import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
+import { iiifImageTemplate } from '../../../utils/convert-image-uri';
 
 type Props = {|
   width: number,
@@ -45,6 +45,13 @@ const IIIFResponsiveImage = ({
         image: true,
         [extraClasses || '']: true,
       })}
+      onError={event =>
+        Raven.captureException(new Error('IIIF image loading error'), {
+          tags: {
+            service: 'dlcs',
+          },
+        })
+      }
       src={urlTemplate({ size: `${initialSrcWidth},` })}
       srcSet={
         sizes


### PR DESCRIPTION
@Heesoomoon noticed we were getting a few errors on images from DLCS.
They seem to be `503`s, and non-replicable. 

I have asked DLCS if they could give us further insight into this, and have now added sentry tracking.

It might be worth looking at sentry as a point to get it into a usable state again.