### PR TITLE
Use Contact component on visit-us template

### DIFF
--- a/content/webapp/content/visit-us-content.js
+++ b/content/webapp/content/visit-us-content.js
@@ -914,26 +914,5 @@ export const lastPara = {
       text: 'If you have any questions about your visit, contact us:',
       spans: [],
     },
-    {
-      type: 'paragraph',
-      text:
-        'Telephone: +44 (0)20 7611 2222\nEmail: info@wellcomecollection.org',
-      spans: [
-        {
-          start: 38,
-          end: 65,
-          type: 'hyperlink',
-          data: {
-            link_type: 'Web',
-            url: 'mailto:info@wellcomecollection.org',
-          },
-        },
-      ],
-    },
-    {
-      type: 'paragraph',
-      text: '',
-      spans: [],
-    },
   ],
 };

--- a/content/webapp/pages/visit-us.js
+++ b/content/webapp/pages/visit-us.js
@@ -33,6 +33,7 @@ import {
   lastPara,
 } from '@weco/content/content/visit-us-content';
 import Space from '@weco/common/views/components/styled/Space';
+import Contact from '@weco/common/views/components/Contact/Contact';
 
 type ContainerProps = {|
   children: any,
@@ -210,6 +211,12 @@ const BespokeBody = (
       <PrismicHtmlBlock
         html={lastPara.value}
         htmlSerialiser={defaultSerializer}
+      />
+      <Contact
+        subtitle={null}
+        title={'Wellcome Collection enquiries'}
+        phone={'+44 (0)20 7611 2222'}
+        email={'info@wellcomecollection.org'}
       />
     </Container>
   </>


### PR DESCRIPTION
We've currently got a hard-coded template for `visit-us`, so need to do this content change manually.

![image](https://user-images.githubusercontent.com/1394592/62940980-c1911680-bdcc-11e9-9465-76e01f6f2675.png)
