### PR TITLE
only show first preview image if browser doesn’t support css grid

### DIFF
--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -53,17 +53,21 @@ const PagePreview = styled.div`
    * prevents webkit downloading the images unnecessarily.
    * Display none is not sufficient */
   @media (min-width: 708px) {
-    /* 24px(gutter) + 200px(image) + 12px(gap) + 200px + 12px + 200px + 24px = 708px */
-    &:nth-child(2) {
-      display: block;
-      background-image: url(${props => props.backgroundImage});
+    @supports (display: grid) {
+      /* 24px(gutter) + 200px(image) + 12px(gap) + 200px + 12px + 200px + 24px = 708px */
+      &:nth-child(2) {
+        display: block;
+        background-image: url(${props => props.backgroundImage});
+      }
     }
   }
 
-  ${props => props.theme.media.large`
+  @supports (display: grid) {
+    ${props => props.theme.media.large`
     display: block;
     background-image: url(${props => props.backgroundImage});
   `};
+  }
 
   &:nth-child(3) {
     grid-row-end: 3;
@@ -117,13 +121,15 @@ const CallToAction = styled.div`
     fill: currentColor;
   }
 
-  .cta__inner {
-    @media (min-width: 708px) {
-      display: block;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
+  @supports (display: grid) {
+    .cta__inner {
+      @media (min-width: 708px) {
+        display: block;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
     }
   }
 


### PR DESCRIPTION
While trying to replicate the bug reported in #4347 (still can't), noticed the preview doesn't look good in browsers that don't support css grid.

This makes the preview look nicer in browsers that don't support css grid, by just showing a single image like we do on mobile
