### PR TITLE
show button only if we haven't managed to load the page with JS

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -485,9 +485,9 @@ ItemPage.getInitialProps = async (ctx: Context): Promise<Props> => {
     `https://wellcomelibrary.org/iiif/${sierraId}/manifest`
   )).json();
 
-  const canvases = manifest.sequences[0].canvases;
-  const currentCanvas = canvases[canvasIndex];
-  const canvasOcr = await getCanvasOcr(currentCanvas);
+  const canvases = manifest.sequences && manifest.sequences[0].canvases;
+  const currentCanvas = canvases && canvases[canvasIndex];
+  const canvasOcr = currentCanvas ? await getCanvasOcr(currentCanvas) : null;
 
   return {
     workId,

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -256,9 +256,15 @@ const IIIFPresentationDisplay = ({
   iiifPresentationLocation,
   itemUrl,
 }: Props) => {
+  const [loaded, setLoaded] = useState(false);
   const [imageThumbnails, setImageThumbnails] = useState([]);
   const [imageTotal, setImageTotal] = useState(0);
   const iiifPresentationManifest = useContext(ManifestContext);
+
+  useEffect(() => {
+    setLoaded(true);
+  }, []);
+
   useEffect(() => {
     if (iiifPresentationManifest) {
       setImageTotal(getCanvases(iiifPresentationManifest).length);
@@ -275,7 +281,29 @@ const IIIFPresentationDisplay = ({
     return acc + pageType.images.length;
   }, 0);
 
-  if (imageTotal > 0) {
+  if (!loaded) {
+    return (
+      <div
+        className={classNames({
+          [spacing({ s: 2 }, { margin: ['top', 'bottom'] })]: true,
+        })}
+      >
+        <Button
+          type="primary"
+          url={`/works/${itemUrl.href.query.workId}/items`}
+          trackingEvent={{
+            category: 'ViewBookNonJSButton',
+            action: 'follow link',
+            label: itemUrl.href.query.workId,
+          }}
+          text="View the item"
+          link={itemUrl}
+        />
+      </div>
+    );
+  }
+
+  if (loaded && imageTotal > 0) {
     return (
       <BookPreviewContainer>
         <NextLink {...itemUrl}>
@@ -343,25 +371,7 @@ const IIIFPresentationDisplay = ({
       </BookPreviewContainer>
     );
   } else {
-    return (
-      <div
-        className={classNames({
-          [spacing({ s: 2 }, { margin: ['top', 'bottom'] })]: true,
-        })}
-      >
-        <Button
-          type="primary"
-          url={`/works/${itemUrl.href.query.workId}/items`}
-          trackingEvent={{
-            category: 'ViewBookNonJSButton',
-            action: 'follow link',
-            label: itemUrl.href.query.workId,
-          }}
-          text="View the item"
-          link={itemUrl}
-        />
-      </div>
-    );
+    return null;
   }
 };
 


### PR DESCRIPTION
Makes the logic more explicit as to what we want to render.

This way we don't land up rendering the link when we know there aren't any images from the manifest.

As, without JS, we can't tell if we'll be able to render the item, we just show the button.

@wellcometrust/experience-devs do we think this is a decent strategy for non-js loading (the `loaded`) or would something more generic make sense? I can't think of what that is though.

There's a few fixes where we are being a bit loose with out array checking, we should think about how not to let these slip in, probably with typing.