### PR TITLE
Helvetica regular

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -408,7 +408,7 @@ export default class WecoApp extends App {
                                 __html: `
                                 @font-face {
                                   font-family: 'Helvetica Neue Light Web';
-                                  src: local('Helvetica Neue Light'),
+                                  src: local('Helvetica Neue Regular'),
                                     local('HelveticaNeue-Regular'),
                                     url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
                                     url('https://i.wellcomecollection.org/assets/fonts/955441c8-2039-4256-bf4a-c475c31d1c0d.woff') format('woff');

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -399,6 +399,28 @@ export default class WecoApp extends App {
                 <CatalogueSearchProvider>
                   <OutboundLinkTracker>
                     <Fragment>
+                      <TogglesContext.Consumer>
+                        {({ helveticaRegular }) =>
+                          helveticaRegular && (
+                            <style
+                              type="text/css"
+                              dangerouslySetInnerHTML={{
+                                __html: `
+                                @font-face {
+                                  font-family: 'Helvetica Neue Light Web';
+                                  src: local('Helvetica Neue Light'),
+                                    local('HelveticaNeue-Regular'),
+                                    url('https://i.wellcomecollection.org/assets/fonts/d460c8dd-ab48-422e-ac1c-d9b6392b605a.woff2') format('woff2'),
+                                    url('https://i.wellcomecollection.org/assets/fonts/955441c8-2039-4256-bf4a-c475c31d1c0d.woff') format('woff');
+                                  font-weight: normal;
+                                  font-style: normal;
+                                }
+                              `,
+                              }}
+                            />
+                          )
+                        }
+                      </TogglesContext.Consumer>
                       {!pageProps.statusCode && <Component {...pageProps} />}
                       {pageProps.statusCode && pageProps.statusCode !== 200 && (
                         <ErrorPage statusCode={pageProps.statusCode} />

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -57,5 +57,12 @@ module.exports = {
       description:
         'Shows filters on the works search pages. Geared towards exploration.',
     },
+    {
+      id: 'helveticaRegular',
+      title: 'Helvetica regular',
+      defaultValue: false,
+      description:
+        'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
+    },
   ],
 };


### PR DESCRIPTION
## Who is this for?
Experience team initially. Maybe everyone who longs for legible text on the site, ultimately.

## What is it doing for them?
Giving them the option to swap out Helvetica light for regular via the toggles dash.