### PR TITLE
Add rotate control to IIIFImageViewer

### DIFF
--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -90,6 +90,9 @@ const ViewerContent = ({
   return (
     <div className={`${classes} image-viewer__content image-viewer__content2`}>
       <div className="image-viewer__controls flex flex-end flex--v-center">
+        {/* Setting OpenSeaDragon's `showRotationControl` option to `true` means we have to provide
+        a dummy `rotateLeftButton` or handle rotation programatically. The former is simpler. */}
+        <span id={`rotate-left-${id}`} className={'is-hidden'} />
         <Control
           type="light"
           text="Rotate"

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -84,6 +84,15 @@ const ViewerContent = ({
       <div className="image-viewer__controls flex flex-end flex--v-center">
         <Control
           type="light"
+          text="Rotate"
+          id={`rotate-right-${id}`}
+          icon="rotateRight"
+          extraClasses={`${spacing({ s: 1 }, { margin: ['right'] })}`}
+          clickHandler={handleZoomIn}
+        />
+
+        <Control
+          type="light"
           text="Zoom in"
           id={`zoom-in-${id}`}
           icon="zoomIn"

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -56,6 +56,14 @@ const ViewerContent = ({
     }
   };
 
+  const handleRotate = event => {
+    trackEvent({
+      category: 'Control',
+      action: 'rotate ImageViewer',
+      label: id,
+    });
+  };
+
   const handleZoomIn = event => {
     trackEvent({
       category: 'Control',
@@ -88,7 +96,7 @@ const ViewerContent = ({
           id={`rotate-right-${id}`}
           icon="rotateRight"
           extraClasses={`${spacing({ s: 1 }, { margin: ['right'] })}`}
-          clickHandler={handleZoomIn}
+          clickHandler={handleRotate}
         />
 
         <Control

--- a/common/views/components/ImageViewer/ImageViewerImage.js
+++ b/common/views/components/ImageViewer/ImageViewerImage.js
@@ -16,6 +16,7 @@ function setupViewer(imageInfoSrc, viewerId, handleScriptError) {
         zoomInButton: `zoom-in-${viewerId}`,
         zoomOutButton: `zoom-out-${viewerId}`,
         rotateRightButton: `rotate-right-${viewerId}`,
+        rotateLeftButton: `rotate-left-${viewerId}`,
         showRotationControl: true,
         showNavigator: true,
         controlsFadeDelay: 0,

--- a/common/views/components/ImageViewer/ImageViewerImage.js
+++ b/common/views/components/ImageViewer/ImageViewerImage.js
@@ -15,6 +15,8 @@ function setupViewer(imageInfoSrc, viewerId, handleScriptError) {
         showHomeControl: false,
         zoomInButton: `zoom-in-${viewerId}`,
         zoomOutButton: `zoom-out-${viewerId}`,
+        rotateRightButton: `rotate-right-${viewerId}`,
+        showRotationControl: true,
         showNavigator: true,
         controlsFadeDelay: 0,
         animationTime: 0.5,


### PR DESCRIPTION
Relates to #4442

Adding a rotate (90º clockwise) control to the `IIIFImageViewer`.

![Screenshot 2019-05-07 at 17 12 16](https://user-images.githubusercontent.com/1394592/57315348-4e9c4380-70eb-11e9-9b35-832a99cddb75.png)
