### PR TITLE
Update 'black' per Google Material Design guidelines recommendation

### DIFF
--- a/cardigan/config/colors.js
+++ b/cardigan/config/colors.js
@@ -1,6 +1,6 @@
 const colors = {
   white: '#ffffff',
-  black: '#010101',
+  black: '#121212',
   purple: '#944aa0',
   teal: '#006272',
   cyan: '#298187',

--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -95,6 +95,8 @@ body {
   @extend %font-hnl;
   @extend %font-size-4;
 
+  color: color('black');
+
   font-variant-ligatures: no-common-ligatures;
   -webkit-font-smoothing: antialiased;
   -moz-font-smoothing: antialiased;

--- a/common/styles/utilities/compiled_variables/_colors.scss
+++ b/common/styles/utilities/compiled_variables/_colors.scss
@@ -1,6 +1,6 @@
 $colors: (
   'white': #ffffff,
-  'black': #010101,
+  'black': #121212,
   'purple': #944aa0,
   'teal': #006272,
   'cyan': #298187,


### PR DESCRIPTION
☝️ 

@GarethOrmerod suggested this change for improved readability after reading about [Material Design dark theme contrast and legibility](https://material.io/design/color/dark-theme.html#properties)