### PR TITLE
Start dates prototype with two inputs

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -46,16 +46,16 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
     workType,
     _queryType,
     setQueryType,
-    dateFrom,
-    dateTo,
+    _dateFrom,
+    _dateTo,
   } = useContext(CatalogueSearchContext);
 
   // This is the query used by the input, that is then eventually passed to the
   // Router
   const [inputQuery, setInputQuery] = useState(query);
   const searchInput = useRef(null);
-  const [inputDateFrom, setInputDateFrom] = useState(dateFrom);
-  const [inputDateTo, setInputDateTo] = useState(dateTo);
+  const [inputDateFrom, setInputDateFrom] = useState(_dateFrom);
+  const [inputDateTo, setInputDateTo] = useState(_dateTo);
 
   // We need to make sure that the changes to `query` affect `inputQuery` as
   // when we navigate between pages which all contain `SearchForm`, each
@@ -66,14 +66,14 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
       setInputQuery(query);
     }
 
-    if (dateFrom !== inputDateFrom) {
-      setInputDateFrom(dateFrom);
+    if (_dateFrom !== `${inputDateFrom || ''}-01-01`) {
+      setInputDateFrom((_dateFrom || '').split('-')[0]);
     }
 
-    if (dateTo !== inputDateTo) {
-      setInputDateTo(dateTo);
+    if (_dateTo !== `${inputDateTo || ''}-01-01`) {
+      setInputDateTo((_dateTo || '').split('-')[0]);
     }
-  }, [query, dateFrom, dateTo]);
+  }, [query, _dateFrom, _dateTo]);
 
   function updateDateFrom(event) {
     setInputDateFrom(event.currentTarget.value);
@@ -102,8 +102,8 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
             workType,
             page: 1,
             _queryType,
-            dateFrom: inputDateFrom,
-            dateTo: inputDateTo,
+            _dateFrom: inputDateFrom,
+            _dateTo: inputDateTo,
           });
 
           Router.push(link.href, link.as);

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -9,6 +9,7 @@ import { classNames, font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { worksUrl } from '@weco/common/services/catalogue/urls';
 import CatalogueSearchContext from '@weco/common/views/components/CatalogueSearchContext/CatalogueSearchContext';
+import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
 
 type Props = {|
   ariaDescribedBy: string,
@@ -40,14 +41,21 @@ const ClearSearch = styled.button`
 `;
 
 const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
-  const { query, workType, _queryType, setQueryType } = useContext(
-    CatalogueSearchContext
-  );
+  const {
+    query,
+    workType,
+    _queryType,
+    setQueryType,
+    dateFrom,
+    dateTo,
+  } = useContext(CatalogueSearchContext);
 
   // This is the query used by the input, that is then eventually passed to the
   // Router
   const [inputQuery, setInputQuery] = useState(query);
   const searchInput = useRef(null);
+  const [inputDateFrom, setInputDateFrom] = useState(dateFrom);
+  const [inputDateTo, setInputDateTo] = useState(dateTo);
 
   // We need to make sure that the changes to `query` affect `inputQuery` as
   // when we navigate between pages which all contain `SearchForm`, each
@@ -57,7 +65,23 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
     if (query !== inputQuery) {
       setInputQuery(query);
     }
-  }, [query]);
+
+    if (dateFrom !== inputDateFrom) {
+      setInputDateFrom(dateFrom);
+    }
+
+    if (dateTo !== inputDateTo) {
+      setInputDateTo(dateTo);
+    }
+  }, [query, dateFrom, dateTo]);
+
+  function updateDateFrom(event) {
+    setInputDateFrom(event.currentTarget.value);
+  }
+
+  function updateDateTo(event) {
+    setInputDateTo(event.currentTarget.value);
+  }
 
   return (
     <>
@@ -78,6 +102,8 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
             workType,
             page: 1,
             _queryType,
+            dateFrom: inputDateFrom,
+            dateTo: inputDateTo,
           });
 
           Router.push(link.href, link.as);
@@ -160,6 +186,42 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
               </label>
             )
           }
+        </TogglesContext.Consumer>
+
+        <TogglesContext.Consumer>
+          {({ showDatesPrototype }) => (
+            <>
+              {showDatesPrototype && (
+                <VerticalSpace
+                  as="details"
+                  size="m"
+                  properties={['margin-top']}
+                >
+                  <summary>Date range</summary>
+                  <VerticalSpace size="s" properties={['margin-top']}>
+                    <label>
+                      from:{' '}
+                      <input
+                        value={inputDateFrom}
+                        onChange={updateDateFrom}
+                        placeholder="YYYY"
+                        style={{ width: '5em', padding: '0.5em' }}
+                      />
+                    </label>{' '}
+                    <label>
+                      to:{' '}
+                      <input
+                        value={inputDateTo}
+                        onChange={updateDateTo}
+                        placeholder="YYYY"
+                        style={{ width: '5em', padding: '0.5em' }}
+                      />
+                    </label>
+                  </VerticalSpace>
+                </VerticalSpace>
+              )}
+            </>
+          )}
         </TogglesContext.Consumer>
       </form>
     </>

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -75,14 +75,6 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
     }
   }, [query, _dateFrom, _dateTo]);
 
-  function updateDateFrom(event) {
-    setInputDateFrom(event.currentTarget.value);
-  }
-
-  function updateDateTo(event) {
-    setInputDateTo(event.currentTarget.value);
-  }
-
   return (
     <>
       <form
@@ -203,7 +195,9 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
                       from:{' '}
                       <input
                         value={inputDateFrom}
-                        onChange={updateDateFrom}
+                        onChange={event => {
+                          setInputDateFrom(event.currentTarget.value);
+                        }}
                         placeholder="YYYY-MM-DD"
                         pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])"
                         style={{ width: '8em', padding: '0.5em' }}
@@ -213,7 +207,9 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
                       to:{' '}
                       <input
                         value={inputDateTo}
-                        onChange={updateDateTo}
+                        onChange={event => {
+                          setInputDateTo(event.currentTarget.value);
+                        }}
                         placeholder="YYYY-MM-DD"
                         pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])"
                         style={{ width: '8em', padding: '0.5em' }}

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -66,12 +66,12 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
       setInputQuery(query);
     }
 
-    if (_dateFrom !== `${inputDateFrom || ''}-01-01`) {
-      setInputDateFrom((_dateFrom || '').split('-')[0]);
+    if (_dateFrom !== inputDateFrom) {
+      setInputDateFrom(_dateFrom);
     }
 
-    if (_dateTo !== `${inputDateTo || ''}-01-01`) {
-      setInputDateTo((_dateTo || '').split('-')[0]);
+    if (_dateTo !== inputDateTo) {
+      setInputDateTo(_dateTo);
     }
   }, [query, _dateFrom, _dateTo]);
 
@@ -204,8 +204,9 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
                       <input
                         value={inputDateFrom}
                         onChange={updateDateFrom}
-                        placeholder="YYYY"
-                        style={{ width: '5em', padding: '0.5em' }}
+                        placeholder="YYYY-MM-DD"
+                        pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])"
+                        style={{ width: '8em', padding: '0.5em' }}
                       />
                     </label>{' '}
                     <label>
@@ -213,8 +214,9 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
                       <input
                         value={inputDateTo}
                         onChange={updateDateTo}
-                        placeholder="YYYY"
-                        style={{ width: '5em', padding: '0.5em' }}
+                        placeholder="YYYY-MM-DD"
+                        pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])"
+                        style={{ width: '8em', padding: '0.5em' }}
                       />
                     </label>
                   </VerticalSpace>

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -184,38 +184,27 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
           {({ showDatesPrototype }) => (
             <>
               {showDatesPrototype && (
-                <VerticalSpace
-                  as="details"
-                  size="m"
-                  properties={['margin-top']}
-                >
-                  <summary>Date range</summary>
-                  <VerticalSpace size="s" properties={['margin-top']}>
-                    <label>
-                      from:{' '}
-                      <input
-                        value={inputDateFrom}
-                        onChange={event => {
-                          setInputDateFrom(event.currentTarget.value);
-                        }}
-                        placeholder="YYYY-MM-DD"
-                        pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])"
-                        style={{ width: '8em', padding: '0.5em' }}
-                      />
-                    </label>{' '}
-                    <label>
-                      to:{' '}
-                      <input
-                        value={inputDateTo}
-                        onChange={event => {
-                          setInputDateTo(event.currentTarget.value);
-                        }}
-                        placeholder="YYYY-MM-DD"
-                        pattern="[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])"
-                        style={{ width: '8em', padding: '0.5em' }}
-                      />
-                    </label>
-                  </VerticalSpace>
+                <VerticalSpace size="m" properties={['margin-top']}>
+                  <label>
+                    from:{' '}
+                    <input
+                      value={inputDateFrom}
+                      onChange={event => {
+                        setInputDateFrom(event.currentTarget.value);
+                      }}
+                      style={{ width: '8em', padding: '0.5em' }}
+                    />
+                  </label>{' '}
+                  <label>
+                    to:{' '}
+                    <input
+                      value={inputDateTo}
+                      onChange={event => {
+                        setInputDateTo(event.currentTarget.value);
+                      }}
+                      style={{ width: '8em', padding: '0.5em' }}
+                    />
+                  </label>
                 </VerticalSpace>
               )}
             </>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -30,7 +30,7 @@ import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
 import WorkCard from '../components/WorkCard/WorkCard';
 import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
-import moment from 'moment';
+import { formatDateForApi } from '@weco/common/utils/dates';
 
 type Props = {|
   query: ?string,
@@ -440,15 +440,9 @@ const Works = ({ works }: Props) => {
 
 WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
-  const _dateFrom = makeApiSafeDateString(ctx.query._dateFrom);
-  const _dateTo = makeApiSafeDateString(ctx.query._dateTo);
+  const _dateFrom = formatDateForApi(ctx.query._dateFrom);
+  const _dateTo = formatDateForApi(ctx.query._dateTo);
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
-
-  function makeApiSafeDateString(dateString) {
-    const date = dateString && moment(dateString);
-
-    return date && date.isValid() ? date.format('YYYY-MM-DD') : undefined;
-  }
 
   const {
     useStageApi,

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -44,7 +44,7 @@ const WorksSearchProvider = ({ works, query, page, workType }: Props) => (
 
 const Works = ({ works }: Props) => {
   const [loading, setLoading] = useState(false);
-  const { query, page, workType, _queryType } = useContext(
+  const { query, page, workType, _queryType, dateFrom, dateTo } = useContext(
     CatalogueSearchContext
   );
   const trackEvent = () => {
@@ -212,6 +212,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: undefined,
                       page: 1,
+                      dateFrom,
+                      dateTo,
                     }),
                     selected: !workType,
                   },
@@ -221,6 +223,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['a', 'v'],
                       page: 1,
+                      dateFrom,
+                      dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -234,6 +238,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['k', 'q'],
                       page: 1,
+                      dateFrom,
+                      dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -249,6 +255,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['f', 's'],
                       page: 1,
+                      dateFrom,
+                      dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -427,7 +435,15 @@ const Works = ({ works }: Props) => {
 
 WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
+  const dateFrom = makeYearMonthDayString(ctx.query.dateFrom);
+  const dateTo = makeYearMonthDayString(ctx.query.dateTo);
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
+
+  function makeYearMonthDayString(year) {
+    const isYear = year && year.match(/\d{4}/);
+
+    return isYear && `${isYear}-01-01`;
+  }
 
   const {
     useStageApi,
@@ -456,6 +472,8 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     workType: workTypeFilter,
     'items.locations.locationType': ['iiif-image', 'iiif-presentation'],
     _queryType,
+    _dateFrom: dateFrom,
+    _dateTo: dateTo,
   };
 
   const worksOrError =

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -44,7 +44,7 @@ const WorksSearchProvider = ({ works, query, page, workType }: Props) => (
 
 const Works = ({ works }: Props) => {
   const [loading, setLoading] = useState(false);
-  const { query, page, workType, _queryType, dateFrom, dateTo } = useContext(
+  const { query, page, workType, _queryType, _dateFrom, _dateTo } = useContext(
     CatalogueSearchContext
   );
   const trackEvent = () => {
@@ -212,8 +212,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: undefined,
                       page: 1,
-                      dateFrom,
-                      dateTo,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !workType,
                   },
@@ -223,8 +223,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['a', 'v'],
                       page: 1,
-                      dateFrom,
-                      dateTo,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -238,8 +238,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['k', 'q'],
                       page: 1,
-                      dateFrom,
-                      dateTo,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -255,8 +255,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['f', 's'],
                       page: 1,
-                      dateFrom,
-                      dateTo,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -435,14 +435,12 @@ const Works = ({ works }: Props) => {
 
 WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
-  const dateFrom = makeYearMonthDayString(ctx.query.dateFrom);
-  const dateTo = makeYearMonthDayString(ctx.query.dateTo);
+  const _dateFrom = ctx.query._dateFrom;
+  const _dateTo = ctx.query._dateTo;
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
-  function makeYearMonthDayString(year) {
-    const isYear = year && year.match(/\d{4}/);
-
-    return isYear && `${isYear}-01-01`;
+  function isIsoDate(string) {
+    return string && string.match(/^\d{4}-\d{2}-\d{2}$/);
   }
 
   const {
@@ -472,8 +470,8 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     workType: workTypeFilter,
     'items.locations.locationType': ['iiif-image', 'iiif-presentation'],
     _queryType,
-    _dateFrom: dateFrom,
-    _dateTo: dateTo,
+    ...(isIsoDate(_dateFrom) && { _dateFrom }),
+    ...(isIsoDate(_dateTo) && { _dateTo }),
   };
 
   const worksOrError =

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -439,10 +439,6 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const _dateTo = ctx.query._dateTo;
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
-  function isIsoDate(string) {
-    return string && string.match(/^\d{4}-\d{2}-\d{2}$/);
-  }
-
   const {
     useStageApi,
     searchCandidateQueryMsm,
@@ -470,8 +466,8 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     workType: workTypeFilter,
     'items.locations.locationType': ['iiif-image', 'iiif-presentation'],
     _queryType,
-    ...(isIsoDate(_dateFrom) && { _dateFrom }),
-    ...(isIsoDate(_dateTo) && { _dateTo }),
+    ...(Date.parse(_dateFrom) ? { _dateFrom } : {}),
+    ...(Date.parse(_dateTo) ? { _dateTo } : {}),
   };
 
   const worksOrError =

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -444,13 +444,10 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const _dateTo = makeApiSafeDateString(ctx.query._dateTo);
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
-  // API doesn't seem to like dates above the year 9999
   function makeApiSafeDateString(dateString) {
     const date = dateString && moment(dateString);
 
-    return date && date.isValid() && date.isBefore('9999-12-31')
-      ? date.format('YYYY-MM-DD')
-      : undefined;
+    return date && date.isValid() ? date.format('YYYY-MM-DD') : undefined;
   }
 
   const {

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -292,6 +292,8 @@ const Works = ({ works }: Props) => {
                             query,
                             workType,
                             page,
+                            _dateFrom,
+                            _dateTo,
                           })}
                           onPageChange={async (event, newPage) => {
                             event.preventDefault();
@@ -299,6 +301,8 @@ const Works = ({ works }: Props) => {
                               query,
                               workType,
                               page: newPage,
+                              _dateFrom,
+                              _dateTo,
                             });
                             Router.push(link.href, link.as).then(() =>
                               window.scrollTo(0, 0)
@@ -442,9 +446,9 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
 
   // API doesn't seem to like dates above the year 9999
   function makeApiSafeDateString(dateString) {
-    const date = moment(dateString);
+    const date = dateString && moment(dateString);
 
-    return date.isValid() && date.isBefore('9999-12-31')
+    return date && date.isValid() && date.isBefore('9999-12-31')
       ? date.format('YYYY-MM-DD')
       : undefined;
   }

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -45,7 +45,7 @@ export async function getWorks({
 }: GetWorksProps): Promise<CatalogueResultsList | CatalogueApiError> {
   const filterQueryString = Object.keys(filters).map(key => {
     const val = filters[key];
-    return `${key}=${val}`;
+    return val && `${key}=${val}`;
   });
   const url =
     `${rootUris[env]}/v2/works?include=${includes.join(',')}` +

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -45,7 +45,7 @@ export async function getWorks({
 }: GetWorksProps): Promise<CatalogueResultsList | CatalogueApiError> {
   const filterQueryString = Object.keys(filters).map(key => {
     const val = filters[key];
-    return val && `${key}=${val}`;
+    return `${key}=${val}`;
   });
   const url =
     `${rootUris[env]}/v2/works?include=${includes.join(',')}` +

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -76,8 +76,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        _dateFrom: _dateFrom ? `${_dateFrom}-01-01` : undefined,
-        _dateTo: _dateTo ? `${_dateTo}-01-01` : undefined,
+        _dateFrom,
+        _dateTo,
       }),
     },
     as: {
@@ -87,8 +87,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        _dateFrom: _dateFrom ? `${_dateFrom}-01-01` : undefined,
-        _dateTo: _dateTo ? `${_dateTo}-01-01` : undefined,
+        _dateFrom,
+        _dateTo,
       }),
     },
   };

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -14,6 +14,8 @@ type WorksUrlProps = {|
   workType?: ?(string[]),
   itemsLocationsLocationType?: ?(string[]),
   _queryType?: ?QueryType,
+  dateFrom?: ?string,
+  dateTo?: ?string,
 |};
 
 type WorkUrlProps = {|
@@ -61,6 +63,8 @@ export function workUrl({ id }: WorkUrlProps): NextLinkType {
 export function worksUrl({
   query,
   page,
+  dateFrom,
+  dateTo,
   workType,
   _queryType,
 }: WorksUrlProps): NextLinkType {
@@ -72,6 +76,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
+        dateFrom: dateFrom || undefined,
+        dateTo: dateTo || undefined,
       }),
     },
     as: {
@@ -81,6 +87,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
+        dateFrom: dateFrom || undefined,
+        dateTo: dateTo || undefined,
       }),
     },
   };

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -76,8 +76,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        _dateFrom,
-        _dateTo,
+        _dateFrom: _dateFrom && Date.parse(_dateFrom) ? _dateFrom : undefined,
+        _dateTo: _dateTo && Date.parse(_dateTo) ? _dateTo : undefined,
       }),
     },
     as: {
@@ -87,8 +87,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        _dateFrom,
-        _dateTo,
+        _dateFrom: _dateFrom && Date.parse(_dateFrom) ? _dateFrom : undefined,
+        _dateTo: _dateTo && Date.parse(_dateTo) ? _dateTo : undefined,
       }),
     },
   };

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -14,8 +14,8 @@ type WorksUrlProps = {|
   workType?: ?(string[]),
   itemsLocationsLocationType?: ?(string[]),
   _queryType?: ?QueryType,
-  dateFrom?: ?string,
-  dateTo?: ?string,
+  _dateFrom?: ?string,
+  _dateTo?: ?string,
 |};
 
 type WorkUrlProps = {|
@@ -63,10 +63,10 @@ export function workUrl({ id }: WorkUrlProps): NextLinkType {
 export function worksUrl({
   query,
   page,
-  dateFrom,
-  dateTo,
   workType,
   _queryType,
+  _dateFrom,
+  _dateTo,
 }: WorksUrlProps): NextLinkType {
   return {
     href: {
@@ -76,8 +76,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        dateFrom: dateFrom || undefined,
-        dateTo: dateTo || undefined,
+        _dateFrom: _dateFrom ? `${_dateFrom}-01-01` : undefined,
+        _dateTo: _dateTo ? `${_dateTo}-01-01` : undefined,
       }),
     },
     as: {
@@ -87,8 +87,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        dateFrom: dateFrom || undefined,
-        dateTo: dateTo || undefined,
+        _dateFrom: _dateFrom ? `${_dateFrom}-01-01` : undefined,
+        _dateTo: _dateTo ? `${_dateTo}-01-01` : undefined,
       }),
     },
   };

--- a/common/utils/dates.js
+++ b/common/utils/dates.js
@@ -37,3 +37,9 @@ export function getNextWeekendDateRange(date: Date): DateRange {
     end: end.endOf('day').toDate(),
   };
 }
+
+export function formatDateForApi(dateString: string): ?string {
+  const date = dateString && london(dateString);
+
+  return date && date.isValid() ? date.format('YYYY-MM-DD') : undefined;
+}

--- a/common/views/components/BackToResults/BackToResults.js
+++ b/common/views/components/BackToResults/BackToResults.js
@@ -7,7 +7,7 @@ import { trackEvent } from '../../../utils/ga';
 import { worksUrl } from '../../../services/catalogue/urls';
 
 const BackToResults = () => {
-  const { query, workType, page, _queryType } = useContext(
+  const { query, workType, page, _queryType, _dateFrom, _dateTo } = useContext(
     CatalogueSearchContext
   );
   const link = worksUrl({
@@ -15,6 +15,8 @@ const BackToResults = () => {
     page,
     workType,
     _queryType,
+    _dateFrom,
+    _dateTo,
   });
   return (
     <NextLink {...link}>

--- a/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
+++ b/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
@@ -15,8 +15,8 @@ export type CatalogueQuery = {|
   workType: ?(string[]),
   itemsLocationsLocationType: ?(string[]),
   _queryType: ?string,
-  dateFrom: ?string,
-  dateTo: ?string,
+  _dateFrom: ?string,
+  _dateTo: ?string,
 |};
 
 type ContextProps = {|
@@ -36,8 +36,8 @@ const defaultState: CatalogueQuery = {
   workType: null,
   itemsLocationsLocationType: null,
   _queryType: null,
-  dateFrom: null,
-  dateTo: null,
+  _dateFrom: null,
+  _dateTo: null,
 };
 
 const CatalogueSearchContext = createContext<ContextProps>({
@@ -69,8 +69,8 @@ const CatalogueSearchProvider = ({
     itemsLocationsLocationType: router.query['items.locations.locationType']
       ? router.query['items.locations.locationType'].split(',')
       : null,
-    dateFrom: router.query.dateFrom ? router.query.dateFrom : null,
-    dateTo: router.query.dateTo ? router.query.dateTo : null,
+    _dateFrom: router.query._dateFrom ? router.query._dateFrom : null,
+    _dateTo: router.query._dateTo ? router.query._dateTo : null,
   };
   const state = {
     ...defaultState,
@@ -80,8 +80,8 @@ const CatalogueSearchProvider = ({
   const [query, setQuery] = useState(state.query);
   const [page, setPage] = useState(state.page);
   const [workType, setWorkType] = useState(state.workType);
-  const [dateFrom, setDateFrom] = useState(state.dateFrom);
-  const [dateTo, setDateTo] = useState(state.dateTo);
+  const [_dateFrom, setDateFrom] = useState(state._dateFrom);
+  const [_dateTo, setDateTo] = useState(state._dateTo);
   const [itemsLocationsLocationType, setItemsLocationsLocationType] = useState(
     state.itemsLocationsLocationType
   );
@@ -92,8 +92,8 @@ const CatalogueSearchProvider = ({
     workType,
     itemsLocationsLocationType,
     _queryType,
-    dateFrom,
-    dateTo,
+    _dateFrom,
+    _dateTo,
     setQuery,
     setPage,
     setWorkType,
@@ -132,8 +132,8 @@ const CatalogueSearchProvider = ({
             ? params['items.locations.location.type'].split(',')
             : defaultState.itemsLocationsLocationType,
           _queryType: params._queryType || defaultState._queryType,
-          dateFrom: params.dateFrom || null,
-          dateTo: params.dateTo || null,
+          _dateFrom: params._dateFrom || null,
+          _dateTo: params._dateTo || null,
         };
 
         setQuery(state.query);
@@ -141,8 +141,8 @@ const CatalogueSearchProvider = ({
         setWorkType(state.workType);
         setItemsLocationsLocationType(state.itemsLocationsLocationType);
         setQueryType(state._queryType);
-        setDateFrom(state.dateFrom);
-        setDateTo(state.dateTo);
+        setDateFrom(state._dateFrom);
+        setDateTo(state._dateTo);
       }
     }
 
@@ -170,6 +170,8 @@ const SearchRouter = ({ children }: SearchRouterProps) => {
     workType,
     itemsLocationsLocationType,
     _queryType,
+    _dateFrom,
+    _dateTo,
   } = useContext(CatalogueSearchContext);
   const push = () => {
     const link = worksUrl({
@@ -178,6 +180,8 @@ const SearchRouter = ({ children }: SearchRouterProps) => {
       workType: workType,
       itemsLocationsLocationType: itemsLocationsLocationType,
       _queryType: _queryType,
+      _dateFrom: _dateFrom,
+      _dateTo: _dateTo,
     });
     Router.push(
       { ...link.href, pathname: '/works-context' },

--- a/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
+++ b/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
@@ -15,6 +15,8 @@ export type CatalogueQuery = {|
   workType: ?(string[]),
   itemsLocationsLocationType: ?(string[]),
   _queryType: ?string,
+  dateFrom: ?string,
+  dateTo: ?string,
 |};
 
 type ContextProps = {|
@@ -24,6 +26,8 @@ type ContextProps = {|
   setWorkType: (value: ?(string[])) => void,
   setItemsLocationsLocationType: (value: ?(string[])) => void,
   setQueryType: (value: ?string) => void,
+  setDateFrom: (value: ?string) => void,
+  setDateTo: (value: ?string) => void,
 |};
 
 const defaultState: CatalogueQuery = {
@@ -32,6 +36,8 @@ const defaultState: CatalogueQuery = {
   workType: null,
   itemsLocationsLocationType: null,
   _queryType: null,
+  dateFrom: null,
+  dateTo: null,
 };
 
 const CatalogueSearchContext = createContext<ContextProps>({
@@ -41,6 +47,8 @@ const CatalogueSearchContext = createContext<ContextProps>({
   setWorkType: () => {},
   setItemsLocationsLocationType: () => {},
   setQueryType: () => {},
+  setDateFrom: () => {},
+  setDateTo: () => {},
 });
 
 type CatalogueSearchProviderProps = {
@@ -61,6 +69,8 @@ const CatalogueSearchProvider = ({
     itemsLocationsLocationType: router.query['items.locations.locationType']
       ? router.query['items.locations.locationType'].split(',')
       : null,
+    dateFrom: router.query.dateFrom ? router.query.dateFrom : null,
+    dateTo: router.query.dateTo ? router.query.dateTo : null,
   };
   const state = {
     ...defaultState,
@@ -70,6 +80,8 @@ const CatalogueSearchProvider = ({
   const [query, setQuery] = useState(state.query);
   const [page, setPage] = useState(state.page);
   const [workType, setWorkType] = useState(state.workType);
+  const [dateFrom, setDateFrom] = useState(state.dateFrom);
+  const [dateTo, setDateTo] = useState(state.dateTo);
   const [itemsLocationsLocationType, setItemsLocationsLocationType] = useState(
     state.itemsLocationsLocationType
   );
@@ -80,11 +92,15 @@ const CatalogueSearchProvider = ({
     workType,
     itemsLocationsLocationType,
     _queryType,
+    dateFrom,
+    dateTo,
     setQuery,
     setPage,
     setWorkType,
     setItemsLocationsLocationType,
     setQueryType,
+    setDateFrom,
+    setDateTo,
   };
 
   useEffect(() => {
@@ -116,6 +132,8 @@ const CatalogueSearchProvider = ({
             ? params['items.locations.location.type'].split(',')
             : defaultState.itemsLocationsLocationType,
           _queryType: params._queryType || defaultState._queryType,
+          dateFrom: params.dateFrom || null,
+          dateTo: params.dateTo || null,
         };
 
         setQuery(state.query);
@@ -123,6 +141,8 @@ const CatalogueSearchProvider = ({
         setWorkType(state.workType);
         setItemsLocationsLocationType(state.itemsLocationsLocationType);
         setQueryType(state._queryType);
+        setDateFrom(state.dateFrom);
+        setDateTo(state.dateTo);
       }
     }
 

--- a/common/views/components/Tracker/Tracker.js
+++ b/common/views/components/Tracker/Tracker.js
@@ -89,10 +89,11 @@ const track = (eventProps: LoggerEvent) => {
 
   const { event, ...restOfEvent } = eventProps;
 
-  window.analytics.track(event, {
-    ...restOfEvent,
-    toggles,
-  });
+  window.analytics &&
+    window.analytics.track(event, {
+      ...restOfEvent,
+      toggles,
+    });
 };
 
 const TrackerScript = () => {

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -41,5 +41,12 @@ module.exports = {
       description:
         'Shows a preview for each volume in a multi volume work on the work page.',
     },
+    {
+      id: 'showDatesPrototype',
+      title: 'Show exploratory work on faceting by date',
+      defaultValue: false,
+      description:
+        'Shows additional UI to allow a user to narrow search results by a date range.',
+    },
   ],
 };


### PR DESCRIPTION
<img width="642" alt="Screenshot 2019-07-25 at 16 42 33" src="https://user-images.githubusercontent.com/1394592/61888866-3e328280-aefc-11e9-9f69-dc4ac657b49c.png">

A starter for the dates prototype work – this adds two inputs below the search input.

The dates have to be four digits (years) and we append `-01-01` (January first) to put them in the ISO format the API expects.

I haven't put in any validation for this – if they're not four digits, they'll just be ignored.

If we enhance this to use a slider/sliders, we can guarantee the values will be in the right format, so didn't seem necessary to add validation (and we can still track what kinds of things people type in the boxes).