### PR TITLE
Aggregate date bugfixes

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -353,7 +353,9 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
                   </VerticalSpace>
                 )}
               {showDatesAggregatePrototype &&
-                (inputQuery && inputQuery.toLowerCase() === 'darwin') && (
+                (query &&
+                  inputQuery &&
+                  inputQuery.toLowerCase() === 'darwin') && (
                   <TabNav items={dateRangeItems} />
                 )}
             </>

--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -132,8 +132,8 @@ const SearchForm = ({ ariaDescribedBy, compact }: Props) => {
         query,
         workType,
         page: 1,
-        _dateFrom: range.from,
-        _dateTo: range.to,
+        _dateFrom: `${range.from}-01-01`,
+        _dateTo: `${range.to}-01-01`,
       }),
       selected: !!(
         _dateFrom &&

--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -96,11 +96,11 @@ const NavItem = ({
       <TogglesContext.Consumer>
         {({ showDatesAggregatePrototype }) => (
           <>
-            {!showDatesAggregatePrototype && (
-              <NavItemInner selected={selected}>{text}</NavItemInner>
-            )}
-            {showDatesAggregatePrototype && (
+            {showDatesAggregatePrototype &&
+            (text !== 'All' && text !== 'Pictures' && text !== 'Books') ? (
               <NavItemInnerTemp selected={selected}>{text}</NavItemInnerTemp>
+            ) : (
+              <NavItemInner selected={selected}>{text}</NavItemInner>
             )}
           </>
         )}


### PR DESCRIPTION
- Add `month-day` to link so Safari can handle client side routing by date
- Wait for the search form to have been submitted with the term 'darwin' before showing the aggregate links
- Keep the `TabNav` with the yellow underline for 'All', 'Books', and 'Pictures' links.