### PR TITLE
Reuse OSD viewer

### DIFF
--- a/common/views/components/ImageViewer/ImageViewerImage.js
+++ b/common/views/components/ImageViewer/ImageViewerImage.js
@@ -72,6 +72,9 @@ const ImageViewerImage = ({ id, infoUrl }: Props) => {
 
   useEffect(() => {
     if (viewer) {
+      // If we have an instantiated viewer, we reuse it calling open() rather than destroy()
+      // This gets around some issues we were having with OSD apparently not cleaning
+      // up event handlers on zoom/rotate buttons when using destroy().
       fetch(infoUrl)
         .then(response => response.json())
         .then(data => viewer.open(getTileSources(data)));


### PR DESCRIPTION
Reusing the current viewer circumvents the JS errors we're getting with `destroy()`.