### PR TITLE
Remove date picker

### DIFF
--- a/common/data/facility-promos.js
+++ b/common/data/facility-promos.js
@@ -3,6 +3,7 @@ import type { EventPromo } from '../model/events';
 
 export const readingRoomPromo: Promo = {
   type: 'promo',
+  id: 'readingRoomPromo',
   contentType: 'place',
   title: 'Reading Room',
   url: 'https://wellcomecollection.org/pages/Wvlk4yAAAB8A3ufp',

--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -451,7 +451,13 @@ function getNextDateInFuture(event: UiEvent): ?EventTime {
 function filterEventsByTimeRange(events, start, end) {
   return events.filter(event => {
     return event.times.find(time => {
-      return london(time.range.endDateTime).isBetween(start, end);
+      const eventStart = london(time.range.startDateTime);
+      const eventEnd = london(time.range.endDateTime);
+      return (
+        eventStart.isBetween(start, end) ||
+        eventEnd.isBetween(start, end) ||
+        (eventStart.isSameOrBefore(start) && eventEnd.isSameOrAfter(end))
+      );
     });
   });
 }

--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -39,7 +39,7 @@ const CardGrid = ({
         <div className="css-grid">
           {items.map((item, i) => (
             <div
-              key={item.id}
+              key={i}
               className={classNames({
                 [cssGrid({
                   s: 12,

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -7,11 +7,9 @@ import { getEarliestFutureDateRange } from '../../../utils/dates';
 import CardGrid from '../CardGrid/CardGrid';
 import { data as dailyTourPromo } from '../DailyTourPromo/DailyTourPromo';
 import { type UiEvent } from '../../../model/events';
-import { type Link } from '../../../model/link';
 
 type Props = {|
   events: UiEvent[],
-  links?: Link[],
 |};
 
 type State = {|
@@ -34,7 +32,7 @@ class EventsByMonth extends Component<Props, State> {
     activeId: null,
   };
   render() {
-    const { events, links } = this.props;
+    const { events } = this.props;
     const monthsIndex = {
       January: 0,
       February: 1,
@@ -133,7 +131,7 @@ class EventsByMonth extends Component<Props, State> {
         return r.concat(eventsInMonths[k]);
       }, [])
       .concat(dailyTourPromo);
-    return <CardGrid items={eventsArray} itemsPerRow={3} links={links} />;
+    return <CardGrid items={eventsArray} itemsPerRow={3} links={[]} />;
   }
 }
 

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -127,8 +127,8 @@ class EventsByMonth extends Component<Props, State> {
       ]);
     });
     const eventsArray = Object.keys(eventsInMonths)
-      .reduce(function(r, k) {
-        return r.concat(eventsInMonths[k]);
+      .reduce((acc, curr) => {
+        return acc.concat(eventsInMonths[curr]);
       }, [])
       .concat(dailyTourPromo);
     return <CardGrid items={eventsArray} itemsPerRow={3} links={[]} />;

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -4,8 +4,6 @@ import { Component } from 'react';
 import sortBy from 'lodash.sortby';
 import { london } from '../../../utils/format-date';
 import { getEarliestFutureDateRange } from '../../../utils/dates';
-import { classNames, cssGrid, spacing } from '../../../utils/classnames';
-import SegmentedControl from '../SegmentedControl/SegmentedControl';
 import CardGrid from '../CardGrid/CardGrid';
 import { data as dailyTourPromo } from '../DailyTourPromo/DailyTourPromo';
 import { type UiEvent } from '../../../model/events';
@@ -37,7 +35,6 @@ class EventsByMonth extends Component<Props, State> {
   };
   render() {
     const { events, links } = this.props;
-    const { activeId } = this.state;
     const monthsIndex = {
       January: 0,
       February: 1,
@@ -115,12 +112,6 @@ class EventsByMonth extends Component<Props, State> {
       })
       .map(key => (orderedMonths[key] = eventsInMonths[key]));
 
-    const months = Object.keys(orderedMonths).map(month => ({
-      id: month,
-      url: `#${month}`,
-      text: london(month).format('MMMM'),
-    }));
-
     // Need to order the events for each month based on their earliest future date range
     Object.keys(eventsInMonths).map(month => {
       eventsInMonths[month] = sortBy(eventsInMonths[month], [
@@ -137,71 +128,12 @@ class EventsByMonth extends Component<Props, State> {
         },
       ]);
     });
-
-    return (
-      <div>
-        <div
-          className={classNames({
-            [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
-          })}
-        >
-          <div className="css-grid__container">
-            <div className="css-grid">
-              <div
-                className={classNames({
-                  [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                })}
-              >
-                <SegmentedControl
-                  id="monthControls"
-                  activeId={months[0].id}
-                  items={months}
-                  extraClasses={'segmented-control__list--inline'}
-                  onActiveIdChange={id => {
-                    this.setState({ activeId: id });
-                  }}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {months.map(month => (
-          <div
-            key={month.id}
-            className={classNames({
-              [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-            })}
-            style={{
-              display: !activeId
-                ? 'block'
-                : activeId === month.id
-                ? 'block'
-                : 'none',
-            }}
-          >
-            <div className="css-grid__container">
-              <div className="css-grid">
-                <h2
-                  id={month.id}
-                  className={classNames({
-                    tabfocus: true,
-                    [cssGrid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                  })}
-                >
-                  {month.id}
-                </h2>
-              </div>
-            </div>
-            <CardGrid
-              items={eventsInMonths[month.id].concat(dailyTourPromo)}
-              itemsPerRow={3}
-              links={links}
-            />
-          </div>
-        ))}
-      </div>
-    );
+    const eventsArray = Object.keys(eventsInMonths)
+      .reduce(function(r, k) {
+        return r.concat(eventsInMonths[k]);
+      }, [])
+      .concat(dailyTourPromo);
+    return <CardGrid items={eventsArray} itemsPerRow={3} links={links} />;
   }
 }
 

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -413,12 +413,7 @@ export class WhatsOnPage extends Component<Props> {
                           <SectionHeader title={'Events'} />
                         </SpacingComponent>
                         <SpacingComponent>
-                          <EventsByMonth
-                            events={events}
-                            links={[
-                              { text: 'View all events', url: '/events' },
-                            ]}
-                          />
+                          <EventsByMonth events={events} />
                         </SpacingComponent>
                       </SpacingSection>
                     </div>


### PR DESCRIPTION
References #2939

This removes the month picker from what's on and shows all the events together. @Heesoomoon are we happy for this to go in and then look at limiting the number displayed and adding a view more control etc. at a later date, with design input etc?

The same logic still applies to what we display, i.e. events which occur in multiple months, display once for each month in which they occur, showing and ordered by their next upcoming date for that month.
