### PR TITLE
Horizontal space tidy

### DIFF
--- a/cardigan/stories/components/PageHeader.js
+++ b/cardigan/stories/components/PageHeader.js
@@ -32,9 +32,7 @@ const ContentTypeInfo = (
     >
       <p
         className={classNames({
-          [spacing({ s: 1 }, { margin: ['top'] })]: true,
           [spacing({ s: 1 }, { margin: ['right'] })]: true,
-          [spacing({ s: 0 }, { margin: ['bottom'] })]: true,
           [font('hnl', 5)]: true,
         })}
       >

--- a/cardigan/stories/components/PageHeader.js
+++ b/cardigan/stories/components/PageHeader.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react';
-import { classNames, spacing, font } from '../../../common/utils/classnames';
+import { classNames, font } from '../../../common/utils/classnames';
 import PageHeader from '../../../common/views/components/PageHeader/PageHeader';
 import PageHeaderStandfirst from '../../../common/views/components/PageHeaderStandfirst/PageHeaderStandfirst';
 import Picture from '../../../common/views/components/Picture/Picture';
@@ -32,7 +32,7 @@ const ContentTypeInfo = (
     >
       <p
         className={classNames({
-          [spacing({ s: 1 }, { margin: ['right'] })]: true,
+          'margin-right-6': true,
           [font('hnl', 5)]: true,
         })}
       >

--- a/catalogue/webapp/components/Download/Download.js
+++ b/catalogue/webapp/components/Download/Download.js
@@ -4,7 +4,7 @@ import { type IIIFRendering } from '@weco/common/model/iiif';
 import { trackEvent } from '@weco/common/utils/ga';
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { font, spacing, classNames } from '@weco/common/utils/classnames';
+import { font, classNames } from '@weco/common/utils/classnames';
 import License from '@weco/common/views/components/License/License';
 import Icon from '@weco/common/views/components/Icon/Icon';
 
@@ -129,7 +129,7 @@ const Download = ({
               <span className="flex-inline flex--v-center">
                 <span
                   className={classNames({
-                    [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                    'margin-right-6': true,
                   })}
                 >
                   Download
@@ -194,7 +194,7 @@ const Download = ({
                             className={classNames({
                               [font('hnm', 5)]: true,
                               'font-pewter': true,
-                              [spacing({ s: 2 }, { margin: ['left'] })]: true,
+                              'margin-left-12': true,
                             })}
                           >
                             {format}
@@ -213,7 +213,7 @@ const Download = ({
             <span
               className={classNames({
                 'inline-block': true,
-                [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                'margin-right-12': true,
               })}
             >
               {licenseInfo && (
@@ -225,7 +225,7 @@ const Download = ({
             <span
               className={classNames({
                 'inline-block': true,
-                [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                'margin-right-12': true,
               })}
             >
               Credit: {credit}{' '}

--- a/catalogue/webapp/components/Download/ViewerDownload.js
+++ b/catalogue/webapp/components/Download/ViewerDownload.js
@@ -5,7 +5,7 @@ import { type IIIFRendering } from '@weco/common/model/iiif';
 import { trackEvent } from '@weco/common/utils/ga';
 import { useState, useRef, useEffect } from 'react';
 import styled from 'styled-components';
-import { font, spacing, classNames } from '@weco/common/utils/classnames';
+import { font, classNames } from '@weco/common/utils/classnames';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
 import Icon from '@weco/common/views/components/Icon/Icon';
@@ -98,7 +98,7 @@ const Download = ({
           relative: true,
           'btn--secondary-black': true,
           'btn--small': true,
-          [spacing({ s: 1 }, { margin: ['left'] })]: true,
+          'margin-left-6': true,
         })}
         icon="download"
         text="Download"
@@ -145,7 +145,7 @@ const Download = ({
                             className={classNames({
                               'font-pewter': true,
                               [font('hnm', 5)]: true,
-                              [spacing({ s: 2 }, { margin: ['left'] })]: true,
+                              'margin-left-12': true,
                             })}
                           >
                             {format}

--- a/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
+++ b/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
@@ -5,23 +5,19 @@ import { createPrismicParagraph } from '@weco/common/utils/prismic';
 import Tags from '@weco/common/views/components/Tags/Tags';
 import { CaptionedImage } from '@weco/common/views/components/Images/Images';
 import { worksUrl } from '@weco/common/services/catalogue/urls';
+import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
 
 const StaticWorksContent = () => (
   <Fragment>
-    <div className={`row ${spacing({ s: 3, m: 5 }, { padding: ['top'] })}`}>
+    <VerticalSpace size="l" properties={['padding-top']} className={`row`}>
       <div className="container">
         <div className="grid">
           <div className="grid__cell">
             <h3 className="h2">Feeling curious?</h3>
-            <p
-              className={`${spacing({ s: 2 }, { margin: ['bottom'] })} ${font(
-                'hnl',
-                4
-              )}`}
-            >
+            <VerticalSpace as="p" size="m" className={font('hnl', 4)}>
               Discover our collections through these topics.
-            </p>
-            <div className={spacing({ s: 4 }, { margin: ['bottom'] })}>
+            </VerticalSpace>
+            <VerticalSpace size="l">
               <Tags
                 tags={[
                   {
@@ -64,7 +60,7 @@ const StaticWorksContent = () => (
                   },
                 ]}
               />
-            </div>
+            </VerticalSpace>
             <hr
               className={`divider divider--dashed ${spacing(
                 { s: 6 },
@@ -74,7 +70,7 @@ const StaticWorksContent = () => (
           </div>
         </div>
       </div>
-    </div>
+    </VerticalSpace>
     <div
       className={`row bg-cream row--has-wobbly-background ${spacing(
         { s: 10 },
@@ -85,14 +81,9 @@ const StaticWorksContent = () => (
         <div className="row__wobbly-background" />
         <div className="grid grid--dividers">
           <div className={grid({ s: 12, m: 10, l: 7, xl: 7 })}>
-            <h2
-              className={`h2 ${spacing(
-                { s: 6 },
-                { margin: ['bottom'] }
-              )} ${spacing({ s: 0 }, { margin: ['top'] })}`}
-            >
+            <VerticalSpace as="h2" size="l" className={`h2`}>
               About the historical images
-            </h2>
+            </VerticalSpace>
             <div className="body-text">
               <div className={`standfirst ${font('hnl', 3)}`}>
                 <p>
@@ -152,11 +143,9 @@ const StaticWorksContent = () => (
               </p>
             </div>
           </div>
-          <div
-            className={`${grid({ s: 12, m: 8, l: 5, xl: 5 })} ${spacing(
-              { s: 1 },
-              { margin: ['bottom'] }
-            )}`}
+          <VerticalSpace
+            size="s"
+            className={grid({ s: 12, m: 8, l: 5, xl: 5 })}
           >
             <CaptionedImage
               caption={createPrismicParagraph(
@@ -182,7 +171,7 @@ const StaticWorksContent = () => (
                 crops: {},
               }}
             />
-          </div>
+          </VerticalSpace>
         </div>
       </div>
     </div>

--- a/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
+++ b/catalogue/webapp/components/StaticWorksContent/StaticWorksContent.js
@@ -1,6 +1,6 @@
 // @flow
 import { Fragment } from 'react';
-import { spacing, font, grid } from '@weco/common/utils/classnames';
+import { font, grid } from '@weco/common/utils/classnames';
 import { createPrismicParagraph } from '@weco/common/utils/prismic';
 import Tags from '@weco/common/views/components/Tags/Tags';
 import { CaptionedImage } from '@weco/common/views/components/Images/Images';
@@ -61,21 +61,19 @@ const StaticWorksContent = () => (
                 ]}
               />
             </VerticalSpace>
-            <hr
-              className={`divider divider--dashed ${spacing(
-                { s: 6 },
-                { margin: ['bottom'] }
-              )}`}
+            <VerticalSpace
+              size="l"
+              as="hr"
+              className={`divider divider--dashed`}
             />
           </div>
         </div>
       </div>
     </VerticalSpace>
-    <div
-      className={`row bg-cream row--has-wobbly-background ${spacing(
-        { s: 10 },
-        { padding: ['bottom'] }
-      )}`}
+    <VerticalSpace
+      size="xl"
+      properties={['padding-bottom']}
+      className={`row bg-cream row--has-wobbly-background`}
     >
       <div className="container">
         <div className="row__wobbly-background" />
@@ -174,7 +172,7 @@ const StaticWorksContent = () => (
           </VerticalSpace>
         </div>
       </div>
-    </div>
+    </VerticalSpace>
   </Fragment>
 );
 

--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -17,6 +17,7 @@ import { workUrl } from '@weco/common/services/catalogue/urls';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { imageSizes } from '@weco/common/utils/image-sizes';
+import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
 
 type Props = {|
   work: Work,
@@ -73,11 +74,13 @@ const WorkCard = ({ work }: Props) => {
           id: work.id,
         })}
       >
-        <a
+        <VerticalSpace
+          as="a"
+          properties={['padding-top', 'padding-bottom']}
+          size="m"
           className={classNames({
             'plain-link': true,
             block: true,
-            [spacing({ s: 3 }, { padding: ['bottom', 'top'] })]: true,
             'card-link': true,
           })}
           onClick={() => {
@@ -90,12 +93,12 @@ const WorkCard = ({ work }: Props) => {
         >
           <Container>
             <Details>
-              <div
+              <VerticalSpace
+                size="s"
                 className={classNames({
                   flex: true,
                   'flex--v-center': true,
                   [font('hnl', 5)]: true,
-                  [spacing({ s: 1 }, { margin: ['bottom'] })]: true,
                 })}
               >
                 {workTypeIcon && (
@@ -107,7 +110,7 @@ const WorkCard = ({ work }: Props) => {
                   />
                 )}
                 {work.workType.label}
-              </div>
+              </VerticalSpace>
               <h2
                 className={classNames({
                   [font('hnm', 4)]: true,
@@ -180,11 +183,7 @@ const WorkCard = ({ work }: Props) => {
             {({ showWorkLocations }) =>
               showWorkLocations &&
               (digitalLocations.length > 0 || physicalLocations.length > 0) && (
-                <div
-                  className={classNames({
-                    [spacing({ s: 2 }, { margin: ['top'] })]: true,
-                  })}
-                >
+                <VerticalSpace size="m" properties={['margin-top']}>
                   <LinkLabels
                     heading={'See it'}
                     icon={'eye'}
@@ -203,11 +202,11 @@ const WorkCard = ({ work }: Props) => {
                         : null,
                     ].filter(Boolean)}
                   />
-                </div>
+                </VerticalSpace>
               )
             }
           </TogglesContext.Consumer>
-        </a>
+        </VerticalSpace>
       </NextLink>
     </div>
   );

--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -2,7 +2,7 @@
 import NextLink from 'next/link';
 import styled from 'styled-components';
 import { type Work } from '@weco/common/model/work';
-import { classNames, spacing, font } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
@@ -35,7 +35,7 @@ const Details = styled.div`
 `;
 const Preview = styled.div.attrs(() => ({
   className: classNames({
-    [spacing({ s: 2 }, { margin: ['left'] })]: true,
+    'margin-left-12': true,
     'text-align-center': true,
   }),
 }))`
@@ -105,7 +105,7 @@ const WorkCard = ({ work }: Props) => {
                   <Icon
                     name={workTypeIcon}
                     extraClasses={classNames({
-                      [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                      'margin-right-6': true,
                     })}
                   />
                 )}
@@ -127,7 +127,7 @@ const WorkCard = ({ work }: Props) => {
                 {work.contributors.length > 0 && (
                   <div
                     className={classNames({
-                      [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                      'margin-right-12': true,
                     })}
                   >
                     <LinkLabels

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -1,7 +1,7 @@
 // @flow
 import { type Node, Fragment } from 'react';
 import { type IIIFManifest } from '@weco/common/model/iiif';
-import { font, spacing, grid, classNames } from '@weco/common/utils/classnames';
+import { font, grid, classNames } from '@weco/common/utils/classnames';
 import { worksUrl, downloadUrl } from '@weco/common/services/catalogue/urls';
 import {
   getDownloadOptionsFromManifest,
@@ -24,6 +24,7 @@ import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import Download from '../Download/Download';
+import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
 
 type WorkDetailsSectionProps = {|
   headingText?: string,
@@ -364,10 +365,11 @@ const WorkDetails = ({
   );
 
   return (
-    <div
+    <VerticalSpace
+      size="xl"
+      properties={['padding-top', 'padding-bottom']}
       className={classNames({
         row: true,
-        [spacing({ s: 6, m: 8 }, { padding: ['top', 'bottom'] })]: true,
       })}
     >
       <Layout12>
@@ -385,7 +387,7 @@ const WorkDetails = ({
           );
         })}
       </Layout12>
-    </div>
+    </VerticalSpace>
   );
 };
 

--- a/catalogue/webapp/pages/download.js
+++ b/catalogue/webapp/pages/download.js
@@ -4,7 +4,7 @@ import {
   type Work,
   type CatalogueApiError,
 } from '@weco/common/model/catalogue';
-import { classNames, font, spacing } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import {
   getDownloadOptionsFromManifest,
   getDownloadOptionsFromImageUrl,
@@ -25,6 +25,7 @@ import Download from '@weco/catalogue/components/Download/Download';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
+import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
 
 type Props = {|
   workId: string,
@@ -78,15 +79,17 @@ const DownloadPage = ({ workId, sierraId, manifest, work }: Props) => {
       <Layout8>
         <SpacingSection>
           <SpacingComponent>
-            <h1
+            <VerticalSpace
+              size="l"
+              as="h1"
+              properties={['margin-top']}
               id="work-info"
               className={classNames({
-                [spacing({ s: 4 }, { margin: ['top'] })]: true,
                 [font('hnm', 1)]: true,
               })}
             >
               {title}
-            </h1>
+            </VerticalSpace>
           </SpacingComponent>
           <SpacingComponent>
             <Download

--- a/common/styles/components/_footer.scss
+++ b/common/styles/components/_footer.scss
@@ -1,7 +1,9 @@
 $footer-strap-width: 220px;
 
 .footer {
+  padding-top: 46px;
   color: color('white');
+
   .icon__shape {
     fill: currentColor;
   }

--- a/common/styles/components/_footer.scss
+++ b/common/styles/components/_footer.scss
@@ -39,6 +39,8 @@ $footer-strap-width: 220px;
     width: auto;
     border-bottom: 0;
     border-right: 1px solid color('charcoal');
+    margin-right: 24px;
+    padding-right: 24px;
   }
 
   .icon__shape {

--- a/common/styles/utilities/_mixins.scss
+++ b/common/styles/utilities/_mixins.scss
@@ -168,22 +168,6 @@
   }
 }
 
-@mixin spacing-classes($spacing-size-key) {
-  @each $spacing-direction in $spacing-directions {
-    @for $i from -4 through 10 {
-      .margin-#{$spacing-direction}-#{$spacing-size-key}#{$i}.margin-#{$spacing-direction}-#{$spacing-size-key}#{$i} {
-        margin-#{$spacing-direction}: #{$i * $spacing-unit};
-      }
-
-      @if ($i >= 0) {
-        .padding-#{$spacing-direction}-#{$spacing-size-key}#{$i}.padding-#{$spacing-direction}-#{$spacing-size-key}#{$i} {
-          padding-#{$spacing-direction}: #{$i * $spacing-unit};
-        }
-      }
-    }
-  }
-}
-
 $slider-one-column-width: (100 / 12) * 1%;
 
 @mixin position-article-slides-container {

--- a/common/styles/utilities/_root-scope-classes.scss
+++ b/common/styles/utilities/_root-scope-classes.scss
@@ -1,19 +1,3 @@
-@each $spacing-size in $grid-config {
-  $spacing-size-key: nth($spacing-size, 1);
-  $spacing-size-map: nth($spacing-size, 2);
-  $spacing-size-respond: map-get($spacing-size-map, 'respond');
-
-  @if (length($spacing-size-respond) > 1) {
-    @include respond-to(nth($spacing-size-respond, 1)) {
-      @include spacing-classes($spacing-size-key);
-    }
-  } @else {
-    @include respond-to($spacing-size-respond) {
-      @include spacing-classes($spacing-size-key);
-    }
-  }
-}
-
 @for $i from 1 through 5 {
   .border-width-#{$i} {
     border-width: #{$i}px;
@@ -578,4 +562,36 @@
 // that would be in it, but you have no content.
 .empty-filler:before {
   content: "\200b";
+}
+
+.margin-left-6 {
+  margin-left: 6px;
+}
+
+.margin-right-6 {
+  margin-right: 6px;
+}
+
+.margin-left-12 {
+  margin-left: 12px;
+}
+
+.margin-right-12 {
+  margin-right: 12px;
+}
+
+.padding-left-6 {
+  padding-left: 6px;
+}
+
+.padding-right-6 {
+  padding-right: 6px;
+}
+
+.padding-left-12 {
+  padding-left: 12px;
+}
+
+.padding-right-12 {
+  padding-right: 12px;
 }

--- a/common/styles/utilities/_variables.scss
+++ b/common/styles/utilities/_variables.scss
@@ -21,7 +21,7 @@ $v-spacing-unit: 6px;
 $spacing-unit: 6px;
 $article-top-space: 2 * $vertical-space-unit;
 $border-radius-unit: 6px;
-$spacing-directions: ('top', 'right', 'bottom', 'left');
+$spacing-directions: ('right', 'left');
 
 $container-padding-s: map-get($container-padding, 'small');
 $container-padding-m: map-get($container-padding, 'medium');

--- a/common/styles/utilities/_variables.scss
+++ b/common/styles/utilities/_variables.scss
@@ -21,7 +21,7 @@ $v-spacing-unit: 6px;
 $spacing-unit: 6px;
 $article-top-space: 2 * $vertical-space-unit;
 $border-radius-unit: 6px;
-$spacing-directions: ('right', 'left');
+$spacing-directions: ('top', 'bottom', 'right', 'left');
 
 $container-padding-s: map-get($container-padding, 'small');
 $container-padding-m: map-get($container-padding, 'medium');

--- a/common/utils/classnames.js
+++ b/common/utils/classnames.js
@@ -1,8 +1,5 @@
 // @flow
 export type SizeMap = { [string]: number };
-type SpacingCssProps = 'margin' | 'padding';
-type SpacingCssPropValues = 'top' | 'bottom' | 'left' | 'right';
-type SpacingProps = { [SpacingCssProps]: SpacingCssPropValues[] };
 
 export function withModifiers(
   className: string,
@@ -11,26 +8,6 @@ export function withModifiers(
   return Object.keys(modifiers).reduce((acc, curr) => {
     return modifiers[curr] ? ` ${acc} ${className}--${curr}` : ` ${acc}`;
   }, className);
-}
-
-export function spacing(sizes: SizeMap, properties: SpacingProps): string {
-  return Object.keys(sizes)
-    .map(key => {
-      const size = sizes[key];
-
-      return Object.keys(properties)
-        .map(property => {
-          const directions = properties[property];
-
-          return directions
-            .map(direction => {
-              return `${property}-${direction}-${key}${size}`;
-            })
-            .join(' ');
-        })
-        .join(' ');
-    })
-    .join(' ');
 }
 
 export function grid(sizes: SizeMap): string {

--- a/common/views/components/BookPromo/BookPromo.js
+++ b/common/views/components/BookPromo/BookPromo.js
@@ -1,5 +1,5 @@
 // @flow
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import UiImage from '../Image/Image';
 import Icon from '../Icon/Icon';
@@ -24,7 +24,7 @@ const BookPromo = ({ url, image, title, subtitle, description }: Props) => {
       href={url}
       className={classNames({
         'book-promo rounded-diagonal': true,
-        [spacing({ s: 4 }, { padding: ['right', 'left'] })]: true,
+        'padding-left-12 padding-right-12': true,
       })}
       onClick={() => {
         trackEvent({
@@ -38,7 +38,6 @@ const BookPromo = ({ url, image, title, subtitle, description }: Props) => {
         size="m"
         className={classNames({
           'book-promo__image-container': true,
-          [spacing({ s: 4 }, { margin: ['right'] })]: true,
         })}
       >
         {image && image.contentUrl && (
@@ -97,9 +96,7 @@ const BookPromo = ({ url, image, title, subtitle, description }: Props) => {
           })}
         >
           <Icon name="arrow" extraClasses="icon--green" />
-          <span className={spacing({ s: 1 }, { margin: ['left'] })}>
-            More information
-          </span>
+          <span className={'margin-left-6'}>More information</span>
         </VerticalSpace>
       </div>
     </VerticalSpace>

--- a/common/views/components/Breadcrumb/Breadcrumb.js
+++ b/common/views/components/Breadcrumb/Breadcrumb.js
@@ -1,5 +1,5 @@
 // @flow
-import { font, classNames, spacing } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import { breadcrumbsLd } from '../../../utils/json-ld';
 
 export type Breadcrumbs = {|
@@ -30,8 +30,8 @@ const Breadcrumb = ({ items }: Props) => (
             className={classNames({
               [font('hnl', 5)]: true,
               'border-left-width-1 border-color-black': i !== 0,
-              [spacing({ s: 2 }, { padding: ['right'] })]: true,
-              [spacing({ s: 2 }, { padding: ['left'] })]: i !== 0,
+              'padding-right-12': true,
+              'padding-left-12': i !== 0,
             })}
             style={{ lineHeight: 1 }}
           >

--- a/common/views/components/Caption/Caption.js
+++ b/common/views/components/Caption/Caption.js
@@ -16,6 +16,7 @@ const Caption = ({ caption, preCaptionNode, width }: Props) => {
     <VerticalSpace
       as="figcaption"
       size="m"
+      properties={['margin-top']}
       style={width ? { width: `${width}px` } : undefined}
       className={classNames({
         [font('lr', 6)]: true,

--- a/common/views/components/Caption/Caption.js
+++ b/common/views/components/Caption/Caption.js
@@ -1,6 +1,6 @@
 // @flow
 import type { HTMLString } from '../../../services/prismic/types';
-import { font, spacing, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import type { Node } from 'react';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import VerticalSpace from '../styled/VerticalSpace';
@@ -26,17 +26,13 @@ const Caption = ({ caption, preCaptionNode, width }: Props) => {
       <div
         className={classNames({
           'overflow-hidden': true,
-          [spacing({ s: 3, m: 4, l: 5 }, { padding: ['right'] })]: true,
         })}
         style={{ maxWidth: '55em' }}
         tabIndex="0"
       >
         {preCaptionNode}
         <div
-          className={`border-left-width-1 ${spacing(
-            { s: 2 },
-            { padding: ['left'] }
-          )}`}
+          className={`border-left-width-1 padding-left-12`}
           style={{ borderColor: 'currentColor' }}
         >
           <PrismicHtmlBlock html={caption} />

--- a/common/views/components/CompactCard/CompactCard.js
+++ b/common/views/components/CompactCard/CompactCard.js
@@ -3,7 +3,6 @@ import { type Element, type ElementProps, type Node } from 'react';
 import {
   grid,
   font,
-  spacing,
   conditionalClassNames,
   classNames,
 } from '../../../utils/classnames';
@@ -89,7 +88,6 @@ const CompactCard = ({
           className={classNames({
             'card-link__title': true,
             [font('wb', 3)]: true,
-            [spacing({ s: 0 }, { margin: ['top'] })]: true,
           })}
         >
           {title}

--- a/common/views/components/Contact/Contact.js
+++ b/common/views/components/Contact/Contact.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 
 type Props = {|
   title: string,
@@ -13,7 +13,7 @@ function Contact({ title, subtitle, phone, email }: Props) {
   return (
     <div
       className={classNames({
-        [spacing({ s: 2 }, { padding: ['left'] })]: true,
+        'padding-left-12': true,
         'border-color-turquoise border-left-width-5 body-text': true,
       })}
     >
@@ -33,7 +33,7 @@ function Contact({ title, subtitle, phone, email }: Props) {
           <span
             className={classNames({
               [font('hnl', 4)]: true,
-              [spacing({ s: 1 }, { margin: ['left'] })]: true,
+              'margin-left-6': true,
             })}
           >
             {subtitle}

--- a/common/views/components/Contributor/Contributor.js
+++ b/common/views/components/Contributor/Contributor.js
@@ -1,5 +1,5 @@
 // @flow
-import { font, grid, spacing, classNames } from '../../../utils/classnames';
+import { font, grid, classNames } from '../../../utils/classnames';
 import Image from '../Image/Image';
 import Avatar from '../Avatar/Avatar';
 import LinkLabels from '../LinkLabels/LinkLabels';
@@ -29,10 +29,7 @@ const Contributor = ({ contributor, role, description }: ContributorType) => {
   return (
     <div className="grid">
       <div className={`flex ${grid({ s: 12, m: 12, l: 12, xl: 12 })}`}>
-        <div
-          style={{ minWidth: '78px' }}
-          className={spacing({ s: 2 }, { margin: ['right'] })}
-        >
+        <div style={{ minWidth: '78px' }} className={'margin-right-12'}>
           {contributor.type === 'people' && <Avatar imageProps={imageProps} />}
           {contributor.type !== 'people' && (
             <div style={{ width: '72px' }}>

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -1,5 +1,5 @@
 // @flow
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import { UiImage } from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
@@ -63,7 +63,7 @@ const EventPromo = ({
         properties={['padding-top', 'padding-bottom']}
         className={classNames({
           'flex flex--column flex-1 flex--h-space-between': true,
-          [spacing({ s: 2 }, { padding: ['left', 'right'] })]: true,
+          'padding-left-12 padding-right-12': true,
         })}
       >
         <div>
@@ -102,12 +102,7 @@ const EventPromo = ({
 
           {!isPast && fullyBooked && (
             <div className={`${font('hnl', 5)} flex flex--v-center`}>
-              <span
-                className={`${spacing(
-                  { s: 1 },
-                  { margin: ['right'] }
-                )} flex flex--v-center`}
-              >
+              <span className={`margin-right-6 flex flex--v-center`}>
                 <Icon
                   name="statusIndicator"
                   extraClasses={'icon--red icon--match-text'}
@@ -130,12 +125,7 @@ const EventPromo = ({
 
           {isPast && (
             <div className={`${font('hnl', 5)} flex flex--v-center`}>
-              <span
-                className={`${spacing(
-                  { s: 1 },
-                  { margin: ['right'] }
-                )} flex flex--v-center`}
-              >
+              <span className={`margin-right-6 flex flex--v-center`}>
                 <Icon
                   name="statusIndicator"
                   extraClasses={'icon--marble icon--match-text'}

--- a/common/views/components/EventScheduleItem/EventScheduleItem.js
+++ b/common/views/components/EventScheduleItem/EventScheduleItem.js
@@ -1,6 +1,6 @@
 // @flow
 import { Fragment } from 'react';
-import { grid, font, spacing, classNames } from '../../../utils/classnames';
+import { grid, font, classNames } from '../../../utils/classnames';
 import EventBookingButton from '../EventBookingButton/EventBookingButton';
 import EventbriteButton from '../EventbriteButton/EventbriteButton';
 import LabelsList from '../LabelsList/LabelsList';
@@ -27,7 +27,6 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
       size="l"
       properties={['margin-bottom', 'padding-bottom']}
       className={classNames({
-        [spacing({ l: 0 }, { padding: ['left'] })]: true,
         'border-color-smoke border-bottom-width-1': true,
       })}
     >
@@ -116,7 +115,7 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
                   ]}
                   className={classNames({
                     'bg-yellow inline-block': true,
-                    [spacing({ s: 4 }, { padding: ['left', 'right'] })]: true,
+                    'padding-left-12 padding-right-12': true,
                     [font('hnm', 5)]: true,
                   })}
                 >

--- a/common/views/components/EventScheduleItem/EventScheduleItem.js
+++ b/common/views/components/EventScheduleItem/EventScheduleItem.js
@@ -81,11 +81,9 @@ const EventScheduleItem = ({ event, isNotLinked }: Props) => {
               </VerticalSpace>
             )}
 
-            <p
-              className={`${spacing({ s: 2 }, { margin: ['bottom'] })} ${font(
-                'hnl',
-                5
-              )}`}
+            <VerticalSpace
+              size="m"
+              className={font('hnl', 5)}
               dangerouslySetInnerHTML={{ __html: event.promoText }}
             />
 

--- a/common/views/components/Excerpt/Excerpt.js
+++ b/common/views/components/Excerpt/Excerpt.js
@@ -1,7 +1,7 @@
 // @flow
 import { Fragment } from 'react';
 import type { Book } from '../../../model/books';
-import { font, spacing } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import VerticalSpace from '../styled/VerticalSpace';
 
 type Props = {|
@@ -19,10 +19,10 @@ const Excerpt = ({ title, content, source, audio }: Props) => (
         properties={['margin-bottom', 'padding-top', 'padding-bottom']}
       >
         <pre
-          className={`${spacing(
-            { s: 3 },
-            { padding: ['left', 'right'] }
-          )} ${font('lr', 5)} pre  border-color-smoke border-left-width-5`}
+          className={`padding-left-12 padding-right-12 ${font(
+            'lr',
+            5
+          )} pre  border-color-smoke border-left-width-5`}
         >
           {content}
         </pre>

--- a/common/views/components/ExhibitionPromo/ExhibitionPromo.js
+++ b/common/views/components/ExhibitionPromo/ExhibitionPromo.js
@@ -1,6 +1,6 @@
 // @flow
 import { Fragment } from 'react';
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import { formatDate } from '../../../utils/format-date';
 import { UiImage } from '../Images/Images';
@@ -79,8 +79,7 @@ const ExhibitionPromo = ({
         properties={['padding-top', 'padding-bottom']}
         className={`
           flex flex--column flex-1 flex--h-space-between
-          ${spacing({ s: 2 }, { padding: ['left', 'right'] })}
-
+          padding-left-12 padding-right-12
         `}
       >
         <div>

--- a/common/views/components/FindUs/FindUs.js
+++ b/common/views/components/FindUs/FindUs.js
@@ -1,7 +1,7 @@
 // @flow
 
 import styled from 'styled-components';
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import {
   wellcomeCollectionGallery,
@@ -49,13 +49,7 @@ const FindUs = () => (
         className="plain-link block"
       >
         <span className="flex">
-          <Icon
-            name="location"
-            extraClasses={`float-l ${spacing(
-              { s: 2, m: 2, l: 2, xl: 2 },
-              { margin: ['right'] }
-            )}`}
-          />
+          <Icon name="location" extraClasses={`float-l margin-right-12`} />
           <VerticalSpace size="m" as="p">
             <span className="block">
               {wellcomeCollectionAddress.streetAddress}

--- a/common/views/components/Footer/Footer.js
+++ b/common/views/components/Footer/Footer.js
@@ -46,7 +46,6 @@ const Footer = ({
       ref={footer}
       className={classNames({
         'footer row bg-black relative': true,
-        [spacing({ s: 9 }, { padding: ['top'] })]: true,
       })}
     >
       <div className="container">

--- a/common/views/components/Footer/Footer.js
+++ b/common/views/components/Footer/Footer.js
@@ -1,6 +1,6 @@
 // @flow
 import { useRef, useEffect } from 'react';
-import { spacing, font, grid, classNames } from '../../../utils/classnames';
+import { font, grid, classNames } from '../../../utils/classnames';
 import { getTodaysVenueHours } from '@weco/common/services/prismic/opening-times';
 import FooterWellcomeLogo from '../FooterWellcomeLogo/FooterWellcomeLogo';
 import FooterNav from '../FooterNav/FooterNav';
@@ -104,13 +104,7 @@ const Footer = ({
             </VerticalSpace>
             <TopBorderBox>
               <VerticalSpace size="l" properties={['padding-top']}>
-                <Icon
-                  name="clock"
-                  extraClasses={`float-l ${spacing(
-                    { s: 2, m: 2, l: 2, xl: 2 },
-                    { margin: ['right'] }
-                  )}`}
-                />
+                <Icon name="clock" extraClasses={`float-l margin-right-12`} />
                 <div
                   className={classNames({
                     [font('hnl', 5)]: true,
@@ -169,14 +163,13 @@ const Footer = ({
               properties={['margin-top', 'padding-bottom', 'margin-bottom']}
               className={classNames({
                 [font('hnm', 6)]: true,
-                [spacing({ m: 4, l: 6 }, { margin: ['right'] })]: true,
                 footer__strap: true,
               })}
             >
               <Icon
                 name="wellcome"
                 extraClasses={classNames({
-                  [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                  'margin-right-6': true,
                 })}
               />
               <span className="footer__strap-text">
@@ -188,7 +181,6 @@ const Footer = ({
               properties={['margin-top', 'padding-bottom', 'margin-bottom']}
               className={classNames({
                 [font('hnm', 6)]: true,
-                [spacing({ xl: 2 }, { padding: ['right'] })]: true,
                 footer__licensing: true,
               })}
             >

--- a/common/views/components/FreeSticker/FreeSticker.js
+++ b/common/views/components/FreeSticker/FreeSticker.js
@@ -1,4 +1,4 @@
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import VerticalSpace from '../styled/VerticalSpace';
 
 const FreeSticker = () => (
@@ -9,7 +9,7 @@ const FreeSticker = () => (
     className={classNames({
       'font-white bg-black rotate-r-8 absolute': true,
       [font('wb', 5)]: true,
-      [spacing({ s: 2 }, { padding: ['left', 'right'] })]: true,
+      'padding-left-12 padding-right-12': true,
     })}
     style={{ marginTop: '-20px', right: '0' }}
   >

--- a/common/views/components/HTMLInput/HTMLInput.js
+++ b/common/views/components/HTMLInput/HTMLInput.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { font, spacing } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 
 type Props = {|
   inputRef?: ?Function,
@@ -65,10 +65,9 @@ const HTMLInput = ({
     )}
 
     <span
-      className={`input__label-wrap line-height-1 ${spacing(
-        { s: 2 },
-        { margin: ['left'] }
-      )} ${isLabelHidden ? 'input__label-wrap--hidden' : ''}`}
+      className={`input__label-wrap line-height-1 margin-left-12 ${
+        isLabelHidden ? 'input__label-wrap--hidden' : ''
+      }`}
       dangerouslySetInnerHTML={{ __html: label }}
     />
   </label>

--- a/common/views/components/HighlightedHeading/HighlightedHeading.js
+++ b/common/views/components/HighlightedHeading/HighlightedHeading.js
@@ -1,4 +1,3 @@
-import { spacing } from '../../../utils/classnames';
 import VerticalSpace from '../styled/VerticalSpace';
 
 type Props = {|
@@ -11,10 +10,7 @@ const HighlightedHeading = ({ text }: Props) => {
       <VerticalSpace
         size="s"
         properties={['padding-top', 'padding-bottom']}
-        className={`highlighted-heading bg-white ${spacing(
-          { s: 2 },
-          { padding: ['left', 'right'] }
-        )}`}
+        className={`highlighted-heading bg-white padding-left-12 padding-right-12`}
       >
         {text}
       </VerticalSpace>

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -8,7 +8,7 @@ import {
 import NextLink from 'next/link';
 import styled from 'styled-components';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
-import { classNames, spacing, grid } from '@weco/common/utils/classnames';
+import { grid } from '@weco/common/utils/classnames';
 import { useEffect, useState, useContext } from 'react';
 import { trackEvent } from '@weco/common/utils/ga';
 import ManifestContext from '@weco/common/views/components/ManifestContext/ManifestContext';
@@ -16,6 +16,7 @@ import Button from '@weco/common/views/components/Buttons/Button/Button';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import WobblyRow from '@weco/common/views/components/WobblyRow/WobblyRow';
+import VerticalSpace from '../styled/VerticalSpace';
 
 const PresentationPreview = styled.div`
   text-align: center;
@@ -251,10 +252,9 @@ const IIIFPresentationDisplay = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div
-              className={classNames({
-                [spacing({ s: 2 }, { margin: ['top', 'bottom'] })]: true,
-              })}
+            <VerticalSpace
+              size="m"
+              properties={['margin-top', 'margin-bottom']}
             >
               <Button
                 type="primary"
@@ -267,7 +267,7 @@ const IIIFPresentationDisplay = ({
                 text="View the item"
                 link={itemUrl}
               />
-            </div>{' '}
+            </VerticalSpace>{' '}
           </div>{' '}
         </div>{' '}
       </div>
@@ -325,11 +325,7 @@ const IIIFPresentationDisplay = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div
-              className={classNames({
-                [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
-              })}
-            >
+            <VerticalSpace size="l">
               <video
                 controls
                 style={{
@@ -342,7 +338,7 @@ const IIIFPresentationDisplay = ({
                 <source src={video['@id']} type={video.format} />
                 {`Sorry, your browser doesn't support embedded video.`}
               </video>
-            </div>
+            </VerticalSpace>
           </div>
         </div>
       </div>
@@ -354,11 +350,7 @@ const IIIFPresentationDisplay = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div
-              className={classNames({
-                [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
-              })}
-            >
+            <VerticalSpace size="l">
               <audio
                 controls
                 style={{
@@ -370,7 +362,7 @@ const IIIFPresentationDisplay = ({
               >
                 {`Sorry, your browser doesn't support embedded audio.`}
               </audio>
-            </div>{' '}
+            </VerticalSpace>{' '}
           </div>{' '}
         </div>{' '}
       </div>
@@ -382,13 +374,9 @@ const IIIFPresentationDisplay = ({
       <div className="container">
         <div className="grid">
           <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
-            <div
-              className={classNames({
-                [spacing({ s: 4 }, { margin: ['bottom'] })]: true,
-              })}
-            >
+            <VerticalSpace size="l">
               <BetaMessage message="We are working to make this item available online in July 2019." />
-            </div>
+            </VerticalSpace>
           </div>
         </div>
       </div>

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -12,7 +12,7 @@ import styled from 'styled-components';
 import { useState, useEffect, useRef } from 'react';
 import getLicenseInfo from '@weco/common/utils/get-license-info';
 import { itemUrl, workUrl } from '@weco/common/services/catalogue/urls';
-import { classNames, spacing, font } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import NextLink from 'next/link';
 import {
   convertIiifUriToInfoUri,
@@ -136,7 +136,7 @@ const IIIFViewer = styled.div.attrs(props => ({
 const IIIFViewerMain = styled.div.attrs(props => ({
   className: classNames({
     'relative bg-charcoal font-white': true,
-    [spacing({ s: 1 }, { padding: ['right', 'left'] })]: true,
+    'padding-left-6 padding-right-6': true,
   }),
 }))`
   noscript & {
@@ -155,11 +155,20 @@ const IIIFViewerMain = styled.div.attrs(props => ({
   }
 `;
 
-const IIIFViewerThumb = styled.div.attrs(props => ({
-  className: classNames({
-    [spacing({ s: 2, m: 4, l: 6 }, { margin: ['left', 'right'] })]: true,
-  }),
-}))`
+const IIIFViewerThumb = styled.div`
+  margin-left: 12px;
+  margin-right: 12px;
+
+  ${props => props.theme.media.medium`
+    margin-left: 24px;
+    margin-right: 24px;
+  `}
+
+  ${props => props.theme.media.large`
+    margin-left: 36px;
+    margin-right: 36px;
+  `}
+
   width: 130px;
   noscript & {
     height: 100%;

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -136,9 +136,7 @@ const IIIFViewer = styled.div.attrs(props => ({
 const IIIFViewerMain = styled.div.attrs(props => ({
   className: classNames({
     'relative bg-charcoal font-white': true,
-    [spacing({ s: 4 }, { padding: ['top'] })]: true,
     [spacing({ s: 1 }, { padding: ['right', 'left'] })]: true,
-    [spacing({ s: 10 }, { padding: ['bottom'] })]: true,
   }),
 }))`
   noscript & {
@@ -148,6 +146,8 @@ const IIIFViewerMain = styled.div.attrs(props => ({
     }
   }
   width: 100%;
+  padding-top: 24px;
+  padding-bottom: 60px;
 
   @media (min-width: ${props => props.theme.sizes.medium}px) {
     height: 100%;
@@ -185,13 +185,13 @@ const IIIFViewerThumb = styled.div.attrs(props => ({
 const IIIFViewerThumbLink = styled.a.attrs(props => ({
   className: classNames({
     'block h-center': true,
-    [spacing({ s: 1 }, { margin: ['top'] })]: true,
-    [spacing({ s: 6 }, { margin: ['bottom'] })]: true,
   }),
 }))`
   height: 100%;
   text-align: center;
   display: block;
+  margin-top: 6px;
+  margin-bottom: 36px;
 `;
 
 const IIIFViewerThumbNumber = styled.span.attrs(props => ({
@@ -202,9 +202,9 @@ const IIIFViewerThumbNumber = styled.span.attrs(props => ({
     'font-black': props.isActive,
     'bg-yellow': props.isActive,
     [font('hnl', 5)]: true,
-    [spacing({ s: 2 }, { margin: ['top'] })]: true,
   }),
 }))`
+  margin-top: 12px;
   padding: 3px 2px;
 `;
 
@@ -626,7 +626,6 @@ const IIIFViewerComponent = ({
                     sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`}
                     extraClasses={classNames({
                       'block h-center': true,
-                      [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
                     })}
                     lang={lang}
                     alt={
@@ -644,7 +643,6 @@ const IIIFViewerComponent = ({
                     sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`}
                     extraClasses={classNames({
                       'block h-center': true,
-                      [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
                     })}
                     lang={lang}
                     alt={

--- a/common/views/components/ImageGallery/ImageGallery.js
+++ b/common/views/components/ImageGallery/ImageGallery.js
@@ -1,7 +1,7 @@
 // @flow
 // TODO: use styled components
 import { Fragment, Component, createRef } from 'react';
-import { font, spacing, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import { CaptionedImage } from '../Images/Images';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
 import Button from '../Buttons/Button/Button';
@@ -121,10 +121,7 @@ class ImageGallery extends Component<Props, State> {
                   'flex flex--v-top image-gallery-v2-title': true,
                 })}
               >
-                <Icon
-                  name="gallery"
-                  extraClasses={`${spacing({ s: 1 }, { margin: ['right'] })}`}
-                />
+                <Icon name="gallery" extraClasses={`margin-right-6`} />
                 <h2 id={`gallery-${id}`} className="h2 no-margin">
                   {title || 'In pictures'}
                 </h2>
@@ -188,7 +185,7 @@ class ImageGallery extends Component<Props, State> {
                           'flex flex-end': true,
                           'image-gallery-v2__close': true,
                           'opacity-0': !isActive,
-                          [spacing({ s: 3 }, { padding: ['right'] })]: true,
+                          'padding-right-12': true,
                         })}
                       >
                         <Control

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import Router from 'next/router';
 import styled from 'styled-components';
 import fetch from 'isomorphic-unfetch';
-import { spacing, classNames } from '../../../utils/classnames';
+import { classNames } from '../../../utils/classnames';
 import Raven from 'raven-js';
 import { trackEvent } from '../../../utils/ga';
 import IIIFResponsiveImage from '../IIIFResponsiveImage/IIIFResponsiveImage';
@@ -287,7 +287,7 @@ const ImageViewer = ({
           {isError && (
             <p
               className={classNames({
-                [spacing({ s: 10 }, { padding: ['right', 'left'] })]: true,
+                'padding-left-12 padding-right-12': true,
               })}
             >
               The image viewer is not working

--- a/common/views/components/ImageViewer/ImageViewer.js
+++ b/common/views/components/ImageViewer/ImageViewer.js
@@ -301,10 +301,6 @@ const ImageViewer = ({
               src={src}
               srcSet={srcSet}
               sizes={`(min-width: 860px) 800px, calc(92.59vw + 22px)`}
-              extraClasses={classNames({
-                'block h-center': true,
-                [spacing({ s: 2 }, { margin: ['bottom'] })]: true,
-              })}
               lang={lang}
               clickHandler={handleZoomIn}
               loadHandler={() => setImageLoading(false)}

--- a/common/views/components/InfoBanner/InfoBanner.js
+++ b/common/views/components/InfoBanner/InfoBanner.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import type { HTMLString } from '../../../../common/services/prismic/types';
 import cookie from 'cookie-cutter';
-import { spacing, grid, font } from '../../../utils/classnames';
+import { grid, font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import VerticalSpace from '../styled/VerticalSpace';
@@ -69,12 +69,7 @@ class InfoBanner extends React.Component<Props, State> {
                 >
                   <div>
                     <span className="flex flex--v-center">
-                      <div
-                        className={`flex flex--v-center ${spacing(
-                          { s: 2 },
-                          { margin: ['right'] }
-                        )}`}
-                      >
+                      <div className={`flex flex--v-center margin-right-12`}>
                         <Icon name="information" />
                       </div>
                       <div className="first-para-no-margin">

--- a/common/views/components/InfoBox/InfoBox.js
+++ b/common/views/components/InfoBox/InfoBox.js
@@ -1,6 +1,6 @@
 // @flow
 import { Fragment } from 'react';
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
 import Icon from '../Icon/Icon';
 import type { Element } from 'react';
@@ -25,19 +25,14 @@ const InfoBox = ({ title, items, children }: Props) => {
         properties={['padding-top', 'padding-bottom']}
         className={classNames({
           'bg-yellow': true,
-          [spacing({ s: 4 }, { padding: ['right', 'left'] })]: true,
+          'padding-left-12 padding-right-12': true,
         })}
       >
         {items.map(({ title, description, icon }, i) => (
           <Fragment key={i}>
             <div className={font('hnm', 4)}>
               {icon && (title || description) && (
-                <span
-                  className={`float-l ${spacing(
-                    { s: 1 },
-                    { margin: ['right'] }
-                  )}`}
-                >
+                <span className={`float-l margin-right-6`}>
                   <Icon name={icon} />
                 </span>
               )}

--- a/common/views/components/Label/Label.js
+++ b/common/views/components/Label/Label.js
@@ -1,16 +1,18 @@
 // @flow
-import { font, spacing } from '../../../utils/classnames';
 import type { Label as LabelType } from '../../../model/labels';
+import { font, spacing } from '../../../utils/classnames';
+import VerticalSpace from '../styled/VerticalSpace';
 
 export type Props = {|
   label: LabelType,
 |};
 
 const Label = ({ label }: Props) => {
-  const HtmlTag = label.url ? 'a' : 'span';
-
   return (
-    <HtmlTag
+    <VerticalSpace
+      as={label.url ? 'a' : 'span'}
+      size="s"
+      properties={['padding-top', 'padding-bottom']}
       href={label.url}
       className={`
       line-height-1
@@ -20,12 +22,12 @@ const Label = ({ label }: Props) => {
           : 'font-black bg-yellow'
       }
       ${font('hnm', 6)}
-      ${spacing({ s: 1 }, { padding: ['top', 'bottom', 'left', 'right'] })}
+      ${spacing({ s: 1 }, { padding: ['left', 'right'] })}
     `}
       style={{ display: 'block', whiteSpace: 'nowrap' }}
     >
       {label.text}
-    </HtmlTag>
+    </VerticalSpace>
   );
 };
 

--- a/common/views/components/Label/Label.js
+++ b/common/views/components/Label/Label.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Label as LabelType } from '../../../model/labels';
-import { font, spacing } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import VerticalSpace from '../styled/VerticalSpace';
 
 export type Props = {|
@@ -22,7 +22,7 @@ const Label = ({ label }: Props) => {
           : 'font-black bg-yellow'
       }
       ${font('hnm', 6)}
-      ${spacing({ s: 1 }, { padding: ['left', 'right'] })}
+      padding-left-6 padding-right-6
     `}
       style={{ display: 'block', whiteSpace: 'nowrap' }}
     >

--- a/common/views/components/LabelsList/LabelsList.js
+++ b/common/views/components/LabelsList/LabelsList.js
@@ -1,7 +1,6 @@
 // @flow
 import type { Label as LabelType } from '../../../model/labels';
 import { sized } from '../../../utils/style';
-import { spacing } from '../../../utils/classnames';
 import Label from '../../components/Label/Label';
 import VerticalSpace from '../styled/VerticalSpace';
 
@@ -15,10 +14,7 @@ const LabelsList = ({ labels }: Props) => (
     properties={['margin-bottom']}
     negative
     as="ul"
-    className={`flex-inline plain-list no-margin ${spacing(
-      { s: 0 },
-      { padding: ['left'] }
-    )} ${spacing({ s: 2 }, { padding: ['right'] })}`}
+    className={`flex-inline plain-list no-margin no-padding padding-right-12`}
     style={{ flexWrap: 'wrap' }}
   >
     {labels.filter(Boolean).map((label, i) => (

--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -5,7 +5,7 @@ import Layout12 from '../Layout12/Layout12';
 import Divider from '../Divider/Divider';
 import Pagination from '../Pagination/Pagination';
 import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
-import { classNames, spacing, font, grid } from '../../../utils/classnames';
+import { classNames, font, grid } from '../../../utils/classnames';
 import type { Period } from '../../../model/periods';
 import type { UiExhibition } from '../../../model/exhibitions';
 import type { UiEvent } from '../../../model/events';
@@ -124,11 +124,7 @@ const LayoutPaginatedResults = ({
         </Layout12>
       )}
 
-      <VerticalSpace
-        size="l"
-        properties={['margin-top']}
-        className={spacing({ s: 4 }, { margin: ['top'] })}
-      >
+      <VerticalSpace size="l" properties={['margin-top']}>
         <CardGrid items={paginatedResults.results} itemsPerRow={3} />
       </VerticalSpace>
 

--- a/common/views/components/LinkLabels/LinkLabels.js
+++ b/common/views/components/LinkLabels/LinkLabels.js
@@ -1,7 +1,6 @@
 // @flow
 import {
   font,
-  spacing,
   conditionalClassNames,
   classNames,
 } from '../../../utils/classnames';
@@ -22,8 +21,8 @@ function getClassName(i) {
   return conditionalClassNames({
     [`${font('hnm', 5)}`]: true,
     'border-left-width-1 border-color-marble': i !== 0,
-    [spacing({ s: 1 }, { padding: ['left'] })]: i !== 0,
-    [spacing({ s: 1 }, { margin: ['right'] })]: true,
+    'padding-left-6': i !== 0,
+    'margin-right-6': true,
   });
 }
 const LinkLabels = ({ items, heading, icon }: Props) => (
@@ -39,14 +38,14 @@ const LinkLabels = ({ items, heading, icon }: Props) => (
       <dt
         className={classNames({
           flex: true,
-          [spacing({ s: 1 }, { margin: ['right'] })]: true,
+          'margin-right-6': true,
         })}
       >
         {icon && (
           <Icon
             name={icon}
             extraClasses={classNames({
-              [spacing({ s: 1 }, { margin: ['right'] })]: true,
+              'margin-right-6': true,
             })}
           />
         )}

--- a/common/views/components/Message/Message.js
+++ b/common/views/components/Message/Message.js
@@ -1,5 +1,5 @@
 // @flow
-import { classNames, spacing, font } from '../../../utils/classnames';
+import { classNames, font } from '../../../utils/classnames';
 import VerticalSpace from '../styled/VerticalSpace';
 type Props = {|
   text: string,
@@ -13,7 +13,7 @@ const Message = ({ text }: Props) => (
       'border-left-width-5': true,
       'border-color-yellow': true,
       'inline-block': true,
-      [spacing({ s: 2 }, { padding: ['left', 'right'] })]: true,
+      'padding-left-12 padding-right-12': true,
       [font('hnm', 5)]: true,
     })}
   >

--- a/common/views/components/MessageBar/MessageBar.js
+++ b/common/views/components/MessageBar/MessageBar.js
@@ -1,7 +1,7 @@
 // @flow
 import { type Node } from 'react';
 import styled from 'styled-components';
-import { classNames, font, spacing } from '../../../utils/classnames';
+import { classNames, font } from '../../../utils/classnames';
 import VerticalSpace from '../styled/VerticalSpace';
 
 const PurpleTag = styled.span.attrs(props => ({
@@ -11,7 +11,7 @@ const PurpleTag = styled.span.attrs(props => ({
     'bg-purple': true,
     'font-white': true,
     [font('hnm', 5)]: true,
-    [spacing({ s: 1 }, { margin: ['right'] })]: true,
+    'margin-right-6': true,
   }),
 }))`
   padding: 0.2em 0.5em;

--- a/common/views/components/MetaUnit/MetaUnit.js
+++ b/common/views/components/MetaUnit/MetaUnit.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Node } from 'react';
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import NextLink from 'next/link';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import Tags, { type TagType } from '../Tags/Tags';
@@ -61,8 +61,7 @@ const LinksList = ({ links }) => {
         as="ul"
         size="m"
         className={classNames({
-          'plain-list no-padding': true,
-          [spacing({ s: 0 }, { margin: ['top'] })]: true,
+          'plain-list no-margin no-padding': true,
         })}
       >
         {links.map((link, i, arr) => (
@@ -84,8 +83,7 @@ const List = ({ list }) => {
         as="ul"
         size="m"
         className={classNames({
-          'plain-list no-padding': true,
-          [spacing({ s: 0 }, { margin: ['top'] })]: true,
+          'plain-list no-margin no-padding': true,
         })}
       >
         {list.map((item, i, arr) => (

--- a/common/views/components/NewsletterSignup/NewsletterSignup.js
+++ b/common/views/components/NewsletterSignup/NewsletterSignup.js
@@ -1,5 +1,5 @@
 // @flow
-import { spacing, font } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import HTMLInput from '../HTMLInput/HTMLInput';
 import Button from '../Buttons/Button/Button';
 import { Component, Fragment } from 'react';
@@ -243,12 +243,7 @@ class NewsletterSignup extends Component<Props, State> {
               <VerticalSpace
                 as="p"
                 properties={['padding-top', 'padding-bottom', 'margin-bottom']}
-                className={`${spacing(
-                  { s: 2 },
-                  {
-                    padding: ['right', 'left'],
-                  }
-                )} border-width-1 border-color-red font-red`}
+                className={`padding-left-12 padding-right-12 border-width-1 border-color-red font-red`}
               >
                 Please select at least one option.
               </VerticalSpace>
@@ -258,12 +253,7 @@ class NewsletterSignup extends Component<Props, State> {
               <VerticalSpace
                 as="p"
                 properties={['padding-top', 'padding-bottom', 'margin-bottom']}
-                className={`${spacing(
-                  { s: 2 },
-                  {
-                    padding: ['right', 'left'],
-                  }
-                )} border-width-1 border-color-red font-red`}
+                className={`padding-left-12 padding-right-12 border-width-1 border-color-red font-red`}
               >
                 Please enter a valid email address.
               </VerticalSpace>

--- a/common/views/components/PageHeader/PageHeader.js
+++ b/common/views/components/PageHeader/PageHeader.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { font, spacing, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import Breadcrumb from '../Breadcrumb/Breadcrumb';
 import LabelsList from '../LabelsList/LabelsList';
 import { UiImage } from '../Images/Images';
@@ -28,6 +28,16 @@ const HeroPictureBackground = styled.div`
 
   ${props => props.theme.media.large`
     bottom: -${props => props.theme.spaceAtBreakpoints.large.xl}px;
+  `}
+`;
+
+const HeroPictureContainer = styled.div`
+  max-width: 1450px;
+  margin: 0 auto;
+
+  ${props => props.theme.media.medium`
+    padding-left: 24px;
+    padding-right: 24px;
   `}
 `;
 
@@ -196,15 +206,9 @@ const PageHeader = ({
             className={`bg-${heroImageBgColor} absolute`}
           />
 
-          <div
-            style={{ maxWidth: '1450px' }}
-            className={classNames({
-              'margin-h-auto': true,
-              [spacing({ m: 4 }, { padding: ['left', 'right'] })]: true,
-            })}
-          >
+          <HeroPictureContainer>
             <WobblyBottom color={heroImageBgColor}>{HeroPicture}</WobblyBottom>
-          </div>
+          </HeroPictureContainer>
         </div>
       )}
     </div>

--- a/common/views/components/Pagination/Pagination.js
+++ b/common/views/components/Pagination/Pagination.js
@@ -1,5 +1,5 @@
 // @flow
-import { font, spacing } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import Control from '../Buttons/Control/Control';
 
 export type Props = {|
@@ -37,7 +37,7 @@ const Pagination = ({
           as: prevQueryString,
         }}
         type="light"
-        extraClasses={`icon--180 ${spacing({ s: 2 }, { margin: ['right'] })}`}
+        extraClasses={`icon--180 margin-right-12`}
         icon="arrow"
         text={`Previous (page ${prevPage})`}
       />
@@ -54,7 +54,7 @@ const Pagination = ({
           as: nextQueryString,
         }}
         type="light"
-        extraClasses={`${spacing({ s: 2 }, { margin: ['left'] })}`}
+        extraClasses={`margin-left-12`}
         icon="arrow"
         text={`Next (page ${nextPage})`}
       />

--- a/common/views/components/Paginator/Paginator.js
+++ b/common/views/components/Paginator/Paginator.js
@@ -1,6 +1,6 @@
 // @flow
 import { Fragment } from 'react';
-import { classNames, font, spacing } from '../../../utils/classnames';
+import { classNames, font } from '../../../utils/classnames';
 import Control from '../Buttons/Control/Control';
 
 type Link = {|
@@ -96,7 +96,7 @@ const Paginator = ({
             }}
             type="light"
             extraClasses={classNames({
-              [spacing({ s: 2 }, { margin: ['right'] })]: true,
+              'margin-right-12': true,
               'icon--180': true,
             })}
             icon="arrow"
@@ -117,7 +117,7 @@ const Paginator = ({
             }}
             type="light"
             extraClasses={classNames({
-              [spacing({ s: 2 }, { margin: ['left'] })]: true,
+              'margin-left-12': true,
             })}
             icon="arrow"
             text={`Next (page ${next})`}

--- a/common/views/components/PartNumberIndicator/PartNumberIndicator.js
+++ b/common/views/components/PartNumberIndicator/PartNumberIndicator.js
@@ -1,5 +1,5 @@
 // @flow
-import { classNames, spacing, font } from '../../../utils/classnames';
+import { classNames, font } from '../../../utils/classnames';
 import type { ColorSelection } from '../../../model/color-selections';
 
 type Props = {|
@@ -17,7 +17,7 @@ const PartNumberIndicator = ({ number, color }: Props) => (
     <span
       className={classNames({
         [`bg-${color || 'purple'}`]: true,
-        [spacing({ s: 1 }, { margin: ['left'] })]: true,
+        'margin-left-6': true,
       })}
       style={{
         transform: 'rotateZ(-6deg)',

--- a/common/views/components/RelevanceRater/RelevanceRater.js
+++ b/common/views/components/RelevanceRater/RelevanceRater.js
@@ -1,6 +1,6 @@
 // @flow
 import styled from 'styled-components';
-import { classNames, font, spacing } from '../../../utils/classnames';
+import { classNames, font } from '../../../utils/classnames';
 import {
   trackRelevanceRating,
   RelevanceRatingEventNames,
@@ -19,7 +19,7 @@ const RelevanceRaterStyle = styled.div.attrs(props => ({
 const RelevanceRating = styled(VerticalSpace).attrs(props => ({
   className: classNames({
     'plain-button': true,
-    [spacing({ s: 2 }, { padding: ['left', 'right'] })]: true,
+    'padding-left-12 padding-right-12': true,
   }),
 }))`
   width: 25%;

--- a/common/views/components/SegmentedControl/SegmentedControl.js
+++ b/common/views/components/SegmentedControl/SegmentedControl.js
@@ -1,6 +1,6 @@
 // @flow
 import { Component, Fragment } from 'react';
-import { classNames, spacing, font } from '../../../utils/classnames';
+import { classNames, font } from '../../../utils/classnames';
 import Icon from '../Icon/Icon';
 import { trackEvent } from '../../../utils/ga';
 import VerticalSpace from '../styled/VerticalSpace';
@@ -66,7 +66,7 @@ class SegmentedControl extends Component<Props, State> {
                     properties={['padding-top', 'padding-bottom']}
                     className={classNames({
                       [font('wb', 4)]: true,
-                      [spacing({ s: 2 }, { padding: ['right', 'left'] })]: true,
+                      'padding-left-12 padding-right-12': true,
                       'segmented-control__button-text': true,
                       flex: true,
                       'bg-black': true,
@@ -91,7 +91,7 @@ class SegmentedControl extends Component<Props, State> {
           <div
             id={id}
             className={classNames({
-              [spacing({ s: 3 }, { padding: ['left', 'right'] })]: true,
+              'padding-left-12 padding-right-12': true,
               'segmented-control__body': true,
               'bg-white': true,
             })}
@@ -206,7 +206,7 @@ class SegmentedControl extends Component<Props, State> {
                 }}
                 href={item.url}
                 className={classNames({
-                  [spacing({ s: 2 }, { padding: ['right', 'left'] })]: true,
+                  'padding-left-12 padding-right-12': true,
                   'is-active bg-black font-white bg-hover-pewter':
                     item.id === activeId,
                   'bg-white font-black bg-hover-pumice': item.id !== activeId,

--- a/common/views/components/StatusIndicator/StatusIndicator.js
+++ b/common/views/components/StatusIndicator/StatusIndicator.js
@@ -1,5 +1,5 @@
 // @flow
-import { font, spacing } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import { formatDateRangeWithMessage } from '../../../utils/format-date';
 import Icon from '../Icon/Icon';
 
@@ -15,12 +15,7 @@ const StatusIndicator = ({ start, end, statusOverride }: Props) => {
     : formatDateRangeWithMessage({ start, end });
   return (
     <span className={`flex flex--v-center ${font('hnl', 6)}`}>
-      <span
-        className={`${spacing(
-          { s: 1 },
-          { margin: ['right'] }
-        )} flex flex--v-center`}
-      >
+      <span className={`margin-right-6 flex flex--v-center`}>
         <Icon
           name="statusIndicator"
           extraClasses={`icon--match-text icon--${color}`}

--- a/common/views/components/StoryPromo/StoryPromo.js
+++ b/common/views/components/StoryPromo/StoryPromo.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Article } from '../../../model/articles';
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import { getPositionInSeries, getArticleColor } from '../../../model/articles';
 import { UiImage } from '../Images/Images';
@@ -69,10 +69,8 @@ const StoryPromo = ({
         className={classNames({
           'story-promo__text flex flex--column flex-1': true,
           'flex--h-space-between': !hasTransparentBackground,
-          [spacing(
-            { s: hasTransparentBackground ? 0 : 2 },
-            { padding: ['left', 'right'] }
-          )]: true,
+          'padding-left-12': !hasTransparentBackground,
+          'padding-right-12': !hasTransparentBackground,
         })}
       >
         <div>

--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -64,7 +64,7 @@ const NavItem = ({
 }: {|
   ...SelectableTextLink,
 |}) => (
-  <NextLink {...link}>
+  <NextLink {...link} passHref>
     <VerticalSpace
       as="a"
       size="m"

--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -3,7 +3,7 @@
 import styled from 'styled-components';
 import NextLink from 'next/link';
 import { type TextLink } from '../../../model/text-links';
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import VerticalSpace from '../styled/VerticalSpace';
 
 type SelectableTextLink = {|
@@ -21,7 +21,7 @@ const NavItemInner = styled.span.attrs(props => ({
     selected: props.selected,
     block: true,
     relative: true,
-    [spacing({ s: 3 }, { margin: ['right'] })]: true,
+    'margin-right-12': true,
   }),
 }))`
   z-index: 1;

--- a/common/views/components/Tags/Tags.js
+++ b/common/views/components/Tags/Tags.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import type { NextLinkType } from '@weco/common/model/next-link-type';
-import { spacing, font, classNames } from '../../../utils/classnames';
+import { font, classNames } from '../../../utils/classnames';
 import NextLink from 'next/link';
 import VerticalSpace from '../styled/VerticalSpace';
 
@@ -42,7 +42,7 @@ const Tags = ({ tags }: Props) => {
                   <Tag
                     size="s"
                     className={classNames({
-                      [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                      'margin-right-6': true,
                       'line-height-1': true,
                       'inline-block bg-hover-green font-hover-white': true,
                       'border-color-green border-width-1': true,
@@ -66,8 +66,7 @@ const Tags = ({ tags }: Props) => {
                         key={part}
                         className={classNames({
                           [font(i === 0 ? 'hnm' : 'hnl', 5)]: true,
-                          [spacing({ s: 1 }, { margin: ['right'] })]:
-                            i !== arr.length - 1,
+                          'margin-right-6': i !== arr.length - 1,
                           'inline-block': true,
                         })}
                       >

--- a/common/views/components/Tasl/Tasl.js
+++ b/common/views/components/Tasl/Tasl.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { font, spacing } from '../../../utils/classnames';
+import { font } from '../../../utils/classnames';
 import getLicenseInfo from '../../../utils/get-license-info';
 import { trackEvent } from '../../../utils/ga';
 import { Fragment } from 'react';
@@ -166,8 +166,8 @@ const Tasl = withToggler(
             properties={['padding-top', 'padding-bottom']}
             className={`
               drawer__body bg-black font-white
-              ${spacing({ s: 1 }, { padding: ['left'] })}
-              ${spacing({ s: 6 }, { padding: ['right'] })}`}
+              padding-left-6`}
+            style={{ paddingRight: '36px' }}
           >
             {getMarkup(
               title,

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -2,7 +2,7 @@
 import { forwardRef } from 'react';
 import styled from 'styled-components';
 import VerticalSpace from '../styled/VerticalSpace';
-import { classNames, spacing } from '../../../utils/classnames';
+import { classNames } from '../../../utils/classnames';
 
 const VisuallyHidden = styled.div`
   border: 0;
@@ -18,7 +18,7 @@ const VisuallyHidden = styled.div`
 
 const StyledInput = styled(VerticalSpace).attrs({
   className: classNames({
-    [spacing({ s: 2 }, { padding: ['left'] })]: true,
+    'padding-left-12': true,
   }),
 })`
   width: 100%;

--- a/common/views/components/VenueHours/VenueHours.js
+++ b/common/views/components/VenueHours/VenueHours.js
@@ -1,6 +1,6 @@
 import { type Weight } from '@weco/common/services/prismic/parsers';
 import { useContext } from 'react';
-import { classNames, font, spacing } from '@weco/common/utils/classnames';
+import { classNames, font } from '@weco/common/utils/classnames';
 import { formatDay, formatDayMonth } from '@weco/common/utils/format-date';
 import styled from 'styled-components';
 import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
@@ -39,11 +39,17 @@ const VenueHoursTimes = styled(VerticalSpace)`
 const JauntyBox = styled(VerticalSpace).attrs(props => ({
   className: classNames({
     'bg-yellow inline-block': true,
-    [spacing({ s: 5 }, { padding: ['left'] })]: true,
-    [spacing({ s: 7 }, { padding: ['right'] })]: true,
-    [spacing({ s: -2, m: -4 }, { margin: ['left', 'right'] })]: true,
   }),
 }))`
+  padding-left: 30px;
+  padding-right: 42px;
+  margin-left: -12px;
+  margin-right: -12px;
+
+  ${props => props.theme.media.medium`
+    margin-left: -24px;
+    margin-right: -24px;
+  `}
   clip-path: ${({ topLeft, topRight, bottomRight, bottomLeft }) =>
     `polygon(
       ${topLeft} ${topLeft},
@@ -140,7 +146,7 @@ const VenueHours = ({ venue, weight }: Props) => {
         <h2
           className={classNames({
             h2: true,
-            [spacing({ s: 2 }, { padding: ['right'] })]: true,
+            'padding-right-12': true,
           })}
         >
           {weight === 'featured'
@@ -192,7 +198,7 @@ const VenueHours = ({ venue, weight }: Props) => {
                   <Icon
                     name="clock"
                     extraClasses={classNames({
-                      [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                      'margin-right-6': true,
                     })}
                   />
                   <span>{overrideType} hours</span>

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -1,6 +1,6 @@
 // @flow
 import { type Work } from '../../../model/work';
-import { font, classNames, spacing, grid } from '../../../utils/classnames';
+import { font, classNames, grid } from '../../../utils/classnames';
 import {
   getDigitalLocations,
   getPhysicalLocations,
@@ -39,7 +39,7 @@ const WorkHeader = ({ work }: Props) => {
             <Icon
               name={workTypeIcon}
               extraClasses={classNames({
-                [spacing({ s: 1 }, { margin: ['right'] })]: true,
+                'margin-right-6': true,
               })}
             />
           )}
@@ -68,7 +68,7 @@ const WorkHeader = ({ work }: Props) => {
             {work.contributors.length > 0 && (
               <div
                 className={classNames({
-                  [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                  'margin-right-12': true,
                 })}
               >
                 <LinkLabels

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -17,7 +17,7 @@ import InfoBox from '@weco/common/views/components/InfoBox/InfoBox';
 import { UiImage } from '@weco/common/views/components/Images/Images';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import type { UiEvent } from '@weco/common/model/events';
-import { spacing, font, classNames } from '@weco/common/utils/classnames';
+import { font, classNames } from '@weco/common/utils/classnames';
 import camelize from '@weco/common/utils/camelize';
 import {
   formatDayDate,
@@ -48,12 +48,7 @@ function EventStatus(text, color) {
   return (
     <div className="flex">
       <div className={`${font('hnm', 6)} flex flex--v-center`}>
-        <span
-          className={`${spacing(
-            { s: 1 },
-            { margin: ['right'] }
-          )} flex flex--v-center`}
-        >
+        <span className={`margin-right-6 flex flex--v-center`}>
           <Icon
             name="statusIndicator"
             extraClasses={`icon--match-text icon--${color}`}
@@ -282,7 +277,7 @@ class EventPage extends Component<Props, State> {
               <EventDateRange event={event} />
               <div
                 className={classNames({
-                  [spacing({ s: 0, m: 2 }, { margin: ['left'] })]: true,
+                  'margin-left-12': true,
                 })}
               >
                 {!event.isPast && <EventDatesLink id={event.id} />}

--- a/content/webapp/pages/visit-us.js
+++ b/content/webapp/pages/visit-us.js
@@ -9,7 +9,7 @@ import PageHeader from '@weco/common/views/components/PageHeader/PageHeader';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { getPage } from '@weco/common/services/prismic/pages';
 import { contentLd } from '@weco/common/utils/json-ld';
-import { classNames, spacing, font, grid } from '@weco/common/utils/classnames';
+import { classNames, font, grid } from '@weco/common/utils/classnames';
 import type { Page as PageType } from '@weco/common/model/pages';
 import FindUs from '@weco/common/views/components/FindUs/FindUs';
 import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
@@ -74,13 +74,7 @@ const BespokeBody = (
                 [font('hnl', 4)]: true,
               })}
             >
-              <Icon
-                name="clock"
-                extraClasses={`float-l ${spacing(
-                  { s: 2, m: 2, l: 2, xl: 2 },
-                  { margin: ['right'] }
-                )}`}
-              />
+              <Icon name="clock" extraClasses={`float-l margin-right-12`} />
               <div
                 className={classNames({
                   [font('hnl', 4)]: true,

--- a/content/webapp/pages/whats-on.js
+++ b/content/webapp/pages/whats-on.js
@@ -6,13 +6,7 @@ import { type Period } from '@weco/common/model/periods';
 import { type PaginatedResults } from '@weco/common/services/prismic/types';
 import NextLink from 'next/link';
 import { Component, Fragment } from 'react';
-import {
-  classNames,
-  font,
-  spacing,
-  grid,
-  cssGrid,
-} from '@weco/common/utils/classnames';
+import { classNames, font, grid, cssGrid } from '@weco/common/utils/classnames';
 import { getExhibitions } from '@weco/common/services/prismic/exhibitions';
 import {
   getEvents,
@@ -222,7 +216,7 @@ const Header = ({ activeId, openingTimes }: HeaderProps) => {
                     <span
                       className={classNames({
                         [font('hnm', 5)]: true,
-                        [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                        'margin-right-12': true,
                       })}
                     >
                       Galleries
@@ -235,7 +229,7 @@ const Header = ({ activeId, openingTimes }: HeaderProps) => {
                         <span
                           className={classNames({
                             [font('hnl', 5)]: true,
-                            [spacing({ s: 2 }, { margin: ['right'] })]: true,
+                            'margin-right-12': true,
                           })}
                         >
                           <Fragment>


### PR DESCRIPTION
Removing the `spacing()` helper altogether.

We were generating all possible classes to account for `4 x 4 x 2 x 15` possibilities (480), but auditing how we use them revealed that we very rarely use the responsive element for horizontal cases, and the unit is almost always either `6px` or `12px`.

So replacing the 480 classes with just the 8 that we tend to use seemed to make sense.