### PR TITLE
don't require .exe on wellcomeimages URLs

### DIFF
--- a/cache/edge_lambdas/wiRedirector.js
+++ b/cache/edge_lambdas/wiRedirector.js
@@ -50,7 +50,7 @@ exports.wiRedirector = (event, context) => {
       }
     }
 
-    if (request.querystring && request.uri.match('/ixbin/hixclient.exe')) {
+    if (request.querystring && request.uri.match('/ixbin/hixclient')) {
       // e.g. http://wellcomeimages.org/ixbin/hixclient.exe?MIROPAC=V0042017
       const params = querystring.parse(request.querystring);
       if (params.MIROPAC) {


### PR DESCRIPTION
Turns out it does, or doesn't, have a `.exe` - so we can just match both.