### PR TITLE
Add toggle for moving image controls closer to pagination controls

### DIFF
--- a/cache/edge_lambdas/toggler.js
+++ b/cache/edge_lambdas/toggler.js
@@ -37,6 +37,14 @@ let tests = [
       return request.uri.match(/^\/works\/*/);
     },
   },
+  {
+    id: 'groupImageControlsWithPagination',
+    title: 'Group image controls with pagination',
+    range: [0, 50],
+    shouldRun(request) {
+      return request.uri.match(/^\/works\/.*/);
+    },
+  },
 ];
 exports.tests = tests;
 exports.setTests = function(newTests) {

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -32,6 +32,7 @@ import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveIma
 import { trackEvent } from '@weco/common/utils/ga';
 import Download from '@weco/catalogue/components/Download/ViewerDownload';
 import Router from 'next/router';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 const TitleContainer = styled.div.attrs(props => ({
   className: classNames({
@@ -252,28 +253,10 @@ const IIIFViewerPaginatorButtons = styled.div.attrs(props => ({
     absolute: true,
   }),
 }))`
-  right: ${props => props.theme.spacingUnit * 2}px;
-  bottom: ${props =>
-    !props.isThumbs ? `${props.theme.spacingUnit * 2}px` : 0};
-  top: ${props => props.isThumbs && `${props.theme.spacingUnit}px`};
-
-  ${props =>
-    props.isThumbs &&
-    `
-    @media (min-width: ${props.theme.sizes.medium}px) {
-      top: auto;
-    bottom: ${props.theme.spacingUnit}px;
-    right: auto;
-    left: 50%;
-    transform: translateX(-50%);
-    div {
-      flex-direction: row;
-      .control {
-        margin: 0;
-      }
-    }
-    }
-  `}
+  right: ${props => (props.isGroupedWithControls ? undefined : '12px')};
+  left: ${props => (props.isGroupedWithControls ? '12px' : undefined)};
+  bottom: ${props => (props.isGroupedWithControls ? undefined : '12px')};
+  top: ${props => (props.isGroupedWithControls ? '12px' : undefined)};
 `;
 
 function scrollIntoViewIfOutOfView(container, index) {
@@ -412,7 +395,6 @@ const PaginatorButtons = (isTabbable: boolean, workId: string) => {
             tabIndex={isTabbable ? '0' : '-1'}
             extraClasses={classNames({
               'icon--270': true,
-              [spacing({ s: 1 }, { margin: ['bottom'] })]: true,
             })}
             clickHandler={() => {
               trackEvent({
@@ -756,12 +738,18 @@ const IIIFViewerComponent = ({
                   />
                 )}
               </IIIFViewerImageWrapper>
-              <IIIFViewerPaginatorButtons>
-                <Paginator
-                  {...mainPaginatorProps}
-                  render={PaginatorButtons(!showThumbs, workId)}
-                />
-              </IIIFViewerPaginatorButtons>
+              <TogglesContext.Consumer>
+                {({ groupImageControlsWithPagination }) => (
+                  <IIIFViewerPaginatorButtons
+                    isGroupedWithControls={groupImageControlsWithPagination}
+                  >
+                    <Paginator
+                      {...mainPaginatorProps}
+                      render={PaginatorButtons(!showThumbs, workId)}
+                    />
+                  </IIIFViewerPaginatorButtons>
+                )}
+              </TogglesContext.Consumer>
             </IIIFViewerMain>
 
             {thumbnailsRequired && (

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -41,10 +41,8 @@ const ImageViewerControls = styled.div`
   }
 
   position: absolute;
-  top: ${props => (props.isGroupedWithPagination ? undefined : 0)};
-  left: ${props => (props.isGroupedWithPagination ? undefined : '12px')};
-  right: ${props => (props.isGroupedWithPagination ? '12px' : undefined)};
-  bottom: ${props => (props.isGroupedWithPagination ? '110px' : undefined)};
+  top: ${props => (props.isGroupedWithPagination ? '100px' : 0)};
+  left: 12px;
   z-index: 1;
 }`;
 
@@ -237,7 +235,9 @@ const ImageViewer = ({
     <>
       <TogglesContext.Consumer>
         {({ groupImageControlsWithPagination }) => (
-          <ImageViewerControls isGroupedWithPagination={true}>
+          <ImageViewerControls
+            isGroupedWithPagination={groupImageControlsWithPagination}
+          >
             <Control
               tabIndex={tabbableControls ? '0' : '-1'}
               type="on-black"

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -9,6 +9,7 @@ import { trackEvent } from '../../../utils/ga';
 import IIIFResponsiveImage from '../IIIFResponsiveImage/IIIFResponsiveImage';
 import Control from '../Buttons/Control/Control';
 import LL from '../styled/LL';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 const ImageViewerControls = styled.div`
   /* TODO: keep an eye on https://github.com/openseadragon/openseadragon/issues/1586
@@ -40,8 +41,10 @@ const ImageViewerControls = styled.div`
   }
 
   position: absolute;
-  top: 0;
-  left: 12px;
+  top: ${props => (props.isGroupedWithPagination ? undefined : 0)};
+  left: ${props => (props.isGroupedWithPagination ? undefined : '12px')};
+  right: ${props => (props.isGroupedWithPagination ? '12px' : undefined)};
+  bottom: ${props => (props.isGroupedWithPagination ? '110px' : undefined)};
   z-index: 1;
 }`;
 
@@ -232,29 +235,33 @@ const ImageViewer = ({
 
   return (
     <>
-      <ImageViewerControls>
-        <Control
-          tabIndex={tabbableControls ? '0' : '-1'}
-          type="on-black"
-          text="Zoom in"
-          icon="zoomIn"
-          clickHandler={handleZoomIn}
-        />
-        <Control
-          tabIndex={tabbableControls ? '0' : '-1'}
-          type="on-black"
-          text="Zoom out"
-          icon="zoomOut"
-          clickHandler={handleZoomOut}
-        />
-        <Control
-          tabIndex={tabbableControls ? '0' : '-1'}
-          type="on-black"
-          text="Rotate"
-          icon="rotatePageRight"
-          clickHandler={handleRotate}
-        />
-      </ImageViewerControls>
+      <TogglesContext.Consumer>
+        {({ groupImageControlsWithPagination }) => (
+          <ImageViewerControls isGroupedWithPagination={true}>
+            <Control
+              tabIndex={tabbableControls ? '0' : '-1'}
+              type="on-black"
+              text="Zoom in"
+              icon="zoomIn"
+              clickHandler={handleZoomIn}
+            />
+            <Control
+              tabIndex={tabbableControls ? '0' : '-1'}
+              type="on-black"
+              text="Zoom out"
+              icon="zoomOut"
+              clickHandler={handleZoomOut}
+            />
+            <Control
+              tabIndex={tabbableControls ? '0' : '-1'}
+              type="on-black"
+              text="Rotate"
+              icon="rotatePageRight"
+              clickHandler={handleRotate}
+            />
+          </ImageViewerControls>
+        )}
+      </TogglesContext.Consumer>
 
       <div
         style={{

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -41,12 +41,5 @@ module.exports = {
       description:
         'Shows a preview for each volume in a multi volume work on the work page.',
     },
-    {
-      id: 'groupImageControlsWithPagination',
-      title: 'Group image controls with pagination',
-      defaultValue: false,
-      description:
-        'Moves the zoom/rotate controls to the same location as the previous/next page controls',
-    },
   ],
 };

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -41,5 +41,12 @@ module.exports = {
       description:
         'Shows a preview for each volume in a multi volume work on the work page.',
     },
+    {
+      id: 'groupImageControlsWithPagination',
+      title: 'Group image controls with pagination',
+      defaultValue: false,
+      description:
+        'Moves the zoom/rotate controls to the same location as the previous/next page controls',
+    },
   ],
 };


### PR DESCRIPTION
![Screenshot 2019-06-28 at 11 55 26](https://user-images.githubusercontent.com/1394592/60338379-af365700-999d-11e9-9ec4-db415f106ad7.png)

~If we want to test this, we can come up with a question and promote the toggle to an A/B test.~

This splits traffic 50:50 into a condition with all controls top right, and a condition with the zoom/rotate top right and pagination bottom left.
