### PR TITLE
add RFC for URL parameters

### DIFF
--- a/docs/rfcs/001-url_parameters/README.md
+++ b/docs/rfcs/001-url_parameters/README.md
@@ -1,0 +1,26 @@
+# RFC 001: URL Parameter Strategy
+
+**Last updated: March 2018.**
+
+## Background
+After discussions of creating a URL strategy, and documents to help support
+sticking to that strategy in the future, we thought a good starting point could
+be where we have a use case - URL parameters.
+
+
+## Problem statement
+URL parameters are used for storing information needed to render a page, such
+as a query, or page number.
+
+They are also other reasons you might want to store parameters in the URL, such
+as application state, user preferences, display logic etc.
+
+With the latter, there are considerations in clarity, sharing, immutability and
+privacy.
+
+
+# Proposed solution
+We come up with a strategy document, potentially to become part of a greater
+URL strategy document, to guide us when we are thinking of using URL parameters.
+
+[Example document](./url_parameters_strategy.md)

--- a/docs/rfcs/001-url_parameters/url_parameters_strategy.md
+++ b/docs/rfcs/001-url_parameters/url_parameters_strategy.md
@@ -1,0 +1,49 @@
+# URL Parameters strategy
+There are some potential candidates of information you might want to store as
+URL parameters.
+
+## Considerations
+
+###  Clarity
+The name of the parameter should be clear as to what it is doing.
+
+If you are paginating through a set of results call the parameter `page`, not
+`index`.
+
+Interoperability between systems should also be adhered to when possible. If you
+are interfacing with an API that uses `query`, you should use `query`, not `q`.
+
+
+### Privacy and sharing
+Is the content in the URL something someone would always want to share?
+
+Does it expose any information that might make it possible for others to assume
+intent?
+
+Based on the seventh article of the [Library Bill of Rights](https://en.wikipedia.org/wiki/Library_Bill_of_Rights#cite_note-2)
+we should not be leaking information that a person might share in regards to
+their research and access to our library unwittingly.
+
+Another consideration is that URLs can be obfuscated by browsers and Operating
+systems, people might not see the URL before sharing or citing, you should
+always consider:
+
+- Is the content likely to be shared?
+- Is the information in the URL something a person would __expect__ to be in the
+  URL when shared?
+
+If not, the information should be obfuscated and retrieved via another
+mechanism.
+
+An example of something a person would expect to be in the URL which also gives
+insight into the person's research would be the search terms when searching the
+API.
+
+e.g. `/works?query=hats`.
+
+An example of where parameters are useful for application state, not integral to
+the rendering of the core content on the page, and thus could not be expected by
+a person to be in the URL is to have that context stored to be able to go back
+to their search from a result page.
+
+e.g. `/works/1001?query=hats`.

--- a/docs/rfcs/001-url_parameters/url_parameters_strategy.md
+++ b/docs/rfcs/001-url_parameters/url_parameters_strategy.md
@@ -35,15 +35,28 @@ always consider:
 If not, the information should be obfuscated and retrieved via another
 mechanism.
 
-An example of something a person would expect to be in the URL which also gives
-insight into the person's research would be the search terms when searching the
-API.
+#### Do: Expected parameters exposed through the URL
+`/works?query=hats`.
 
-e.g. `/works?query=hats`.
+Search terms when searching the API.
 
-An example of where parameters are useful for application state, not integral to
-the rendering of the core content on the page, and thus could not be expected by
-a person to be in the URL is to have that context stored to be able to go back
-to their search from a result page.
+#### Don't: Unexpected parameters exposed through the URL
+`/works/1001?query=hats`.
 
-e.g. `/works/1001?query=hats`.
+Exposing the search parameters to be able to render the search for on a work
+page. As much as this might be a useful feature, if a person was sharing the
+link they might unwittingly share their search parameters too.
+
+
+### Storing contextual information
+We have chosen a strategy that stores the least amount of information
+persistently e.g. in a cookie, `localStorage` etc.
+
+We store the information in the application state.
+
+This information is lost whenever a new application state is created.
+
+This could be opening your session in a new tab, refreshing the page, starting
+a new browser session, or anything along those lines.
+
+This will not work unless you have JavaScript enabled.


### PR DESCRIPTION
Simpler RFC for how we deal with URL parameters in terms of privacy and clarity.

@jennpb are we agreed that we should not be sharing the query state in the URL? Or more broadly, if it's not related to the core content on the page and can be used to infer what someone is looking for, we should obfuscate it?

@wellcometrust/experience-devs do we feel this is enough guidance for now on how to act in the future?