### PR TITLE
Add isOverview to query for initial thumbs view

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -229,6 +229,7 @@ export const WorkPage = ({ work }: Props) => {
                   langCode: work.language && work.language.id,
                   page: 1,
                   canvas: 1,
+                  isOverview: true,
                 })}
               />
             </WobblyRow>
@@ -244,6 +245,7 @@ export const WorkPage = ({ work }: Props) => {
                 langCode: work.language && work.language.id,
                 page: 1,
                 canvas: 1,
+                isOverview: true,
               })}
               title={work.title}
             />

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -26,6 +26,7 @@ type ItemUrlProps = {|
   langCode: string,
   canvas: number,
   page: ?number,
+  isOverview?: boolean,
 |};
 
 function removeEmpty(obj: Object): Object {
@@ -86,6 +87,7 @@ export function itemUrl({
   sierraId,
   langCode,
   canvas,
+  isOverview,
 }: ItemUrlProps): NextLinkType {
   return {
     href: {
@@ -97,6 +99,7 @@ export function itemUrl({
           canvas: canvas && canvas > 1 ? canvas : undefined,
           sierraId: sierraId,
           langCode: langCode,
+          isOverview: isOverview,
         }),
       },
     },

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -540,7 +540,7 @@ const IIIFViewerComponent = ({
   const iiifPresentationLicenseInfo =
     manifest && manifest.license ? getLicenseInfo(manifest.license) : null;
   useEffect(() => {
-    setShowThumbs(Router.router.query.isOverview);
+    setShowThumbs(Router.query.isOverview);
     setEnhanced(true);
   }, []);
 

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -31,6 +31,7 @@ import LL from '@weco/common/views/components/styled/LL';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import { trackEvent } from '@weco/common/utils/ga';
 import Download from '@weco/catalogue/components/Download/ViewerDownload';
+import Router from 'next/router';
 
 const TitleContainer = styled.div.attrs(props => ({
   className: classNames({
@@ -481,7 +482,7 @@ const IIIFViewerComponent = ({
   work,
   manifest,
 }: IIIFViewerProps) => {
-  const [showThumbs, setShowThumbs] = useState(true);
+  const [showThumbs, setShowThumbs] = useState(false);
   const [enhanced, setEnhanced] = useState(false);
   const thumbnailContainer = useRef(null);
   const activeThumbnailRef = useRef(null);
@@ -539,6 +540,7 @@ const IIIFViewerComponent = ({
   const iiifPresentationLicenseInfo =
     manifest && manifest.license ? getLicenseInfo(manifest.license) : null;
   useEffect(() => {
+    setShowThumbs(Router.router.query.isOverview);
     setEnhanced(true);
   }, []);
 


### PR DESCRIPTION
Going to the viewer from the preview page sets a flag to make the viewer display the overview thumbs.

Arriving from anywhere else/refreshing the page will display the detail view instead.

__TODO__

- [x] Flow