### PR TITLE
Add groupImageControlsWithPagination to dash

### DIFF
--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -57,6 +57,13 @@ const abTests = [
     description: '',
     range: [20, 30],
   },
+  {
+    id: 'groupImageControlsWithPagination',
+    title: 'Group image controls with pagination',
+    defaultValue: false,
+    description: '',
+    range: [0, 50],
+  },
 ];
 const IndexPage = () => {
   const [toggleStates, setToggleStates] = useState({});


### PR DESCRIPTION
Displaying `groupImageControlsWithPagination` on the [toggles/AB dash](https://dash.wellcomecollection.org/toggles/).