### PR TITLE
Fix Safari bug that could hide labels in featured card

### DIFF
--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -190,7 +190,7 @@ const FeaturedCardRight = styled.div.attrs({
   }),
 })`
   padding-left: ${props => props.theme.gutter.small}px;
-  margin-top: -60px;
+  transform: translateY(-60px);
   width: 100%;
   height: 100%;
   min-height: 200px;
@@ -201,7 +201,7 @@ const FeaturedCardRight = styled.div.attrs({
 
   ${props => props.theme.media.large`
     margin-left: -${props => props.theme.gutter.large}px;
-    margin-top: 0;
+    transform: translateY(0);
   `}
 `;
 


### PR DESCRIPTION
__Before__
<img width="420" alt="Screenshot 2019-09-13 at 15 59 31" src="https://user-images.githubusercontent.com/1394592/64872715-97d34580-d63f-11e9-86a4-9e22e54a1ddd.png">

__After__
<img width="420" alt="Screenshot 2019-09-13 at 15 59 48" src="https://user-images.githubusercontent.com/1394592/64872730-9e61bd00-d63f-11e9-81f8-c89a4eec93e8.png">
