### PR TITLE
remove wellcomeimages.org cnames from cache

### DIFF
--- a/cache/cloudfront_dev.tf
+++ b/cache/cloudfront_dev.tf
@@ -36,8 +36,6 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
         "page",
         "current",
         "uri",
-        "MIROPAC", # Wellcome Images redirect
-        "MIRO",    # Wellcome Images redirect
 
         # dotmailer gives us a 'result' (if we run out of params,
         # consider making new urls for newsletter pages instead)

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -32,8 +32,6 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
     "works.wellcomecollection.org",
     "content.wellcomecollection.org",
     "whats-on.wellcomecollection.org",
-    "wellcomeimages.org",
-    "*.wellcomeimages.org",
   ]
 
   default_cache_behavior {
@@ -53,8 +51,6 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
         "page",
         "current",
         "uri",
-        "MIROPAC", # Wellcome Images redirect
-        "MIRO",    # Wellcome Images redirect
 
         # dotmailer gives us a 'result' (if we run out of params,
         # consider making new urls for newsletter pages instead)


### PR DESCRIPTION
In favour of https://github.com/wellcometrust/wellcomeimages which can redirect people to the actual source.