### PR TITLE
Event missing from homepage

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -451,7 +451,13 @@ function getNextDateInFuture(event: UiEvent): ?EventTime {
 function filterEventsByTimeRange(events, start, end) {
   return events.filter(event => {
     return event.times.find(time => {
-      return london(time.range.endDateTime).isBetween(start, end);
+      const eventStart = london(time.range.startDateTime);
+      const eventEnd = london(time.range.endDateTime);
+      return (
+        eventStart.isBetween(start, end) ||
+        eventEnd.isBetween(start, end) ||
+        (eventStart.isSameOrBefore(start) && eventEnd.isSameOrAfter(end))
+      );
     });
   });
 }


### PR DESCRIPTION
Until now the start and end date of an event had always occurred on the same day, this is not the case for 'Smoke and Mirrors Live Performances' (although we might look at using an event series for this).

The filter didn't account for events that spanned the time period or started in the time period, so this event wasn't showing, it does now.
