### PR TITLE
Work preview

### DIFF
--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -11,12 +11,14 @@ import Icon from '@weco/common/views/components/Icon/Icon';
 
 const DownloadButton = styled.button`
   text-align: center;
-  border: 0;
-  background: ${props => props.theme.colors.green};
-  color: ${props => props.theme.colors.white};
+  border: ${props => `1px solid ${props.theme.colors.green}`};
+  border-radius: ${props => `${props.theme.borderRadiusUnit}px`};
+  background: ${props => props.theme.colors.white};
+  color: ${props => props.theme.colors.green};
   padding: ${props =>
-    `${props.theme.spacingUnit * 2}px ${props.theme.spacingUnit * 2}px ${props
-      .theme.spacingUnit * 2}px ${props.theme.spacingUnit * 3}px`};
+    `${props.theme.spacingUnit}px ${props.theme.spacingUnit}px ${
+      props.theme.spacingUnit
+    }px ${props.theme.spacingUnit * 2}px`};
   display: inline-block;
   margin: ${props =>
     `0 ${props.theme.spacingUnit * 2}px ${props.theme.spacingUnit}px 0`};

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -329,7 +329,6 @@ const WorkDetails = ({
     <div
       className={classNames({
         row: true,
-        'bg-cream': true,
         [spacing({ s: 6, m: 8 }, { padding: ['top', 'bottom'] })]: true,
       })}
     >

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -128,15 +128,30 @@ const WorkDetails = ({
 
   if (allDownloadOptions.length > 0) {
     WorkDetailsSections.push(
-      <WorkDetailsSection>
-        <Download
-          work={work}
-          licenseInfo={definitiveLicenseInfo}
-          iiifImageLocationLicenseId={iiifImageLocationLicenseId}
-          iiifImageLocationCredit={iiifImageLocationCredit}
-          downloadOptions={allDownloadOptions}
-        />
-      </WorkDetailsSection>
+      <div
+        className={classNames({
+          grid: true,
+        })}
+      >
+        <div
+          className={classNames({
+            [grid({
+              s: 12,
+              m: 12,
+              l: 10,
+              xl: 10,
+            })]: true,
+          })}
+        >
+          <Download
+            work={work}
+            licenseInfo={definitiveLicenseInfo}
+            iiifImageLocationLicenseId={iiifImageLocationLicenseId}
+            iiifImageLocationCredit={iiifImageLocationCredit}
+            downloadOptions={allDownloadOptions}
+          />
+        </div>
+      </div>
     );
   }
   if (

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -198,45 +198,57 @@ export const WorkPage = ({ work }: Props) => {
           </div>
         </div>
       </div>
-
-      <ManifestContext.Provider value={iiifPresentationManifest}>
-        {sierraIdFromPresentationManifestUrl && !iiifImageLocationUrl && (
-          <div className="container">
-            <IIIFPresentationPreview
-              iiifPresentationLocation={iiifPresentationLocation}
-              itemUrl={itemUrl({
-                workId: work.id,
-                sierraId: sierraIdFromPresentationManifestUrl,
-                langCode: work.language && work.language.id,
-                page: 1,
-                canvas: 1,
-              })}
-            />
+      <div
+        className={classNames({
+          'row bg-cream row--has-wobbly-background': true,
+        })}
+      >
+        <div className="container">
+          <div className="grid">
+            <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+              <ManifestContext.Provider value={iiifPresentationManifest}>
+                {sierraIdFromPresentationManifestUrl && !iiifImageLocationUrl && (
+                  <div className="container">
+                    <IIIFPresentationPreview
+                      iiifPresentationLocation={iiifPresentationLocation}
+                      itemUrl={itemUrl({
+                        workId: work.id,
+                        sierraId: sierraIdFromPresentationManifestUrl,
+                        langCode: work.language && work.language.id,
+                        page: 1,
+                        canvas: 1,
+                      })}
+                    />
+                  </div>
+                )}
+                {iiifImageLocationUrl && (
+                  <IIIFImagePreview
+                    id={work.id}
+                    iiifUrl={iiifImageLocationUrl}
+                    itemUrl={itemUrl({
+                      workId: work.id,
+                      sierraId: null,
+                      langCode: work.language && work.language.id,
+                      page: 1,
+                      canvas: 1,
+                    })}
+                    title={work.title}
+                  />
+                )}
+              </ManifestContext.Provider>
+            </div>
           </div>
-        )}
-        {iiifImageLocationUrl && (
-          <IIIFImagePreview
-            id={work.id}
-            iiifUrl={iiifImageLocationUrl}
-            itemUrl={itemUrl({
-              workId: work.id,
-              sierraId: null,
-              langCode: work.language && work.language.id,
-              page: 1,
-              canvas: 1,
-            })}
-            title={work.title}
-          />
-        )}
-        <WorkDetails
-          work={work}
-          licenseInfo={licenseInfo}
-          iiifImageLocationCredit={iiifImageLocationCredit}
-          iiifImageLocationLicenseId={iiifImageLocationLicenseId}
-          encoreLink={encoreLink}
-          downloadOptions={downloadOptions}
-        />
-      </ManifestContext.Provider>
+        </div>
+        <div className="row__wobbly-background" />
+      </div>
+      <WorkDetails
+        work={work}
+        licenseInfo={licenseInfo}
+        iiifImageLocationCredit={iiifImageLocationCredit}
+        iiifImageLocationLicenseId={iiifImageLocationLicenseId}
+        encoreLink={encoreLink}
+        downloadOptions={downloadOptions}
+      />
     </CataloguePageLayout>
   );
 };

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -198,15 +198,15 @@ export const WorkPage = ({ work }: Props) => {
           </div>
         </div>
       </div>
-      <div
-        className={classNames({
-          'row bg-cream row--has-wobbly-background': true,
-        })}
-      >
-        <div className="container">
-          <div className="grid">
-            <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-              <ManifestContext.Provider value={iiifPresentationManifest}>
+      <ManifestContext.Provider value={iiifPresentationManifest}>
+        <div
+          className={classNames({
+            'row bg-cream row--has-wobbly-background': true,
+          })}
+        >
+          <div className="container">
+            <div className="grid">
+              <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                 {sierraIdFromPresentationManifestUrl && !iiifImageLocationUrl && (
                   <div className="container">
                     <IIIFPresentationPreview
@@ -235,20 +235,20 @@ export const WorkPage = ({ work }: Props) => {
                     title={work.title}
                   />
                 )}
-              </ManifestContext.Provider>
+              </div>
             </div>
           </div>
+          <div className="row__wobbly-background" />
         </div>
-        <div className="row__wobbly-background" />
-      </div>
-      <WorkDetails
-        work={work}
-        licenseInfo={licenseInfo}
-        iiifImageLocationCredit={iiifImageLocationCredit}
-        iiifImageLocationLicenseId={iiifImageLocationLicenseId}
-        encoreLink={encoreLink}
-        downloadOptions={downloadOptions}
-      />
+        <WorkDetails
+          work={work}
+          licenseInfo={licenseInfo}
+          iiifImageLocationCredit={iiifImageLocationCredit}
+          iiifImageLocationLicenseId={iiifImageLocationLicenseId}
+          encoreLink={encoreLink}
+          downloadOptions={downloadOptions}
+        />
+      </ManifestContext.Provider>
     </CataloguePageLayout>
   );
 };

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -208,18 +208,16 @@ export const WorkPage = ({ work }: Props) => {
             <div className="grid">
               <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
                 {sierraIdFromPresentationManifestUrl && !iiifImageLocationUrl && (
-                  <div className="container">
-                    <IIIFPresentationPreview
-                      iiifPresentationLocation={iiifPresentationLocation}
-                      itemUrl={itemUrl({
-                        workId: work.id,
-                        sierraId: sierraIdFromPresentationManifestUrl,
-                        langCode: work.language && work.language.id,
-                        page: 1,
-                        canvas: 1,
-                      })}
-                    />
-                  </div>
+                  <IIIFPresentationPreview
+                    iiifPresentationLocation={iiifPresentationLocation}
+                    itemUrl={itemUrl({
+                      workId: work.id,
+                      sierraId: sierraIdFromPresentationManifestUrl,
+                      langCode: work.language && work.language.id,
+                      page: 1,
+                      canvas: 1,
+                    })}
+                  />
                 )}
                 {iiifImageLocationUrl && (
                   <IIIFImagePreview

--- a/common/views/components/IIIFImagePreview/IIIFImagePreview.js
+++ b/common/views/components/IIIFImagePreview/IIIFImagePreview.js
@@ -19,14 +19,17 @@ const ImagePreview = styled.div`
   overflow: hidden;
   text-align: center;
 
-  img {
-    width: auto;
-  }
   a {
-    display: inline-flex;
-    align-items: flex-end;
+    display: inline-block;
     padding-bottom: ${props => `${props.theme.spacingUnit * 8}px`};
     cursor: zoom-in;
+  }
+
+  img {
+    display: block;
+    max-height: 400px;
+    max-width: 100%;
+    width: auto;
   }
 
   button {
@@ -63,10 +66,9 @@ const IIIFImagePreview = ({
             width={width}
             contentUrl={imageContentUrl}
             lazyload={true}
-            sizesQueries="(min-width: 940px) 800px, (min-width: 600px) 88.75vw, calc(100vw - 36px)"
+            sizesQueries=""
             alt=""
-            defaultSize={1010}
-            extraClasses="margin-h-auto width-auto full-height full-max-width block"
+            defaultSize={30}
           />
           <Control type="dark" text="View larger image" icon="zoomIn" />
         </a>
@@ -76,3 +78,4 @@ const IIIFImagePreview = ({
 };
 
 export default IIIFImagePreview;
+// TODO thumbnail service for non landscape...

--- a/common/views/components/IIIFImagePreview/IIIFImagePreview.js
+++ b/common/views/components/IIIFImagePreview/IIIFImagePreview.js
@@ -66,9 +66,9 @@ const IIIFImagePreview = ({
             width={width}
             contentUrl={imageContentUrl}
             lazyload={true}
-            sizesQueries=""
+            sizesQueries="(min-width: 1420px) 1218px, (min-width: 600px) 87.75vw, calc(100vw - 36px)"
             alt=""
-            defaultSize={30}
+            defaultSize={180}
           />
           <Control type="dark" text="View larger image" icon="zoomIn" />
         </a>
@@ -78,4 +78,3 @@ const IIIFImagePreview = ({
 };
 
 export default IIIFImagePreview;
-// TODO thumbnail service for non landscape...

--- a/common/views/components/IIIFImagePreview/IIIFImagePreview.js
+++ b/common/views/components/IIIFImagePreview/IIIFImagePreview.js
@@ -15,18 +15,25 @@ type Props = {|
   itemUrl: NextLinkType,
 |};
 
-const PreviewContainer = styled.div`
-  min-height: 200px;
-  height: calc(100vh - 160px);
+const ImagePreview = styled.div`
+  overflow: hidden;
   text-align: center;
-  padding: ${props =>
-    `${props.theme.spacingUnit * 4}px 0 ${props.theme.spacingUnit * 6}px`};
-  * {
+
+  img {
+    width: auto;
+  }
+  a {
+    display: inline-flex;
+    align-items: flex-end;
+    padding-bottom: ${props => `${props.theme.spacingUnit * 8}px`};
     cursor: zoom-in;
   }
+
   button {
-    position: relative;
-    transform: translateY(-50%);
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%, 50%);
   }
 `;
 
@@ -34,19 +41,19 @@ const IIIFImagePreview = ({
   id,
   title,
   iiifUrl,
-  width = 800,
+  width = 1010,
   itemUrl,
 }: Props) => {
   const imageContentUrl = iiifImageTemplate(iiifUrl)({ size: `${width},` });
 
   return (
-    <PreviewContainer>
+    <ImagePreview>
       <NextLink {...itemUrl}>
         <a
           className="plain-link"
           onClick={() => {
             trackEvent({
-              category: 'IIIFImagePreview', // TODO tell Hayley we're changing the event for viewing an image
+              category: 'IIIFImagePreview',
               action: 'follow link',
               label: itemUrl.href.query.workId,
             });
@@ -56,15 +63,15 @@ const IIIFImagePreview = ({
             width={width}
             contentUrl={imageContentUrl}
             lazyload={true}
-            sizesQueries="(min-width: 860px) 800px, calc(92.59vw + 22px)"
+            sizesQueries="(min-width: 940px) 800px, (min-width: 600px) 88.75vw, calc(100vw - 36px)"
             alt=""
-            defaultSize={800}
+            defaultSize={1010}
             extraClasses="margin-h-auto width-auto full-height full-max-width block"
           />
           <Control type="dark" text="View larger image" icon="zoomIn" />
         </a>
       </NextLink>
-    </PreviewContainer>
+    </ImagePreview>
   );
 };
 

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -17,7 +17,7 @@ import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 
 // TODO classes etc.
-const Preview = styled.div`
+const PresentationPreview = styled.div`
   overflow: hidden;
   text-align: center;
   a {
@@ -229,7 +229,7 @@ const IIIFPresentationDisplay = ({
 
   if (viewType === 'iiif') {
     return (
-      <Preview>
+      <PresentationPreview>
         <NextLink {...itemUrl}>
           <a
             className="plain-link"
@@ -269,7 +269,7 @@ const IIIFPresentationDisplay = ({
             />
           </a>
         </NextLink>
-      </Preview>
+      </PresentationPreview>
     );
   }
 

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -22,10 +22,14 @@ const PresentationPreview = styled.div`
   a {
     display: inline-flex;
     align-items: flex-end;
+    flex-basis: min-content;
     padding-bottom: ${props => `${props.theme.spacingUnit * 8}px`};
   }
   img {
+    display: block;
     max-width: 800px;
+    max-height: 400px;
+    width: auto;
     margin-left: ${props => `${props.theme.spacingUnit * 5}px`};
   }
   img:first-of-type {
@@ -281,5 +285,3 @@ const IIIFPresentationDisplay = ({
 };
 
 export default IIIFPresentationDisplay;
-
-// Cross browser testing

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -244,7 +244,7 @@ const IIIFPresentationDisplay = ({
                 return (
                   <IIIFResponsiveImage
                     key={image.id}
-                    lang={'en'}
+                    lang={null}
                     width={image.width * (400 / image.height)}
                     height={400}
                     src={iiifImageTemplate(image.id)({

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -16,7 +16,6 @@ import Button from '@weco/common/views/components/Buttons/Button/Button';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 
-// TODO classes etc.
 const PresentationPreview = styled.div`
   overflow: hidden;
   text-align: center;
@@ -25,23 +24,18 @@ const PresentationPreview = styled.div`
     align-items: flex-end;
     padding-bottom: ${props => `${props.theme.spacingUnit * 8}px`};
   }
-
+  img {
+    max-width: 800px;
+    margin-left: ${props => `${props.theme.spacingUnit * 5}px`};
+  }
+  img:first-of-type {
+    margin-left: 0;
+  }
   .btn--primary {
     position: absolute;
     bottom: 0;
     left: 50%;
     transform: translate(-50%, 50%);
-  }
-`;
-
-const PagePreview = styled.div`
-  &:first-of-type img {
-    margin-left: 0;
-  }
-  img {
-    max-width: 800px;
-    width: auto;
-    margin-left: ${props => `${props.theme.spacingUnit * 5}px`};
   }
 `;
 
@@ -244,21 +238,19 @@ const IIIFPresentationDisplay = ({
             {imageThumbnails.map((pageType, i) => {
               return pageType.images.map(image => {
                 return (
-                  <PagePreview key={image.id}>
-                    <IIIFResponsiveImage
-                      key={image.id}
-                      lang={'en'}
-                      width={image.width * (400 / image.height)}
-                      height={400}
-                      src={iiifImageTemplate(image.id)({
-                        size: ',400',
-                      })}
-                      srcSet={''}
-                      alt=""
-                      sizes={null}
-                      isLazy={true}
-                    />
-                  </PagePreview>
+                  <IIIFResponsiveImage
+                    key={image.id}
+                    lang={'en'}
+                    width={image.width * (400 / image.height)}
+                    height={400}
+                    src={iiifImageTemplate(image.id)({
+                      size: ',400',
+                    })}
+                    srcSet={''}
+                    alt=""
+                    sizes={null}
+                    isLazy={true}
+                  />
                 );
               });
             })}
@@ -290,16 +282,4 @@ const IIIFPresentationDisplay = ({
 
 export default IIIFPresentationDisplay;
 
-// align single image preview (1010px)
-// TIDY styling, styled components
-// reposition download
 // Cross browser testing
-// Cardigan
-
-// Questions
-// CTA text?
-// lazyload DONE - how restrict to fewer images?
-// Mobile?
-// Should we have a max width?
-
-// restyle download

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -8,133 +8,40 @@ import {
 import NextLink from 'next/link';
 import styled from 'styled-components';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
-import { font, classNames, spacing } from '@weco/common/utils/classnames';
+import { classNames, spacing } from '@weco/common/utils/classnames';
 import { useEffect, useState, useContext } from 'react';
 import { trackEvent } from '@weco/common/utils/ga';
-import Icon from '@weco/common/views/components/Icon/Icon';
 import ManifestContext from '@weco/common/views/components/ManifestContext/ManifestContext';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
+import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 
-const BookPreviewContainer = styled.div`
+// TODO classes etc.
+const Preview = styled.div`
+  overflow: hidden;
   text-align: center;
-
-  /* 42px(container padding) + 200px(image) + 12px(gap) + 200px + 12px + 200px + 42px = 708px */
-  @media (min-width: 708px) {
-    padding: ${props =>
-      `${props.theme.spacingUnit * 4}px 0 ${props.theme.spacingUnit * 6}px`};
-  }
-`;
-
-const BookPreview = styled.div`
-  @media (min-width: 708px) {
-    display: ${props => (props.hasThumbs ? 'inline-grid' : 'inline')};
-    grid-gap: ${props =>
-      props.columnNumber > 1 ? `${props.theme.spacingUnit * 2}px` : 0};
-    grid-template-columns: ${props => `repeat(3, 200px)`};
-    grid-template-rows: 200px;
+  a {
+    display: inline-flex;
+    align-items: flex-end;
+    padding-bottom: ${props => `${props.theme.spacingUnit * 8}px`};
   }
 
-  ${props => props.theme.media.large`
-    grid-template-columns: ${props => `repeat(${props.columnNumber}, 200px)`};
-  `}
+  .btn--primary {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translate(-50%, 50%);
+  }
 `;
 
 const PagePreview = styled.div`
-  overflow: hidden;
-  display: none;
-  width: 200px;
-  height: 200px;
-  background-position: center;
-  background-size: cover;
-  background-repeat: no-repeat;
-
-  /* Putting the background inside a media query,
-   * prevents webkit downloading the images unnecessarily.
-   * Display none is not sufficient */
-  @media (min-width: 708px) {
-    @supports (display: grid) {
-      /* 24px(gutter) + 200px(image) + 12px(gap) + 200px + 12px + 200px + 24px = 708px */
-      &:nth-child(2) {
-        display: block;
-        background-image: url(${props => props.backgroundImage});
-      }
-    }
+  &:first-of-type img {
+    margin-left: 0;
   }
-
-  @supports (display: grid) {
-    ${props => props.theme.media.large`
-    display: block;
-    background-image: url(${props => props.backgroundImage});
-  `};
-  }
-
-  &:nth-child(3) {
-    grid-row-end: 3;
-  }
-
-  &:first-child {
-    display: block;
-    height: ${props => `${400 + props.theme.spacingUnit * 2}px`};
-    width: 100%;
-    background-size: contain;
-    background-image: url(${props => props.backgroundImage});
-    background-color: ${props => props.theme.colors.smoke};
-
-    @media (min-width: 708px) {
-      grid-column-start: 1;
-      grid-column-end: span 2;
-      grid-row-start: 1;
-      grid-row-end: span 2;
-    }
-
-    ${props => props.theme.media.large`
-    grid-template-columns: ${props => `repeat(${props.columnNumber}, 200px)`};
-  `}
-  }
-`;
-
-const CallToAction = styled.div`
-  display: inline-block;
-  padding: 6px 24px;
-  grid-row-end: 3;
-  ${props => props.hasThumbs && 'transform: translateY(-50%)'};
-  background: ${props => props.theme.colors.green};
-  color: ${props => props.theme.colors.white};
-  transition: all 500ms ease;
-  position: relative;
-
-  @media (min-width: 708px) {
-    transform: none;
-  }
-
-  a:hover &,
-  a:focus & {
-    background: ${props => props.theme.colors.black};
-  }
-
-  .icon {
-    margin-right: 6px;
-  }
-
-  .icon__shape {
-    fill: currentColor;
-  }
-
-  @supports (display: grid) {
-    .cta__inner {
-      @media (min-width: 708px) {
-        display: block;
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-      }
-    }
-  }
-
-  .cta__text {
-    display: block;
+  img {
+    max-width: 800px;
+    width: auto;
+    margin-left: ${props => `${props.theme.spacingUnit * 5}px`};
   }
 `;
 
@@ -143,11 +50,22 @@ type IIIFThumbnails = {|
   images: {
     id: string,
     canvasId: string,
+    width: number,
+    height: number,
   }[],
 |};
 
+// We want to display the images at 400px high (400px is a size available from the thumbnail service)
+// However, we can only use the thumbnail service, with its associated performance benefits, if the image is not landscape.
+// When the image is landscape, the image from the thumbnail service has a width of 400px
+function appropriateServiceId(canvas) {
+  return canvas.width > canvas.height
+    ? canvas.images[0].resource.service['@id']
+    : canvas.thumbnail.service['@id'];
+}
+
 // Ideal preview thumbnails order: Title page, Front Cover, first page of Table of Contents, 2 random.
-// If we don't have any of the structured pages, we fill with random ones, so there are always 4 images if possible.
+// If we don't have any of the structured pages, we fill with random ones, so there are up to 5 images if possible.
 function randomImages(
   iiifManifest: IIIFManifest,
   structuredImages: IIIFThumbnails[],
@@ -174,8 +92,10 @@ function randomImages(
     const randomCanvas = canvases.splice(randomNumber, 1)[0];
     if (randomCanvas.thumbnail.service) {
       images.push({
-        id: randomCanvas.thumbnail.service['@id'],
+        id: appropriateServiceId(randomCanvas),
         canvasId: randomCanvas['@id'],
+        width: randomCanvas.width,
+        height: randomCanvas.height,
       });
     }
   }
@@ -195,8 +115,10 @@ function structuredImages(iiifManifest: IIIFManifest): IIIFThumbnails[] {
             });
             if (matchingCanvas) {
               return {
-                id: matchingCanvas.thumbnail.service['@id'],
+                id: appropriateServiceId(matchingCanvas),
                 canvasId: matchingCanvas && matchingCanvas['@id'],
+                width: matchingCanvas.width,
+                height: matchingCanvas.height,
               };
             }
           })
@@ -236,7 +158,7 @@ function orderedStructuredImages(
 function previewThumbnails(
   iiifManifest: IIIFManifest,
   structuredImages: IIIFThumbnails[],
-  idealNumber: number = 4
+  idealNumber: number = 5
 ): IIIFThumbnails[] {
   return structuredImages.length < idealNumber
     ? structuredImages.concat(
@@ -277,14 +199,11 @@ const IIIFPresentationDisplay = ({
         previewThumbnails(
           iiifPresentationManifest,
           orderedStructuredImages(structuredImages(iiifPresentationManifest)),
-          4
+          5
         )
       );
     }
   }, [iiifPresentationManifest]);
-  const itemsNumber = imageThumbnails.reduce((acc, pageType) => {
-    return acc + pageType.images.length;
-  }, 0);
 
   if (viewType === 'unknown' || viewType === 'pdf') {
     return (
@@ -310,7 +229,7 @@ const IIIFPresentationDisplay = ({
 
   if (viewType === 'iiif') {
     return (
-      <BookPreviewContainer>
+      <Preview>
         <NextLink {...itemUrl}>
           <a
             className="plain-link"
@@ -322,58 +241,35 @@ const IIIFPresentationDisplay = ({
               });
             }}
           >
-            <BookPreview
-              columnNumber={
-                itemsNumber === 1
-                  ? 3
-                  : itemsNumber === 3
-                  ? 4
-                  : 2 + Math.floor(itemsNumber / 2)
-              }
-              hasThumbs={imageThumbnails.length > 0}
-            >
-              {imageThumbnails.map((pageType, i) => {
-                return pageType.images.map(image => {
-                  return i === 0 ? (
-                    <PagePreview
+            {imageThumbnails.map((pageType, i) => {
+              return pageType.images.map(image => {
+                return (
+                  <PagePreview key={image.id}>
+                    <IIIFResponsiveImage
                       key={image.id}
-                      backgroundImage={iiifImageTemplate(image.id)({
-                        size: 'max',
+                      lang={'en'}
+                      width={image.width * (400 / image.height)}
+                      height={400}
+                      src={iiifImageTemplate(image.id)({
+                        size: ',400',
                       })}
+                      srcSet={''}
+                      alt=""
+                      sizes={null}
+                      isLazy={true}
                     />
-                  ) : (
-                    <PagePreview
-                      key={image.id}
-                      backgroundImage={iiifImageTemplate(image.id)({
-                        size: '!400,400',
-                      })}
-                    />
-                  );
-                });
-              })}
-              <CallToAction
-                hasThumbs={imageThumbnails.length > 0}
-                className={classNames({
-                  [font({ s: 'HNM4' })]: true,
-                })}
-              >
-                <span className="cta__inner">
-                  <span
-                    className={classNames({
-                      'flex-inline': true,
-                      'flex--v-center': true,
-                    })}
-                  >
-                    <Icon name="gallery" />
-                    {imageTotal}
-                  </span>
-                  <span className="cta__text">Full view</span>
-                </span>
-              </CallToAction>
-            </BookPreview>
+                  </PagePreview>
+                );
+              });
+            })}
+            <Button
+              icon={'gallery'}
+              text={`${imageTotal} images`}
+              extraClasses={`btn--primary`}
+            />
           </a>
         </NextLink>
-      </BookPreviewContainer>
+      </Preview>
     );
   }
 
@@ -384,7 +280,7 @@ const IIIFPresentationDisplay = ({
           [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
         })}
       >
-        <BetaMessage message="We are working to make this item available online in April 2019." />
+        <BetaMessage message="We are working to make this item available online in the near future." />
       </div>
     );
   } else {
@@ -393,3 +289,17 @@ const IIIFPresentationDisplay = ({
 };
 
 export default IIIFPresentationDisplay;
+
+// align single image preview (1010px)
+// TIDY styling, styled components
+// reposition download
+// Cross browser testing
+// Cardigan
+
+// Questions
+// CTA text?
+// lazyload DONE - how restrict to fewer images?
+// Mobile?
+// Should we have a max width?
+
+// restyle download

--- a/common/views/themes/default.js
+++ b/common/views/themes/default.js
@@ -4,6 +4,7 @@ import { css } from 'styled-components';
 // When units are `number`s, we assume pixels
 const theme = {
   spacingUnit: 6,
+  borderRadiusUnit: 6,
   sizes: {
     small: 0,
     medium: 600,


### PR DESCRIPTION
References: #4492

Implements new work preview designs (includes making page background white and restyling download):
<img width="695" alt="Screenshot 2019-05-22 at 15 55 36" src="https://user-images.githubusercontent.com/6051896/58185315-bf765a80-7caa-11e9-9e1c-f9af4c47e967.png">

<img width="1274" alt="Screenshot 2019-05-22 at 15 39 30" src="https://user-images.githubusercontent.com/6051896/58185331-c8672c00-7caa-11e9-9d1a-06ff864e5986.png">
<img width="1270" alt="Screenshot 2019-05-22 at 15 36 09" src="https://user-images.githubusercontent.com/6051896/58185356-d026d080-7caa-11e9-9f4d-7accdcaf7bdf.png">
<img width="1275" alt="Screenshot 2019-05-22 at 15 37 00" src="https://user-images.githubusercontent.com/6051896/58185345-cdc47680-7caa-11e9-9f14-4ed48d9addf1.png">
<img width="1273" alt="Screenshot 2019-05-22 at 15 36 47" src="https://user-images.githubusercontent.com/6051896/58185490-1a0fb680-7cab-11e9-85e7-2de9eb23541e.png">
