### PR TITLE
Show the date override on the exhibition template

### DIFF
--- a/content/webapp/components/Exhibition/Exhibition.js
+++ b/content/webapp/components/Exhibition/Exhibition.js
@@ -205,6 +205,7 @@ const Exhibition = ({ exhibition }: Props) => {
   ) : (
     <HTMLDate date={new Date(exhibition.start)} />
   );
+
   // This is for content that we don't have the crops for in Prismic
   const maybeHeroPicture = getHeroPicture(genericFields);
   const maybeFeaturedMedia = !maybeHeroPicture
@@ -223,6 +224,7 @@ const Exhibition = ({ exhibition }: Props) => {
           <StatusIndicator
             start={exhibition.start}
             end={exhibition.end || new Date()}
+            statusOverride={exhibition.statusOverride}
           />
         </Fragment>
       }


### PR DESCRIPTION
Allows us to show custom status messages on the exhibition template, e.g. 'Now closed' for Medicine Man, rather than 'Past' which would be the default from inference about dates.

![Screenshot 2019-04-23 at 14 53 29](https://user-images.githubusercontent.com/1394592/56586403-985b3900-65d7-11e9-907d-85912314d220.png)
