### PR TITLE
Remove short title toggle

### DIFF
--- a/cache/edge_lambdas/toggler.js
+++ b/cache/edge_lambdas/toggler.js
@@ -10,15 +10,7 @@
 // }
 
 // This is mutable for testing
-let tests = [
-  {
-    id: 'showShortTitles',
-    title: 'Short exhibition titles',
-    shouldRun: request => {
-      return request.uri.match(/^\/whats-on.*/) || request.uri === '/';
-    },
-  },
-];
+let tests = [];
 
 exports.setTests = function(newTests) {
   tests = newTests;

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -7,7 +7,6 @@ import { UiImage } from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
 import { type ExhibitionPromo as ExhibitionPromoProps } from '../../../model/exhibitions';
 import StatusIndicator from '../StatusIndicator/StatusIndicator';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 type Props = {|
   ...ExhibitionPromoProps,
@@ -91,15 +90,7 @@ const ExhibitionPromo = ({
             ${spacing({ s: 1 }, { margin: ['bottom'] })}
           `}
           >
-            <TogglesContext.Consumer>
-              {({ showShortTitles }) => {
-                if (showShortTitles && shortTitle) {
-                  return shortTitle;
-                } else {
-                  return title;
-                }
-              }}
-            </TogglesContext.Consumer>
+            {title}
           </h2>
 
           {!statusOverride && start && end && (

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -35,13 +35,7 @@ function setCookie(name, value) {
     ''}; Path=/; Domain=wellcomecollection.org; ${expiration}`;
 }
 
-const abTests = [
-  {
-    title: 'Short exhibition titles',
-    description: 'Display short exhibition titles',
-    id: 'showShortTitles',
-  },
-];
+const abTests = [];
 const IndexPage = () => {
   const [toggleStates, setToggleStates] = useState({});
   const [toggles, setToggles] = useState([]);


### PR DESCRIPTION
The test is over.

Short titles performed significantly better on the homepage, but not on the 'what's on' page.

Because we don't understand the result, we're going to stick with what we have.

I think we should think/specify more about what we're going to do in the event of various outcomes to these tests – seems like this one could be seen as a bit of a waste of time?

I promise this thought was less passive-aggressive than it sounds.