### PR TITLE
Make error more specific/useful

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -59,7 +59,12 @@ async function getCanvasOcr(canvas) {
         .join(' ');
       return textString.length > 0 ? textString : null;
     } catch (e) {
-      Raven.captureException(e);
+      Raven.captureException(new Error(`IIIF text service error: ${e}`), {
+        tags: {
+          service: 'dlcs',
+        },
+      });
+
       return null;
     }
   }


### PR DESCRIPTION
We might feasibly see `unexpected token > in JSON at…` errors from things other than IIIF services.

This makes the error message more specific and tags it with `dlcs` when we know that's the culprit.