### PR TITLE
Add private endpoint for libsys

### DIFF
--- a/infra/terraform/templates/ec2.tf
+++ b/infra/terraform/templates/ec2.tf
@@ -31,6 +31,7 @@ resource "aws_launch_configuration" "wellcomecollection_ecs" {
     "${aws_security_group.https.id}",
     "${aws_security_group.node_app_port.id}",
     "${aws_security_group.docker.id}",
+    "${aws_security_group.interservice_security_group.id}"
   ]
 
   user_data = <<EOF

--- a/infra/terraform/templates/endpoints.tf
+++ b/infra/terraform/templates/endpoints.tf
@@ -1,0 +1,29 @@
+# libsys
+
+resource "aws_vpc_endpoint" "libsys" {
+  vpc_id            = "${aws_vpc.wellcomecollection.id}"
+  service_name      = "${var.service-libsys}"
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    "${aws_security_group.interservice_security_group.id}",
+  ]
+
+  subnet_ids = [
+    "${aws_subnet.private_a.id}",
+    "${aws_subnet.private_b.id}",
+  ]
+
+  private_dns_enabled = false
+}
+
+resource "aws_route53_record" "libsys" {
+  zone_id = "${aws_route53_zone.internal.zone_id}"
+  name    = "libsys.${aws_route53_zone.internal.name}"
+  type    = "CNAME"
+  ttl     = "300"
+
+  records = [
+    "${lookup(aws_vpc_endpoint.libsys.dns_entry[0], "dns_name")}",
+  ]
+}

--- a/infra/terraform/templates/route53.tf
+++ b/infra/terraform/templates/route53.tf
@@ -1,0 +1,7 @@
+resource "aws_route53_zone" "internal" {
+  name = "experience.internal."
+
+  vpc {
+    vpc_id = "${aws_vpc.wellcomecollection.id}"
+  }
+}

--- a/infra/terraform/templates/sg.tf
+++ b/infra/terraform/templates/sg.tf
@@ -102,6 +102,24 @@ resource "aws_security_group" "ssh_in" {
   }
 }
 
+
+resource "aws_security_group" "interservice_security_group" {
+  name        = "interservice_security_group"
+  description = "Allow traffic between services"
+  vpc_id      = "${aws_vpc.wellcomecollection.id}"
+
+  ingress {
+    from_port = 0
+    to_port   = 0
+    protocol  = "-1"
+    self      = true
+  }
+
+  tags {
+    Name = "${var.project_name}-interservice"
+  }
+}
+
 output "https_sg_id" {
   value = "${aws_security_group.https.id}"
 }

--- a/infra/terraform/templates/vars.tf
+++ b/infra/terraform/templates/vars.tf
@@ -11,3 +11,7 @@ variable "alb_log_prefix" {
 }
 
 variable "platform_team_account_id" {}
+
+# Endpoints
+
+variable "service-libsys" {}


### PR DESCRIPTION
In order to provide a private route access to libsys (AKA Sierra) we need a route via the VPN connection provided by D&T.

This PR adds an endpoint to connect to that route via the VPC endpoint.

Depends: https://github.com/wellcometrust/platform-private/pull/47

Part of https://github.com/wellcometrust/platform/issues/3570