### PR TITLE
Make sure spacing component has href passed when it's an a tag

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -73,6 +73,7 @@ const WorkCard = ({ work }: Props) => {
         {...workUrl({
           id: work.id,
         })}
+        passHref
       >
         <VerticalSpace
           as="a"

--- a/common/views/components/IIIFImagePreview/IIIFImagePreview.js
+++ b/common/views/components/IIIFImagePreview/IIIFImagePreview.js
@@ -51,7 +51,7 @@ const IIIFImagePreview = ({
 
   return (
     <ImagePreview>
-      <NextLink {...itemUrl}>
+      <NextLink {...itemUrl} passHref>
         <VerticalSpace
           size="xl"
           properties={['padding-bottom']}

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -426,6 +426,7 @@ class EventPage extends Component<Props, State> {
                         ? event.bookingEnquiryTeam.email
                         : ''
                     }?subject=${event.title}`}
+                    passHref
                   >
                     <VerticalSpace
                       as="a"


### PR DESCRIPTION
I noticed the cursor wasn't a pointer when `<NextLink />`s contained a `<VerticalSpace />` as the first child (so links wouldn't work with JS off). This sorts it. (instead of #4617). Fixes #4616.

[See here for explanation](https://github.com/zeit/next.js/#forcing-the-link-to-expose-href-to-its-child)