### PR TITLE
Constrain and immediately launch OpenSeadragon viewer

### DIFF
--- a/common/styles/components/_image_viewer.scss
+++ b/common/styles/components/_image_viewer.scss
@@ -3,17 +3,14 @@
 }
 
 .image-viewer__content {
-  background-color: color('black');
-  width: 100vw;
-  height: 100vh;
-  position: fixed;
+  background-color: color('charcoal');
+  position: absolute;
   display: none;
   z-index: 1000;
   top: 0;
   left: 0;
-}
-
-.image-viewer__content2 {
+  bottom: 0;
+  right: 0;
   display: block;
 }
 
@@ -35,6 +32,13 @@
   .btn__text {
     @include visually-hidden;
   }
+
+  position: absolute;
+  top: 12px;
+  right: 6px;
+  bottom: 60px;
+  width: 46px;
+  z-index: 1;
 }
 
 .image-viewer__error {
@@ -47,9 +51,11 @@
 }
 
 .image-viewer__image {
-  background: color('black');
-  width: 100%;
-  height: calc(100vh - 3em);
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
 }
 
 .image-viewer__launch-button {

--- a/common/styles/components/_work_media.scss
+++ b/common/styles/components/_work_media.scss
@@ -14,13 +14,6 @@
     width: auto;
     align-self: center;
     margin: 0 auto;
-    display: none;
-
-    .enhanced & {
-      display: block;
-      padding: 0;
-      cursor: zoom-in;
-    }
 
     @supports (object-fit: contain) {
       width: 100%;

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -159,6 +159,17 @@ const IIIFViewer = styled.div.attrs(props => ({
   }
 `;
 
+const IIIFViewerImageWrapper = styled.div.attrs(props => ({
+  className: classNames({
+    absolute: true,
+  }),
+}))`
+  top: 30px;
+  right: 0;
+  bottom: 60px;
+  left: 0;
+`;
+
 type IIIFCanvasThumbnailProps = {|
   canvas: IIIFCanvas,
   lang: string,
@@ -284,16 +295,18 @@ const IIIFViewerComponent = ({
     <IIIFViewer>
       <IIIFViewerMain>
         <Paginator {...mainPaginatorProps} render={XOfY} />
-        <ImageViewer
-          id="item-page"
-          infoUrl={convertIiifUriToInfoUri(mainImageService['@id'])}
-          src={urlTemplate({ size: '640,' })}
-          srcSet={srcSet}
-          width={currentCanvas.width}
-          height={currentCanvas.height}
-          canvasOcr={canvasOcr}
-          lang={lang}
-        />
+        <IIIFViewerImageWrapper>
+          <ImageViewer
+            id="item-page"
+            infoUrl={convertIiifUriToInfoUri(mainImageService['@id'])}
+            src={urlTemplate({ size: '640,' })}
+            srcSet={srcSet}
+            width={currentCanvas.width}
+            height={currentCanvas.height}
+            canvasOcr={canvasOcr}
+            lang={lang}
+          />
+        </IIIFViewerImageWrapper>
         <IIIFViewerPaginatorButtons>
           <Paginator {...mainPaginatorProps} render={PaginatorButtons} />
         </IIIFViewerPaginatorButtons>

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -1,6 +1,5 @@
 // @flow
-import { Fragment, useState, useEffect } from 'react';
-import { Transition } from 'react-transition-group';
+import { useState, useEffect } from 'react';
 import IIIFResponsiveImage from '../IIIFResponsiveImage/IIIFResponsiveImage';
 import Control from '../Buttons/Control/Control';
 import { spacing, classNames } from '../../../utils/classnames';
@@ -9,37 +8,10 @@ import dynamic from 'next/dynamic';
 
 const ImageViewerImage = dynamic(import('./ImageViewerImage'), { ssr: false });
 
-type LaunchViewerButtonProps = {|
-  classes: string,
-  clickHandler: () => void,
-  didMountHandler: () => void,
-|};
-
-const LaunchViewerButton = ({
-  classes,
-  clickHandler,
-  didMountHandler,
-}: LaunchViewerButtonProps) => {
-  useEffect(() => {
-    didMountHandler();
-  }, []);
-
-  return (
-    <Control
-      type="dark"
-      text="View larger image"
-      icon="zoomIn"
-      extraClasses={`image-viewer__launch-button ${classes}`}
-      clickHandler={clickHandler}
-    />
-  );
-};
-
 type ViewerContentProps = {|
   id: string,
   classes: string,
   viewerVisible: boolean,
-  handleViewerDisplay: Function,
   infoUrl: string,
 |};
 
@@ -47,15 +19,8 @@ const ViewerContent = ({
   id,
   classes,
   viewerVisible,
-  handleViewerDisplay,
   infoUrl,
 }: ViewerContentProps) => {
-  const escapeCloseViewer = ({ keyCode }: KeyboardEvent) => {
-    if (keyCode === 27 && viewerVisible) {
-      handleViewerDisplay('Keyboard');
-    }
-  };
-
   const handleRotate = event => {
     trackEvent({
       category: 'Control',
@@ -80,16 +45,9 @@ const ViewerContent = ({
     });
   };
 
-  useEffect(() => {
-    document.addEventListener('keydown', escapeCloseViewer);
-    return function cleanup() {
-      document.removeEventListener('keydown', escapeCloseViewer);
-    };
-  }, []);
-
   return (
-    <div className={`${classes} image-viewer__content image-viewer__content2`}>
-      <div className="image-viewer__controls flex flex-end flex--v-center">
+    <div className={`${classes} image-viewer__content`}>
+      <div className="image-viewer__controls">
         {/* Setting OpenSeaDragon's `showRotationControl` option to `true` means we have to provide
         a dummy `rotateLeftButton` or handle rotation programatically. The former is simpler. */}
         <span id={`rotate-left-${id}`} className={'is-hidden'} />
@@ -98,7 +56,7 @@ const ViewerContent = ({
           text="Rotate"
           id={`rotate-right-${id}`}
           icon="rotateRight"
-          extraClasses={`${spacing({ s: 1 }, { margin: ['right'] })}`}
+          extraClasses={`${spacing({ s: 1 }, { margin: ['bottom'] })}`}
           clickHandler={handleRotate}
         />
 
@@ -107,7 +65,7 @@ const ViewerContent = ({
           text="Zoom in"
           id={`zoom-in-${id}`}
           icon="zoomIn"
-          extraClasses={`${spacing({ s: 1 }, { margin: ['right'] })}`}
+          extraClasses={`${spacing({ s: 1 }, { margin: ['bottom'] })}`}
           clickHandler={handleZoomIn}
         />
 
@@ -116,18 +74,8 @@ const ViewerContent = ({
           text="Zoom out"
           id={`zoom-out-${id}`}
           icon="zoomOut"
-          extraClasses={`${spacing({ s: 8 }, { margin: ['right'] })}`}
+          extraClasses={`${spacing({ s: 1 }, { margin: ['bottom'] })}`}
           clickHandler={handleZoomOut}
-        />
-
-        <Control
-          type="light"
-          text="Close image viewer"
-          icon="cross"
-          extraClasses={`${spacing({ s: 2 }, { margin: ['right'] })}`}
-          clickHandler={() => {
-            handleViewerDisplay('Control');
-          }}
         />
       </div>
       {viewerVisible && <ImageViewerImage id={id} infoUrl={infoUrl} />}
@@ -157,71 +105,38 @@ const ImageViewer = ({
   srcSet,
 }: ImageViewerProps) => {
   const [showViewer, setShowViewer] = useState(false);
-  const [mountViewButton, setMountViewButton] = useState(false);
-  const [viewButtonMounted, setViewButtonMounted] = useState(false);
-
-  const handleViewerDisplay = (initiator: 'Control' | 'Image' | 'Keyboard') => {
-    trackEvent({
-      category: initiator,
-      action: `${showViewer ? 'closed' : 'opened'} ImageViewer`,
-      label: id,
-    });
-    setShowViewer(!showViewer);
-  };
-
-  const viewButtonMountedHandler = () => {
-    setViewButtonMounted(!viewButtonMounted);
-  };
 
   useEffect(() => {
-    setMountViewButton(!viewButtonMounted);
+    setShowViewer(true);
   }, []);
 
   return (
-    <Fragment>
-      <IIIFResponsiveImage
-        width={width}
-        height={height}
-        src={src}
-        srcSet={srcSet}
-        sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`} // FIXME: do this better
-        extraClasses={classNames({
-          'block h-center': true,
-          [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
-          'cursor-zoom-in': viewButtonMounted,
-        })}
-        lang={lang}
-        clickHandler={() => handleViewerDisplay('Image')}
-        alt={
-          (canvasOcr && canvasOcr.replace(/"/g, '')) || 'no text alternative'
-        }
-      />
-      <Transition in={mountViewButton} timeout={700}>
-        {status => {
-          if (status === 'exited') {
-            return null;
-          }
-          return (
-            <LaunchViewerButton
-              classes={`slideup-viewer-btn slideup-viewer-btn-${status}`}
-              didMountHandler={viewButtonMountedHandler}
-              clickHandler={() => {
-                handleViewerDisplay('Control');
-              }}
-            />
-          );
-        }}
-      </Transition>
-      {showViewer && (
+    <>
+      {showViewer ? (
         <ViewerContent
           classes=""
           viewerVisible={showViewer}
           id={id}
-          handleViewerDisplay={handleViewerDisplay}
           infoUrl={infoUrl}
         />
+      ) : (
+        <IIIFResponsiveImage
+          width={width}
+          height={height}
+          src={src}
+          srcSet={srcSet}
+          sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`} // FIXME: do this better
+          extraClasses={classNames({
+            'block h-center': true,
+            [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
+          })}
+          lang={lang}
+          alt={
+            (canvasOcr && canvasOcr.replace(/"/g, '')) || 'no text alternative'
+          }
+        />
       )}
-    </Fragment>
+    </>
   );
 };
 

--- a/common/views/components/ImageViewer/ImageViewerImage.js
+++ b/common/views/components/ImageViewer/ImageViewerImage.js
@@ -21,6 +21,12 @@ function setupViewer(imageInfoSrc, viewerId, handleScriptError) {
         showNavigator: true,
         controlsFadeDelay: 0,
         animationTime: 0.5,
+        navigatorBackground: '#333',
+        navigatorPosition: 'ABSOLUTE',
+        navigatorLeft: 12,
+        navigatorTop: 12,
+        navigatorWidth: 100,
+        navigatorHeight: 100,
         tileSources: [
           {
             '@context': 'http://iiif.io/api/image/2/context.json',

--- a/common/views/components/ImageViewer/ImageViewerImage.js
+++ b/common/views/components/ImageViewer/ImageViewerImage.js
@@ -18,15 +18,8 @@ function setupViewer(imageInfoSrc, viewerId, handleScriptError) {
         rotateRightButton: `rotate-right-${viewerId}`,
         rotateLeftButton: `rotate-left-${viewerId}`,
         showRotationControl: true,
-        showNavigator: true,
         controlsFadeDelay: 0,
         animationTime: 0.5,
-        navigatorBackground: '#333',
-        navigatorPosition: 'ABSOLUTE',
-        navigatorLeft: 12,
-        navigatorTop: 12,
-        navigatorWidth: 100,
-        navigatorHeight: 100,
         tileSources: [
           {
             '@context': 'http://iiif.io/api/image/2/context.json',


### PR DESCRIPTION
Launching the OpenSeadragon image viewer immediately without the user having to click on the image or the zoom button.

There's some  get-'er-done styling for the `IIIFViewer`, but these components are on the verge of changing fairly dramatically with the new viewer designs, so I didn't want to be too precious about it.

![Screenshot 2019-05-09 at 13 02 28](https://user-images.githubusercontent.com/1394592/57455065-37cc2d00-7262-11e9-9c0e-3a70c53dae49.png)
