### PR TITLE
Use responsive lazyloaded image for works thumbnails

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -14,6 +14,9 @@ import {
 } from '@weco/common/utils/works';
 import { trackEvent } from '@weco/common/utils/ga';
 import { workUrl } from '@weco/common/services/catalogue/urls';
+import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
+import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import { imageSizes } from '@weco/common/utils/image-sizes';
 
 type Props = {|
   work: Work,
@@ -29,15 +32,28 @@ const Details = styled.div`
     flex-grow: 1;
   `}
 `;
-const Preview = styled.div`
+const Preview = styled.div.attrs(() => ({
+  className: classNames({
+    [spacing({ s: 2 }, { margin: ['left'] })]: true,
+    'text-align-center': true,
+  }),
+}))`
+  flex-grow: 0;
+  flex-shrink: 0;
+  flex-basis: 178px;
+  height: 178px;
   margin-top: ${props => props.theme.spacingUnit * 2}px;
+
   ${props => props.theme.media.medium`
-    flex-grow: 0;
-    flex-shrink: 0;
-    flex-basis: '178px';
-    height: '178px';
     margin-top: 0;
   `}
+
+  img {
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
+  }
 `;
 
 const WorkCard = ({ work }: Props) => {
@@ -135,31 +151,26 @@ const WorkCard = ({ work }: Props) => {
               </div>
             </Details>
 
-            <Preview
-              className={classNames({
-                [spacing({ s: 2 }, { margin: ['left'] })]: true,
-                'text-align-center': true,
-              })}
-              style={{
-                flexGrow: 0,
-                flexShrink: 0,
-                flexBasis: '178px',
-                height: '178px',
-              }}
-            >
+            <Preview>
               {work.thumbnail && (
-                <img
-                  src={work.thumbnail.url}
-                  className={classNames({
+                <IIIFResponsiveImage
+                  width={178}
+                  src={convertImageUri(work.thumbnail.url, 178)}
+                  srcSet={imageSizes(2048)
+                    .map(width => {
+                      return `${convertImageUri(
+                        work.thumbnail.url,
+                        width
+                      )} ${width}w`;
+                    })
+                    .join(',')}
+                  sizes={`178px`}
+                  alt={''}
+                  lang={null}
+                  extraClasses={classNames({
                     'h-center': true,
                   })}
-                  style={{
-                    width: 'auto',
-                    height: 'auto',
-                    maxWidth: '100%',
-                    maxHeight: '100%',
-                  }}
-                  alt=""
+                  isLazy={true}
                 />
               )}
             </Preview>

--- a/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage.js
+++ b/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage.js
@@ -11,6 +11,7 @@ type Props = {|
   alt: string,
   extraClasses?: string,
   lang: ?string,
+  isLazy: boolean,
   clickHandler?: () => void,
 |};
 
@@ -24,6 +25,7 @@ const IIIFResponsiveImage = ({
   extraClasses,
   lang,
   clickHandler,
+  isLazy,
 }: Props) => {
   return (
     <img
@@ -33,6 +35,7 @@ const IIIFResponsiveImage = ({
       className={classNames({
         image: true,
         [extraClasses || '']: true,
+        'lazy-image lazyload': isLazy,
       })}
       onClick={clickHandler}
       onError={event =>
@@ -43,7 +46,8 @@ const IIIFResponsiveImage = ({
         })
       }
       src={src}
-      srcSet={srcSet}
+      srcSet={isLazy ? undefined : srcSet}
+      data-srcSet={isLazy ? srcSet : undefined}
       sizes={sizes}
       alt={alt}
     />

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -194,6 +194,7 @@ const IIIFCanvasThumbnail = ({ canvas, lang }: IIIFCanvasThumbnailProps) => {
       srcSet={srcSet}
       alt=""
       sizes={`(min-width: 600px) 200px, 100px`}
+      isLazy={false}
     />
   );
 };

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -134,6 +134,7 @@ const ImageViewer = ({
           alt={
             (canvasOcr && canvasOcr.replace(/"/g, '')) || 'no text alternative'
           }
+          isLazy={false}
         />
       )}
     </>


### PR DESCRIPTION
Relates to #4459

We're currently loading all `/works` thumbnails at `300px` (often up to ~10MB per page of results 😦).

This PR adds lazy-loading for those images. It also makes them responsive, although because we limit image size by height and the `src-set`/`sizes` responsive `img` API expects a `w` (width) attribute, there's not a great way to do it.

I've reduced the width of the thumbnail to `178px` (which is the _height_ we're currently limiting to) since more often than not it doesn't come close to being `300px` wide (as the majority of images are portrait).

Seems to have been a problem since early March:
![Screenshot 2019-05-15 at 11 35 36](https://user-images.githubusercontent.com/1394592/57772788-4dcc6880-770e-11e9-9290-9071fbd5c149.png)

It also seems that shortly after that, we [stopped getting data from speedtracker](http://ghp.wellcomecollection.org/speedtracker/works/?period=month)

Have opened #4469 to look into speedtracker.