### PR TITLE
Multi volume preview

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -75,6 +75,7 @@ type Props = {|
   sierraId: ?string,
   iiifPresentationManifest: ?IIIFManifest,
   encoreLink: ?string,
+  childManifestsCount?: number,
 |};
 
 const WorkDetails = ({
@@ -82,6 +83,7 @@ const WorkDetails = ({
   sierraId,
   iiifPresentationManifest,
   encoreLink,
+  childManifestsCount,
 }: Props) => {
   const iiifImageLocation = getLocationType(work, 'iiif-image');
   const iiifImageLocationUrl = iiifImageLocation && iiifImageLocation.url;
@@ -156,7 +158,7 @@ const WorkDetails = ({
         </div>
       </div>
     );
-  } else if (sierraId) {
+  } else if (sierraId && childManifestsCount === 0) {
     WorkDetailsSections.push(
       <div
         className={classNames({

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -265,6 +265,7 @@ export const WorkPage = ({ work }: Props) => {
         sierraId={sierraIdFromPresentationManifestUrl}
         iiifPresentationManifest={iiifPresentationManifest}
         encoreLink={encoreLink}
+        childManifestsCount={childManifestsCount}
       />
     </CataloguePageLayout>
   );

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -39,13 +39,6 @@ type Props = {|
   work: Work | CatalogueApiError,
 |};
 
-const getManifests = async function(manifests) {
-  const data = Promise.all(
-    manifests.map(async manifest => (await fetch(manifest['@id'])).json())
-  );
-  return data;
-};
-
 const getFirstChildManifest = async function(manifests) {
   const firstManifestUrl = manifests.find(manifest => manifest['@id'])['@id'];
   const data = await (await fetch(firstManifestUrl)).json();
@@ -54,9 +47,6 @@ const getFirstChildManifest = async function(manifests) {
 
 export const WorkPage = ({ work }: Props) => {
   const [iiifPresentationManifest, setIIIFPresentationManifest] = useState(
-    null
-  );
-  const [iiifPresentationManifests, setIIIFPresentationManifests] = useState(
     null
   );
   const [childManifestsCount, setChildManifestsCount] = useState(0);
@@ -71,9 +61,6 @@ export const WorkPage = ({ work }: Props) => {
         setChildManifestsCount(manifestData.manifests.length);
         setFirstChildManifest(
           await getFirstChildManifest(manifestData.manifests)
-        );
-        setIIIFPresentationManifests(
-          await getManifests(manifestData.manifests)
         );
       }
       setIIIFPresentationManifest(manifestData);
@@ -235,33 +222,8 @@ export const WorkPage = ({ work }: Props) => {
         </SpacingComponent>
       )}
 
-      {iiifPresentationManifests &&
-        iiifPresentationManifests.map((manifest, i) => (
-          <ManifestContext.Provider value={manifest} key={i}>
-            <SpacingComponent>
-              {sierraIdFromPresentationManifestUrl && !iiifImageLocationUrl && (
-                <IIIFPresentationPreview
-                  iiifPresentationLocation={iiifPresentationLocation}
-                  itemUrl={itemUrl({
-                    workId: work.id,
-                    sierraId:
-                      manifest['@id'].match(
-                        /^https:\/\/wellcomelibrary\.org\/iiif\/(.*)\/manifest$/
-                      )[1] || sierraIdFromPresentationManifestUrl,
-                    langCode: work.language && work.language.id,
-                    page: 1,
-                    canvas: 1,
-                    isOverview: true,
-                  })}
-                />
-              )}
-            </SpacingComponent>
-          </ManifestContext.Provider>
-        ))}
-
       <ManifestContext.Provider value={iiifPresentationManifest}>
-        {!iiifPresentationManifests &&
-          !(childManifestsCount > 0) &&
+        {!(childManifestsCount > 0) &&
           sierraIdFromPresentationManifestUrl &&
           !iiifImageLocationUrl && (
             <IIIFPresentationPreview

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -54,6 +54,7 @@ export const WorkPage = ({ work }: Props) => {
   const [iiifPresentationManifests, setIIIFPresentationManifests] = useState(
     null
   );
+  const [manifestsCount, setManifestsCount] = useState(0);
   const fetchIIIFPresentationManifest = async () => {
     try {
       const iiifPresentationLocation = getIIIFPresentationLocation(work);
@@ -61,6 +62,7 @@ export const WorkPage = ({ work }: Props) => {
       const manifestData = await iiifManifest.json();
 
       if (manifestData.manifests) {
+        setManifestsCount(manifestData.manifests.length);
         setIIIFPresentationManifests(
           await getManifests(manifestData.manifests)
         );
@@ -200,7 +202,7 @@ export const WorkPage = ({ work }: Props) => {
       >
         <div className="container">
           <div className="grid">
-            <WorkHeader work={work} />
+            <WorkHeader work={work} manifestsCount={manifestsCount} />
           </div>
         </div>
       </VerticalSpace>

--- a/common/hooks/useOnScreen.js
+++ b/common/hooks/useOnScreen.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export default function useOnScreen({
+  ref,
+  rootMargin = '0px',
+  threshold = 0,
+}) {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  useEffect(() => {
+    const observer = new window.IntersectionObserver(
+      ([entry]) => {
+        setIsIntersecting(entry.isIntersecting);
+      },
+      {
+        rootMargin,
+        threshold,
+      }
+    );
+    if (ref.current) {
+      observer.observe(ref.current);
+    }
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return isIntersecting;
+}

--- a/common/styles/works.scss
+++ b/common/styles/works.scss
@@ -54,3 +54,4 @@ $is-next: true;
 @import 'components/tags';
 @import 'components/tasl';
 @import 'components/work_media';
+@import 'components/wobbly_edge';

--- a/common/views/components/HeaderBackground/HeaderBackground.js
+++ b/common/views/components/HeaderBackground/HeaderBackground.js
@@ -33,7 +33,7 @@ const HeaderBackground = ({
 
   return (
     <div
-      className="absolute overflow-hidden full-width bg-cream"
+      className="absolute overflow-hidden full-width bg-charcoal"
       style={styles}
     >
       {hasWobblyEdge && (

--- a/common/views/components/IIIFImagePreview/IIIFImagePreview.js
+++ b/common/views/components/IIIFImagePreview/IIIFImagePreview.js
@@ -30,6 +30,8 @@ const ImagePreview = styled.div`
     max-height: 400px;
     max-width: 100%;
     width: auto;
+    position: relative;
+    z-index: 1;
   }
 
   button {

--- a/common/views/components/IIIFImagePreview/IIIFImagePreview.js
+++ b/common/views/components/IIIFImagePreview/IIIFImagePreview.js
@@ -34,6 +34,7 @@ const ImagePreview = styled.div`
 
   button {
     position: absolute;
+    z-index: 3;
     bottom: 0;
     left: 50%;
     transform: translate(-50%, 50%);

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -9,13 +9,22 @@ import NextLink from 'next/link';
 import styled from 'styled-components';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { classNames, spacing, grid } from '@weco/common/utils/classnames';
-import { useEffect, useState, useContext } from 'react';
+import { useEffect, useState, useContext, useRef } from 'react';
 import { trackEvent } from '@weco/common/utils/ga';
 import ManifestContext from '@weco/common/views/components/ManifestContext/ManifestContext';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import WobblyRow from '@weco/common/views/components/WobblyRow/WobblyRow';
+
+const MultiVolumeContainer = styled.div`
+  box-shadow: ${props =>
+    props.loaded
+      ? `12px 12px 0px 0px ${props.theme.colors.yellow}`
+      : `0px 0px 0px 0px ${props.theme.colors.yellow}`};
+  margin: ${props => (props.loaded ? '0 auto 12px' : '0 auto')};
+  transition: all 700ms ease;
+`;
 
 const PresentationPreview = styled.div`
   text-align: center;
@@ -233,7 +242,9 @@ const IIIFPresentationDisplay = ({
   const [viewType, setViewType] = useState<ViewType>('unknown');
   const [imageThumbnails, setImageThumbnails] = useState([]);
   const [imageTotal, setImageTotal] = useState(0);
+  const [previewImageLoaded, setPreviewImageLoaded] = useState(false);
   const iiifPresentationManifest = useContext(ManifestContext);
+  const multiPreview = useRef(null);
   const video = getVideo(iiifPresentationManifest);
   const audio = getAudio(iiifPresentationManifest);
 
@@ -318,19 +329,27 @@ const IIIFPresentationDisplay = ({
                 imageThumbnails.slice(0, 1).map((pageType, i) => {
                   return pageType.images.map(image => {
                     return (
-                      <IIIFResponsiveImage
+                      <MultiVolumeContainer
+                        ref={multiPreview}
                         key={image.id}
-                        lang={null}
-                        width={image.width * (400 / image.height)}
-                        height={400}
-                        src={iiifImageTemplate(image.id)({
-                          size: ',400',
-                        })}
-                        srcSet={''}
-                        alt=""
-                        sizes={null}
-                        isLazy={true}
-                      />
+                        loaded={previewImageLoaded}
+                      >
+                        <IIIFResponsiveImage
+                          lang={null}
+                          width={image.width * (400 / image.height)}
+                          height={400}
+                          src={iiifImageTemplate(image.id)({
+                            size: ',400',
+                          })}
+                          srcSet={''}
+                          alt=""
+                          sizes={null}
+                          isLazy={true}
+                          loadHandler={() => {
+                            setPreviewImageLoaded(true);
+                          }}
+                        />
+                      </MultiVolumeContainer>
                     );
                   });
                 })}

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -206,6 +206,7 @@ function previewThumbnails(
 type Props = {|
   iiifPresentationLocation: IIIFPresentationLocation,
   itemUrl: any,
+  childManifestsCount?: number,
 |};
 
 type ViewType =
@@ -224,6 +225,7 @@ type ViewType =
 const IIIFPresentationDisplay = ({
   iiifPresentationLocation,
   itemUrl,
+  childManifestsCount = 0,
 }: Props) => {
   const [viewType, setViewType] = useState<ViewType>('unknown');
   const [imageThumbnails, setImageThumbnails] = useState([]);
@@ -289,28 +291,53 @@ const IIIFPresentationDisplay = ({
                 });
               }}
             >
-              {imageThumbnails.map((pageType, i) => {
-                return pageType.images.map(image => {
-                  return (
-                    <IIIFResponsiveImage
-                      key={image.id}
-                      lang={null}
-                      width={image.width * (400 / image.height)}
-                      height={400}
-                      src={iiifImageTemplate(image.id)({
-                        size: ',400',
-                      })}
-                      srcSet={''}
-                      alt=""
-                      sizes={null}
-                      isLazy={true}
-                    />
-                  );
-                });
-              })}
+              {childManifestsCount === 0 &&
+                imageThumbnails.map((pageType, i) => {
+                  return pageType.images.map(image => {
+                    return (
+                      <IIIFResponsiveImage
+                        key={image.id}
+                        lang={null}
+                        width={image.width * (400 / image.height)}
+                        height={400}
+                        src={iiifImageTemplate(image.id)({
+                          size: ',400',
+                        })}
+                        srcSet={''}
+                        alt=""
+                        sizes={null}
+                        isLazy={true}
+                      />
+                    );
+                  });
+                })}
+              {childManifestsCount > 0 &&
+                imageThumbnails.slice(0, 1).map((pageType, i) => {
+                  return pageType.images.map(image => {
+                    return (
+                      <IIIFResponsiveImage
+                        key={image.id}
+                        lang={null}
+                        width={image.width * (400 / image.height)}
+                        height={400}
+                        src={iiifImageTemplate(image.id)({
+                          size: ',400',
+                        })}
+                        srcSet={''}
+                        alt=""
+                        sizes={null}
+                        isLazy={true}
+                      />
+                    );
+                  });
+                })}
               <Button
-                icon={'gallery'}
-                text={`${imageTotal} images`}
+                icon={childManifestsCount > 0 ? 'zoomIn' : 'gallery'}
+                text={
+                  childManifestsCount > 0
+                    ? `${childManifestsCount} volumes online`
+                    : `${imageTotal} images`
+                }
                 extraClasses={`btn--primary`}
               />
             </a>

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -38,9 +38,12 @@ const PresentationPreview = styled.div`
   img:first-of-type {
     margin-left: 0;
   }
+  img:first-of-type:last-of-type {
+    margin: auto;
+  }
   .btn--primary {
     position: absolute;
-    z-index: 1;
+    z-index: 3;
     bottom: 0;
     left: 50%;
     transform: translate(-50%, 50%);

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -25,7 +25,7 @@ const MultiVolumeContainer = styled.div`
       ? `12px 12px 0px 0px ${props.theme.colors.yellow}`
       : `0px 0px 0px 0px ${props.theme.colors.yellow}`};
   margin: 0 auto 12px;
-  transition: all 1200ms ease;
+  transition: all 600ms ease;
 `;
 
 const PresentationPreview = styled.div`

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -20,11 +20,10 @@ import useOnScreen from '@weco/common/hooks/useOnScreen';
 
 const MultiVolumeContainer = styled.div`
   box-shadow: ${props =>
-    props.isOnScreen || props.hasBeenSeen
+    props.isOnScreen
       ? `12px 12px 0px 0px ${props.theme.colors.yellow}`
       : `0px 0px 0px 0px ${props.theme.colors.yellow}`};
-  margin: ${props =>
-    props.isOnScreen || props.hasBeenSeen ? '0 auto 12px' : '0 auto'};
+  margin: 0 auto 12px;
   transition: all 1200ms ease;
 `;
 
@@ -240,21 +239,11 @@ type MultiVolumePreviewProps = {|
 |};
 
 const MultiVolumePreview = ({ children }: MultiVolumePreviewProps) => {
-  const [hasBeenSeen, setHasBeenSeen] = useState(false);
   const multiPreview = useRef();
   const isOnScreen = useOnScreen({ ref: multiPreview, threshold: 0.75 });
-  useEffect(() => {
-    if (!hasBeenSeen) {
-      setHasBeenSeen(isOnScreen);
-    }
-  }, [isOnScreen]);
 
   return (
-    <MultiVolumeContainer
-      ref={multiPreview}
-      hasBeenSeen={hasBeenSeen}
-      isOnScreen={isOnScreen}
-    >
+    <MultiVolumeContainer ref={multiPreview} isOnScreen={isOnScreen}>
       {children}
     </MultiVolumeContainer>
   );

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -9,7 +9,7 @@ import NextLink from 'next/link';
 import styled from 'styled-components';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { classNames, spacing, grid } from '@weco/common/utils/classnames';
-import { useEffect, useState, useContext, useRef } from 'react';
+import { type Node, useEffect, useState, useContext, useRef } from 'react';
 import { trackEvent } from '@weco/common/utils/ga';
 import ManifestContext from '@weco/common/views/components/ManifestContext/ManifestContext';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
@@ -353,7 +353,7 @@ const IIIFPresentationDisplay = ({
                 imageThumbnails.slice(0, 1).map((pageType, i) => {
                   return pageType.images.map(image => {
                     return (
-                      <MultiVolumePreview key={image.id} image={image}>
+                      <MultiVolumePreview key={image.id}>
                         <IIIFResponsiveImage
                           lang={null}
                           width={image.width * (400 / image.height)}

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -242,7 +242,7 @@ type MultiVolumePreviewProps = {|
 const MultiVolumePreview = ({ children }: MultiVolumePreviewProps) => {
   const [hasBeenSeen, setHasBeenSeen] = useState(false);
   const multiPreview = useRef();
-  const isOnScreen = useOnScreen({ ref: multiPreview, threshold: 0.5 });
+  const isOnScreen = useOnScreen({ ref: multiPreview, threshold: 0.75 });
   useEffect(() => {
     if (!hasBeenSeen) {
       setHasBeenSeen(isOnScreen);

--- a/common/views/components/Label/Label.js
+++ b/common/views/components/Label/Label.js
@@ -22,7 +22,7 @@ const Label = ({ label }: Props) => {
       ${font('hnm', 6)}
       ${spacing({ s: 1 }, { padding: ['top', 'bottom', 'left', 'right'] })}
     `}
-      style={{ display: 'block', whiteSpace: 'nowrap' }}
+      style={{ display: 'inline-block', whiteSpace: 'nowrap' }}
     >
       {label.text}
     </HtmlTag>

--- a/common/views/components/Number/Number.js
+++ b/common/views/components/Number/Number.js
@@ -1,0 +1,35 @@
+// @flow
+import { classNames, font } from '../../../utils/classnames';
+import type { ColorSelection } from '../../../model/color-selections';
+
+type Props = {|
+  number: number,
+  color: ?ColorSelection,
+|};
+
+const Number = ({ number, color }: Props) => (
+  <span
+    className={classNames({
+      [font('wb', 5)]: true,
+      [`bg-${color || 'purple'}`]: true,
+      'margin-left-6': true,
+    })}
+    style={{
+      transform: 'rotateZ(-6deg)',
+      width: '24px',
+      height: '24px',
+      display: 'inline-block',
+      borderRadius: '3px',
+      textAlign: 'center',
+    }}
+  >
+    <span
+      className={color === 'yellow' ? 'font-black' : 'font-white'}
+      style={{ transform: 'rotateZ(6deg) scale(1.2)' }}
+    >
+      {number}
+    </span>
+  </span>
+);
+
+export default Number;

--- a/common/views/components/PartNumberIndicator/PartNumberIndicator.js
+++ b/common/views/components/PartNumberIndicator/PartNumberIndicator.js
@@ -1,6 +1,7 @@
 // @flow
 import { classNames, font } from '../../../utils/classnames';
 import type { ColorSelection } from '../../../model/color-selections';
+import Number from '@weco/common/views/components/Number/Number';
 
 type Props = {|
   number: number,
@@ -14,27 +15,7 @@ const PartNumberIndicator = ({ number, color }: Props) => (
     })}
   >
     Part
-    <span
-      className={classNames({
-        [`bg-${color || 'purple'}`]: true,
-        'margin-left-6': true,
-      })}
-      style={{
-        transform: 'rotateZ(-6deg)',
-        width: '24px',
-        height: '24px',
-        display: 'inline-block',
-        borderRadius: '3px',
-        textAlign: 'center',
-      }}
-    >
-      <span
-        className={'font-white'}
-        style={{ transform: 'rotateZ(6deg) scale(1.2)' }}
-      >
-        {number}
-      </span>
-    </span>
+    <Number color={color} number={number} />
   </div>
 );
 

--- a/common/views/components/WobblyRow/WobblyRow.js
+++ b/common/views/components/WobblyRow/WobblyRow.js
@@ -1,6 +1,7 @@
 import { grid, classNames } from '@weco/common/utils/classnames';
 import { type Node } from 'react';
 import WobblyEdge from '../WobblyEdge/WobblyEdge';
+import { repeatingLsBlack } from '../../../utils/backgrounds';
 
 type WobblyProps = {|
   children: Node,
@@ -9,12 +10,31 @@ type WobblyProps = {|
 const WobblyRow = ({ children }: WobblyProps) => (
   <div
     className={classNames({
-      'row bg-charcoal': true,
+      'row bg-charcoal relative': true,
     })}
   >
+    <div
+      className={classNames({
+        absolute: true,
+      })}
+      style={{
+        backgroundImage: `url(${repeatingLsBlack})`,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'top center',
+        opacity: 0.1,
+        height: '100%',
+        left: 0,
+        right: 0,
+      }}
+    ></div>
     <div className="container">
-      <div className="grid">
-        <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>{children}</div>
+      <div className="grid" style={{ marginTop: '50px' }}>
+        <div
+          className={grid({ s: 12, m: 12, l: 12, xl: 12 })}
+          style={{ marginTop: '-50px' }}
+        >
+          {children}
+        </div>
       </div>
     </div>
     <WobblyEdge isValley={true} intensity={20} background={'white'} />

--- a/common/views/components/WobblyRow/WobblyRow.js
+++ b/common/views/components/WobblyRow/WobblyRow.js
@@ -1,5 +1,6 @@
 import { grid, classNames } from '@weco/common/utils/classnames';
 import { type Node } from 'react';
+import WobblyEdge from '../WobblyEdge/WobblyEdge';
 
 type WobblyProps = {|
   children: Node,
@@ -8,7 +9,7 @@ type WobblyProps = {|
 const WobblyRow = ({ children }: WobblyProps) => (
   <div
     className={classNames({
-      'row bg-cream row--has-wobbly-background': true,
+      'row bg-charcoal': true,
     })}
   >
     <div className="container">
@@ -16,7 +17,7 @@ const WobblyRow = ({ children }: WobblyProps) => (
         <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>{children}</div>
       </div>
     </div>
-    <div className="row__wobbly-background" />
+    <WobblyEdge isValley={true} intensity={20} background={'white'} />
   </div>
 );
 

--- a/common/views/components/WobblyRow/WobblyRow.js
+++ b/common/views/components/WobblyRow/WobblyRow.js
@@ -14,17 +14,19 @@ const WobblyRow = ({ children }: WobblyProps) => (
     })}
   >
     <div
-      className={classNames({
-        absolute: true,
-      })}
       style={{
+        position: 'absolute',
         backgroundImage: `url(${repeatingLsBlack})`,
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'top center',
-        opacity: 0.1,
-        height: '100%',
+        opacity: 0.15,
+        height: '65%',
+        overflow: 'hidden',
+        top: 0,
         left: 0,
         right: 0,
+        transform: 'scale(1.5)',
+        transformOrigin: 'top left',
       }}
     ></div>
     <div className="container">
@@ -37,7 +39,7 @@ const WobblyRow = ({ children }: WobblyProps) => (
         </div>
       </div>
     </div>
-    <WobblyEdge isValley={true} intensity={20} background={'white'} />
+    <WobblyEdge isValley={true} intensity={25} background={'white'} />
   </div>
 );
 

--- a/common/views/components/WobblyRow/WobblyRow.js
+++ b/common/views/components/WobblyRow/WobblyRow.js
@@ -20,13 +20,11 @@ const WobblyRow = ({ children }: WobblyProps) => (
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'top center',
         opacity: 0.15,
-        height: '65%',
         overflow: 'hidden',
         top: 0,
         left: 0,
         right: 0,
-        transform: 'scale(1.5)',
-        transformOrigin: 'top left',
+        height: '100%',
       }}
     ></div>
     <div className="container">

--- a/common/views/components/WobblyRow/WobblyRow.js
+++ b/common/views/components/WobblyRow/WobblyRow.js
@@ -37,7 +37,7 @@ const WobblyRow = ({ children }: WobblyProps) => (
         </div>
       </div>
     </div>
-    <WobblyEdge isValley={true} intensity={25} background={'white'} />
+    <WobblyEdge isValley={false} intensity={35} background={'white'} />
   </div>
 );
 

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -12,12 +12,14 @@ import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import LinkLabels from '../LinkLabels/LinkLabels';
 import TogglesContext from '../TogglesContext/TogglesContext';
 import VerticalSpace from '../styled/VerticalSpace';
+import Label from '@weco/common/views/components/Label/Label';
 
 type Props = {|
   work: Work,
+  manifestsCount?: number,
 |};
 
-const WorkHeader = ({ work }: Props) => {
+const WorkHeader = ({ work, manifestsCount = 0 }: Props) => {
   const digitalLocations = getDigitalLocations(work);
   const physicalLocations = getPhysicalLocations(work);
   const productionDates = getProductionDates(work);
@@ -122,6 +124,13 @@ const WorkHeader = ({ work }: Props) => {
             )
           }
         </TogglesContext.Consumer>
+        {manifestsCount > 0 && (
+          <VerticalSpace size="m" properties={['margin-top']}>
+            <Label
+              label={{ url: null, text: `${manifestsCount} volumes online` }}
+            />
+          </VerticalSpace>
+        )}
       </SpacingComponent>
     </VerticalSpace>
   );

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -12,7 +12,7 @@ import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import LinkLabels from '../LinkLabels/LinkLabels';
 import TogglesContext from '../TogglesContext/TogglesContext';
 import VerticalSpace from '../styled/VerticalSpace';
-import Label from '@weco/common/views/components/Label/Label';
+import Number from '@weco/common/views/components/Number/Number';
 
 type Props = {|
   work: Work,
@@ -126,12 +126,15 @@ const WorkHeader = ({ work, childManifestsCount = 0 }: Props) => {
         </TogglesContext.Consumer>
         {childManifestsCount > 0 && (
           <VerticalSpace size="m" properties={['margin-top']}>
-            <Label
-              label={{
-                url: null,
-                text: `${childManifestsCount} volumes online`,
-              }}
-            />
+            <p
+              className={classNames({
+                [font('hnm', 5)]: true,
+                'no-margin': true,
+              })}
+            >
+              <Number color="yellow" number={childManifestsCount} /> Volumes
+              online
+            </p>
           </VerticalSpace>
         )}
       </SpacingComponent>

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -16,10 +16,10 @@ import Label from '@weco/common/views/components/Label/Label';
 
 type Props = {|
   work: Work,
-  manifestsCount?: number,
+  childManifestsCount?: number,
 |};
 
-const WorkHeader = ({ work, manifestsCount = 0 }: Props) => {
+const WorkHeader = ({ work, childManifestsCount = 0 }: Props) => {
   const digitalLocations = getDigitalLocations(work);
   const physicalLocations = getPhysicalLocations(work);
   const productionDates = getProductionDates(work);
@@ -124,10 +124,13 @@ const WorkHeader = ({ work, manifestsCount = 0 }: Props) => {
             )
           }
         </TogglesContext.Consumer>
-        {manifestsCount > 0 && (
+        {childManifestsCount > 0 && (
           <VerticalSpace size="m" properties={['margin-top']}>
             <Label
-              label={{ url: null, text: `${manifestsCount} volumes online` }}
+              label={{
+                url: null,
+                text: `${childManifestsCount} volumes online`,
+              }}
             />
           </VerticalSpace>
         )}


### PR DESCRIPTION
references #4483

Removes the multi volume preview from behind a toggle and updates it based on Gareth's design.
Updates other previews to match.
![multi-preview](https://user-images.githubusercontent.com/6051896/62007048-d4ef8100-b140-11e9-9ca2-48f6f9632ea0.gif)
<img width="1323" alt="book-preview" src="https://user-images.githubusercontent.com/6051896/62007050-d91b9e80-b140-11e9-8584-406549e3524f.png">
<img width="1245" alt="image-preview" src="https://user-images.githubusercontent.com/6051896/62007052-dae56200-b140-11e9-9d77-52729a73d504.png">

