### PR TITLE
Match icon to text size to prevent page jump

### DIFF
--- a/common/styles/base/_icons.scss
+++ b/common/styles/base/_icons.scss
@@ -8,6 +8,7 @@
 
 .icon--match-text {
   height: 1em;
+  width: 1em;
 }
 
 .icon__canvas {

--- a/common/views/components/CopyUrl/CopyUrl.js
+++ b/common/views/components/CopyUrl/CopyUrl.js
@@ -128,7 +128,9 @@ class CopyUrl extends Component<Props, State> {
           <span className="flex-inline flex--v-center">
             <Icon
               name="check"
-              extraClasses={`icon--black ${isTextCopied ? '' : 'is-hidden'}`}
+              extraClasses={`icon--black icon--match-text ${
+                isTextCopied ? '' : 'is-hidden'
+              }`}
             />
             <span className="js-copy-text">
               {getButtonMarkup(isTextCopied, isClicked)}


### PR DESCRIPTION
Fixes #4216 

Sizing the icon relative to the button's text height, rather than the default (24px) prevents the button from growing once the icon is displayed.

![button](https://user-images.githubusercontent.com/1394592/57942570-b6ac1000-78c9-11e9-990c-a5442e2f1bf4.gif)

