### PR TITLE
Revert "remove unnecessary conditional"

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -211,7 +211,7 @@ const ItemPage = ({
       {pdfRendering && !mainImageService && (
         <IframePdfViewer title={`PDF: ${title}`} src={pdfRendering['@id']} />
       )}
-      {((currentCanvas && navigationCanvases) ||
+      {((mainImageService && currentCanvas && navigationCanvases) ||
         (imageUrl && iiifImageLocationUrl)) && (
         <IIIFViewer
           mainPaginatorProps={mainPaginatorProps}


### PR DESCRIPTION
This reverts commit de912e87301a4cf57a7a78b9a86699ebe2eaff5e.

> is `mainImageService` a necessary check anymore? Doesn't look like we use it inside this conditional.

Turns out it is