### PR TITLE
Fix check for last item in tag array

### DIFF
--- a/common/views/components/Tags/Tags.js
+++ b/common/views/components/Tags/Tags.js
@@ -69,7 +69,7 @@ const Tags = ({ tags }: Props) => {
                       <Space
                         as="span"
                         h={
-                          i !== arr.length
+                          i !== arr.length - 1
                             ? { size: 's', properties: ['margin-right'] }
                             : undefined
                         }


### PR DESCRIPTION
The check for the last item in the array of items that can be within a `Tag` has a bug after the spacing update. This fixes it.

__Before__
![image](https://user-images.githubusercontent.com/1394592/62618743-ee48b800-b90c-11e9-946c-6c82497ab28f.png)

__After__
![image](https://user-images.githubusercontent.com/1394592/62618712-d5400700-b90c-11e9-9715-40119a18bb40.png)
