### PR TITLE
refresh inputQuery state when query changes

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -1,5 +1,5 @@
 // @flow
-import { useRef, useContext, useState } from 'react';
+import { useRef, useContext, useState, useEffect } from 'react';
 import Router from 'next/router';
 import styled from 'styled-components';
 import TextInput from '@weco/common/views/components/TextInput/TextInput';
@@ -46,6 +46,16 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
   // Router
   const [inputQuery, setInputQuery] = useState(query);
   const searchInput = useRef(null);
+
+  // We need to make sure that the changes to `query` affect `inputQuery` as
+  // when we navigate between pages which all contain `SearchForm`, each
+  // instance of that component maintains it's own state so they go out of sync.
+  // TODO: Think about if this is worth it.
+  useEffect(() => {
+    if (query !== inputQuery) {
+      setInputQuery(query);
+    }
+  }, [query]);
 
   return (
     <>


### PR DESCRIPTION
I noticed when you search from the `Work` page, when returning to the `ResultList` page, if you had a previous `SearchForm` mounted, it maintains the state from that.

## Wrong!
![screencast-wellcomecollection org-2019 04 11-11-46-05](https://user-images.githubusercontent.com/31692/55951607-94cac800-5c4f-11e9-8118-759a4c27dc4d.gif)

By updating the `inputQuery` => `query` when query changes (from the Router), this fixes that problem.

## Right
![screencast-localhost-3000-2019 04 11-11-47-07](https://user-images.githubusercontent.com/31692/55951755-e5dabc00-5c4f-11e9-9f81-612dee3e3c99.gif)

## 2¢
Worth thinking about if this is all worth it, especially as we've now simplified the URL structure. We could just maintain the query state in sessionStorage or similar.

The benefit of this is that we get really fine grained control over the interface, how we would load things in etc, but we're not massively leveraging that. 

If we think it's worth removing, let's have a chat about it. 