### PR TITLE
Allow events in content list

### DIFF
--- a/common/services/prismic/exhibitions.js
+++ b/common/services/prismic/exhibitions.js
@@ -19,6 +19,7 @@ import {
   articleSeriesFields,
   articleFormatsFields,
   articlesFields,
+  eventsFields,
 } from './fetch-links';
 import { breakpoints } from '../../utils/breakpoints';
 import {
@@ -361,7 +362,8 @@ export async function getExhibition(
       placesFields,
       exhibitionResourcesFields,
       eventSeriesFields,
-      articlesFields
+      articlesFields,
+      eventsFields
     ),
   });
 

--- a/common/services/prismic/fetch-links.js
+++ b/common/services/prismic/fetch-links.js
@@ -83,3 +83,11 @@ export const articleFormatsFields = [
   'article-formats.description',
 ];
 export const articlesFields = ['articles.title'];
+export const eventsFields = [
+  'events.title',
+  'events.schedule',
+  'events.interpretations',
+  'events.audiences',
+  'events.series',
+  'events.times',
+];

--- a/common/services/prismic/parsers.js
+++ b/common/services/prismic/parsers.js
@@ -30,6 +30,7 @@ import isEmptyObj from '../../utils/is-empty-object';
 import isEmptyDocLink from '../../utils/is-empty-doc-link';
 import linkResolver from './link-resolver';
 import { parseArticle } from './articles';
+import { parseEventDoc } from './events';
 
 const placeHolderImage = ({
   contentUrl: 'https://via.placeholder.com/1600x900?text=%20',
@@ -560,6 +561,8 @@ export function parseBody(fragment: PrismicFragment[]): any[] {
                       return parseExhibitionDoc(item.content);
                     case 'articles':
                       return parseArticle(item.content);
+                    case 'events':
+                      return parseEventDoc(item.content);
                   }
                 })
                 .filter(Boolean),


### PR DESCRIPTION
## Who is this for?
Content team

## What is it doing for them?
Letting them add `event` items to a content list slice

![image](https://user-images.githubusercontent.com/1394592/63600640-d97e4c80-c5bb-11e9-8fd9-064c78694c91.png)
