### PR TITLE
check for string before applying .trim

### DIFF
--- a/common/views/components/SearchLogger/SearchLogger.js
+++ b/common/views/components/SearchLogger/SearchLogger.js
@@ -35,10 +35,10 @@ export type AnalyticsEvent = {|
 const track = (name: SearchLoggerEvent, event: AnalyticsEvent) => {
   const toggles = document.cookie.split(';').reduce(function(acc, cookie) {
     const parts = cookie.split('=');
-    const key = parts[0].trim();
-    const value = parts[1].trim();
+    const key = parts[0] && parts[0].trim();
+    const value = parts[1] && parts[1].trim();
 
-    if (key.match('toggle_')) {
+    if (key && key.match('toggle_')) {
       acc[key] = value;
     }
     return acc;


### PR DESCRIPTION
Sentry error because we're sometimes trying to apply trim method to undefined
