### PR TITLE
Fix divider in IE

### DIFF
--- a/common/styles/components/_divider.scss
+++ b/common/styles/components/_divider.scss
@@ -32,6 +32,5 @@
 
 .divider--dashed {
   height: 12px;
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAgNiAxMiI+PHJlY3Qgd2lkdGg9IjMiIGhlaWdodD0iMTIiLz48L3N2Zz4=');
-  background-repeat: repeat;
+  background-image: repeating-linear-gradient(to right, color('charcoal'), color('charcoal') 3px, transparent 3px, transparent 6px);
 }


### PR DESCRIPTION
Using `repeating-linear-gradient` function instead of a background repeating base64-encoded svg works in all browsers.

And because it's CSS we could do this:

![oof](https://user-images.githubusercontent.com/1394592/57935126-01715c00-78b9-11e9-938a-4ed70c4ef604.gif)


Sorry.