### PR TITLE
Empty query with dates

### DIFF
--- a/catalogue/webapp/components/DateSlider/DateSlider.js
+++ b/catalogue/webapp/components/DateSlider/DateSlider.js
@@ -1,0 +1,155 @@
+import { Slider, Rail, Handles, Tracks } from 'react-compound-slider';
+import theme from '@weco/common/views/themes/default';
+
+type KeyboardHandleProps = {|
+  domain: [number, number],
+  handle: {
+    id: string,
+    value: number,
+    percent: number,
+  },
+  disabled: boolean,
+  getHandleProps: () => void,
+|};
+
+const KeyboardHandle = ({
+  domain: [min, max],
+  handle: { id, value, percent },
+  disabled,
+  getHandleProps,
+}: KeyboardHandleProps) => {
+  return (
+    <button
+      type="button"
+      role="slider"
+      aria-valuemin={min}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      style={{
+        left: `${percent}%`,
+        position: 'absolute',
+        transform: 'translate(-50%, 0)',
+        borderRadius: '50%',
+        backgroundColor: disabled ? '#666' : 'black',
+        zIndex: 2,
+        width: 24,
+        height: 24,
+        cursor: 'pointer',
+      }}
+      {...getHandleProps(id)}
+    >
+      <span
+        style={{
+          display: 'block',
+          position: 'absolute',
+          transform: 'translate(-50%, -36px)',
+        }}
+      >
+        {value || ''}
+      </span>
+    </button>
+  );
+};
+
+type TrackProps = {|
+  source: {| id: string, value: number, percent: number |},
+  target: {| id: string, value: number, percent: number |},
+  getTrackProps: () => void,
+|};
+const Track = ({ source, target, getTrackProps }: TrackProps) => {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        height: 10,
+        zIndex: 1,
+        marginTop: 6,
+        backgroundColor: theme.colors.green,
+        borderRadius: 5,
+        cursor: 'pointer',
+        left: `${source.percent}%`,
+        width: `${target.percent - source.percent}%`,
+      }}
+      {...getTrackProps()} // this will set up events if you want it to be clickeable (optional)
+    />
+  );
+};
+
+const sliderStyle = {
+  position: 'relative',
+  width: '100%',
+  height: 50,
+};
+
+const railStyle = {
+  position: 'absolute',
+  width: '100%',
+  height: 10,
+  marginTop: 6,
+  borderRadius: 5,
+  backgroundColor: theme.colors.green,
+};
+
+type DateSliderProps = {|
+  startValues: {| to: number, from: number |},
+  updateTo: () => void,
+  updateFrom: () => void,
+|};
+
+const DateSlider = ({ startValues, updateTo, updateFrom }: DateSliderProps) => {
+  const domain = { from: 1780, to: 2020 };
+  return (
+    <div style={{ marginTop: '42px' }}>
+      <Slider
+        rootStyle={sliderStyle}
+        domain={[domain.from, domain.to]}
+        step={10}
+        mode={2}
+        values={[startValues.from || domain.from, startValues.to || domain.to]}
+        onUpdate={([from, to]) => {
+          updateFrom(`${from}`);
+          updateTo(`${to}`);
+        }}
+      >
+        <div style={railStyle} />
+        <Rail>
+          {(
+            { getRailProps } // adding the rail props sets up events on the rail
+          ) => <div style={railStyle} {...getRailProps()} />}
+        </Rail>
+        <Handles>
+          {({ handles, getHandleProps }) => (
+            <div className="slider-handles">
+              {handles.map(handle => (
+                <div key={handle.id}>
+                  <KeyboardHandle
+                    handle={handle}
+                    domain={[0, 2020]}
+                    getHandleProps={getHandleProps}
+                    disabled={false}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </Handles>
+        <Tracks right={false}>
+          {({ tracks, getTrackProps }) => (
+            <div className="slider-tracks">
+              {tracks.map(({ id, source, target }) => (
+                <Track
+                  key={id}
+                  source={source}
+                  target={target}
+                  getTrackProps={getTrackProps}
+                />
+              ))}
+            </div>
+          )}
+        </Tracks>
+      </Slider>
+    </div>
+  );
+};
+
+export default DateSlider;

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -9,6 +9,9 @@ import { classNames, font } from '@weco/common/utils/classnames';
 import { trackEvent } from '@weco/common/utils/ga';
 import { worksUrl } from '@weco/common/services/catalogue/urls';
 import CatalogueSearchContext from '@weco/common/views/components/CatalogueSearchContext/CatalogueSearchContext';
+import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
+import DateSlider from '@weco/catalogue/components/DateSlider/DateSlider';
+import Button from '@weco/common/views/components/Buttons/Button/Button';
 
 type Props = {|
   ariaDescribedBy: string,
@@ -40,14 +43,21 @@ const ClearSearch = styled.button`
 `;
 
 const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
-  const { query, workType, _queryType, setQueryType } = useContext(
-    CatalogueSearchContext
-  );
+  const {
+    query,
+    workType,
+    _queryType,
+    setQueryType,
+    _dateFrom,
+    _dateTo,
+  } = useContext(CatalogueSearchContext);
 
   // This is the query used by the input, that is then eventually passed to the
   // Router
   const [inputQuery, setInputQuery] = useState(query);
   const searchInput = useRef(null);
+  const [inputDateFrom, setInputDateFrom] = useState(_dateFrom);
+  const [inputDateTo, setInputDateTo] = useState(_dateTo);
 
   // We need to make sure that the changes to `query` affect `inputQuery` as
   // when we navigate between pages which all contain `SearchForm`, each
@@ -57,7 +67,34 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
     if (query !== inputQuery) {
       setInputQuery(query);
     }
-  }, [query]);
+
+    if (_dateFrom !== inputDateFrom) {
+      setInputDateFrom(_dateFrom);
+    }
+
+    if (_dateTo !== inputDateTo) {
+      setInputDateTo(_dateTo);
+    }
+  }, [query, _dateFrom, _dateTo]);
+
+  useEffect(() => {
+    if (inputDateFrom !== _dateFrom || inputDateTo !== _dateTo) {
+      updateUrl();
+    }
+  }, [inputDateFrom, inputDateTo]);
+
+  function updateUrl() {
+    const link = worksUrl({
+      query: inputQuery,
+      workType,
+      page: 1,
+      _queryType,
+      _dateFrom: inputDateFrom,
+      _dateTo: inputDateTo,
+    });
+
+    typeof window !== 'undefined' && Router.push(link.href, link.as);
+  }
 
   return (
     <>
@@ -73,14 +110,7 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
             label: query,
           });
 
-          const link = worksUrl({
-            query: inputQuery,
-            workType,
-            page: 1,
-            _queryType,
-          });
-
-          Router.push(link.href, link.as);
+          updateUrl();
 
           return false;
         }}
@@ -160,6 +190,75 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
               </label>
             )
           }
+        </TogglesContext.Consumer>
+
+        <TogglesContext.Consumer>
+          {({ showDatesPrototype, showDatesSliderPrototype }) => (
+            <>
+              {(showDatesPrototype || showDatesSliderPrototype) && (
+                <VerticalSpace size="m" properties={['margin-top']}>
+                  <div
+                    style={{
+                      display: showDatesSliderPrototype ? 'none' : 'block',
+                    }}
+                  >
+                    <VerticalSpace size="s" properties={['margin-top']}>
+                      <label>
+                        from:{' '}
+                        <input
+                          value={inputDateFrom || ''}
+                          onChange={event => {
+                            setInputDateFrom(`${event.currentTarget.value}`);
+                          }}
+                          style={{ width: '8em', padding: '0.5em' }}
+                        />
+                      </label>{' '}
+                      <label>
+                        to:{' '}
+                        <input
+                          value={inputDateTo || ''}
+                          onChange={event => {
+                            setInputDateTo(`${event.currentTarget.value}`);
+                          }}
+                          style={{ width: '8em', padding: '0.5em' }}
+                        />
+                      </label>
+                    </VerticalSpace>
+                    <VerticalSpace size="m" properties={['margin-top']}>
+                      <Button
+                        type="primary"
+                        text="Clear dates"
+                        clickHandler={() => {
+                          setInputDateFrom('');
+                          setInputDateTo('');
+                        }}
+                      />
+                    </VerticalSpace>
+                  </div>
+                  {showDatesSliderPrototype && (
+                    <>
+                      <DateSlider
+                        startValues={{
+                          to: inputDateTo,
+                          from: inputDateFrom,
+                        }}
+                        updateFrom={setInputDateFrom}
+                        updateTo={setInputDateTo}
+                      />
+                      <Button
+                        type="primary"
+                        text="Clear dates"
+                        clickHandler={() => {
+                          setInputDateFrom('');
+                          setInputDateTo('');
+                        }}
+                      />
+                    </>
+                  )}
+                </VerticalSpace>
+              )}
+            </>
+          )}
         </TogglesContext.Consumer>
       </form>
     </>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -30,6 +30,7 @@ import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
 import WorkCard from '../components/WorkCard/WorkCard';
 import VerticalSpace from '@weco/common/views/components/styled/VerticalSpace';
+import { formatDateForApi } from '@weco/common/utils/dates';
 
 type Props = {|
   query: ?string,
@@ -44,7 +45,7 @@ const WorksSearchProvider = ({ works, query, page, workType }: Props) => (
 
 const Works = ({ works }: Props) => {
   const [loading, setLoading] = useState(false);
-  const { query, page, workType, _queryType } = useContext(
+  const { query, page, workType, _queryType, _dateFrom, _dateTo } = useContext(
     CatalogueSearchContext
   );
   const trackEvent = () => {
@@ -212,6 +213,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: undefined,
                       page: 1,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !workType,
                   },
@@ -221,6 +224,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['a', 'v'],
                       page: 1,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -234,6 +239,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['k', 'q'],
                       page: 1,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -249,6 +256,8 @@ const Works = ({ works }: Props) => {
                       query,
                       workType: ['f', 's'],
                       page: 1,
+                      _dateFrom,
+                      _dateTo,
                     }),
                     selected: !!(
                       workType &&
@@ -283,6 +292,8 @@ const Works = ({ works }: Props) => {
                             query,
                             workType,
                             page,
+                            _dateFrom,
+                            _dateTo,
                           })}
                           onPageChange={async (event, newPage) => {
                             event.preventDefault();
@@ -290,6 +301,8 @@ const Works = ({ works }: Props) => {
                               query,
                               workType,
                               page: newPage,
+                              _dateFrom,
+                              _dateTo,
                             });
                             Router.push(link.href, link.as).then(() =>
                               window.scrollTo(0, 0)
@@ -427,6 +440,9 @@ const Works = ({ works }: Props) => {
 
 WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
+  const _dateFrom = formatDateForApi(ctx.query._dateFrom);
+  const _dateTo = formatDateForApi(ctx.query._dateTo);
+
   const page = ctx.query.page ? parseInt(ctx.query.page, 10) : 1;
 
   const {
@@ -456,6 +472,8 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     workType: workTypeFilter,
     'items.locations.locationType': ['iiif-image', 'iiif-presentation'],
     _queryType,
+    ...(_dateFrom ? { _dateFrom } : {}),
+    ...(_dateTo ? { _dateTo } : {}),
   };
 
   const worksOrError = await getWorks({

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -458,15 +458,21 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     _queryType,
   };
 
-  const worksOrError =
-    query && query !== ''
-      ? await getWorks({
-          query,
-          page,
-          filters,
-          env: useStageApi ? 'stage' : 'prod',
-        })
-      : null;
+  const worksOrError = await getWorks({
+    query,
+    page,
+    filters,
+    env: useStageApi ? 'stage' : 'prod',
+  });
+  // const worksOrError =
+  //   query && query !== ''
+  //     ? await getWorks({
+  //         query,
+  //         page,
+  //         filters,
+  //         env: useStageApi ? 'stage' : 'prod',
+  //       })
+  //     : null;
 
   return {
     works: worksOrError,

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -451,6 +451,8 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     searchCandidateQueryBoost,
     searchCandidateQueryMsmBoost,
     audioVideoInSearch,
+    showDatesPrototype,
+    showDatesSliderPrototype,
   } = ctx.query.toggles;
   const toggledQueryType = searchCandidateQueryMsm
     ? 'msm'
@@ -476,21 +478,19 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     ...(_dateTo ? { _dateTo } : {}),
   };
 
-  const worksOrError = await getWorks({
-    query,
-    page,
-    filters,
-    env: useStageApi ? 'stage' : 'prod',
-  });
-  // const worksOrError =
-  //   query && query !== ''
-  //     ? await getWorks({
-  //         query,
-  //         page,
-  //         filters,
-  //         env: useStageApi ? 'stage' : 'prod',
-  //       })
-  //     : null;
+  const isDatesPrototype = showDatesPrototype || showDatesSliderPrototype;
+  const shouldGetWorks = isDatesPrototype
+    ? filters._dateTo || filters._dateFrom || (query && query !== '')
+    : query && query !== '';
+
+  const worksOrError = shouldGetWorks
+    ? await getWorks({
+        query,
+        page,
+        filters,
+        env: useStageApi ? 'stage' : 'prod',
+      })
+    : null;
 
   return {
     works: worksOrError,

--- a/common/package.json
+++ b/common/package.json
@@ -39,6 +39,7 @@
     "raven-js": "^3.26.3",
     "raw-loader": "^2.0.0",
     "react": "^16.8.2",
+    "react-compound-slider": "^2.2.0",
     "react-dom": "^16.8.2",
     "react-ga": "^2.5.6",
     "react-transition-group": "^2.5.0",

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -14,6 +14,8 @@ type WorksUrlProps = {|
   workType?: ?(string[]),
   itemsLocationsLocationType?: ?(string[]),
   _queryType?: ?QueryType,
+  _dateFrom?: ?string,
+  _dateTo?: ?string,
 |};
 
 type WorkUrlProps = {|
@@ -63,6 +65,8 @@ export function worksUrl({
   page,
   workType,
   _queryType,
+  _dateFrom,
+  _dateTo,
 }: WorksUrlProps): NextLinkType {
   return {
     href: {
@@ -72,6 +76,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
+        _dateFrom: _dateFrom,
+        _dateTo: _dateTo,
       }),
     },
     as: {
@@ -81,6 +87,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
+        _dateFrom: _dateFrom,
+        _dateTo: _dateTo,
       }),
     },
   };

--- a/common/utils/dates.js
+++ b/common/utils/dates.js
@@ -37,3 +37,9 @@ export function getNextWeekendDateRange(date: Date): DateRange {
     end: end.endOf('day').toDate(),
   };
 }
+
+export function formatDateForApi(dateString: string): ?string {
+  const date = dateString && london(dateString);
+
+  return date && date.isValid() ? date.format('YYYY-MM-DD') : undefined;
+}

--- a/common/views/components/BackToResults/BackToResults.js
+++ b/common/views/components/BackToResults/BackToResults.js
@@ -7,7 +7,7 @@ import { trackEvent } from '../../../utils/ga';
 import { worksUrl } from '../../../services/catalogue/urls';
 
 const BackToResults = () => {
-  const { query, workType, page, _queryType } = useContext(
+  const { query, workType, page, _queryType, _dateFrom, _dateTo } = useContext(
     CatalogueSearchContext
   );
   const link = worksUrl({
@@ -15,6 +15,8 @@ const BackToResults = () => {
     page,
     workType,
     _queryType,
+    _dateFrom,
+    _dateTo,
   });
   return (
     <NextLink {...link}>

--- a/common/views/components/Buttons/Button/Button.js
+++ b/common/views/components/Buttons/Button/Button.js
@@ -98,6 +98,7 @@ const Button = forwardRef(
         )} flex-inline flex--v-center`}
         onClick={handleClick}
         disabled={disabled}
+        type="button"
       >
         <span className="flex-inline flex--v-center">
           {icon && <Icon name={icon} />}

--- a/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
+++ b/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
@@ -15,6 +15,8 @@ export type CatalogueQuery = {|
   workType: ?(string[]),
   itemsLocationsLocationType: ?(string[]),
   _queryType: ?string,
+  _dateFrom: ?string,
+  _dateTo: ?string,
 |};
 
 type ContextProps = {|
@@ -24,6 +26,8 @@ type ContextProps = {|
   setWorkType: (value: ?(string[])) => void,
   setItemsLocationsLocationType: (value: ?(string[])) => void,
   setQueryType: (value: ?string) => void,
+  setDateFrom: (value: ?string) => void,
+  setDateTo: (value: ?string) => void,
 |};
 
 const defaultState: CatalogueQuery = {
@@ -32,6 +36,8 @@ const defaultState: CatalogueQuery = {
   workType: null,
   itemsLocationsLocationType: null,
   _queryType: null,
+  _dateFrom: null,
+  _dateTo: null,
 };
 
 const CatalogueSearchContext = createContext<ContextProps>({
@@ -41,6 +47,8 @@ const CatalogueSearchContext = createContext<ContextProps>({
   setWorkType: () => {},
   setItemsLocationsLocationType: () => {},
   setQueryType: () => {},
+  setDateFrom: () => {},
+  setDateTo: () => {},
 });
 
 type CatalogueSearchProviderProps = {
@@ -61,6 +69,8 @@ const CatalogueSearchProvider = ({
     itemsLocationsLocationType: router.query['items.locations.locationType']
       ? router.query['items.locations.locationType'].split(',')
       : null,
+    _dateFrom: router.query._dateFrom ? router.query._dateFrom : null,
+    _dateTo: router.query._dateTo ? router.query._dateTo : null,
   };
   const state = {
     ...defaultState,
@@ -70,6 +80,8 @@ const CatalogueSearchProvider = ({
   const [query, setQuery] = useState(state.query);
   const [page, setPage] = useState(state.page);
   const [workType, setWorkType] = useState(state.workType);
+  const [_dateFrom, setDateFrom] = useState(state._dateFrom);
+  const [_dateTo, setDateTo] = useState(state._dateTo);
   const [itemsLocationsLocationType, setItemsLocationsLocationType] = useState(
     state.itemsLocationsLocationType
   );
@@ -80,11 +92,15 @@ const CatalogueSearchProvider = ({
     workType,
     itemsLocationsLocationType,
     _queryType,
+    _dateFrom,
+    _dateTo,
     setQuery,
     setPage,
     setWorkType,
     setItemsLocationsLocationType,
     setQueryType,
+    setDateFrom,
+    setDateTo,
   };
 
   useEffect(() => {
@@ -116,6 +132,8 @@ const CatalogueSearchProvider = ({
             ? params['items.locations.location.type'].split(',')
             : defaultState.itemsLocationsLocationType,
           _queryType: params._queryType || defaultState._queryType,
+          _dateFrom: params._dateFrom || null,
+          _dateTo: params._dateTo || null,
         };
 
         setQuery(state.query);
@@ -123,6 +141,8 @@ const CatalogueSearchProvider = ({
         setWorkType(state.workType);
         setItemsLocationsLocationType(state.itemsLocationsLocationType);
         setQueryType(state._queryType);
+        setDateFrom(state._dateFrom);
+        setDateTo(state._dateTo);
       }
     }
 
@@ -150,6 +170,8 @@ const SearchRouter = ({ children }: SearchRouterProps) => {
     workType,
     itemsLocationsLocationType,
     _queryType,
+    _dateFrom,
+    _dateTo,
   } = useContext(CatalogueSearchContext);
   const push = () => {
     const link = worksUrl({
@@ -158,6 +180,8 @@ const SearchRouter = ({ children }: SearchRouterProps) => {
       workType: workType,
       itemsLocationsLocationType: itemsLocationsLocationType,
       _queryType: _queryType,
+      _dateFrom: _dateFrom,
+      _dateTo: _dateTo,
     });
     Router.push(
       { ...link.href, pathname: '/works-context' },

--- a/common/views/components/Tracker/Tracker.js
+++ b/common/views/components/Tracker/Tracker.js
@@ -89,10 +89,11 @@ const track = (eventProps: LoggerEvent) => {
 
   const { event, ...restOfEvent } = eventProps;
 
-  window.analytics.track(event, {
-    ...restOfEvent,
-    toggles,
-  });
+  window.analytics &&
+    window.analytics.track(event, {
+      ...restOfEvent,
+      toggles,
+    });
 };
 
 const TrackerScript = () => {

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -41,5 +41,19 @@ module.exports = {
       description:
         'Shows a preview for each volume in a multi volume work on the work page.',
     },
+    {
+      id: 'showDatesPrototype',
+      title: 'Show exploratory work on faceting by date',
+      defaultValue: false,
+      description:
+        'Shows additional UI to allow a user to narrow search results by a date range.',
+    },
+    {
+      id: 'showDatesSliderPrototype',
+      title: 'Show exploratory work on using a slider UI to facet by date',
+      defaultValue: false,
+      description:
+        'Shows additional UI to allow a user to narrow search results by using a date range slider.',
+    },
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,6 +816,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.4":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
@@ -3276,6 +3283,11 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
+
+d3-array@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -8874,6 +8886,16 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-compound-slider@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/react-compound-slider/-/react-compound-slider-2.2.0.tgz#d79adb60d3b42fb2f2e6a88d7630795244a434a2"
+  integrity sha512-HFYKtbL1MZyrBrK29Y7KBRU2INnPqX0yODdcWd539sif7eLPoG2uEULloga2ju7l7zcIWzJcehO12WrieHDIiA==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    d3-array "^1.2.4"
+    prop-types "^15.7.2"
+    warning "^3.0.0"
+
 react-dom@^16.8.2:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.6.tgz#71d6303f631e8b0097f56165ef608f051ff6e10f"
@@ -10921,6 +10943,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@^1.5.0:
   version "1.6.0"


### PR DESCRIPTION
Currently we don't fetch works if the query is `null` or an empty string, but it's not unreasonable to expect people might want to refine the entire collection by date (regardless of whether a search term is included).