### PR TITLE
Keep visibilityRatio at 1

### DIFF
--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -70,6 +70,7 @@ const ImageViewer = ({
         const osdViewer = OpenSeadragon({
           id: `image-viewer-${viewerId}`,
           showNavigationControl: false,
+          visibilityRatio: 1,
           gestureSettingsMouse: {
             scrollToZoom: false,
           },


### PR DESCRIPTION
This ensures as much of the zoomed image as possible is maintained within the viewport (it was set at this before we made OpenSeadragon programmatic).