### PR TITLE
Add describedBy words to contributors in bylines

### DIFF
--- a/common/model/contributors.js
+++ b/common/model/contributors.js
@@ -16,6 +16,7 @@ export type Organisation = {|
 type ContributorRole = {|
   id: string,
   title: string,
+  describedBy: ?string,
 |};
 
 export type PersonContributor = {|

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -250,7 +250,7 @@ export function parseContributors(
           ? {
               id: contributor.role.id,
               title: asText(contributor.role.data.title) || '',
-              describedBy: contributor.role.data.describedBy || '',
+              describedBy: contributor.role.data.describedBy,
             }
           : null;
 

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -250,6 +250,7 @@ export function parseContributors(
           ? {
               id: contributor.role.id,
               title: asText(contributor.role.data.title) || '',
+              describedBy: contributor.role.data.describedBy || '',
             }
           : null;
 

--- a/common/utils/capitalise.js
+++ b/common/utils/capitalise.js
@@ -1,0 +1,7 @@
+// @flow
+export default (word: string): string => {
+  const [firstLetter] = word;
+  const restOfWord = word.slice(1);
+
+  return `${firstLetter.toUpperCase()}${restOfWord}`;
+};

--- a/common/utils/capitalise.js
+++ b/common/utils/capitalise.js
@@ -1,7 +1,0 @@
-// @flow
-export default (word: string): string => {
-  const [firstLetter] = word;
-  const restOfWord = word.slice(1);
-
-  return `${firstLetter.toUpperCase()}${restOfWord}`;
-};

--- a/common/utils/grammar.js
+++ b/common/utils/grammar.js
@@ -1,5 +1,12 @@
 // @flow
-export default (title: string): string => {
+export function capitalize(word: string): string {
+  const [firstLetter] = word;
+  const restOfWord = word.slice(1);
+
+  return `${firstLetter.toUpperCase()}${restOfWord}`;
+}
+
+export function camelize(title: string): string {
   const titleArray = title.toLowerCase().split(/-|_| /);
 
   return titleArray.reduce((acc, val, i) => {
@@ -9,4 +16,4 @@ export default (title: string): string => {
       return acc + val.charAt(0).toUpperCase() + val.slice(1);
     }
   }, '');
-};
+}

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -7,6 +7,7 @@ import type { PrismicApiError } from '@weco/common/services/prismic/types';
 import { getArticle } from '@weco/common/services/prismic/articles';
 import { getArticleSeries } from '@weco/common/services/prismic/article-series';
 import { classNames, font } from '@weco/common/utils/classnames';
+import capitalise from '@weco/common/utils/capitalise';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import ContentPage from '@weco/common/views/components/ContentPage/ContentPage';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
@@ -142,10 +143,16 @@ export class ArticlePage extends Component<Props, State> {
                 [font('hnl', 6)]: true,
               })}
             >
-              {article.contributors.length > 0 && <span>By </span>}
-
-              {article.contributors.map(({ contributor }, i, arr) => (
+              {article.contributors.map(({ contributor, role }, i, arr) => (
                 <Fragment key={contributor.id}>
+                  {role && role.describedBy && (
+                    <span>
+                      {i === 0
+                        ? capitalise(role.describedBy)
+                        : role.describedBy}{' '}
+                      by{' '}
+                    </span>
+                  )}
                   <span
                     className={classNames({
                       [font('hnm', 6)]: true,

--- a/content/webapp/pages/article.js
+++ b/content/webapp/pages/article.js
@@ -7,7 +7,7 @@ import type { PrismicApiError } from '@weco/common/services/prismic/types';
 import { getArticle } from '@weco/common/services/prismic/articles';
 import { getArticleSeries } from '@weco/common/services/prismic/article-series';
 import { classNames, font } from '@weco/common/utils/classnames';
-import capitalise from '@weco/common/utils/capitalise';
+import { capitalize } from '@weco/common/utils/grammar';
 import PageLayout from '@weco/common/views/components/PageLayout/PageLayout';
 import ContentPage from '@weco/common/views/components/ContentPage/ContentPage';
 import HTMLDate from '@weco/common/views/components/HTMLDate/HTMLDate';
@@ -148,7 +148,7 @@ export class ArticlePage extends Component<Props, State> {
                   {role && role.describedBy && (
                     <span>
                       {i === 0
-                        ? capitalise(role.describedBy)
+                        ? capitalize(role.describedBy)
                         : role.describedBy}{' '}
                       by{' '}
                     </span>

--- a/content/webapp/pages/book.js
+++ b/content/webapp/pages/book.js
@@ -175,6 +175,7 @@ export class ArticleSeriesPage extends Component<Props> {
       role: {
         id: 'WcUWeCgAAFws-nGh',
         title: 'Author',
+        describedBy: 'words',
       },
     };
     const contributors =

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -18,7 +18,7 @@ import { UiImage } from '@weco/common/views/components/Images/Images';
 import DateRange from '@weco/common/views/components/DateRange/DateRange';
 import type { UiEvent } from '@weco/common/model/events';
 import { font, classNames } from '@weco/common/utils/classnames';
-import camelize from '@weco/common/utils/camelize';
+import { camelize } from '@weco/common/utils/grammar';
 import {
   formatDayDate,
   isTimePast,

--- a/prismic-model/js/editorial-contributor-roles.js
+++ b/prismic-model/js/editorial-contributor-roles.js
@@ -1,0 +1,11 @@
+import structuredText from './parts/structured-text';
+import text from './parts/text';
+
+const ContributorRoles = {
+  Contributor: {
+    title: structuredText('Title', 'single', ['heading1']),
+    describedBy: text('Byline word for role', 'e.g. words'),
+  },
+};
+
+export default ContributorRoles;

--- a/prismic-model/js/editorial-contributor-roles.js
+++ b/prismic-model/js/editorial-contributor-roles.js
@@ -4,7 +4,7 @@ import text from './parts/text';
 const ContributorRoles = {
   Contributor: {
     title: structuredText('Title', 'single', ['heading1']),
-    describedBy: text('Byline word for role', 'e.g. words'),
+    describedBy: text('Word to describe the role'),
   },
 };
 

--- a/prismic-model/js/editorial-contributor-roles.js
+++ b/prismic-model/js/editorial-contributor-roles.js
@@ -4,7 +4,7 @@ import text from './parts/text';
 const ContributorRoles = {
   Contributor: {
     title: structuredText('Title', 'single', ['heading1']),
-    describedBy: text('Word to describe the role'),
+    describedBy: text('Word to describe output of the role'),
   },
 };
 

--- a/prismic-model/json/editorial-contributor-roles.json
+++ b/prismic-model/json/editorial-contributor-roles.json
@@ -10,8 +10,7 @@
     "describedBy": {
       "type": "Text",
       "config": {
-        "label": "Byline word for role",
-        "placeholder": "e.g. words"
+        "label": "Word to describe the role"
       }
     }
   }

--- a/prismic-model/json/editorial-contributor-roles.json
+++ b/prismic-model/json/editorial-contributor-roles.json
@@ -1,10 +1,17 @@
 {
-  "Contributor" : {
-    "title" : {
-      "type" : "StructuredText",
-      "config" : {
-        "single" : "heading1",
-        "label" : "title"
+  "Contributor": {
+    "title": {
+      "type": "StructuredText",
+      "config": {
+        "single": "paragraph,hyperlink,strong,em,heading1",
+        "label": "Title"
+      }
+    },
+    "describedBy": {
+      "type": "Text",
+      "config": {
+        "label": "Byline word for role",
+        "placeholder": "e.g. words"
       }
     }
   }

--- a/prismic-model/json/editorial-contributor-roles.json
+++ b/prismic-model/json/editorial-contributor-roles.json
@@ -10,7 +10,7 @@
     "describedBy": {
       "type": "Text",
       "config": {
-        "label": "Word to describe the role"
+        "label": "Word to describe output of the role"
       }
     }
   }


### PR DESCRIPTION
References #4479

Adding what a contributor _does_ to their mention in the byline.

![image](https://user-images.githubusercontent.com/1394592/62875074-440cce00-bd1a-11e9-9d25-5f109403a48c.png)

Added the concept of `describedBy` to contributor roles in Prismic, with these two for starters (if this is incorrect, it is content editable in Prismic, of course).

| role | describedBy |
|-----------|----------|
|Author | words |
|Photographer | images |
