### PR TITLE
Check a work is viewable

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -16,6 +16,7 @@ import Raven from 'raven-js';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import TruncatedText from '@weco/common/views/components/TruncatedText/TruncatedText';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
+import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 
 const IIIFViewerPaginatorButtons = styled.div.attrs(props => ({
   className: classNames({
@@ -381,10 +382,16 @@ const ItemPage = ({
           </NextLink>
         </div>
         {!pdfRendering && !mainImageService && (
-          <p>
-            We are unable to show you this work online at present, but are
-            working on making it available.
-          </p>
+          <div
+            className={classNames({
+              [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
+            })}
+          >
+            <BetaMessage
+              message="We are currently unable to show this work online, but will be
+        working on making it available."
+            />
+          </div>
         )}
       </Layout12>
       {pdfRendering && !mainImageService && (

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -395,10 +395,7 @@ const ItemPage = ({
               [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
             })}
           >
-            <BetaMessage
-              message="We are currently unable to show this work online, but will be
-        working on making it available."
-            />
+            <BetaMessage message="We are working to make this item available online in April 2019." />
           </div>
         )}
       </Layout12>

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -380,6 +380,12 @@ const ItemPage = ({
             </a>
           </NextLink>
         </div>
+        {!pdfRendering && !mainImageService && (
+          <p>
+            We are unable to show you this work online at present, but are
+            working on making it available.
+          </p>
+        )}
       </Layout12>
       {pdfRendering && !mainImageService && (
         <iframe
@@ -394,6 +400,7 @@ const ItemPage = ({
           }}
         />
       )}
+
       {mainImageService && (
         <IIIFViewer>
           <IIIFViewerMain>

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -162,6 +162,14 @@ const IIIFViewer = styled.div.attrs(props => ({
   }
 `;
 
+const IframePdfViewer = styled.iframe`
+  width: 90vw;
+  height: 90vh;
+  margin: 0 auto 24px;
+  display: block;
+  border: none;
+`;
+
 type Props = {|
   workId: string,
   sierraId: string,
@@ -395,17 +403,7 @@ const ItemPage = ({
         )}
       </Layout12>
       {pdfRendering && !mainImageService && (
-        <iframe
-          title={`PDF: ${title}`}
-          src={pdfRendering['@id']}
-          style={{
-            width: '90vw',
-            height: '90vh',
-            margin: '0 auto 24px ',
-            display: 'block',
-            border: 'none',
-          }}
-        />
+        <IframePdfViewer title={`PDF: ${title}`} src={pdfRendering['@id']} />
       )}
 
       {mainImageService && (

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -4,6 +4,7 @@ import {
   type IIIFManifest,
   type IIIFRendering,
   type IIIFMetadata,
+  type IIIFCanvas,
 } from '../model/iiif';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 
@@ -85,6 +86,25 @@ export function getDownloadOptionsFromImageUrl(
       label: 'Download small (760px)',
     },
   ];
+}
+
+export function getCanvases(iiifManifest: IIIFManifest): IIIFCanvas[] {
+  const sequence =
+    iiifManifest.sequences &&
+    iiifManifest.sequences.find(
+      sequence =>
+        sequence['@type'] === 'sc:Sequence' &&
+        sequence.compatibilityHint !== 'displayIfContentUnsupported'
+    );
+  return sequence ? sequence.canvases : [];
+}
+
+export function manifestViewable(iiifManifest: IIIFManifest) {
+  const canvases = getCanvases(iiifManifest);
+  const downloadOptions = getDownloadOptionsFromManifest(iiifManifest);
+  const pdfRendering =
+    downloadOptions.find(option => option.label === 'Download PDF') || false;
+  return canvases.length > 0 ? 'iiif' : pdfRendering ? 'pdf' : 'none';
 }
 
 export type IIIFPresentationLocation = {|

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -99,7 +99,7 @@ export function getCanvases(iiifManifest: IIIFManifest): IIIFCanvas[] {
   return sequence ? sequence.canvases : [];
 }
 
-export function manifestViewable(iiifManifest: IIIFManifest) {
+export function getManifestViewType(iiifManifest: IIIFManifest) {
   const canvases = getCanvases(iiifManifest);
   const downloadOptions = getDownloadOptionsFromManifest(iiifManifest);
   const pdfRendering =

--- a/common/views/components/BetaMessage/BetaMessage.js
+++ b/common/views/components/BetaMessage/BetaMessage.js
@@ -1,0 +1,30 @@
+import { font, classNames } from '../../../utils/classnames';
+import styled from 'styled-components';
+import Icon from '@weco/common/views/components/Icon/Icon';
+
+const StyledBetaMessage = styled.div.attrs(props => ({
+  className: classNames({
+    [font({ s: 'HNL5', m: 'HNL4' })]: true,
+    'flex flex--v-center': true,
+  }),
+}))`
+  border-left: ${props => `4px solid ${props.theme.colors.purple}`};
+  padding-left: ${props => props.theme.spacingUnit}px;
+
+  p {
+    margin: 0;
+  }
+`;
+
+type Props = {| message: string |};
+
+const BetaMessage = ({ message }: Props) => {
+  return (
+    <StyledBetaMessage>
+      <Icon name="underConstruction" extraClasses="margin-right-s2" />
+      <p>{message}</p>
+    </StyledBetaMessage>
+  );
+};
+
+export default BetaMessage;

--- a/common/views/components/BetaMessage/BetaMessage.js
+++ b/common/views/components/BetaMessage/BetaMessage.js
@@ -1,4 +1,6 @@
-import { font, classNames } from '../../../utils/classnames';
+import { useEffect } from 'react';
+import { trackEvent } from '@weco/common/utils/ga';
+import { font, classNames } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import Icon from '@weco/common/views/components/Icon/Icon';
 
@@ -19,6 +21,13 @@ const StyledBetaMessage = styled.div.attrs(props => ({
 type Props = {| message: string |};
 
 const BetaMessage = ({ message }: Props) => {
+  useEffect(() => {
+    trackEvent({
+      category: 'BetaMessage',
+      action: 'message displayed',
+      label: message,
+    });
+  }, []);
   return (
     <StyledBetaMessage>
       <Icon name="underConstruction" extraClasses="margin-right-s2" />

--- a/common/views/components/BetaMessage/BetaMessage.js
+++ b/common/views/components/BetaMessage/BetaMessage.js
@@ -12,10 +12,6 @@ const StyledBetaMessage = styled.div.attrs(props => ({
 }))`
   border-left: ${props => `4px solid ${props.theme.colors.purple}`};
   padding-left: ${props => props.theme.spacingUnit}px;
-
-  p {
-    margin: 0;
-  }
 `;
 
 type Props = {| message: string |};
@@ -31,7 +27,7 @@ const BetaMessage = ({ message }: Props) => {
   return (
     <StyledBetaMessage>
       <Icon name="underConstruction" extraClasses="margin-right-s2" />
-      <p>{message}</p>
+      <p className="no-margin">{message}</p>
     </StyledBetaMessage>
   );
 };

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -14,6 +14,7 @@ import { trackEvent } from '@weco/common/utils/ga';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import ManifestContext from '@weco/common/views/components/ManifestContext/ManifestContext';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
+import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 
 const BookPreviewContainer = styled.div`
   overflow: scroll;
@@ -365,10 +366,16 @@ const IIIFPresentationDisplay = ({
 
   if (viewType === 'none') {
     return (
-      <p>
-        We are unable to show you this work online at present, but are working
-        on making it available.
-      </p>
+      <div
+        className={classNames({
+          [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
+        })}
+      >
+        <BetaMessage
+          message="We are currently unable to show this work online, but will be
+        working on making it available."
+        />
+      </div>
     );
   } else {
     return null;

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -377,10 +377,7 @@ const IIIFPresentationDisplay = ({
           [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
         })}
       >
-        <BetaMessage
-          message="We are currently unable to show this work online, but will be
-        working on making it available."
-        />
+        <BetaMessage message="We are working to make this item available online in April 2019." />
       </div>
     );
   } else {

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -247,11 +247,17 @@ type Props = {|
   itemUrl: any,
 |};
 
+type ViewType = 'unknown' | 'iiif' | 'pdf' | 'none';
+// Can we show the user the work described by the manifest?
+// unknown === can't/haven't checked
+// iiif | pdf === checked manifest and can render
+// none === checked manifest and know we can't render it
+
 const IIIFPresentationDisplay = ({
   iiifPresentationLocation,
   itemUrl,
 }: Props) => {
-  const [viewType, setViewType] = useState('unknown');
+  const [viewType, setViewType] = useState<ViewType>('unknown');
   const [imageThumbnails, setImageThumbnails] = useState([]);
   const [imageTotal, setImageTotal] = useState(0);
   const iiifPresentationManifest = useContext(ManifestContext);


### PR DESCRIPTION
Fixes #4333 and adds tracking when we display the user a message saying we are unable to show the work online.

N.B. Wording of the message and styling might need work.

When we have javascript available we replace the link to the viewer with the message:
![Screen Shot 2019-03-26 at 16 49 38](https://user-images.githubusercontent.com/6051896/55018371-a45cd680-4fea-11e9-83b6-28e7fe055c3c.png)

When we don't have javascript available we show the message on the viewer/item page:
![Screen Shot 2019-03-26 at 16 49 25](https://user-images.githubusercontent.com/6051896/55018435-c8b8b300-4fea-11e9-9475-911cf6c4d05a.png)
