### PR TITLE
No results messaging

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -440,7 +440,7 @@ const Works = ({ works }: Props) => {
                     {(_dateFrom || _dateTo) && (
                       <> within the date range provided</>
                     )}
-                    .
+                    . Please try different search terms or attributes.
                   </p>
                 </div>
               </div>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -412,7 +412,10 @@ const Works = ({ works }: Props) => {
         )}
 
         {works && works.results.length === 0 && (
-          <VerticalSpace size="l" properties={['padding-top']}>
+          <VerticalSpace
+            size="xl"
+            properties={['padding-top', 'padding-bottom']}
+          >
             <div className="container">
               <div className="grid">
                 <div className={grid({ s: 12, m: 10, l: 8, xl: 8 })}>
@@ -440,7 +443,7 @@ const Works = ({ works }: Props) => {
                     {(_dateFrom || _dateTo) && (
                       <> within the date range provided</>
                     )}
-                    . Please try different search terms or attributes.
+                    . Please try again.
                   </p>
                 </div>
               </div>

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -416,16 +416,30 @@ const Works = ({ works }: Props) => {
             <div className="container">
               <div className="grid">
                 <div className={grid({ s: 12, m: 10, l: 8, xl: 8 })}>
-                  <p className="h1">
+                  <p className={font('hnl', 2)}>
                     We couldn{`'`}t find anything that matched{' '}
                     <span
                       className={classNames({
-                        [font('hnl', 2)]: true,
+                        [font('hnm', 2)]: true,
                       })}
                       style={{ fontWeight: '400' }}
                     >
                       {query}
                     </span>
+                    {workType && (
+                      <>
+                        {' '}
+                        in{' '}
+                        <span className={font('hnm', 2)}>
+                          {(workType.includes('k') && 'pictures') ||
+                            (workType.includes('f') && 'audio/video') ||
+                            (workType.includes('a') && 'books')}
+                        </span>
+                      </>
+                    )}
+                    {(_dateFrom || _dateTo) && (
+                      <> within the date range provided</>
+                    )}
                     .
                   </p>
                 </div>


### PR DESCRIPTION
Improving the no-results messaging to account for work types and date ranges.

<img width="951" alt="Screenshot 2019-08-05 at 15 41 32" src="https://user-images.githubusercontent.com/1394592/62472860-89b81c80-b797-11e9-97e3-e7afa1670f2a.png">
