### PR TITLE
Add team fields to async search

### DIFF
--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -20,6 +20,7 @@ import {
   peopleFields,
   organisationsFields,
   contributorsFields,
+  teamsFields,
 } from './fetch-links';
 import { parseArticleSeries } from './article-series';
 import type { MultiContent } from '../../model/multi-content';
@@ -104,7 +105,8 @@ export async function getMultiContent(
       exhibitionFields,
       peopleFields,
       organisationsFields,
-      contributorsFields
+      contributorsFields,
+      teamsFields
     ),
     pageSize: pageSize || 100,
     orderings: `[${(orderings || []).join(',')}]`,

--- a/prismic-model/json/books.json
+++ b/prismic-model/json/books.json
@@ -311,6 +311,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",

--- a/prismic-model/json/event-series.json
+++ b/prismic-model/json/event-series.json
@@ -314,6 +314,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",

--- a/prismic-model/json/events.json
+++ b/prismic-model/json/events.json
@@ -372,6 +372,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",

--- a/prismic-model/json/exhibitions.json
+++ b/prismic-model/json/exhibitions.json
@@ -321,6 +321,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",

--- a/prismic-model/json/places.json
+++ b/prismic-model/json/places.json
@@ -329,6 +329,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",

--- a/prismic-model/json/series.json
+++ b/prismic-model/json/series.json
@@ -316,6 +316,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",

--- a/prismic-model/json/webcomics.json
+++ b/prismic-model/json/webcomics.json
@@ -310,6 +310,22 @@
               }
             }
           },
+          "contact": {
+            "type": "Slice",
+            "fieldset": "Contact",
+            "non-repeat": {
+              "content": {
+                "type": "Link",
+                "config": {
+                  "label": "Content item",
+                  "select": "document",
+                  "customtypes": [
+                    "teams"
+                  ]
+                }
+              }
+            }
+          },
           "inPageAnchor": {
             "type": "Slice",
             "fieldset": "In page anchor",


### PR DESCRIPTION
`AsyncSearchResults` needs to be able to parse everything that it receives – `teams` (contact) fields were missing.