### PR TITLE
add fetchLinks for event series on exhibitions

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -358,7 +358,8 @@ export async function getExhibition(
       organisationsFields,
       contributorsFields,
       placesFields,
-      exhibitionResourcesFields
+      exhibitionResourcesFields,
+      eventSeriesFields
     ),
   });
 
@@ -384,7 +385,6 @@ export async function getExhibitionRelatedContent(
     placesFields,
     interpretationTypesFields,
     audiencesFields,
-    eventSeriesFields,
     organisationsFields,
     peopleFields,
     contributorsFields,

--- a/docs/rfcs/002-public-feedback-on-search-relevancy/README.md
+++ b/docs/rfcs/002-public-feedback-on-search-relevancy/README.md
@@ -1,0 +1,11 @@
+# Background
+
+
+# Problem statement
+
+# Proposed solution
+
+
+
+
+* Multiple endpoints for multiple user scenarios


### PR DESCRIPTION
It would be so nice to consolidate how we interact with Prismic... Maybe GraphQL!?
Makes it possible to put event series in the content list of exhibitions.