### PR TITLE
Empty query with dates

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -458,15 +458,21 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     _queryType,
   };
 
-  const worksOrError =
-    query && query !== ''
-      ? await getWorks({
-          query,
-          page,
-          filters,
-          env: useStageApi ? 'stage' : 'prod',
-        })
-      : null;
+  const worksOrError = await getWorks({
+    query,
+    page,
+    filters,
+    env: useStageApi ? 'stage' : 'prod',
+  });
+  // const worksOrError =
+  //   query && query !== ''
+  //     ? await getWorks({
+  //         query,
+  //         page,
+  //         filters,
+  //         env: useStageApi ? 'stage' : 'prod',
+  //       })
+  //     : null;
 
   return {
     works: worksOrError,

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -451,6 +451,8 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     searchCandidateQueryBoost,
     searchCandidateQueryMsmBoost,
     audioVideoInSearch,
+    showDatesPrototype,
+    showDatesSliderPrototype,
   } = ctx.query.toggles;
   const toggledQueryType = searchCandidateQueryMsm
     ? 'msm'
@@ -476,21 +478,19 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     ...(_dateTo ? { _dateTo } : {}),
   };
 
-  const worksOrError = await getWorks({
-    query,
-    page,
-    filters,
-    env: useStageApi ? 'stage' : 'prod',
-  });
-  // const worksOrError =
-  //   query && query !== ''
-  //     ? await getWorks({
-  //         query,
-  //         page,
-  //         filters,
-  //         env: useStageApi ? 'stage' : 'prod',
-  //       })
-  //     : null;
+  const isDatesPrototype = showDatesPrototype || showDatesSliderPrototype;
+  const shouldGetWorks = isDatesPrototype
+    ? filters._dateTo || filters._dateFrom || (query && query !== '')
+    : query && query !== '';
+
+  const worksOrError = shouldGetWorks
+    ? await getWorks({
+        query,
+        page,
+        filters,
+        env: useStageApi ? 'stage' : 'prod',
+      })
+    : null;
 
   return {
     works: worksOrError,


### PR DESCRIPTION
Currently we don't fetch works if the query is null or an empty string, but it's not unreasonable to expect people might want to refine the entire collection by date (regardless of whether a search term is included).