### PR TITLE
Allow for articles in content lists

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -18,6 +18,7 @@ import {
   eventPoliciesFields,
   articleSeriesFields,
   articleFormatsFields,
+  articlesFields,
 } from './fetch-links';
 import { breakpoints } from '../../utils/breakpoints';
 import {
@@ -359,7 +360,8 @@ export async function getExhibition(
       contributorsFields,
       placesFields,
       exhibitionResourcesFields,
-      eventSeriesFields
+      eventSeriesFields,
+      articlesFields
     ),
   });
 
@@ -393,7 +395,8 @@ export async function getExhibitionRelatedContent(
     contributorsFields,
     articleSeriesFields,
     articleFormatsFields,
-    exhibitionFields
+    exhibitionFields,
+    articlesFields
   );
   const types = ['exhibitions', 'events', 'articles', 'books'];
   const extraContent = await getTypeByIds(req, types, ids, { fetchLinks });

--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -82,3 +82,4 @@ export const articleFormatsFields = [
   'article-formats.title',
   'article-formats.description',
 ];
+export const articlesFields = ['articles.title'];

--- a/common/services/prismic/multi-content.js
+++ b/common/services/prismic/multi-content.js
@@ -21,6 +21,7 @@ import {
   organisationsFields,
   contributorsFields,
   teamsFields,
+  articlesFields,
 } from './fetch-links';
 import { parseArticleSeries } from './article-series';
 import type { MultiContent } from '../../model/multi-content';
@@ -106,7 +107,8 @@ export async function getMultiContent(
       peopleFields,
       organisationsFields,
       contributorsFields,
-      teamsFields
+      teamsFields,
+      articlesFields
     ),
     pageSize: pageSize || 100,
     orderings: `[${(orderings || []).join(',')}]`,

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -29,6 +29,7 @@ import { parseCollectionVenue } from '../../services/prismic/opening-times';
 import isEmptyObj from '../../utils/is-empty-object';
 import isEmptyDocLink from '../../utils/is-empty-doc-link';
 import linkResolver from './link-resolver';
+import { parseArticle } from './articles';
 
 const placeHolderImage = ({
   contentUrl: 'https://via.placeholder.com/1600x900?text=%20',
@@ -557,6 +558,8 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
                       return parseEventSeries(item.content);
                     case 'exhibitions':
                       return parseExhibitionDoc(item.content);
+                    case 'articles':
+                      return parseArticle(item.content);
                   }
                 })
                 .filter(Boolean),


### PR DESCRIPTION
☝️ 

I'm not sure how articles were ever working in content lists without _something_ `articles` related having been added to `fetchLinks`?