### PR TITLE
make selectable queries available upfront

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -154,7 +154,6 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
 
         <TogglesContext.Consumer>
           {({ selectableQueries }) =>
-            query &&
             selectableQueries && (
               <label>
                 Query type:{' '}


### PR DESCRIPTION
Makes the selectable queries available on the landing page.