### PR TITLE
Contact card

### DIFF
--- a/cardigan/stories/components/Contact.js
+++ b/cardigan/stories/components/Contact.js
@@ -7,13 +7,11 @@ const stories = storiesOf('Components', module);
 stories.add(
   'Contact',
   () => (
-    <div className={`body-text`}>
-      <Contact
-        title={`Joe Bloggs`}
-        phone={`+44 (0)20 7444 4444`}
-        email={`j.bloggs@wellcome.ac.uk`}
-      />
-    </div>
+    <Contact
+      title={`Joe Bloggs`}
+      phone={`+44 (0)20 7444 4444`}
+      email={`j.bloggs@wellcome.ac.uk`}
+    />
   ),
   {
     readme: { sidebar: Readme },

--- a/cardigan/stories/components/Contact.js
+++ b/cardigan/stories/components/Contact.js
@@ -1,18 +1,21 @@
 import { storiesOf } from '@storybook/react';
 import Contact from '../../../common/views/components/Contact/Contact';
 import Readme from '../../../common/views/components/Contact/README.md';
-
+import { text } from '@storybook/addon-knobs';
 const stories = storiesOf('Components', module);
 
 stories.add(
   'Contact',
-  () => (
-    <Contact
-      title={`Joe Bloggs`}
-      phone={`+44 (0)20 7444 4444`}
-      email={`j.bloggs@wellcome.ac.uk`}
-    />
-  ),
+  () => {
+    const title = text('Title', 'Joe Bloggs');
+    const subtitle = text('Subtitle', 'Head of Examples');
+    const phone = text('Phone', '+44 (0)20 7444 4444');
+    const email = text('Email', 'j.bloggs@wellcome.ac.uk');
+
+    return (
+      <Contact title={title} subtitle={subtitle} phone={phone} email={email} />
+    );
+  },
   {
     readme: { sidebar: Readme },
   }

--- a/cardigan/stories/components/Contact.js
+++ b/cardigan/stories/components/Contact.js
@@ -1,0 +1,21 @@
+import { storiesOf } from '@storybook/react';
+import Contact from '../../../common/views/components/Contact/Contact';
+import Readme from '../../../common/views/components/Contact/README.md';
+
+const stories = storiesOf('Components', module);
+
+stories.add(
+  'Contact',
+  () => (
+    <div className={`body-text`}>
+      <Contact
+        title={`Joe Bloggs`}
+        phone={`+44 (0)20 7444 4444`}
+        email={`j.bloggs@wellcome.ac.uk`}
+      />
+    </div>
+  ),
+  {
+    readme: { sidebar: Readme },
+  }
+);

--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -61,6 +61,7 @@ export const interpretationTypesFields = [
 ];
 export const teamsFields = [
   'teams.title',
+  'teams.subtitle',
   'teams.email',
   'teams.phone',
   'teams.url',

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -1,15 +1,28 @@
 // @flow
 import Prismic from 'prismic-javascript';
 import { getDocument, getDocuments } from './api';
-import { parseTimestamp, parseGenericFields } from './parsers';
+import { parseTimestamp, parseGenericFields, asText } from './parsers';
 import type { Page } from '../../model/pages';
-import type { PrismicDocument } from './types';
+import type { PrismicDocument, PrismicFragment } from './types';
 import {
   pagesFields,
   collectionVenuesFields,
   eventSeriesFields,
   exhibitionFields,
+  teamsFields,
 } from './fetch-links';
+
+export function parseTeamToContact(team: PrismicFragment) {
+  const {
+    data: { title, email, phone },
+  } = team;
+
+  return {
+    title: asText(title),
+    email,
+    phone,
+  };
+}
 
 export function parsePage(document: PrismicDocument): Page {
   const { data } = document;
@@ -56,9 +69,11 @@ export async function getPage(req: ?Request, id: string): Promise<?Page> {
     fetchLinks: pagesFields.concat(
       eventSeriesFields,
       collectionVenuesFields,
-      exhibitionFields
+      exhibitionFields,
+      teamsFields
     ),
   });
+
   if (page) {
     return parsePage(page);
   }

--- a/common/services/prismic/pages.js
+++ b/common/services/prismic/pages.js
@@ -1,9 +1,9 @@
 // @flow
 import Prismic from 'prismic-javascript';
 import { getDocument, getDocuments } from './api';
-import { parseTimestamp, parseGenericFields, asText } from './parsers';
+import { parseTimestamp, parseGenericFields } from './parsers';
 import type { Page } from '../../model/pages';
-import type { PrismicDocument, PrismicFragment } from './types';
+import type { PrismicDocument } from './types';
 import {
   pagesFields,
   collectionVenuesFields,
@@ -11,18 +11,6 @@ import {
   exhibitionFields,
   teamsFields,
 } from './fetch-links';
-
-export function parseTeamToContact(team: PrismicFragment) {
-  const {
-    data: { title, email, phone },
-  } = team;
-
-  return {
-    title: asText(title),
-    email,
-    phone,
-  };
-}
 
 export function parsePage(document: PrismicDocument): Page {
   const { data } = document;

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -22,7 +22,7 @@ import type { LabelField } from '../../model/label-field';
 import type { SameAs } from '../../model/same-as';
 import type { HtmlSerializer } from './html-serialisers';
 import { licenseTypeArray } from '../../model/license';
-import { parsePage, parseTeamToContact } from './pages';
+import { parsePage } from './pages';
 import { parseEventSeries } from './event-series';
 import { parseExhibitionDoc } from './exhibitions';
 import { parseCollectionVenue } from '../../services/prismic/opening-times';
@@ -318,6 +318,18 @@ export function parseTaslFromString(pipedString: string): Tasl {
       copyrightLink: null,
     };
   }
+}
+
+function parseTeamToContact(team: PrismicFragment) {
+  const {
+    data: { title, email, phone },
+  } = team;
+
+  return {
+    title: asText(title),
+    email,
+    phone,
+  };
 }
 
 // null is valid to use the default image,

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -22,7 +22,7 @@ import type { LabelField } from '../../model/label-field';
 import type { SameAs } from '../../model/same-as';
 import type { HtmlSerializer } from './html-serialisers';
 import { licenseTypeArray } from '../../model/license';
-import { parsePage } from './pages';
+import { parsePage, parseTeamToContact } from './pages';
 import { parseEventSeries } from './event-series';
 import { parseExhibitionDoc } from './exhibitions';
 import { parseCollectionVenue } from '../../services/prismic/opening-times';
@@ -609,6 +609,12 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
               playbackRate: slice.primary.playbackRate || 1,
               tasl: parseTaslFromString(slice.primary.tasl),
             },
+          };
+
+        case 'contact':
+          return {
+            type: 'contact',
+            value: parseTeamToContact(slice.primary.content),
           };
 
         case 'embed':

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -327,7 +327,7 @@ function parseTeamToContact(team: PrismicFragment) {
 
   return {
     title: asText(title),
-    subtitle: asText(subtitle),
+    subtitle,
     email,
     phone,
   };

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -322,11 +322,12 @@ export function parseTaslFromString(pipedString: string): Tasl {
 
 function parseTeamToContact(team: PrismicFragment) {
   const {
-    data: { title, email, phone },
+    data: { title, subtitle, email, phone },
   } = team;
 
   return {
     title: asText(title),
+    subtitle: asText(subtitle),
     email,
     phone,
   };

--- a/common/views/components/Body/Body.js
+++ b/common/views/components/Body/Body.js
@@ -12,6 +12,7 @@ import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import FeaturedText from '../FeaturedText/FeaturedText';
 import VideoEmbed from '../VideoEmbed/VideoEmbed';
 import GifVideo from '../GifVideo/GifVideo';
+import Contact from '../Contact/Contact';
 import Iframe from '../Iframe/Iframe';
 import DeprecatedImageList from '../DeprecatedImageList/DeprecatedImageList';
 import Layout from '../Layout/Layout';
@@ -177,6 +178,11 @@ const Body = ({ body, isDropCapped, pageId }: Props) => {
               <Layout10>
                 <Iframe {...slice.value} />
               </Layout10>
+            )}
+            {slice.type === 'contact' && (
+              <Layout8>
+                <Contact {...slice.value} />
+              </Layout8>
             )}
             {slice.type === 'collectionVenue' && (
               <>

--- a/common/views/components/Contact/Contact.js
+++ b/common/views/components/Contact/Contact.js
@@ -4,11 +4,12 @@ import { spacing, font, classNames } from '../../../utils/classnames';
 
 type Props = {|
   title: string,
+  subtitle: ?string,
   phone: ?string,
   email: ?string,
 |};
 
-function Contact({ title, phone, email }: Props) {
+function Contact({ title, subtitle, phone, email }: Props) {
   return (
     <div
       className={classNames({
@@ -18,11 +19,26 @@ function Contact({ title, phone, email }: Props) {
     >
       <span
         className={classNames({
-          [font({ s: 'HNM3' })]: true,
           block: true,
         })}
       >
-        {title}
+        <span
+          className={classNames({
+            [font({ s: 'HNM3' })]: true,
+          })}
+        >
+          {title}
+        </span>
+        {subtitle && (
+          <span
+            className={classNames({
+              [font({ s: 'HNL3' })]: true,
+              [spacing({ s: 1 }, { margin: ['left'] })]: true,
+            })}
+          >
+            {subtitle}
+          </span>
+        )}
       </span>
       {phone && (
         <span

--- a/common/views/components/Contact/Contact.js
+++ b/common/views/components/Contact/Contact.js
@@ -1,0 +1,53 @@
+// @flow
+
+import { spacing, font, classNames } from '../../../utils/classnames';
+
+type Props = {|
+  title: string,
+  phone: ?string,
+  email: ?string,
+|};
+
+function Contact({ title, phone, email }: Props) {
+  return (
+    <div
+      className={classNames({
+        [spacing({ s: 2 }, { padding: ['left'] })]: true,
+        'border-color-turquoise border-left-width-5': true,
+      })}
+    >
+      <strong
+        className={classNames({
+          [font({ s: 'HNM3' })]: true,
+          block: true,
+        })}
+      >
+        {title}
+      </strong>
+      {phone && (
+        <span
+          className={classNames({
+            [font({ s: 'HNL3' })]: true,
+            block: true,
+          })}
+        >
+          {phone}
+        </span>
+      )}
+      {email && (
+        <div>
+          <a
+            className={classNames({
+              [font({ s: 'HNL3' })]: true,
+            })}
+            href={`mailto:${email}`}
+          >
+            {email}
+          </a>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Contact;

--- a/common/views/components/Contact/Contact.js
+++ b/common/views/components/Contact/Contact.js
@@ -13,17 +13,17 @@ function Contact({ title, phone, email }: Props) {
     <div
       className={classNames({
         [spacing({ s: 2 }, { padding: ['left'] })]: true,
-        'border-color-turquoise border-left-width-5': true,
+        'border-color-turquoise border-left-width-5 body-text': true,
       })}
     >
-      <strong
+      <span
         className={classNames({
           [font({ s: 'HNM3' })]: true,
           block: true,
         })}
       >
         {title}
-      </strong>
+      </span>
       {phone && (
         <span
           className={classNames({

--- a/common/views/components/Contact/README.md
+++ b/common/views/components/Contact/README.md
@@ -1,0 +1,5 @@
+## Purpose
+
+By modelling contact data into a component, we ensure that we present it in a consistent UI, and that the relevant information is kept up-to-date everywhere it appears.
+
+[Edit this on GitHub](https://github.com/wellcometrust/wellcomecollection.org/edit/master/common/views/components/Contact/README.md)

--- a/prismic-model/convert.js
+++ b/prismic-model/convert.js
@@ -7,7 +7,9 @@ if (modelName) {
   fs.writeFile(
     `./json/${modelName}.json`,
     JSON.stringify(model, null, 2),
-    (err) => { if (err) throw err; }
+    err => {
+      if (err) throw err;
+    }
   );
 } else {
   fs.readdir('./js', (err, files) => {
@@ -19,7 +21,9 @@ if (modelName) {
         fs.writeFile(
           `./json/${modelName}.json`,
           JSON.stringify(model, null, 2),
-          (err) => { if (err) throw err; }
+          err => {
+            if (err) throw err;
+          }
         );
       }
     });

--- a/prismic-model/js/parts/body.js
+++ b/prismic-model/js/parts/body.js
@@ -107,6 +107,11 @@ export default {
           showClosingTimes: boolean('Show closing times'),
         },
       }),
+      contact: slice('Contact', {
+        nonRepeat: {
+          content: link('Content item', 'document', ['teams']),
+        },
+      }),
       inPageAnchor: slice('In page anchor', {
         nonRepeat: {
           id: {

--- a/prismic-model/js/teams.js
+++ b/prismic-model/js/teams.js
@@ -1,0 +1,14 @@
+import structuredText from './parts/structured-text';
+import text from './parts/text';
+
+const Teams = {
+  Contact: {
+    title: structuredText('Title', 'single', ['heading1']),
+    subtitle: text('Subtitle'),
+    email: text('Email'),
+    phone: text('Phone'),
+    url: text('URL'),
+  },
+};
+
+export default Teams;

--- a/prismic-model/json/pages.json
+++ b/prismic-model/json/pages.json
@@ -310,6 +310,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",

--- a/prismic-model/json/teams.json
+++ b/prismic-model/json/teams.json
@@ -1,28 +1,34 @@
 {
-  "Team" : {
-    "title" : {
-      "type" : "StructuredText",
-      "config" : {
-        "single" : "heading1",
-        "label" : "Title"
+  "Contact": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "single": "paragraph,hyperlink,strong,em,heading1",
+        "label": "Title"
       }
     },
-    "email" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "email"
+    "subtitle": {
+      "type": "Text",
+      "config": {
+        "label": "Subtitle"
       }
     },
-    "phone" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "Phone"
+    "email": {
+      "type": "Text",
+      "config": {
+        "label": "Email"
       }
     },
-    "url" : {
-      "type" : "Text",
-      "config" : {
-        "label" : "Web address"
+    "phone": {
+      "type": "Text",
+      "config": {
+        "label": "Phone"
+      }
+    },
+    "url": {
+      "type": "Text",
+      "config": {
+        "label": "URL"
       }
     }
   }


### PR DESCRIPTION
Relates to #4355 

Adding a `Contact` component which allows a team name, email and/or phone number to be displayed.

![Screenshot 2019-07-02 at 14 25 58](https://user-images.githubusercontent.com/1394592/60516526-dd85a080-9cd5-11e9-9cc5-3516d70550d2.png)

Adds a `subtitle` field to the current `Team` (and we've changed the Prismic UI to display `Contact` instead of `Team`, to make the editorial flow make more sense).

~@jennpb Is the ability to add individuals a requirement? If so, I think this will require rethinking. Sticking with teams feels like it should be more future proof (even if individuals move roles, the teams remain the same), but not sure if it fits the needs.~