### PR TITLE
Fix type size on visit us

### DIFF
--- a/content/webapp/pages/visit-us.js
+++ b/content/webapp/pages/visit-us.js
@@ -77,13 +77,13 @@ const BespokeBody = (
               <Icon name="clock" extraClasses={`float-l margin-right-12`} />
               <div
                 className={classNames({
-                  [font('hnl', 4)]: true,
+                  [font('hnl', 5)]: true,
                   'float-l': true,
                 })}
               >
                 <h2
                   className={classNames({
-                    [font('hnm', 4)]: true,
+                    [font('hnm', 5)]: true,
                     'no-margin': true,
                   })}
                 >{`Today's opening times`}</h2>


### PR DESCRIPTION
The opening times on `/visit-us` are too big (after the repo-wide typography reshuffle). This sorts it.

<img width="793" alt="Screenshot 2019-07-30 at 13 57 56" src="https://user-images.githubusercontent.com/1394592/62131055-5591b700-b2d2-11e9-9ca1-6d3c8793038e.png">
