### PR TITLE
update s3 website to have cache times and apply to dash.

### DIFF
--- a/client/terraform/terraform.tf
+++ b/client/terraform/terraform.tf
@@ -33,4 +33,7 @@ module "static" {
   source              = "../../terraform-modules/https_s3_website"
   website_uri         = "i.wellcomecollection.org"
   acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
+  min_ttl             = 86400
+  default_ttl         = 86400
+  max_ttl             = 86400
 }

--- a/dash/terraform/terraform.tf
+++ b/dash/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.11"
 
   backend "s3" {
-    key            = "build-state/client.tfstate"
+    key            = "build-state/dash.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
@@ -29,8 +29,8 @@ data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
   domain   = "wellcomecollection.org"
 }
 
-module "static" {
+module "dash" {
   source              = "../../terraform-modules/https_s3_website"
-  website_uri         = "i.wellcomecollection.org"
+  website_uri         = "dash.wellcomecollection.org"
   acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
 }

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -15,9 +15,9 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
     viewer_protocol_policy = "redirect-to-https"
     target_origin_id       = "S3-${var.website_uri}"
     compress               = true
-    min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 86400
+    min_ttl                = "${var.min_ttl}"
+    default_ttl            = "${var.default_ttl}"
+    max_ttl                = "${var.max_ttl}"
 
     forwarded_values {
       query_string = false

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -7,8 +7,7 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
   enabled             = true
   default_root_object = "index.html"
   is_ipv6_enabled     = true
-
-  aliases = ["${var.website_uri}"]
+  aliases             = ["${var.website_uri}"]
 
   default_cache_behavior {
     allowed_methods        = ["HEAD", "GET", "OPTIONS"]
@@ -16,6 +15,9 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
     viewer_protocol_policy = "redirect-to-https"
     target_origin_id       = "S3-${var.website_uri}"
     compress               = true
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
 
     forwarded_values {
       query_string = false

--- a/terraform-modules/https_s3_website/variables.tf
+++ b/terraform-modules/https_s3_website/variables.tf
@@ -1,3 +1,15 @@
+variable "min_ttl" {
+  default = 0
+}
+
+variable "default_ttl" {
+  default = 3600
+}
+
+variable "max_ttl" {
+  default = 86400
+}
+
 variable "website_uri" {
   description = "The URI that people will get to your bucket from."
 }


### PR DESCRIPTION
[Noticed that our Page Insights score is actually very very sad](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fwellcomecollection.org).

One thing was that the cache times aren't being set (although the cache is being hit quite well) for assets on `i.weco`. Those very very rarely have been changed, and we could probably be more conservative with the cache times.

This just gives us the option to start optimising.
