### PR TITLE
add exhibitions to multicontent

### DIFF
--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -17,6 +17,9 @@ import {
   audiencesFields,
   articleSeriesFields,
   exhibitionFields,
+  peopleFields,
+  organisationsFields,
+  contributorsFields,
 } from './fetch-links';
 import { parseArticleSeries } from './article-series';
 import type { MultiContent } from '../../model/multi-content';
@@ -98,7 +101,10 @@ export async function getMultiContent(
       eventPoliciesFields,
       audiencesFields,
       articleSeriesFields,
-      exhibitionFields
+      exhibitionFields,
+      peopleFields,
+      organisationsFields,
+      contributorsFields
     ),
     pageSize: pageSize || 100,
     orderings: `[${(orderings || []).join(',')}]`,

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -8,6 +8,7 @@ import {
   pagesFields,
   collectionVenuesFields,
   eventSeriesFields,
+  exhibitionFields,
 } from './fetch-links';
 
 export function parsePage(document: PrismicDocument): Page {
@@ -52,7 +53,11 @@ export function parsePage(document: PrismicDocument): Page {
 
 export async function getPage(req: ?Request, id: string): Promise<?Page> {
   const page = await getDocument(req, id, {
-    fetchLinks: pagesFields.concat(eventSeriesFields, collectionVenuesFields),
+    fetchLinks: pagesFields.concat(
+      eventSeriesFields,
+      collectionVenuesFields,
+      exhibitionFields
+    ),
   });
   if (page) {
     return parsePage(page);

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -24,6 +24,7 @@ import type { HtmlSerializer } from './html-serialisers';
 import { licenseTypeArray } from '../../model/license';
 import { parsePage } from './pages';
 import { parseEventSeries } from './event-series';
+import { parseExhibitionDoc } from './exhibitions';
 import { parseCollectionVenue } from '../../services/prismic/opening-times';
 import isEmptyObj from '../../utils/is-empty-object';
 import isEmptyDocLink from '../../utils/is-empty-doc-link';
@@ -540,6 +541,8 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
                       return parsePage(item.content);
                     case 'event-series':
                       return parseEventSeries(item.content);
+                    case 'exhibitions':
+                      return parseExhibitionDoc(item.content);
                   }
                 })
                 .filter(Boolean),


### PR DESCRIPTION
Content lists are now being used to create relationships between things - we should probably look at this more abstractly (which we didn't last time due to time restrictions).