### PR TITLE
Tidy works

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -36,8 +36,6 @@ type Props = {|
   works: ?CatalogueResultsList | CatalogueApiError,
 |};
 
-const WorksSearchProvider = ({ works }: Props) => <Works works={works} />;
-
 const Works = ({ works }: Props) => {
   const [loading, setLoading] = useState(false);
   const { query, page, workType, _queryType, _dateFrom, _dateTo } = useContext(
@@ -457,7 +455,7 @@ const Works = ({ works }: Props) => {
   );
 };
 
-WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
+Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const query = ctx.query.query;
   const _dateFrom = formatDateForApi(ctx.query._dateFrom);
   const _dateTo = formatDateForApi(ctx.query._dateTo);
@@ -517,4 +515,4 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
   };
 };
 
-export default WorksSearchProvider;
+export default Works;

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -33,15 +33,10 @@ import Space from '@weco/common/views/components/styled/Space';
 import { formatDateForApi } from '@weco/common/utils/dates';
 
 type Props = {|
-  query: ?string,
   works: ?CatalogueResultsList | CatalogueApiError,
-  page: ?number,
-  workType: ?(string[]),
 |};
 
-const WorksSearchProvider = ({ works, query, page, workType }: Props) => (
-  <Works works={works} query={query} page={page} workType={workType} />
-);
+const WorksSearchProvider = ({ works }: Props) => <Works works={works} />;
 
 const Works = ({ works }: Props) => {
   const [loading, setLoading] = useState(false);
@@ -519,9 +514,6 @@ WorksSearchProvider.getInitialProps = async (ctx: Context): Promise<Props> => {
 
   return {
     works: worksOrError,
-    query,
-    page,
-    workType: workTypeQuery && workTypeQuery.split(',').filter(Boolean),
   };
 };
 

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -76,8 +76,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        _dateFrom: _dateFrom,
-        _dateTo: _dateTo,
+        _dateFrom: _dateFrom && _dateFrom !== '' ? _dateFrom : undefined,
+        _dateTo: _dateTo && _dateTo !== '' ? _dateTo : undefined,
       }),
     },
     as: {
@@ -87,8 +87,8 @@ export function worksUrl({
         page: page && page > 1 ? page : undefined,
         ...getWorkType(workType),
         _queryType: _queryType && _queryType !== '' ? _queryType : undefined,
-        _dateFrom: _dateFrom,
-        _dateTo: _dateTo,
+        _dateFrom: _dateFrom && _dateFrom !== '' ? _dateFrom : undefined,
+        _dateTo: _dateTo && _dateTo !== '' ? _dateTo : undefined,
       }),
     },
   };

--- a/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
+++ b/common/views/components/CatalogueSearchContext/CatalogueSearchContext.js
@@ -177,11 +177,11 @@ const SearchRouter = ({ children }: SearchRouterProps) => {
     const link = worksUrl({
       query,
       page,
-      workType: workType,
-      itemsLocationsLocationType: itemsLocationsLocationType,
-      _queryType: _queryType,
-      _dateFrom: _dateFrom,
-      _dateTo: _dateTo,
+      workType,
+      itemsLocationsLocationType,
+      _queryType,
+      _dateFrom,
+      _dateTo,
     });
     Router.push(
       { ...link.href, pathname: '/works-context' },


### PR DESCRIPTION
Remove a bit of unnecessary complexity, which was a bit confusing (at least for me)

We were passing several props to Works via WorksSearchProvider, which weren't being used as they were coming from the CatalogueSearchContext anyway