### PR TITLE
add Exploromatic component and fromComponent query param

### DIFF
--- a/catalogue/webapp/components/Exploromatic/Exploromatic.js
+++ b/catalogue/webapp/components/Exploromatic/Exploromatic.js
@@ -1,0 +1,101 @@
+// @flow
+import Tags from '@weco/common/views/components/Tags/Tags';
+import { worksUrl } from '@weco/common/services/catalogue/urls';
+import { spacing, font } from '@weco/common/utils/classnames';
+
+const Explororama = () => (
+  <div className={`row ${spacing({ s: 3, m: 5 }, { padding: ['top'] })}`}>
+    <div className="container">
+      <div className="grid">
+        <div className="grid__cell">
+          <h3 className={font({ s: 'WB6', m: 'WB4' })}>Exploromaticus?</h3>
+          <p
+            className={`${spacing({ s: 2 }, { margin: ['bottom'] })} ${font({
+              s: 'HNL4',
+              m: 'HNL3',
+            })}`}
+          >
+            Discover our collections through these topics.
+          </p>
+          <div className={spacing({ s: 4 }, { margin: ['bottom'] })}>
+            <Tags
+              tags={[
+                {
+                  textParts: ['Quacks'],
+                  linkAttributes: worksUrl({
+                    query: 'quack+OR+quacks',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+                {
+                  textParts: ['James Gillray'],
+                  linkAttributes: worksUrl({
+                    query: 'james+gillray',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+                {
+                  textParts: ['Botany'],
+                  linkAttributes: worksUrl({
+                    query: 'botany',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+                {
+                  textParts: ['Optics'],
+                  linkAttributes: worksUrl({
+                    query: 'optics',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+                {
+                  textParts: ['Sun'],
+                  linkAttributes: worksUrl({
+                    query: 'sun',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+                {
+                  textParts: ['Health'],
+                  linkAttributes: worksUrl({
+                    query: 'health',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+                {
+                  textParts: ['Paintings'],
+                  linkAttributes: worksUrl({
+                    query: 'paintings',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+                {
+                  textParts: ['Science'],
+                  linkAttributes: worksUrl({
+                    query: 'science',
+                    page: 1,
+                    fromComponent: 'Exploromatic',
+                  }),
+                },
+              ]}
+            />
+          </div>
+          <hr
+            className={`divider divider--dashed ${spacing(
+              { s: 6 },
+              { margin: ['bottom'] }
+            )}`}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+export default Explororama;

--- a/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
+++ b/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
@@ -2,79 +2,12 @@
 import { Fragment } from 'react';
 import { spacing, font, grid } from '@weco/common/utils/classnames';
 import { createPrismicParagraph } from '@weco/common/utils/prismic';
-import Tags from '@weco/common/views/components/Tags/Tags';
 import { CaptionedImage } from '@weco/common/views/components/Images/Images';
-import { worksUrl } from '@weco/common/services/catalogue/urls';
+import Exploromatic from '../Exploromatic/Exploromatic';
 
 const StaticWorksContent = () => (
   <Fragment>
-    <div className={`row ${spacing({ s: 3, m: 5 }, { padding: ['top'] })}`}>
-      <div className="container">
-        <div className="grid">
-          <div className="grid__cell">
-            <h3 className={font({ s: 'WB6', m: 'WB4' })}>Feeling curious?</h3>
-            <p
-              className={`${spacing({ s: 2 }, { margin: ['bottom'] })} ${font({
-                s: 'HNL4',
-                m: 'HNL3',
-              })}`}
-            >
-              Discover our collections through these topics.
-            </p>
-            <div className={spacing({ s: 4 }, { margin: ['bottom'] })}>
-              <Tags
-                tags={[
-                  {
-                    textParts: ['Quacks'],
-                    linkAttributes: worksUrl({
-                      query: 'quack+OR+quacks',
-                      page: 1,
-                    }),
-                  },
-                  {
-                    textParts: ['James Gillray'],
-                    linkAttributes: worksUrl({
-                      query: 'james+gillray',
-                      page: 1,
-                    }),
-                  },
-                  {
-                    textParts: ['Botany'],
-                    linkAttributes: worksUrl({ query: 'botany', page: 1 }),
-                  },
-                  {
-                    textParts: ['Optics'],
-                    linkAttributes: worksUrl({ query: 'optics', page: 1 }),
-                  },
-                  {
-                    textParts: ['Sun'],
-                    linkAttributes: worksUrl({ query: 'sun', page: 1 }),
-                  },
-                  {
-                    textParts: ['Health'],
-                    linkAttributes: worksUrl({ query: 'health', page: 1 }),
-                  },
-                  {
-                    textParts: ['Paintings'],
-                    linkAttributes: worksUrl({ query: 'paintings', page: 1 }),
-                  },
-                  {
-                    textParts: ['Science'],
-                    linkAttributes: worksUrl({ query: 'science', page: 1 }),
-                  },
-                ]}
-              />
-            </div>
-            <hr
-              className={`divider divider--dashed ${spacing(
-                { s: 6 },
-                { margin: ['bottom'] }
-              )}`}
-            />
-          </div>
-        </div>
-      </div>
-    </div>
+    <Exploromatic />
     <div
       className={`row bg-cream row--has-wobbly-background ${spacing(
         { s: 10 },

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -7,8 +7,12 @@ const QueryTypes = {
   Slop: 'msmboost',
 };
 type QueryType = $Values<typeof QueryTypes>;
+type GenericLinkProps = {|
+  fromComponent?: string,
+|};
 
 type WorksUrlProps = {|
+  ...GenericLinkProps,
   query: ?string,
   page: ?number,
   workType?: ?(string[]),
@@ -17,10 +21,12 @@ type WorksUrlProps = {|
 |};
 
 type WorkUrlProps = {|
+  ...GenericLinkProps,
   id: string,
 |};
 
 type ItemUrlProps = {|
+  ...GenericLinkProps,
   workId: string,
   sierraId: ?string,
   langCode: string,
@@ -38,16 +44,18 @@ function getWorkType(workType: ?(string[])) {
   };
 }
 
-export function workUrl({ id }: WorkUrlProps): NextLinkType {
+export function workUrl({ id, fromComponent }: WorkUrlProps): NextLinkType {
   return {
     href: {
       pathname: `/work`,
       query: {
         id,
+        fromComponent: fromComponent || undefined,
       },
     },
     as: {
       pathname: `/works/${id}`,
+      fromComponent: fromComponent || undefined,
     },
   };
 }
@@ -57,6 +65,7 @@ export function worksUrl({
   page,
   workType,
   _queryType,
+  fromComponent,
 }: WorksUrlProps): NextLinkType {
   return {
     href: {
@@ -66,6 +75,7 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
+        fromComponent: fromComponent || undefined,
       }),
     },
     as: {
@@ -75,6 +85,7 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
+        fromComponent: fromComponent || undefined,
       }),
     },
   };
@@ -86,6 +97,7 @@ export function itemUrl({
   sierraId,
   langCode,
   canvas,
+  fromComponent,
 }: ItemUrlProps): NextLinkType {
   return {
     href: {
@@ -97,6 +109,7 @@ export function itemUrl({
           canvas: canvas && canvas > 1 ? canvas : undefined,
           sierraId: sierraId,
           langCode: langCode,
+          fromComponent: fromComponent || undefined,
         }),
       },
     },
@@ -107,6 +120,7 @@ export function itemUrl({
         canvas: canvas && canvas > 1 ? canvas : undefined,
         sierraId: sierraId,
         langCode: langCode,
+        fromComponent: fromComponent || undefined,
       }),
     },
   };


### PR DESCRIPTION
Adds a new component.
When coming from that component, we add a `fromComponent` to the query string.

Why this is more generic than just `showRatingTools` (maybe this should be the case) is because we were wondering about being able to filter the search logs by people who just search, or use links (tags etc) to do searches.

This is a useful distinction as free term searching implies that you had something in mind, insteaed of being prompted. 

While this is easy to distinguish between now, if the list becomes more dynamic, and we have other links around the site, we might want to filter the search logs by "free text search only" or by other ways we offer into search.

Data from the rating is stored in the `tracking_relevance_rating` index in the `reporting` deployment of 
Elastic.

It's shape is:
```JSON
{
    "event": "Rate Result Relevance",
    "anonymousId": "3c8e372d-7c01-4d7e-aa55-e980c3892824",
    "timestamp": "2019-06-14T13:02:42.492Z",
    "network": "StaffCorporateDevices",
    "toggles": {},
    "data": {
      "_queryType": null,
      "id": "a7bgrgze",
      "page": 1,
      "position": 0,
      "query": "\"Opium poppies\"",
      "rating": 3,
      "workType": null
    }
  }
```
![screencast-www google co uk-2019 06 14-14-01-05](https://user-images.githubusercontent.com/31692/59510967-fc4dff80-8eac-11e9-91ab-76652f514571.gif)
