### PR TITLE
remove Home breadcrumb

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -577,3 +577,9 @@
     }
   }
 }
+
+// This is used when you want an elemnt to take the line-height of the content
+// that would be in it, but you have no content.
+.empty-filler:before {
+  content: "\200b";
+}

--- a/common/views/components/Breadcrumb/Breadcrumb.js
+++ b/common/views/components/Breadcrumb/Breadcrumb.js
@@ -48,12 +48,24 @@ const Breadcrumb = ({ items }: Props) => (
           </BoldOrSpanTag>
         );
       })}
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(breadcrumbsLd({ items })),
-      }}
-    />
+    {/* We do this so that the page doesn't bounce around if we don't have any breadcrumbs */}
+    {items.length === 0 && (
+      <span
+        className={classNames({
+          [font({ s: 'HNL4' })]: true,
+          'empty-filler': true,
+        })}
+        style={{ lineHeight: 1 }}
+      />
+    )}
+    {items.length > 0 && (
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(breadcrumbsLd({ items })),
+        }}
+      />
+    )}
   </div>
 );
 export default Breadcrumb;

--- a/common/views/components/ErrorPage/ErrorPage.js
+++ b/common/views/components/ErrorPage/ErrorPage.js
@@ -27,7 +27,7 @@ const ErrorPage = ({ statusCode, title }: Props) => {
         id={'error'}
         Header={
           <PageHeader
-            breadcrumbs={{ items: [{ url: '/', text: 'Home' }] }}
+            breadcrumbs={{ items: [] }}
             labels={null}
             title={
               title ||

--- a/content/webapp/pages/opening-times.js
+++ b/content/webapp/pages/opening-times.js
@@ -86,7 +86,7 @@ export class OpeningTimesPage extends Component<Props> {
           id={'openingTimes'}
           Header={
             <PageHeader
-              breadcrumbs={{ items: [{ url: '/', text: 'Home' }] }}
+              breadcrumbs={{ items: [] }}
               labels={null}
               title={'Opening times'}
               ContentTypeInfo={null}

--- a/content/webapp/pages/page.js
+++ b/content/webapp/pages/page.js
@@ -66,12 +66,7 @@ export class Page extends Component<Props> {
               url: `/${page.siteSection}`,
             },
           ]
-        : [
-            {
-              url: '/',
-              text: 'Home',
-            },
-          ],
+        : [],
     };
     const Header = (
       <PageHeader


### PR DESCRIPTION
Removes the `Home` breadcrumb and sets the height of the Breadcrumb component if there are no breadcrumbs to avoid jumpiness when navigating.

Request from @Heesoomoon 

## With
![Screenshot 2019-04-04 at 09 47 26](https://user-images.githubusercontent.com/31692/55542374-d17e4880-56be-11e9-930b-730212aad0bf.png)

## Without
![Screenshot 2019-04-04 at 09 47 32](https://user-images.githubusercontent.com/31692/55542375-d17e4880-56be-11e9-83be-4ff8b7fb857c.png)
