### PR TITLE
Add very very draft RPC for URL strategy

### DIFF
--- a/docs/rfcs/001-url_strategy/README.md
+++ b/docs/rfcs/001-url_strategy/README.md
@@ -1,0 +1,74 @@
+# RFC 001: URL strategies
+
+**Last updated: March 2018.**
+
+## Background
+URLs are complicated, and you don't often get a chance to do them twice.
+
+They also serve multiple purposes, especially on a client facing app where
+state, combinations of data sources and search requirements might not reflect
+exactly with corresponding REST APIs.
+
+
+## Problem statement
+We would like to have a list of schemas, policies, processes, and plans that we
+could use whenever we think we need to add URLs to our domain.
+
+This may include topics such as
+- Structure
+- Privacy
+- Content this URL is expected to surface
+
+## Proposed solution
+We create a policy document on how we deal with creating new, and managing old
+URLs and any guiding principles we should follow while doing so.
+
+This could be part process, but also enforced by implementation across the
+teams.
+
+### Process
+The process has been suggested that we go through using RFCs in adding a new
+URL type to our domain, but assumed this could be used for updating them
+too.
+
+[An example document has been started here](./example_strategy_document.md).
+
+
+### Implementation
+Implementation can be done through typing, an example for this could be:
+
+```JS
+// JS... sorry
+type IdentifiedType = {|
+  type: 'IdentifiedThing'
+  pluralisedName = string,
+|}
+
+const Work: IdentifiedType = {
+  type: 'IdentifiedThing',
+  pluralisedName: 'works',
+}
+
+const Authority: IdentifiedType = {
+  type: 'IdentifiedThing',
+  pluralisedName: 'authorities',
+}
+
+function getRouteSchema(thing: IdentifiedThing) {
+  if (thing.type === 'IdentifiedThing') {
+    return `/${thing.pluralisedName.toLowerCase()}/:id`
+  }
+}
+
+// Now doing the schema
+r.get(getroute(Authority), renderAuthority)
+r.get(getroute(Work), renderWork)
+
+```
+
+These could be shared through a cross language code generator, but often the
+time involved in this is not worth the effort in small teams.
+- [Thrift](https://thrift.apache.org/)
+- [gRPC](https://grpc.io)
+- [ProtoBuffs](https://developers.google.com/protocol-buffers/)
+

--- a/docs/rfcs/001-url_strategy/README.md
+++ b/docs/rfcs/001-url_strategy/README.md
@@ -2,7 +2,7 @@
 
 **Last updated: March 2018.**
 
-## Background
+## Background
 URLs are complicated, and you don't often get a chance to do them twice.
 
 They also serve multiple purposes, especially on a client facing app where
@@ -26,7 +26,7 @@ URLs and any guiding principles we should follow while doing so.
 This could be part process, but also enforced by implementation across the
 teams.
 
-### Process
+### Process
 The process has been suggested that we go through using RFCs in adding a new
 URL type to our domain, but assumed this could be used for updating them
 too.
@@ -34,7 +34,7 @@ too.
 [An example document has been started here](./example_strategy_document.md).
 
 
-### Implementation
+### Implementation
 Implementation can be done through typing, an example for this could be:
 
 ```JS

--- a/docs/rfcs/001-url_strategy/example_strategy_document.md
+++ b/docs/rfcs/001-url_strategy/example_strategy_document.md
@@ -1,0 +1,41 @@
+# URL strategy
+TBD
+
+## Identifiers
+TBD
+
+## Parameters
+There are some potential candidates of information you might want to store as
+URL parameters. Our categorisations, and whether we advocate storing them in
+the URL are:
+
+### Do: Application state
+This is needed to render your application in a certain state, and is integral to
+the functionality of this part of the application.
+
+Generally this will be to search and filter lists.
+
+#### Examples
+- Pagination on list of data
+- Search queries and filters on a searchable set of data
+
+#### Sharing and privacy
+Someone using our site should __expect__ these to be in the URL as it is
+integral to what they are sharing.
+
+
+### Don't: Individual contextual state
+This is information that allows for a person to have an easier, more pleasant,
+and efficient experience on our site, but might give information that could be
+interpreted for intent.
+
+#### Examples
+- A person's search across multiple pages
+- A person's language choice
+
+#### Sharing and privacy
+Someone using the site __might not expect__ these to be in the URL, as it is not
+directly related to the content they are sharing.
+
+This is doubly dangerous as not all ways of sharing make the URL editable, or
+even visible to a person before sharing or citing.


### PR DESCRIPTION
As per our conversation, it felt like getting started would be the easiest way to do this.

__Questions__
- [ ] Where does this live?
- [ ] Do we start with an overarching document, or a document to cherry pick from to create different URL strategies for different use cases, e.g. REST API vs client app.
- [ ] Next steps?

