### PR TITLE
Use loadedmetadata to decide when to play video

### DIFF
--- a/common/views/components/GifVideo/GifVideo.js
+++ b/common/views/components/GifVideo/GifVideo.js
@@ -118,12 +118,13 @@ class GifVideo extends Component<Props, State> {
 
   componentDidMount() {
     const video = this.videoRef.current;
+
     if (video) {
       video.playbackRate = this.props.playbackRate;
       if (video.readyState > 3) {
         this.initVideoGif(video);
       } else {
-        video.addEventListener('canplaythrough', () => {
+        video.addEventListener('loadedmetadata', () => {
           this.initVideoGif(video);
         });
       }


### PR DESCRIPTION
The `canplaythrough` and `canplay` events don't fire in Safari unless you're in the user's whitelist.

`loadedmetadata` is the last event that fires consistently.

This change makes `GifVideo` work in Safari.

https://stackoverflow.com/a/50102809