### PR TITLE
toggle queryType on a/b

### DIFF
--- a/cache/edge_lambdas/toggler.js
+++ b/cache/edge_lambdas/toggler.js
@@ -14,7 +14,7 @@
 // This is mutable for testing
 let tests = [
   {
-    id: 'search_cadidate_query_msm',
+    id: 'searchCadidateQueryMsm',
     title: 'Search candidate query: Minimum should match',
     range: [0, 10],
     shouldRun: request => {
@@ -22,7 +22,7 @@ let tests = [
     },
   },
   {
-    id: 'search_cadidate_query_boost',
+    id: 'searchCadidateQueryBoost',
     title: 'Search candidate query: Boost',
     range: [10, 20],
     shouldRun: request => {
@@ -30,7 +30,7 @@ let tests = [
     },
   },
   {
-    id: 'search_cadidate_query_msmboost',
+    id: 'searchCadidateQueryMsmBoost',
     title: 'Search candidate query: Minimum should match with boost',
     range: [20, 30],
     shouldRun: request => {

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -423,9 +423,21 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
-  const { useStageApi } = ctx.query.toggles;
+  const {
+    useStageApi,
+    searchCadidateQueryMsm,
+    searchCadidateQueryBoost,
+    searchCadidateQueryMsmBoost,
+  } = ctx.query.toggles;
+  const toggledQueryType = searchCadidateQueryMsm
+    ? 'msm'
+    : searchCadidateQueryBoost
+    ? 'boost'
+    : searchCadidateQueryMsmBoost
+    ? 'msmboost'
+    : null;
   const workTypeQuery = ctx.query.workType;
-  const _queryType = ctx.query._queryType;
+  const _queryType = ctx.query._queryType || toggledQueryType;
   const defaultWorkType = ['a', 'k', 'q', 'v'];
   const workTypeFilter = workTypeQuery
     ? workTypeQuery.split(',').filter(Boolean)


### PR DESCRIPTION
Switch the _queryType param when someone is in the test.

Make things camelCase. I do wonder how you destructure data from elsewhere, which might be underscored, if you have this rule set?