### PR TITLE
Use an appropriate role for cache terraform

### DIFF
--- a/cache/terraform.tf
+++ b/cache/terraform.tf
@@ -12,6 +12,7 @@ terraform {
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
+    role_arn       = "arn:aws:iam::130871440101:role/developer"
   }
 }
 
@@ -19,6 +20,10 @@ terraform {
 provider "aws" {
   version = "~> 1.56.0"
   region  = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/developer"
+  }
 }
 
 # Making the router state outputs available
@@ -30,6 +35,7 @@ data "terraform_remote_state" "router" {
     bucket = "wellcomecollection-infra"
     key    = "build-state/router.tfstate"
     region = "eu-west-1"
+    role_arn = "arn:aws:iam::130871440101:role/developer"
   }
 }
 


### PR DESCRIPTION
Allows us to deploy lambda@edge to devcache.