### PR TITLE
Display first contributor label in header/search results

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -112,10 +112,12 @@ const WorkCard = ({ work }: Props) => {
                     })}
                   >
                     <LinkLabels
-                      items={work.contributors.map(({ agent }) => ({
-                        text: agent.label,
-                        url: null,
-                      }))}
+                      items={[
+                        {
+                          text: work.contributors[0].agent.label,
+                          url: null,
+                        },
+                      ]}
                     />
                   </div>
                 )}

--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -124,10 +124,12 @@ const WorkCard = ({ work }: Props) => {
                 {productionDates.length > 0 && (
                   <LinkLabels
                     heading={'Date'}
-                    items={productionDates.map(date => ({
-                      text: date,
-                      url: null,
-                    }))}
+                    items={[
+                      {
+                        text: productionDates[0],
+                        url: null,
+                      },
+                    ]}
                   />
                 )}
               </div>

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -72,10 +72,12 @@ const WorkHeader = ({ work }: Props) => {
                 })}
               >
                 <LinkLabels
-                  items={work.contributors.map(({ agent }) => ({
-                    text: agent.label,
-                    url: null,
-                  }))}
+                  items={[
+                    {
+                      text: work.contributors[0].agent.label,
+                      url: null,
+                    },
+                  ]}
                 />
               </div>
             )}

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -85,10 +85,12 @@ const WorkHeader = ({ work }: Props) => {
             {productionDates.length > 0 && (
               <LinkLabels
                 heading={'Date'}
-                items={productionDates.map(date => ({
-                  text: date,
-                  url: null,
-                }))}
+                items={[
+                  {
+                    text: productionDates[0],
+                    url: null,
+                  },
+                ]}
               />
             )}
           </div>


### PR DESCRIPTION
Closes #4452, closes #4280

Only display the first contributor in work search result lists and work headers. Display all contributors in the main body of the work page.

__Search result__
![Screenshot 2019-05-13 at 16 05 44](https://user-images.githubusercontent.com/1394592/57632379-6bc48c80-7599-11e9-9290-7ea215033b8e.png)

__Work page__
![Screenshot 2019-05-13 at 16 06 36](https://user-images.githubusercontent.com/1394592/57632403-80088980-7599-11e9-84bd-e2647ae59080.png)

