### PR TITLE
make subdomains return a strict robots.txt

### DIFF
--- a/router/terraform/alb.tf
+++ b/router/terraform/alb.tf
@@ -13,3 +13,41 @@ module "router_alb" {
 
   alb_access_log_bucket = "${aws_s3_bucket.alb-logs.id}"
 }
+
+resource "aws_lb_listener_rule" "https_robots_txt" {
+  listener_arn = "${module.router_alb.listener_https_arn}"
+  priority     = 1
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+
+      message_body = <<EOF
+User-agent: *
+Disallow: /
+EOF
+
+      status_code = "200"
+    }
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/robots.txt"]
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/robots.txt"]
+  }
+
+  condition {
+    field = "host-header"
+
+    values = [
+      "*.wellcomecollection.org",
+    ]
+  }
+}

--- a/router/terraform/terraform.tf
+++ b/router/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.9"
+  required_version = ">= 0.11"
 
   backend "s3" {
     key            = "build-state/router.tfstate"
@@ -20,12 +20,12 @@ data "terraform_remote_state" "wellcomecollection" {
 }
 
 provider "aws" {
-  version = "~> 1.29.0"
+  version = "~> 2.6.0"
   region  = "eu-west-1"
 }
 
 provider "aws" {
-  version = "~> 1.29.0"
+  version = "~> 2.6.0"
   region  = "us-east-1"
   alias   = "us-east-1"
 }


### PR DESCRIPTION
Noticed `works` / `preview` / `etc` were being indexed.

This assumes that this ALB should only be used for the root wellcomecollection.org, and things that we don't want indexed, which feels fine.