### PR TITLE
use a more standard segment implementation and reduce scope to search

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -1,5 +1,4 @@
 // @flow
-import { useEffect } from 'react';
 import { type Context } from 'next';
 import NextLink from 'next/link';
 import fetch from 'isomorphic-unfetch';
@@ -13,7 +12,6 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import TruncatedText from '@weco/common/views/components/TruncatedText/TruncatedText';
 import IIIFViewer from '@weco/common/views/components/IIIFViewer/IIIFViewer';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
-import { track } from '@weco/common/views/components/SearchLogger/SearchLogger';
 import styled from 'styled-components';
 
 const IframePdfViewer = styled.iframe`
@@ -119,19 +117,6 @@ const ItemPage = ({
     linkKey: 'page',
     ...sharedPaginatorProps,
   };
-
-  useEffect(() => {
-    const event = {
-      event: 'Catalogue View Item',
-      service: 'search_logs',
-      resource: {
-        title: title,
-        id: workId,
-        type: 'Item',
-      },
-    };
-    track(event);
-  }, []);
 
   return (
     <CataloguePageLayout

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -31,7 +31,6 @@ import ManifestContext from '@weco/common/views/components/ManifestContext/Manif
 import { getWork } from '../services/catalogue/works';
 import IIIFPresentationPreview from '@weco/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview';
 import IIIFImagePreview from '@weco/common/views/components/IIIFImagePreview/IIIFImagePreview';
-import { track } from '@weco/common/views/components/SearchLogger/SearchLogger';
 
 type Props = {|
   work: Work | CatalogueApiError,
@@ -49,21 +48,6 @@ export const WorkPage = ({ work }: Props) => {
       setIIIFPresentationManifest(manifestData);
     } catch (e) {}
   };
-
-  useEffect(() => {
-    if (work.type !== 'Error') {
-      const event = {
-        event: 'Catalogue View Work',
-        service: 'search_logs',
-        resource: {
-          title: work.title,
-          id: work.id,
-          type: 'Work',
-        },
-      };
-      track(event);
-    }
-  }, []);
 
   useEffect(() => {
     fetchIIIFPresentationManifest();

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -372,6 +372,8 @@ const Works = ({ works }: Props) => {
                             id: result.id,
                             page: page,
                             position: i,
+                            query,
+                            workType,
                           },
                         };
                         track(SearchLoggerEvents.CatalogueViewWork, event);

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -41,8 +41,8 @@ const Works = ({ works }: Props) => {
   const [loading, setLoading] = useState(false);
   const { query, page, workType } = useContext(CatalogueSearchContext);
   const trackEvent = () => {
+    const eventName = query !== '' ? 'Catalogue Search' : 'Catalogue Landing';
     const event = {
-      event: query !== '' ? 'Catalogue Search' : 'Catalogue Landing',
       service: 'search_logs',
       resource: {
         type: 'ResultList',
@@ -51,7 +51,7 @@ const Works = ({ works }: Props) => {
         workType,
       },
     };
-    track(event);
+    track(eventName, event);
   };
 
   // We have to have this for the initial page load, and have it on the router
@@ -351,12 +351,25 @@ const Works = ({ works }: Props) => {
             >
               <div className="container">
                 <div className="grid">
-                  {works.results.map(result => (
+                  {works.results.map((result, i) => (
                     <div
                       className={classNames({
                         [grid({ s: 12, m: 10, l: 8, xl: 8 })]: true,
                       })}
                       key={result.id}
+                      onClick={() => {
+                        const event = {
+                          service: 'search_logs',
+                          resource: {
+                            type: 'Work',
+                            title: result.title,
+                            id: result.id,
+                            page: page,
+                            position: i,
+                          },
+                        };
+                        track('Catalogue View Work', event);
+                      }}
                     >
                       <WorkCard work={result} />
                     </div>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -20,7 +20,10 @@ import TogglesContext from '@weco/common/views/components/TogglesContext/Toggles
 import BetaBar from '@weco/common/views/components/BetaBar/BetaBar';
 import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import CatalogueSearchContext from '@weco/common/views/components/CatalogueSearchContext/CatalogueSearchContext';
-import { track } from '@weco/common/views/components/SearchLogger/SearchLogger';
+import {
+  track,
+  SearchLoggerEvents,
+} from '@weco/common/views/components/SearchLogger/SearchLogger';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
@@ -41,7 +44,10 @@ const Works = ({ works }: Props) => {
   const [loading, setLoading] = useState(false);
   const { query, page, workType } = useContext(CatalogueSearchContext);
   const trackEvent = () => {
-    const eventName = query !== '' ? 'Catalogue Search' : 'Catalogue Landing';
+    const eventName =
+      query !== ''
+        ? SearchLoggerEvents.CatalogueSearch
+        : SearchLoggerEvents.CatalogueLanding;
     const event = {
       service: 'search_logs',
       resource: {
@@ -368,7 +374,7 @@ const Works = ({ works }: Props) => {
                             position: i,
                           },
                         };
-                        track('Catalogue View Work', event);
+                        track(SearchLoggerEvents.CatalogueViewWork, event);
                       }}
                     >
                       <WorkCard work={result} />

--- a/common/views/components/SearchLogger/SearchLogger.js
+++ b/common/views/components/SearchLogger/SearchLogger.js
@@ -21,6 +21,8 @@ type WorkResultResource = {|
   title: string,
   position: number,
   page: number,
+  query: string,
+  workType: ?(string[]),
 |};
 
 type AnalyticsResource = ResultListResource | WorkResultResource;

--- a/common/views/components/SearchLogger/SearchLogger.js
+++ b/common/views/components/SearchLogger/SearchLogger.js
@@ -1,6 +1,13 @@
 // @flow
 import { useEffect } from 'react';
 
+export const SearchLoggerEvents = {
+  CatalogueViewWork: 'Catalogue View Work',
+  CatalogueSearch: 'Catalogue Search',
+  CatalogueLanding: 'Catalogue Landing',
+};
+type SearchLoggerEvent = $Values<typeof SearchLoggerEvents>;
+
 type ResultListResource = {|
   type: 'ResultList',
   query: string,
@@ -23,7 +30,7 @@ export type AnalyticsEvent = {|
   resource: AnalyticsResource,
 |};
 
-const track = (name: string, event: AnalyticsEvent) => {
+const track = (name: SearchLoggerEvent, event: AnalyticsEvent) => {
   const toggles = document.cookie.split(';').reduce(function(acc, cookie) {
     const parts = cookie.split('=');
     const key = parts[0].trim();

--- a/common/views/components/SearchLogger/SearchLogger.js
+++ b/common/views/components/SearchLogger/SearchLogger.js
@@ -8,79 +8,103 @@ type ResultListResource = {|
   workType: ?(string[]),
 |};
 
-type WorkResource = {|
+type WorkResultResource = {|
   type: 'Work',
   id: string,
   title: string,
+  position: number,
+  page: number,
 |};
 
-type ItemResource = {|
-  type: 'Item',
-  id: string,
-  title: string,
-|};
-
-type AnalyticsResource = ResultListResource | WorkResource | ItemResource;
+type AnalyticsResource = ResultListResource | WorkResultResource;
 
 export type AnalyticsEvent = {|
-  event: string,
   service: 'search_logs',
   resource: AnalyticsResource,
 |};
 
-// This is global to stop the script loading when the component is used in
-// multiple places through the app
-let loaded = false;
-let segment;
+const track = (name: string, event: AnalyticsEvent) => {
+  const toggles = document.cookie.split(';').reduce(function(acc, cookie) {
+    const parts = cookie.split('=');
+    const key = parts[0].trim();
+    const value = parts[1].trim();
 
-const cachedEvents = [];
+    if (key.match('toggle_')) {
+      acc[key] = value;
+    }
+    return acc;
+  }, {});
 
-const track = (event: AnalyticsEvent) => {
-  if (segment) {
-    const toggles = document.cookie.split(';').reduce(function(acc, cookie) {
-      const parts = cookie.split('=');
-      const key = parts[0].trim();
-      const value = parts[1].trim();
-
-      if (key.match('toggle_')) {
-        acc[key] = value;
-      }
-      return acc;
-    }, {});
-
-    const query = Array.from(
-      new URLSearchParams(window.location.search)
-    ).reduce(function(acc, keyVal) {
+  const query = Array.from(new URLSearchParams(window.location.search)).reduce(
+    function(acc, keyVal) {
       acc[keyVal[0]] = keyVal[1];
       return acc;
-    }, {});
+    },
+    {}
+  );
 
-    segment.track({
-      ...event,
-      toggles,
-      query,
-    });
-  } else {
-    cachedEvents.push(event);
-  }
+  window.analytics.track(name, {
+    ...event,
+    toggles,
+    query,
+  });
 };
 
 const SearchLoggerScript = () => {
   useEffect(() => {
-    if (!loaded) {
-      const script = document.createElement('script');
-      script.id = 'search-logger';
-      script.src = `https://cdn.segment.com/analytics.js/v1/78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI/analytics.min.js`;
-      script.async = true;
-      script.onload = () => {
-        segment = window.analytics;
-        cachedEvents.forEach(event => {
-          track(event);
-        });
-        loaded = true;
-      };
-      document.body && document.body.appendChild(script);
-    }
+    const analytics = (window.analytics = window.analytics || []);
+    if (!analytics.initialize)
+      if (analytics.invoked)
+        window.console &&
+          console.error &&
+          console.error('Segment snippet included twice.');
+      else {
+        analytics.invoked = !0;
+        analytics.methods = [
+          'trackSubmit',
+          'trackClick',
+          'trackLink',
+          'trackForm',
+          'pageview',
+          'identify',
+          'reset',
+          'group',
+          'track',
+          'ready',
+          'alias',
+          'debug',
+          'page',
+          'once',
+          'off',
+          'on',
+        ];
+        analytics.factory = function(t) {
+          return function() {
+            var e = Array.prototype.slice.call(arguments);
+            e.unshift(t);
+            analytics.push(e);
+            return analytics;
+          };
+        };
+        for (var t = 0; t < analytics.methods.length; t++) {
+          var e = analytics.methods[t];
+          analytics[e] = analytics.factory(e);
+        }
+        analytics.load = function(t, e) {
+          var n = document.createElement('script');
+          n.type = 'text/javascript';
+          n.async = !0;
+          n.src =
+            'https://cdn.segment.com/analytics.js/v1/' +
+            t +
+            '/analytics.min.js';
+          var a = document.getElementsByTagName('script')[0];
+          a.parentNode && a.parentNode.insertBefore(n, a);
+          analytics._loadOptions = e;
+        };
+        analytics.SNIPPET_VERSION = '4.1.0';
+        analytics.load('78Czn5jNSaMSVrBq2J9K4yJjWxh6fyRI');
+      }
   }, []);
 
   return null;


### PR DESCRIPTION
* Uses a more standard segment implementation as the custom one was causing issues with how the page was tracked
* Actually sends the event name down the pipe (annoyingly segment doesn't error if you don't)
* Reduces the scope to search as that is the issue we're working on. If and when we move to more thorough journeys through the app, we can add those bits and pieces as and when.