### PR TITLE
Add past events link to /events

### DIFF
--- a/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
+++ b/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults.js
@@ -88,7 +88,7 @@ const LayoutPaginatedResults = ({
       </Space>
     </SpacingSection>
 
-    <SpacingSection>
+    <>
       {paginatedResults.totalPages > 1 && (
         <Layout12>
           <Space
@@ -171,7 +171,7 @@ const LayoutPaginatedResults = ({
           </Layout12>
         </Space>
       )}
-    </SpacingSection>
+    </>
   </Fragment>
 );
 

--- a/content/webapp/pages/articles.js
+++ b/content/webapp/pages/articles.js
@@ -11,6 +11,7 @@ import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { articleLd } from '@weco/common/utils/json-ld';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import LayoutPaginatedResults from '@weco/common/views/components/LayoutPaginatedResults/LayoutPaginatedResults';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 
 type Props = {|
   articles: PaginatedResults<Article>,
@@ -54,19 +55,21 @@ export class ArticlesPage extends Component<Props> {
           firstArticle && firstArticle.image && firstArticle.image.alt
         }
       >
-        <LayoutPaginatedResults
-          showFreeAdmissionMessage={false}
-          title={'Articles'}
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescription,
-              spans: [],
-            },
-          ]}
-          paginatedResults={articles}
-          paginationRoot={'articles'}
-        />
+        <SpacingSection>
+          <LayoutPaginatedResults
+            showFreeAdmissionMessage={false}
+            title={'Articles'}
+            description={[
+              {
+                type: 'paragraph',
+                text: pageDescription,
+                spans: [],
+              },
+            ]}
+            paginatedResults={articles}
+            paginationRoot={'articles'}
+          />
+        </SpacingSection>
       </PageLayout>
     );
   }

--- a/content/webapp/pages/books.js
+++ b/content/webapp/pages/books.js
@@ -7,6 +7,7 @@ import LayoutPaginatedResults from '@weco/common/views/components/LayoutPaginate
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import type { Book } from '@weco/common/model/books';
 import type { PaginatedResults } from '@weco/common/services/prismic/types';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 
 type Props = {|
   books: PaginatedResults<Book>,
@@ -53,19 +54,21 @@ export class BooksPage extends Component<Props> {
         }
         imageAltText={firstBook && firstBook.image && firstBook.image.alt}
       >
-        <LayoutPaginatedResults
-          showFreeAdmissionMessage={false}
-          title={'Books'}
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescription,
-              spans: [],
-            },
-          ]}
-          paginatedResults={books}
-          paginationRoot={'books'}
-        />
+        <SpacingSection>
+          <LayoutPaginatedResults
+            showFreeAdmissionMessage={false}
+            title={'Books'}
+            description={[
+              {
+                type: 'paragraph',
+                text: pageDescription,
+                spans: [],
+              },
+            ]}
+            paginatedResults={books}
+            paginationRoot={'books'}
+          />
+        </SpacingSection>
       </PageLayout>
     );
   }

--- a/content/webapp/pages/events.js
+++ b/content/webapp/pages/events.js
@@ -13,6 +13,10 @@ import type { PaginatedResults } from '@weco/common/services/prismic/types';
 import type { Period } from '@weco/common/model/periods';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { convertJsonToDates } from './event';
+import MoreLink from '@weco/common/views/components/MoreLink/MoreLink';
+import Layout12 from '@weco/common/views/components/Layout12/Layout12';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
+import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {|
   displayTitle: string,
@@ -71,19 +75,28 @@ export class ArticleSeriesPage extends Component<Props> {
         }
         imageAltText={firstEvent && firstEvent.image && firstEvent.image.alt}
       >
-        <LayoutPaginatedResults
-          showFreeAdmissionMessage={true}
-          title={displayTitle}
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescription,
-              spans: [],
-            },
-          ]}
-          paginatedResults={convertedPaginatedResults}
-          paginationRoot={`events${period ? `/${period}` : ''}`}
-        />
+        <SpacingSection>
+          <LayoutPaginatedResults
+            showFreeAdmissionMessage={true}
+            title={displayTitle}
+            description={[
+              {
+                type: 'paragraph',
+                text: pageDescription,
+                spans: [],
+              },
+            ]}
+            paginatedResults={convertedPaginatedResults}
+            paginationRoot={`events${period ? `/${period}` : ''}`}
+          />
+          {period === 'current-and-coming-up' && (
+            <Layout12>
+              <Space v={{ size: 'm', properties: ['margin-top'] }}>
+                <MoreLink url={`/events/past`} name={`View past events`} />
+              </Space>
+            </Layout12>
+          )}
+        </SpacingSection>
       </PageLayout>
     );
   }

--- a/content/webapp/pages/exhibitions.js
+++ b/content/webapp/pages/exhibitions.js
@@ -9,6 +9,7 @@ import type { UiExhibition } from '@weco/common/model/exhibitions';
 import type { Period } from '@weco/common/model/periods';
 import type { PaginatedResults } from '@weco/common/services/prismic/types';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
+import SpacingSection from '@weco/common/views/components/SpacingSection/SpacingSection';
 
 type Props = {|
   exhibitions: PaginatedResults<UiExhibition>,
@@ -56,19 +57,21 @@ export class ExhibitionsPage extends Component<Props> {
           firstExhibition && firstExhibition.image && firstExhibition.image.alt
         }
       >
-        <LayoutPaginatedResults
-          showFreeAdmissionMessage={true}
-          title={displayTitle}
-          description={[
-            {
-              type: 'paragraph',
-              text: pageDescription,
-              spans: [],
-            },
-          ]}
-          paginatedResults={exhibitions}
-          paginationRoot={`exhibitions${period ? `/${period}` : ''}`}
-        />
+        <SpacingSection>
+          <LayoutPaginatedResults
+            showFreeAdmissionMessage={true}
+            title={displayTitle}
+            description={[
+              {
+                type: 'paragraph',
+                text: pageDescription,
+                spans: [],
+              },
+            ]}
+            paginatedResults={exhibitions}
+            paginationRoot={`exhibitions${period ? `/${period}` : ''}`}
+          />
+        </SpacingSection>
       </PageLayout>
     );
   }


### PR DESCRIPTION
Fixes #3572

Adds a 'View past events' link to the bottom of the `/events` page. In the (unlikely) event that there is more than a single page of current-and-upcoming events, this link will appear at the end of each page of results.

![image](https://user-images.githubusercontent.com/1394592/62635916-7ee4bf80-b930-11e9-83fa-5b6fd9f3aa25.png)
