### PR TITLE
Audio and video in search

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -85,8 +85,13 @@ type Props = {|
   itemsLocationsLocationType: ?(string[]),
   workType: ?(string[]),
   query: ?string,
-  video: ?{}, // TODO
-  audio: ?{}, // TODO
+  video: ?{
+    '@id': string,
+    format: string,
+  },
+  audio: ?{
+    '@id': string,
+  },
 |};
 
 const ItemPage = ({
@@ -194,7 +199,7 @@ const ItemPage = ({
 
       {video && (
         <Layout12>
-         <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+          <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
             <video
               controls
               style={{

--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -9,7 +9,11 @@ import fetch from 'isomorphic-unfetch';
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import { type IIIFManifest } from '@weco/common/model/iiif';
 import { itemUrl } from '@weco/common/services/catalogue/urls';
-import { getDownloadOptionsFromManifest } from '@weco/common/utils/works';
+import {
+  getDownloadOptionsFromManifest,
+  getVideo,
+  getAudio,
+} from '@weco/common/utils/works';
 import { getWork } from '../services/catalogue/works';
 import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayout/CataloguePageLayout';
 import Raven from 'raven-js';
@@ -30,6 +34,7 @@ const IframePdfViewer: ComponentType<SpaceComponentProps> = styled(Space).attrs(
   height: 90vh;
   display: block;
   border: 0;
+  margin-top: 98px;
 `;
 
 async function getCanvasOcr(canvas) {
@@ -80,6 +85,8 @@ type Props = {|
   itemsLocationsLocationType: ?(string[]),
   workType: ?(string[]),
   query: ?string,
+  video: ?{}, // TODO
+  audio: ?{}, // TODO
 |};
 
 const ItemPage = ({
@@ -97,6 +104,8 @@ const ItemPage = ({
   itemsLocationsLocationType,
   workType,
   query,
+  video,
+  audio,
 }: Props) => {
   const title = (manifest && manifest.label) || (work && work.title) || '';
   const [iiifImageLocation] =
@@ -165,13 +174,55 @@ const ItemPage = ({
       hideFooter={true}
       fixHeader={true}
     >
-      {!pdfRendering && !mainImageService && !iiifImageLocationUrl && (
+      {audio && (
         <Layout12>
           <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
-            <BetaMessage message="We are working to make this item available online in April 2019." />
+            <audio
+              controls
+              style={{
+                maxWidth: '100%',
+                display: 'block',
+                margin: '98px auto 0',
+              }}
+              src={audio['@id']}
+            >
+              {`Sorry, your browser doesn't support embedded audio.`}
+            </audio>
           </Space>
         </Layout12>
       )}
+
+      {video && (
+        <Layout12>
+         <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+            <video
+              controls
+              style={{
+                maxWidth: '100%',
+                maxHeight: '70vh',
+                display: 'block',
+                margin: '98px auto auto',
+              }}
+            >
+              <source src={video['@id']} type={video.format} />
+              {`Sorry, your browser doesn't support embedded video.`}
+            </video>
+          </Space>
+        </Layout12>
+      )}
+      {!audio &&
+        !video &&
+        !pdfRendering &&
+        !mainImageService &&
+        !iiifImageLocationUrl && (
+          <Layout12>
+            <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
+              <div style={{ marginTop: '98px' }}>
+                <BetaMessage message="We are working to make this item available online." />
+              </div>
+            </Space>
+          </Layout12>
+        )}
       {pdfRendering && !mainImageService && (
         <IframePdfViewer
           v={{
@@ -228,12 +279,12 @@ ItemPage.getInitialProps = async (ctx: Context): Promise<Props> => {
     ? `https://wellcomelibrary.org/iiif/${sierraId}/manifest`
     : null;
   const manifest = manifestUrl ? await (await fetch(manifestUrl)).json() : null;
-
+  const video = manifest && getVideo(manifest);
+  const audio = manifest && getAudio(manifest);
   // The sierraId originates from the iiif presentation manifest url
   // If we don't have one, we must be trying to display a work with an iiif image location,
   // so we need to get the work object to get the necessary data to display
   const work = !sierraId ? await getWork({ id: workId }) : null;
-
   const canvases =
     manifest && manifest.sequences && manifest.sequences[0].canvases;
   const currentCanvas = canvases && canvases[canvasIndex];
@@ -255,6 +306,8 @@ ItemPage.getInitialProps = async (ctx: Context): Promise<Props> => {
     itemsLocationsLocationType: null,
     workType: null,
     query,
+    video,
+    audio,
   };
 };
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -469,7 +469,6 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     searchCandidateQueryMsm,
     searchCandidateQueryBoost,
     searchCandidateQueryMsmBoost,
-    audioVideoInSearch,
     showDatesPrototype,
     showDatesSliderPrototype,
   } = ctx.query.toggles;
@@ -482,11 +481,9 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
     : null;
   const workTypeQuery = ctx.query.workType;
   const _queryType = ctx.query._queryType || toggledQueryType;
-  const defaultWorkType = ['a', 'k', 'q', 'v'];
+  const defaultWorkType = ['a', 'k', 'q', 'v', 'f', 's'];
   const workTypeFilter = workTypeQuery
     ? workTypeQuery.split(',').filter(Boolean)
-    : audioVideoInSearch
-    ? defaultWorkType.concat(['f', 's'])
     : defaultWorkType;
 
   const filters = {

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -213,71 +213,61 @@ const Works = ({ works }: Props) => {
 
         {works && (
           <Layout12>
-            <TogglesContext.Consumer>
-              {({ audioVideoInSearch }) => {
-                const items = [
-                  {
-                    text: 'All',
-                    link: worksUrl({
-                      query,
-                      workType: undefined,
-                      page: 1,
-                      _dateFrom,
-                      _dateTo,
-                    }),
-                    selected: !workType,
-                  },
-                  {
-                    text: 'Books',
-                    link: worksUrl({
-                      query,
-                      workType: ['a', 'v'],
-                      page: 1,
-                      _dateFrom,
-                      _dateTo,
-                    }),
-                    selected: !!(
-                      workType &&
-                      (workType.indexOf('a') !== -1 &&
-                        workType.indexOf('v') !== -1)
-                    ),
-                  },
-                  {
-                    text: 'Pictures',
-                    link: worksUrl({
-                      query,
-                      workType: ['k', 'q'],
-                      page: 1,
-                      _dateFrom,
-                      _dateTo,
-                    }),
-                    selected: !!(
-                      workType &&
-                      (workType.indexOf('k') !== -1 &&
-                        workType.indexOf('q') !== -1)
-                    ),
-                  },
-                ];
-                if (audioVideoInSearch) {
-                  items.push({
-                    text: 'Audio/Video',
-                    link: worksUrl({
-                      query,
-                      workType: ['f', 's'],
-                      page: 1,
-                      _dateFrom,
-                      _dateTo,
-                    }),
-                    selected: !!(
-                      workType &&
-                      (workType.indexOf('f') !== -1 &&
-                        workType.indexOf('s') !== -1)
-                    ),
-                  });
-                }
-                return <TabNav items={items} />;
-              }}
-            </TogglesContext.Consumer>
+            <TabNav
+              large={true}
+              items={[
+                {
+                  text: 'All',
+                  link: worksUrl({
+                    query,
+                    workType: undefined,
+                    page: 1,
+                  }),
+                  selected: !workType,
+                },
+                {
+                  text: 'Books',
+                  link: worksUrl({
+                    query,
+                    workType: ['a', 'v'],
+                    page: 1,
+                  }),
+                  selected: !!(
+                    workType &&
+                    (workType.indexOf('a') !== -1 &&
+                      workType.indexOf('v') !== -1)
+                  ),
+                },
+                {
+                  text: 'Pictures',
+                  link: worksUrl({
+                    query,
+                    workType: ['k', 'q'],
+                    page: 1,
+                  }),
+                  selected: !!(
+                    workType &&
+                    (workType.indexOf('k') !== -1 &&
+                      workType.indexOf('q') !== -1)
+                  ),
+                },
+                {
+                  text: 'Audio/Video',
+                  link: worksUrl({
+                    query,
+                    workType: ['f', 's'],
+                    page: 1,
+                    _dateFrom,
+                    _dateTo,
+                  }),
+                  selected: !!(
+                    workType &&
+                    (workType.indexOf('f') !== -1 &&
+                      workType.indexOf('s') !== -1)
+                  ),
+                },
+              ]}
+            />
           </Layout12>
         )}
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -214,7 +214,6 @@ const Works = ({ works }: Props) => {
         {works && (
           <Layout12>
             <TabNav
-              large={true}
               items={[
                 {
                   text: 'All',

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -221,6 +221,8 @@ const Works = ({ works }: Props) => {
                     query,
                     workType: undefined,
                     page: 1,
+                    _dateFrom,
+                    _dateTo,
                   }),
                   selected: !workType,
                 },
@@ -230,6 +232,8 @@ const Works = ({ works }: Props) => {
                     query,
                     workType: ['a', 'v'],
                     page: 1,
+                    _dateFrom,
+                    _dateTo,
                   }),
                   selected: !!(
                     workType &&
@@ -243,6 +247,8 @@ const Works = ({ works }: Props) => {
                     query,
                     workType: ['k', 'q'],
                     page: 1,
+                    _dateFrom,
+                    _dateTo,
                   }),
                   selected: !!(
                     workType &&

--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -134,6 +134,36 @@ export function getManifestViewType(iiifManifest: IIIFManifest) {
     : 'none';
 }
 
+export function getVideo(iiifManifest: IIIFManifest) {
+  const videoSequence =
+    iiifManifest &&
+    iiifManifest.mediaSequences &&
+    iiifManifest.mediaSequences.find(sequence =>
+      sequence.elements.find(
+        element => element['@type'] === 'dctypes:MovingImage'
+      )
+    );
+  return (
+    videoSequence &&
+    videoSequence.elements.find(
+      element => element['@type'] === 'dctypes:MovingImage'
+    )
+  );
+}
+
+export function getAudio(iiifManifest: IIIFManifest) {
+  const videoSequence =
+    iiifManifest &&
+    iiifManifest.mediaSequences &&
+    iiifManifest.mediaSequences.find(sequence =>
+      sequence.elements.find(element => element['@type'] === 'dctypes:Sound')
+    );
+  return (
+    videoSequence &&
+    videoSequence.elements.find(element => element['@type'] === 'dctypes:Sound')
+  );
+}
+
 export type IIIFPresentationLocation = {|
   locationType: {
     id: 'iiif-presentation',

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -4,6 +4,8 @@ import {
   type IIIFPresentationLocation,
   getCanvases,
   getManifestViewType,
+  getAudio,
+  getVideo,
 } from '@weco/common/utils/works';
 import NextLink from 'next/link';
 import styled from 'styled-components';
@@ -119,36 +121,6 @@ function randomImages(
     label: 'random',
     images,
   };
-}
-
-function getVideo(iiifManifest: IIIFManifest) {
-  const videoSequence =
-    iiifManifest &&
-    iiifManifest.mediaSequences &&
-    iiifManifest.mediaSequences.find(sequence =>
-      sequence.elements.find(
-        element => element['@type'] === 'dctypes:MovingImage'
-      )
-    );
-  return (
-    videoSequence &&
-    videoSequence.elements.find(
-      element => element['@type'] === 'dctypes:MovingImage'
-    )
-  );
-}
-
-function getAudio(iiifManifest: IIIFManifest) {
-  const videoSequence =
-    iiifManifest &&
-    iiifManifest.mediaSequences &&
-    iiifManifest.mediaSequences.find(sequence =>
-      sequence.elements.find(element => element['@type'] === 'dctypes:Sound')
-    );
-  return (
-    videoSequence &&
-    videoSequence.elements.find(element => element['@type'] === 'dctypes:Sound')
-  );
 }
 
 function structuredImages(iiifManifest: IIIFManifest): IIIFThumbnails[] {

--- a/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
+++ b/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview.js
@@ -379,9 +379,7 @@ const IIIFPresentationDisplay = ({
 
   if (viewType === 'video' && video) {
     return (
-      <div className="container">
-        <div className="grid">
-          <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+      <WobblyRow>
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <video
                 controls
@@ -396,17 +394,14 @@ const IIIFPresentationDisplay = ({
                 {`Sorry, your browser doesn't support embedded video.`}
               </video>
             </Space>
-          </div>
-        </div>
-      </div>
+        </WobblyRow>
     );
   }
 
   if (viewType === 'audio' && audio) {
     return (
-      <div className="container">
-        <div className="grid">
-          <div className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+      <WobblyRow>
+
             <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <audio
                 controls
@@ -420,9 +415,7 @@ const IIIFPresentationDisplay = ({
                 {`Sorry, your browser doesn't support embedded audio.`}
               </audio>
             </Space>{' '}
-          </div>{' '}
-        </div>{' '}
-      </div>
+  </WobblyRow>
     );
   }
 

--- a/common/views/components/WobblyRow/WobblyRow.js
+++ b/common/views/components/WobblyRow/WobblyRow.js
@@ -31,7 +31,7 @@ const WobblyRow = ({ children }: WobblyProps) => (
       <div className="grid" style={{ marginTop: '50px' }}>
         <div
           className={grid({ s: 12, m: 12, l: 12, xl: 12 })}
-          style={{ marginTop: '-50px' }}
+          style={{ marginTop: '-50px', position: 'relative' }}
         >
           {children}
         </div>

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -29,12 +29,6 @@ module.exports = {
         'These can be either physical or digital locations. We need to do a little bt of work figuring out what all the codes mean to get the messaging right.',
     },
     {
-      id: 'audioVideoInSearch',
-      title: 'Include audio and video in search results',
-      defaultValue: false,
-      description: 'Include audio and video in search results',
-    },
-    {
       id: 'showDatesPrototype',
       title:
         'Display input boxes to allow a user to refine results by a date range',


### PR DESCRIPTION
references #4326

removes audio and video from behind toggle; allows audio and video to be played on item page instead of in the work  preview if there is no javascript
