### PR TITLE
Display block cards in IE to fix flex layout issues

### DIFF
--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -536,6 +536,13 @@
 
 // TODO: this better
 .story-promo-featured {
+  // Because this item's flex-direction is row rather than column,
+  // it doesn't have the same issues as the others, so we can use
+  // flexbox and avoid a poor layout in IE.
+  .flex-ie-block {
+    display: flex;
+  }
+
   @include respond-to('medium') {
     .story-promo {
       min-height: 0;

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -262,7 +262,7 @@
 .flex-ie-block {
   display: block; // IE
 
-  @supports(color: red) { // IE ignores @supports
+  @supports(display: flex) { // IE ignores @supports
     display: flex;
   }
 }

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -258,6 +258,15 @@
   display: block;
 }
 
+// Flex for most browsers, block for IE
+.flex-ie-block {
+  display: block; // IE
+
+  @supports(color: red) { // IE ignores @supports
+    display: flex;
+  }
+}
+
 .inline {
   display: inline;
 }
@@ -374,10 +383,6 @@
   &:focus .promo-link__title {
     text-decoration: underline;
     text-decoration-color: color('green');
-  }
-
-  @include respond-to('medium') {
-    min-height: 370px;
   }
 }
 

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -30,7 +30,7 @@ const EventPromo = ({
       data-component="EventPromo"
       data-component-state={JSON.stringify({ position: position })}
       href={(event.promo && event.promo.link) || `/events/${event.id}`}
-      className="plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column"
+      className="plain-link promo-link bg-cream rounded-corners overflow-hidden flex-ie-block flex--column"
       onClick={() => {
         trackEvent({
           category: 'EventPromo',

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -32,7 +32,7 @@ const ExhibitionPromo = ({
       data-component-state={JSON.stringify({ position: position })}
       id={id}
       href={url}
-      className="plain-link promo-link bg-cream rounded-corners overflow-hidden flex flex--column"
+      className="plain-link promo-link bg-cream rounded-corners overflow-hidden flex--column flex-ie-block"
       onClick={() => {
         trackEvent({
           category: 'ExhibitionPromo',

--- a/common/views/components/StoryPromo/StoryPromo.js
+++ b/common/views/components/StoryPromo/StoryPromo.js
@@ -40,7 +40,7 @@ const StoryPromo = ({
         'bg-cream': !hasTransparentBackground,
         'rounded-corners': true,
         'overflow-hidden': true,
-        flex: true,
+        'flex-ie-block': true,
         'flex--column': true,
       })}
     >


### PR DESCRIPTION
Fixes #4366 

A flexbox bug in IE is causing a couple of issues:

1. The physical height of the `srcset` image is being used to calculate the amount of space taken up at the top of the card (rather than the image's height once it has been resized to 100% of the width of the card).
2. The card height isn't growing to accommodate its contents (we had set a `min-height`, but it often isn't large enough).

This PR adds a `flex-ie-block` class that will display `flex` for browsers that understand `@supports` (evergreens) and block for those that don't (basically, IE).

__Before:__
![Screenshot 2019-05-17 at 12 30 53](https://user-images.githubusercontent.com/1394592/57925651-dda21c00-78a0-11e9-942f-aa0338bd6d4c.png)

__After:__
![Screenshot 2019-05-17 at 12 32 36](https://user-images.githubusercontent.com/1394592/57925660-e4309380-78a0-11e9-989f-cc1c5a8671a6.png)

A side-effect of this is the first (featured) card on the `/stories` page now lays out vertically in IE, rather than horizontally. This feels like the lesser of two evils.

![Screenshot 2019-05-17 at 12 32 50](https://user-images.githubusercontent.com/1394592/57925774-4c7f7500-78a1-11e9-8e56-dee3c1d19e64.png)

We _could_ write some more specific styles to target that card in IE, but my preference would be not to do that if we didn't think it was entirely necessary. What d'you reckon @jennpb ?
