### PR TITLE
s/embed/oembed

### DIFF
--- a/catalogue/terraform/terraform.tf
+++ b/catalogue/terraform/terraform.tf
@@ -118,5 +118,5 @@ module "embed_path_rule" {
   target_group_arn       = "${module.catalogue.target_group_arn}"
   priority               = "202"
   field                  = "path-pattern"
-  values                 = ["/embed*"]
+  values                 = ["/oembed*"]
 }

--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -21,7 +21,7 @@ module.exports = app
     server.use(middleware);
 
     // Next routing
-    route('/embed/works/:id', '/embed', router, app);
+    route('/oembed/works/:id', '/embed', router, app);
     route('/works/progress', '/progress', router, app);
     route('/works/:id', '/work', router, app);
     route('/works', '/works', router, app);


### PR DESCRIPTION
Going through search logs and realised the oembed endpoint was 404ing.
What happened to the 404 report?

e.g. https://wellcomecollection.org/oembed/works/r6nw4cud
