### PR TITLE
Make it jaunty on the client

### DIFF
--- a/common/views/components/VenueHours/VenueHours.js
+++ b/common/views/components/VenueHours/VenueHours.js
@@ -111,7 +111,7 @@ const VenueHours = ({ venue, isInList }: Props) => {
 
   useEffect(() => {
     setRandomClipPath();
-  });
+  }, []);
 
   return (
     <div className="row">

--- a/common/views/components/VenueHours/VenueHours.js
+++ b/common/views/components/VenueHours/VenueHours.js
@@ -35,7 +35,7 @@ const JauntyBox = styled.div.attrs(props => ({
     [spacing({ s: -2, m: -4 }, { margin: ['left', 'right'] })]: true,
   }),
 }))`
-  transition: clip-path 600ms ease;
+  transition: -webkit-clip-path 600ms ease-in-out, clip-path 600ms ease-in-out;
   clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
 `;
 

--- a/common/views/components/VenueHours/VenueHours.js
+++ b/common/views/components/VenueHours/VenueHours.js
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useRef, useEffect } from 'react';
 import { classNames, font, grid, spacing } from '@weco/common/utils/classnames';
 import styled from 'styled-components';
 import MoreLink from '@weco/common/views/components/Links/MoreLink/MoreLink';
@@ -35,13 +35,8 @@ const JauntyBox = styled.div.attrs(props => ({
     [spacing({ s: -2, m: -4 }, { margin: ['left', 'right'] })]: true,
   }),
 }))`
-  clip-path: ${({ topLeft, topRight, bottomRight, bottomLeft }) =>
-    `polygon(
-      ${topLeft} ${topLeft},
-      calc(100% - ${topRight}) ${topRight},
-      100% calc(100% - ${bottomRight}),
-      ${bottomLeft} 100%
-    )`};
+  transition: clip-path 600ms ease;
+  clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
 `;
 
 const randomPx = () => `${Math.floor(Math.random() * 20)}px`;
@@ -95,6 +90,28 @@ const VenueHours = ({ venue, isInList }: Props) => {
       url: '/pages/Wuw19yIAAK1Z3Snk',
     },
   };
+
+  const jauntyRef = useRef(null);
+
+  function setRandomClipPath() {
+    const topLeft = randomPx();
+    const topRight = randomPx();
+    const bottomRight = randomPx();
+    const bottomLeft = randomPx();
+
+    ['clipPath', 'webkitClipPath'].forEach(property => {
+      jauntyRef.current.style[property] = `polygon(
+        ${topLeft} ${topLeft},
+        calc(100% - ${topRight}) ${topRight},
+        100% calc(100% - ${bottomRight}),
+        ${bottomLeft} 100%
+      )`;
+    });
+  }
+
+  useEffect(() => {
+    setRandomClipPath();
+  });
 
   return (
     <div className="row">
@@ -175,12 +192,7 @@ const VenueHours = ({ venue, isInList }: Props) => {
             })}
           >
             {upcomingExceptionalPeriod && upcomingExceptionalPeriod.length > 0 && (
-              <JauntyBox
-                topLeft={randomPx()}
-                topRight={randomPx()}
-                bottomRight={randomPx()}
-                bottomLeft={randomPx()}
-              >
+              <JauntyBox ref={jauntyRef}>
                 <h3
                   className={classNames({
                     [font({ s: 'HNM4' })]: true,


### PR DESCRIPTION
![jaunty](https://user-images.githubusercontent.com/1394592/56044135-725faa00-5d36-11e9-8f8d-187e70ae0314.gif)

Currently, we add a random amount of jaunt to the yellow box using styled-component with SSR, then we rehydrate this behaviour on the client. But the random value is different on the client, so styled-components creates a different class and Next complains (admittedly only in development) that there's a mismatch between client and server.

![Screenshot 2019-04-12 at 16 41 21](https://user-images.githubusercontent.com/1394592/56049637-d8056380-5d41-11e9-83dd-65e9228a7eea.png)

If we add the jauntiness client-side, we can circumvent this warning (and get a bit of animation).

Not sure if we need to consider the mismatch as a real issue, but if this (adding-client-side-with-animation) approach is preferred, we don't have to worry about whether it is or not.