### PR TITLE
Set both icon dimensions

### DIFF
--- a/common/styles/base/_icons.scss
+++ b/common/styles/base/_icons.scss
@@ -1,6 +1,7 @@
 .icon {
   display: inline-block;
   height: $icon-dimension;
+  width: $icon-dimension;
   position: relative;
   user-select: none;
 }

--- a/common/views/components/Icon/Icon.js
+++ b/common/views/components/Icon/Icon.js
@@ -11,7 +11,6 @@ type Props = {|
 
 const Icon = ({ name, title, extraClasses, attrs = {} }: Props) => (
   <div className={`icon ${extraClasses || ''}`} aria-hidden={title && 'true'}>
-    <canvas className="icon__canvas" height="26" width="26" />
     <svg
       className="icon__svg"
       {...(title


### PR DESCRIPTION
Fixes #4314

The `canvas` element as a shim for icon sizing was useful when we didn't know the icons' aspect ratios. Now all of our icons are square, it is redundant.

Setting both icon dimensions was the most straightforward, but it alerted me to the fact that the `viewbox` for some of our icons is `0 0 24 24` (24x24) and some `0 0 26 26` (26x26).

We're still displaying them all at 26x26, but I think @GarethOrmerod did work to update them to be sized by a number that works with our base sizing unit (6px).

This probably leads to aliasing of the 24x24 icons meaning that they won't render as sharp as they would if they were displayed at 24x24.

We should probably push to get all icons using a `0 0 24 24` viewbox and display them all at 24px.