### PR TITLE
Don't show space for image if there isn't an image

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -151,8 +151,8 @@ const WorkCard = ({ work }: Props) => {
               </div>
             </Details>
 
-            <Preview>
-              {work.thumbnail && (
+            {work.thumbnail && (
+              <Preview>
                 <IIIFResponsiveImage
                   width={178}
                   src={convertImageUri(work.thumbnail.url, 178)}
@@ -172,8 +172,8 @@ const WorkCard = ({ work }: Props) => {
                   })}
                   isLazy={true}
                 />
-              )}
-            </Preview>
+              </Preview>
+            )}
           </Container>
 
           <TogglesContext.Consumer>


### PR DESCRIPTION
If there isn't a thumbnail image for a work search result, we don't need to show the element which would hold the thumbnail (and which has a height).

![Screenshot 2019-05-16 at 11 38 14](https://user-images.githubusercontent.com/1394592/57847813-50db5d80-77cf-11e9-88bf-7b45eaa9f58a.png)



