### PR TITLE
Check for existence of secret token from SoundCloud

### DIFF
--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -612,17 +612,17 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
             },
           };
 
-        // case 'gifVideo':
-        //   return {
-        //     type: 'gifVideo',
-        //     weight: slice.slice_label,
-        //     value: {
-        //       caption: parseRichText(slice.primary.caption),
-        //       videoUrl: slice.primary.video && slice.primary.video.url,
-        //       playbackRate: slice.primary.playbackRate || 1,
-        //       tasl: parseTaslFromString(slice.primary.tasl),
-        //     },
-        //   };
+        case 'gifVideo':
+          return {
+            type: 'gifVideo',
+            weight: slice.slice_label,
+            value: {
+              caption: parseRichText(slice.primary.caption),
+              videoUrl: slice.primary.video && slice.primary.video.url,
+              playbackRate: slice.primary.playbackRate || 1,
+              tasl: parseTaslFromString(slice.primary.tasl),
+            },
+          };
 
         case 'contact':
           return {

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -612,17 +612,17 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
             },
           };
 
-        case 'gifVideo':
-          return {
-            type: 'gifVideo',
-            weight: slice.slice_label,
-            value: {
-              caption: parseRichText(slice.primary.caption),
-              videoUrl: slice.primary.video && slice.primary.video.url,
-              playbackRate: slice.primary.playbackRate || 1,
-              tasl: parseTaslFromString(slice.primary.tasl),
-            },
-          };
+        // case 'gifVideo':
+        //   return {
+        //     type: 'gifVideo',
+        //     weight: slice.slice_label,
+        //     value: {
+        //       caption: parseRichText(slice.primary.caption),
+        //       videoUrl: slice.primary.video && slice.primary.video.url,
+        //       playbackRate: slice.primary.playbackRate || 1,
+        //       tasl: parseTaslFromString(slice.primary.tasl),
+        //     },
+        //   };
 
         case 'contact':
           return {
@@ -651,18 +651,20 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
             const apiUrl = embed.html.match(/url=([^&]*)&/);
             const secretToken = embed.html.match(/secret_token=([^"]*)"/);
 
-            return {
-              type: 'soundcloudEmbed',
-              weight: getWeight(slice.slice_label),
-              value: {
-                embedUrl: `https://w.soundcloud.com/player/?url=${
-                  apiUrl[1]
-                }%3Fsecret_token%3D${
-                  secretToken[1]
-                }&color=%23ff5500&inverse=false&auto_play=false&show_user=true`,
-                caption: slice.primary.caption,
-              },
-            };
+            return (
+              secretToken && {
+                type: 'soundcloudEmbed',
+                weight: getWeight(slice.slice_label),
+                value: {
+                  embedUrl: `https://w.soundcloud.com/player/?url=${
+                    apiUrl[1]
+                  }%3Fsecret_token%3D${
+                    secretToken[1]
+                  }&color=%23ff5500&inverse=false&auto_play=false&show_user=true`,
+                  caption: slice.primary.caption,
+                },
+              }
+            );
           }
 
           if (embed.provider_name === 'YouTube') {


### PR DESCRIPTION
[SoundCloud have changed something to do with `secret_token`s](https://community.soundcloud.com/share-embed-230064/playlist-secret-token-not-authenticating-playlist-tracks-getting-404-error-7429924) (which we previously relied on).

This probably means SoundCloud embeds won't be working anywhere.

This fix does a null check on the `secret_token` so pages won't 404, but we'll still need to get SoundCloud embeds working again.

