### PR TITLE
Flow Space component

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -1,4 +1,5 @@
 // @flow
+import type { ComponentType } from 'react';
 import NextLink from 'next/link';
 import styled from 'styled-components';
 import { type Work } from '@weco/common/model/work';
@@ -17,7 +18,9 @@ import { workUrl } from '@weco/common/services/catalogue/urls';
 import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { imageSizes } from '@weco/common/utils/image-sizes';
-import Space from '@weco/common/views/components/styled/Space';
+import Space, {
+  type SpaceComponentProps,
+} from '@weco/common/views/components/styled/Space';
 
 type Props = {|
   work: Work,
@@ -33,7 +36,7 @@ const Details = styled.div`
     flex-grow: 1;
   `}
 `;
-const Preview = styled(Space).attrs(() => ({
+const Preview: ComponentType<SpaceComponentProps> = styled(Space).attrs(() => ({
   className: classNames({
     'text-align-center': true,
   }),

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -1,4 +1,5 @@
 // @flow
+import { type ComponentType } from 'react';
 import { type Context } from 'next';
 import {
   type Work,
@@ -16,11 +17,15 @@ import Layout12 from '@weco/common/views/components/Layout12/Layout12';
 import IIIFViewer from '@weco/common/views/components/IIIFViewer/IIIFViewer';
 import BetaMessage from '@weco/common/views/components/BetaMessage/BetaMessage';
 import styled from 'styled-components';
-import Space from '@weco/common/views/components/styled/Space';
+import Space, {
+  type SpaceComponentProps,
+} from '@weco/common/views/components/styled/Space';
 
-const IframePdfViewer = styled(Space).attrs({
-  className: 'h-center',
-})`
+const IframePdfViewer: ComponentType<SpaceComponentProps> = styled(Space).attrs(
+  {
+    className: 'h-center',
+  }
+)`
   width: 90vw;
   height: 90vh;
   display: block;

--- a/common/views/components/IIIFViewer/IIIFViewer.js
+++ b/common/views/components/IIIFViewer/IIIFViewer.js
@@ -10,7 +10,7 @@ import {
   getDownloadOptionsFromManifest,
 } from '@weco/common/utils/works';
 import styled from 'styled-components';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type ComponentType } from 'react';
 import getLicenseInfo from '@weco/common/utils/get-license-info';
 import { itemUrl, workUrl } from '@weco/common/services/catalogue/urls';
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -34,7 +34,7 @@ import { trackEvent } from '@weco/common/utils/ga';
 import Download from '@weco/catalogue/components/Download/ViewerDownload';
 import ViewerExtraContent from '@weco/catalogue/components/Download/ViewerExtraContent';
 import Router from 'next/router';
-import Space from '../styled/Space';
+import Space, { type SpaceComponentProps } from '../styled/Space';
 
 const headerHeight = 149;
 
@@ -146,11 +146,13 @@ const IIIFViewer = styled.div.attrs(props => ({
   }
 `;
 
-const IIIFViewerMain = styled(Space).attrs(props => ({
-  className: classNames({
-    'relative bg-charcoal font-white': true,
-  }),
-}))`
+const IIIFViewerMain: ComponentType<SpaceComponentProps> = styled(Space).attrs(
+  props => ({
+    className: classNames({
+      'relative bg-charcoal font-white': true,
+    }),
+  })
+)`
   noscript & {
     height: 80%;
     @media (min-width: ${props => props.theme.sizes.medium}px) {

--- a/common/views/components/MessageBar/MessageBar.js
+++ b/common/views/components/MessageBar/MessageBar.js
@@ -1,18 +1,20 @@
 // @flow
-import { type Node } from 'react';
+import { type Node, type ComponentType } from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '../../../utils/classnames';
-import Space from '../styled/Space';
+import Space, { type SpaceComponentProps } from '../styled/Space';
 
-const PurpleTag = styled(Space).attrs(props => ({
-  className: classNames({
-    caps: true,
-    'inline-block': true,
-    'bg-purple': true,
-    'font-white': true,
-    [font('hnm', 5)]: true,
-  }),
-}))`
+const PurpleTag: ComponentType<SpaceComponentProps> = styled(Space).attrs(
+  props => ({
+    className: classNames({
+      caps: true,
+      'inline-block': true,
+      'bg-purple': true,
+      'font-white': true,
+      [font('hnm', 5)]: true,
+    }),
+  })
+)`
   padding: 0.2em 0.5em;
 `;
 

--- a/common/views/components/RelevanceRater/RelevanceRater.js
+++ b/common/views/components/RelevanceRater/RelevanceRater.js
@@ -1,11 +1,12 @@
 // @flow
+import { type ComponentType } from 'react';
 import styled from 'styled-components';
 import { classNames, font } from '../../../utils/classnames';
 import {
   trackRelevanceRating,
   RelevanceRatingEventNames,
 } from '../Tracker/Tracker';
-import Space from '../styled/Space';
+import Space, { type SpaceComponentProps } from '../styled/Space';
 
 const RelevanceRaterStyle = styled.div.attrs(props => ({
   className: classNames({
@@ -16,11 +17,13 @@ const RelevanceRaterStyle = styled.div.attrs(props => ({
   height: 100%;
 `;
 
-const RelevanceRating = styled(Space).attrs(props => ({
-  className: classNames({
-    'plain-button': true,
-  }),
-}))`
+const RelevanceRating: ComponentType<SpaceComponentProps> = styled(Space).attrs(
+  props => ({
+    className: classNames({
+      'plain-button': true,
+    }),
+  })
+)`
   width: 25%;
   cursor: pointer;
   border: 1px solid ${props => props.theme.colors.smoke};

--- a/common/views/components/TabNav/TabNav.js
+++ b/common/views/components/TabNav/TabNav.js
@@ -1,10 +1,11 @@
 // @flow
 
+import { type ComponentType } from 'react';
 import styled from 'styled-components';
 import NextLink from 'next/link';
 import { type TextLink } from '../../../model/text-links';
 import { font, classNames } from '../../../utils/classnames';
-import Space from '../styled/Space';
+import Space, { type SpaceComponentProps } from '../styled/Space';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 
 type SelectableTextLink = {|
@@ -17,13 +18,15 @@ type Props = {
   items: SelectableTextLink[],
 };
 
-const NavItemInner = styled(Space).attrs(props => ({
-  className: classNames({
-    selected: props.selected,
-    block: true,
-    relative: true,
-  }),
-}))`
+const NavItemInner: ComponentType<SpaceComponentProps> = styled(Space).attrs(
+  props => ({
+    className: classNames({
+      selected: props.selected,
+      block: true,
+      relative: true,
+    }),
+  })
+)`
   z-index: 1;
   padding: 0 0.3em;
 

--- a/common/views/components/Tags/Tags.js
+++ b/common/views/components/Tags/Tags.js
@@ -1,16 +1,17 @@
 // @flow
-import styled from 'styled-components';
+import type { ComponentType } from 'react';
 import type { NextLinkType } from '@weco/common/model/next-link-type';
+import styled from 'styled-components';
 import { font, classNames } from '../../../utils/classnames';
 import NextLink from 'next/link';
-import Space from '../styled/Space';
+import Space, { type SpaceComponentProps } from '../styled/Space';
 
 export type TagType = {|
   textParts: string[],
   linkAttributes: NextLinkType,
 |};
 
-const Tag = styled(Space)`
+const Tag: ComponentType<SpaceComponentProps> = styled(Space)`
   border-radius: 3px;
   text-decoration: none;
   padding: 0.2em 0.5em;

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -1,7 +1,7 @@
 // @flow
-import { forwardRef } from 'react';
+import { forwardRef, type ComponentType } from 'react';
 import styled from 'styled-components';
-import Space from '../styled/Space';
+import Space, { type SpaceComponentProps } from '../styled/Space';
 import { classNames } from '../../../utils/classnames';
 
 const VisuallyHidden = styled.div`
@@ -16,7 +16,7 @@ const VisuallyHidden = styled.div`
   white-space: nowrap;
 `;
 
-const StyledInput = styled(Space).attrs({
+const StyledInput: ComponentType<SpaceComponentProps> = styled(Space).attrs({
   className: classNames({}),
 })`
   width: 100%;

--- a/common/views/components/VenueHours/VenueHours.js
+++ b/common/views/components/VenueHours/VenueHours.js
@@ -1,5 +1,5 @@
 import { type Weight } from '@weco/common/services/prismic/parsers';
-import { useContext } from 'react';
+import { useContext, type ComponentType } from 'react';
 import { classNames, font } from '@weco/common/utils/classnames';
 import { formatDay, formatDayMonth } from '@weco/common/utils/format-date';
 import styled from 'styled-components';
@@ -14,9 +14,9 @@ import {
   convertJsonDateStringsToMoment,
 } from '../../../services/prismic/opening-times';
 import OpeningTimesContext from '@weco/common/views/components/OpeningTimesContext/OpeningTimesContext';
-import Space from '../styled/Space';
+import Space, { type SpaceComponentProps } from '../styled/Space';
 
-const VenueHoursImage = styled(Space)`
+const VenueHoursImage: ComponentType<SpaceComponentProps> = styled(Space)`
   ${props => props.theme.media.medium`
     width: 50%;
   `}
@@ -27,7 +27,7 @@ const VenueHoursImage = styled(Space)`
   `}
 `;
 
-const VenueHoursTimes = styled(Space)`
+const VenueHoursTimes: ComponentType<SpaceComponentProps> = styled(Space)`
   ${props => props.theme.media.medium`
     float: left;
     width:33%;
@@ -36,11 +36,13 @@ const VenueHoursTimes = styled(Space)`
   `}
 `;
 
-const JauntyBox = styled(Space).attrs(props => ({
-  className: classNames({
-    'bg-yellow inline-block': true,
-  }),
-}))`
+const JauntyBox: ComponentType<SpaceComponentProps> = styled(Space).attrs(
+  props => ({
+    className: classNames({
+      'bg-yellow inline-block': true,
+    }),
+  })
+)`
   padding-left: 30px;
   padding-right: 42px;
   margin-left: -12px;
@@ -178,8 +180,10 @@ const VenueHours = ({ venue, weight }: Props) => {
         return (
           <>
             <JauntyBox
-              size="l"
-              properties={['padding-top', 'padding-bottom']}
+              v={{
+                size: 'l',
+                properties: ['padding-top', 'padding-bottom'],
+              }}
               key={upcomingExceptionalPeriod}
               topLeft={randomPx()}
               topRight={randomPx()}

--- a/common/views/components/VenueHours/VenueHours.js
+++ b/common/views/components/VenueHours/VenueHours.js
@@ -1,3 +1,5 @@
+// @flow
+
 import { type Weight } from '@weco/common/services/prismic/parsers';
 import { useContext, type ComponentType } from 'react';
 import { classNames, font } from '@weco/common/utils/classnames';
@@ -135,8 +137,17 @@ const VenueHours = ({ venue, weight }: Props) => {
               contentUrl={venueAdditionalInfo[venue.name.toLowerCase()].image}
               width={1600}
               height={900}
+              crops={{}}
               alt=""
-              tasl={null}
+              tasl={{
+                title: null,
+                author: null,
+                sourceName: null,
+                sourceLink: null,
+                license: null,
+                copyrightHolder: null,
+                copyrightLink: null,
+              }}
               sizesQueries="(min-width: 1340px) 303px, (min-width: 960px) calc(30.28vw - 68px), (min-width: 600px) calc(50vw - 42px), calc(100vw - 36px)"
               extraClasses=""
               showTasl={false}
@@ -169,14 +180,14 @@ const VenueHours = ({ venue, weight }: Props) => {
           ))}
         </ul>
       </VenueHoursTimes>
-      {upcomingExceptionalPeriods.map(upcomingExceptionalPeriod => {
+      {upcomingExceptionalPeriods.map((upcomingExceptionalPeriod, i) => {
         const firstOverride = upcomingExceptionalPeriod.find(
           date => date.overrideType
         );
         const overrideType =
           firstOverride && firstOverride.overrideType === 'other'
             ? 'Unusual'
-            : firstOverride.overrideType;
+            : firstOverride && firstOverride.overrideType;
         return (
           <>
             <JauntyBox
@@ -184,7 +195,7 @@ const VenueHours = ({ venue, weight }: Props) => {
                 size: 'l',
                 properties: ['padding-top', 'padding-bottom'],
               }}
-              key={upcomingExceptionalPeriod}
+              key={i}
               topLeft={randomPx()}
               topRight={randomPx()}
               bottomRight={randomPx()}
@@ -216,9 +227,10 @@ const VenueHours = ({ venue, weight }: Props) => {
                 })}
               >
                 {upcomingExceptionalPeriod.map(p => (
-                  <li key={p.overrideDate}>
-                    {formatDay(p.overrideDate)} {formatDayMonth(p.overrideDate)}{' '}
-                    {p.opens ? `${p.opens}—${p.closes}` : 'Closed'}
+                  <li key={p.overrideDate.toString()}>
+                    {formatDay(p.overrideDate.toDate())}{' '}
+                    {formatDayMonth(p.overrideDate.toDate())}{' '}
+                    {p.opens && p.closes ? `${p.opens}—${p.closes}` : 'Closed'}
                   </li>
                 ))}
               </ul>

--- a/common/views/components/styled/Space.js
+++ b/common/views/components/styled/Space.js
@@ -42,7 +42,7 @@ type HorizontalSpaceProps = {|
   negative?: boolean,
 |};
 
-type SpaceComponentProps = {
+export type SpaceComponentProps = {
   v?: VerticalSpaceProps,
   h?: HorizontalSpaceProps,
 };


### PR DESCRIPTION
When we use the `Space` component as-is, we get typing. Unfortunately, if we wrap the `Space` component in a different `styled` component (e.g `const Thingy = styled(Space)...`), the typing from `Space` doesn't come along for free – we have to type the wrapped components in the same way.