### PR TITLE
Put InfoBanner text in correct shape

### DIFF
--- a/cardigan/stories/components/InfoBanner.js
+++ b/cardigan/stories/components/InfoBanner.js
@@ -5,7 +5,13 @@ import Readme from '../../../common/views/components/InfoBanner/README.md';
 const InfoBannerExample = () => {
   return (
     <InfoBanner
-      text={`Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily.`}
+      text={[
+        {
+          type: 'paragraph',
+          text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
+          spans: [],
+        },
+      ]}
     />
   );
 };

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -131,7 +131,13 @@ export const WorkPage = ({ work }: Props) => {
       hideNewsletterPromo={true}
     >
       <InfoBanner
-        text={`Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`}
+        text={[
+          {
+            type: 'paragraph',
+            text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
+            spans: [],
+          },
+        ]}
         cookieName="WC_wellcomeImagesRedirect"
       />
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -127,7 +127,13 @@ const Works = ({ works }: Props) => {
         imageAltText={null}
       >
         <InfoBanner
-          text={`Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`}
+          text={[
+            {
+              type: 'paragraph',
+              text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
+              spans: [],
+            },
+          ]}
           cookieName="WC_wellcomeImagesRedirect"
         />
 

--- a/common/views/components/InfoBanner/InfoBanner.js
+++ b/common/views/components/InfoBanner/InfoBanner.js
@@ -4,10 +4,11 @@ import cookie from 'cookie-cutter';
 import { spacing, grid, font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
+import type { HTMLString } from '../../../../common/services/prismic/types';
 
 type Props = {|
   cookieName?: string,
-  text: string,
+  text: HTMLString,
 |};
 
 type State = {|


### PR DESCRIPTION
Updating `InfoBanner` text to be in Prismic HTML shape. Fixing Sentry errors we're getting from WellcomeImages redirects.