### PR TITLE
Make sure tags will be equal heights

### DIFF
--- a/common/views/components/Tags/Tags.js
+++ b/common/views/components/Tags/Tags.js
@@ -53,6 +53,19 @@ const Tags = ({ tags }: Props) => {
                       'border-color-green border-width-1': true,
                     })}
                   >
+                    {/* An empty span for the light and medium font weights, so that
+                    the tag will always be the height of the larger of the two. */}
+                    <span
+                      className={classNames({
+                        [font({ s: 'HNL5', m: 'HNL4' })]: true,
+                      })}
+                    />
+                    <span
+                      className={classNames({
+                        [font({ s: 'HNM5', m: 'HNM4' })]: true,
+                      })}
+                    />
+
                     {textParts.map((part, i, arr) => (
                       <span
                         key={part}


### PR DESCRIPTION
Fixes #4335

The medium and light helvetica neue can be slightly different heights depending on your system. Rather than setting a `min-height` for the tags, this adds two empty elements – one for each of the possible font weights – such that the taller of the two will be used for the tag height.