### PR TITLE
add toggle to allow access to stage API

### DIFF
--- a/cardigan/stories/components/MessageBar.js
+++ b/cardigan/stories/components/MessageBar.js
@@ -1,0 +1,18 @@
+import { storiesOf } from '@storybook/react';
+import MessageBar from '../../../common/views/components/MessageBar/MessageBar';
+import Readme from '../../../common/views/components/MessageBar/README.md';
+
+const stories = storiesOf('Components', module);
+
+stories.add(
+  'BetaBar',
+  () => (
+    <MessageBar tagText={'Smoke test'}>
+      Things may not always be what they seem.
+      <a href="/works/progress">Find out more</a>.
+    </MessageBar>
+  ),
+  {
+    readme: { sidebar: Readme },
+  }
+);

--- a/cardigan/stories/components/MessageBar.js
+++ b/cardigan/stories/components/MessageBar.js
@@ -5,7 +5,7 @@ import Readme from '../../../common/views/components/MessageBar/README.md';
 const stories = storiesOf('Components', module);
 
 stories.add(
-  'BetaBar',
+  'MessageBar',
   () => (
     <MessageBar tagText={'Smoke test'}>
       Things may not always be what they seem.

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -30,6 +30,8 @@ import ManifestContext from '@weco/common/views/components/ManifestContext/Manif
 import { getWork } from '../services/catalogue/works';
 import IIIFPresentationPreview from '@weco/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview';
 import IIIFImagePreview from '@weco/common/views/components/IIIFImagePreview/IIIFImagePreview';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import MessageBar from '@weco/common/views/components/MessageBar/MessageBar';
 
 type Props = {|
   work: Work | CatalogueApiError,
@@ -134,6 +136,15 @@ export const WorkPage = ({ work }: Props) => {
       />
 
       <Layout12>
+        <TogglesContext.Consumer>
+          {({ useStageApi }) =>
+            useStageApi && (
+              <MessageBar tagText="Dev alert">
+                You are using the stage catalogue API - data mileage may vary!
+              </MessageBar>
+            )
+          }
+        </TogglesContext.Consumer>
         <BetaBar />
       </Layout12>
 
@@ -222,7 +233,12 @@ WorkPage.getInitialProps = async (
   ctx
 ): Promise<Props | CatalogueApiRedirect> => {
   const { id } = ctx.query;
-  const workOrError = await getWork({ id });
+  const { useStageApi } = ctx.query.toggles;
+
+  const workOrError = await getWork({
+    id,
+    env: useStageApi ? 'stage' : 'prod',
+  });
 
   if (workOrError && workOrError.type === 'Redirect') {
     const { res } = ctx;

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -24,6 +24,7 @@ import {
   SearchEventNames,
 } from '@weco/common/views/components/Tracker/Tracker';
 import RelevanceRater from '@weco/common/views/components/RelevanceRater/RelevanceRater';
+import MessageBar from '@weco/common/views/components/MessageBar/MessageBar';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
@@ -131,6 +132,15 @@ const Works = ({ works }: Props) => {
         />
 
         <Layout12>
+          <TogglesContext.Consumer>
+            {({ useStageApi }) =>
+              useStageApi && (
+                <MessageBar tagText="Dev alert">
+                  You are using the stage catalogue API - data mileage may vary!
+                </MessageBar>
+              )
+            }
+          </TogglesContext.Consumer>
           <BetaBar />
         </Layout12>
 
@@ -403,6 +413,7 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
+  const { useStageApi } = ctx.query.toggles;
   const workTypeQuery = ctx.query.workType;
   const _queryType = ctx.query._queryType;
   const defaultWorkType = ['a', 'k', 'q', 'v'];
@@ -417,7 +428,14 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   };
 
   const worksOrError =
-    query && query !== '' ? await getWorks({ query, page, filters }) : null;
+    query && query !== ''
+      ? await getWorks({
+          query,
+          page,
+          filters,
+          env: useStageApi ? 'stage' : 'prod',
+        })
+      : null;
 
   return {
     works: worksOrError,

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -7,17 +7,27 @@ import {
   type CatalogueApiRedirect,
 } from '@weco/common/model/catalogue';
 
+const rootUris = {
+  prod: 'https://api.wellcomecollection.org/catalogue',
+  stage: 'https://api-stage.wellcomecollection.org/catalogue',
+};
+
+type Enviable = {|
+  env?: $Keys<typeof rootUris>,
+|};
+
 type GetWorksProps = {|
   query: string,
   page: number,
   filters: Object,
+  ...Enviable,
 |};
 
 type GetWorkProps = {|
   id: string,
+  ...Enviable,
 |};
 
-const rootUri = 'https://api.wellcomecollection.org/catalogue';
 const includes = [
   'identifiers',
   'items',
@@ -31,13 +41,14 @@ export async function getWorks({
   query,
   page,
   filters,
+  env = 'prod',
 }: GetWorksProps): Promise<CatalogueResultsList | CatalogueApiError> {
   const filterQueryString = Object.keys(filters).map(key => {
     const val = filters[key];
     return `${key}=${val}`;
   });
   const url =
-    `${rootUri}/v2/works?include=${includes.join(',')}` +
+    `${rootUris[env]}/v2/works?include=${includes.join(',')}` +
     `&pageSize=100` +
     (filterQueryString.length > 0 ? `&${filterQueryString.join('&')}` : '') +
     (query ? `&query=${encodeURIComponent(query)}` : '') +
@@ -61,8 +72,9 @@ export async function getWorks({
 
 export async function getWork({
   id,
+  env = 'prod',
 }: GetWorkProps): Promise<Work | CatalogueApiError | CatalogueApiRedirect> {
-  const url = `${rootUri}/v2/works/${id}?include=${includes.join(',')}`;
+  const url = `${rootUris[env]}/v2/works/${id}?include=${includes.join(',')}`;
   const res = await fetch(url, { redirect: 'manual' });
 
   // When records from Miro have been merged with Sierra data, we redirect the

--- a/common/views/components/BetaBar/BetaBar.js
+++ b/common/views/components/BetaBar/BetaBar.js
@@ -1,31 +1,11 @@
 // @flow
-import styled from 'styled-components';
-import { classNames, font, spacing } from '../../../utils/classnames';
-
-const PurpleTag = styled.span.attrs(props => ({
-  className: classNames({
-    caps: true,
-    'inline-block': true,
-    'bg-purple': true,
-    'font-white': true,
-    [font({ s: 'HNM5' })]: true,
-    [spacing({ s: 1 }, { margin: ['right'] })]: true,
-  }),
-}))`
-  padding: 0.2em 0.5em;
-`;
+import MessageBar from '../MessageBar/MessageBar';
 
 const BetaBar = () => (
-  <div
-    className={classNames({
-      [font({ s: 'HNL4' })]: true,
-      [spacing({ s: 3 }, { padding: ['top', 'bottom'] })]: true,
-    })}
-  >
-    <PurpleTag>Beta</PurpleTag>
+  <MessageBar tagText={'Beta'}>
     We’re improving how search works.{' '}
     <a href="/works/progress">Find out more</a>.
-  </div>
+  </MessageBar>
 );
 
 export default BetaBar;

--- a/common/views/components/MessageBar/MessageBar.js
+++ b/common/views/components/MessageBar/MessageBar.js
@@ -1,0 +1,35 @@
+// @flow
+import { type Node } from 'react';
+import styled from 'styled-components';
+import { classNames, font, spacing } from '../../../utils/classnames';
+
+const PurpleTag = styled.span.attrs(props => ({
+  className: classNames({
+    caps: true,
+    'inline-block': true,
+    'bg-purple': true,
+    'font-white': true,
+    [font({ s: 'HNM5' })]: true,
+    [spacing({ s: 1 }, { margin: ['right'] })]: true,
+  }),
+}))`
+  padding: 0.2em 0.5em;
+`;
+
+type Props = {|
+  tagText?: string,
+  children: Node,
+|};
+
+const MessageBar = ({ tagText, children }: Props) => (
+  <div
+    className={classNames({
+      [font({ s: 'HNL4' })]: true,
+      [spacing({ s: 3 }, { padding: ['top', 'bottom'] })]: true,
+    })}
+  >
+    {tagText && <PurpleTag>{tagText}</PurpleTag>}
+    {children}
+  </div>
+);
+export default MessageBar;

--- a/common/views/components/MessageBar/README.md
+++ b/common/views/components/MessageBar/README.md
@@ -1,3 +1,5 @@
 # Purpose
 To make people aware that this is something special about the page they're
 looking at.
+
+[Edit this on GitHub](https://github.com/wellcometrust/wellcomecollection.org/edit/master/common/views/components/MessageBar/README.md)

--- a/common/views/components/MessageBar/README.md
+++ b/common/views/components/MessageBar/README.md
@@ -1,0 +1,3 @@
+# Purpose
+To make people aware that this is something special about the page they're
+looking at.

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -15,6 +15,13 @@ module.exports = {
         'Allow people rate the relevance or results on the search results page.',
     },
     {
+      id: 'useStageApi',
+      title: `Use the staging API`,
+      defaultValue: false,
+      description:
+        'Uses api.stage for requests to the API to view data that we are testing.',
+    },
+    {
       id: 'showWorkLocations',
       title: 'Show the locations of a work in the header',
       defaultValue: false,


### PR DESCRIPTION
Allows access to the stage API for internal testing for those who don't browse the internet in JSON.
Adds the idea of a `MessageBar` too.

![Screenshot 2019-04-26 at 15 17 36](https://user-images.githubusercontent.com/31692/56814329-ddc97180-6836-11e9-8555-01d721bc19c7.png)
