### PR TITLE
Use mask to accomplish repeating pattern

### DIFF
--- a/common/utils/backgrounds.js
+++ b/common/utils/backgrounds.js
@@ -4,3 +4,5 @@ export const repeatingLs =
   'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F805ad61b-fba6-4dc1-b2d3-55dbcda0c9f1_ls_svg.svg';
 export const repeatingLsBlack =
   'https://prismic-io.s3.amazonaws.com/wellcomecollection%2Fe483a8f3-f7bb-4c3f-8081-8f5d8875230e_ls_svg_black.svg';
+export const leaningLMask =
+  'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F881cff32-96a4-4495-8a5a-4f35908ab5f3_leaning-l-mask.svg';

--- a/common/utils/backgrounds.js
+++ b/common/utils/backgrounds.js
@@ -5,4 +5,4 @@ export const repeatingLs =
 export const repeatingLsBlack =
   'https://prismic-io.s3.amazonaws.com/wellcomecollection%2Fe483a8f3-f7bb-4c3f-8081-8f5d8875230e_ls_svg_black.svg';
 export const leaningLMask =
-  'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F881cff32-96a4-4495-8a5a-4f35908ab5f3_leaning-l-mask.svg';
+  'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F696073c9-01ca-4f21-a633-c10bf1ff10e4_l-mask.svg';

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -4,73 +4,76 @@ import { grid, font, classNames } from '../../../utils/classnames';
 import RepeatingLs from '../RepeatingLs/RepeatingLs';
 import Space from '../styled/Space';
 import Layout from '../Layout/Layout';
+import styled from 'styled-components';
+
+const NewsletterButtonContainer = styled(Space)`
+  ${props => props.theme.media.medium`
+    justify-content: center;
+  `}
+`;
 
 const NewsletterPromo = () => (
-  <div className="row">
+  <div className="row bg-teal">
     <Layout gridSizes={{ s: 12, m: 12, l: 12, xl: 12 }}>
-      <Space
-        v={{ size: 'xl', properties: ['margin-top', 'margin-bottom'] }}
-        className="bg-purple"
+      <div
+        className={classNames({
+          grid: true,
+        })}
       >
         <div
           className={classNames({
-            grid: true,
+            [grid({ s: 12, m: 6, l: 6, xl: 6 })]: true,
           })}
         >
-          <div
-            className={classNames({
-              [grid({ s: 12, m: 6, l: 6, xl: 6 })]: true,
-            })}
+          <Space
+            v={{ size: 'xl', properties: ['padding-top', 'padding-bottom'] }}
+            h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
           >
             <Space
-              v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-              h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-            >
-              <h2
-                className={classNames({
-                  'h2 font-white': true,
-                })}
-              >
-                Stay connected with email updates from Wellcome Collection
-              </h2>
-              <p
-                className={classNames({
-                  [font('hnl', 4)]: true,
-                  'font-white': true,
-                })}
-              >
-                Be the first to know about our upcoming exhibitions, events and
-                other activities, with extra options for youth, schools and
-                access events.
-              </p>
-            </Space>
-          </div>
-          <div
-            className={classNames({
-              [grid({ s: 12, m: 6, l: 4, shiftL: 2, xl: 4, shiftXl: 2 })]: true,
-            })}
-          >
-            <Space
-              v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
-              h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
-              style={{ width: '100%', height: '100%' }}
+              as="h2"
+              v={{ size: 's', properties: ['margin-bottom'] }}
               className={classNames({
-                relative: true,
-                'flex flex--v-center': true,
+                'h1 font-white': true,
               })}
             >
-              <RepeatingLs foreground={'yellow'} background={'purple'} />
+              Be the first to know
+            </Space>
+            <p
+              className={classNames({
+                [font('hnl', 4)]: true,
+                'font-white no-margin': true,
+              })}
+            >
+              Stay connected with email updates from Wellcome Collection.
+            </p>
+          </Space>
+        </div>
+        <div
+          className={classNames({
+            [grid({ s: 12, m: 6, l: 4, shiftL: 2, xl: 3, shiftXl: 3 })]: true,
+          })}
+        >
+          <NewsletterButtonContainer
+            v={{ size: 'm', properties: ['padding-top', 'padding-bottom'] }}
+            h={{ size: 'm', properties: ['padding-left', 'padding-right'] }}
+            style={{ width: '100%', height: '100%' }}
+            className={classNames({
+              'flex relative flex--v-end': true,
+            })}
+          >
+            <RepeatingLs background={'teal'} foreground={'purple'} size={56} />
 
+            <Space v={{ size: 'l', properties: ['margin-bottom'] }}>
               <Button
                 type="secondary"
                 extraClasses="btn--primary relative"
                 url="/newsletter"
-                text="Sign up"
+                text="Sign up here"
               />
             </Space>
-          </div>
+          </NewsletterButtonContainer>
         </div>
-      </Space>
+      </div>
     </Layout>
   </div>
 );

--- a/common/views/components/RepeatingLs/RepeatingLs.js
+++ b/common/views/components/RepeatingLs/RepeatingLs.js
@@ -8,7 +8,7 @@ type Props = {|
 |};
 
 const RepeatingLsOuter = styled.div`
-  background: ${props => props.theme.colors[props.foreground]};
+  background: ${props => props.theme.colors[props.background]};
   position: absolute;
   top: 0;
   right: 0;
@@ -24,17 +24,17 @@ const ReapeatingLsInner = styled.div`
   bottom: 0;
   left: 0;
   mask-size: ${props => props.size}px;
-  background: ${props => props.theme.colors[props.background]};
+  background: ${props => props.theme.colors[props.foreground]};
   mask-image: url(${props => props.mask});
   mask-repeat: repeat;
 `;
 
 const RepeatingLs = ({ foreground, background, size }: Props) => (
-  <RepeatingLsOuter foreground={foreground}>
+  <RepeatingLsOuter background={background}>
     <ReapeatingLsInner
       mask={leaningLMask}
       size={size}
-      background={background}
+      foreground={foreground}
     />
   </RepeatingLsOuter>
 );

--- a/common/views/components/RepeatingLs/RepeatingLs.js
+++ b/common/views/components/RepeatingLs/RepeatingLs.js
@@ -1,45 +1,42 @@
 import styled from 'styled-components';
+import { leaningLMask } from '../../../utils/backgrounds';
 
-const RepeatingLsEl = styled.div`
+type Props = {|
+  foreground: string,
+  background: string,
+  size: number,
+|};
+
+const RepeatingLsOuter = styled.div`
+  background: ${props => props.theme.colors[props.foreground]};
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`;
+
+const ReapeatingLsInner = styled.div`
   position: absolute;
   z-index: 0;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
-  background: repeating-linear-gradient(
-    -45deg,
-    ${props => props.theme.colors[props.foreground]},
-    ${props => props.theme.colors[props.foreground]} 10px,
-    ${props => props.theme.colors[props.background]} 10px,
-    ${props => props.theme.colors[props.background]} 50px
-  );
-
-  &:before {
-    position: absolute;
-    z-index: 0;
-    content: '';
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: repeating-linear-gradient(
-      45deg,
-      ${props => props.theme.colors[props.background]},
-      ${props => props.theme.colors[props.background]} 20px,
-      transparent 10px,
-      transparent 60px
-    );
-  }
+  mask-size: ${props => props.size}px;
+  background: ${props => props.theme.colors[props.background]};
+  mask-image: url(${props => props.mask});
+  mask-repeat: repeat;
 `;
 
-type Props = {|
-  foreground: string,
-  background: string,
-|};
-
-const RepeatingLs = ({ foreground, background }: Props) => (
-  <RepeatingLsEl foreground={foreground} background={background} />
+const RepeatingLs = ({ foreground, background, size }: Props) => (
+  <RepeatingLsOuter foreground={foreground}>
+    <ReapeatingLsInner
+      mask={leaningLMask}
+      size={size}
+      background={background}
+    />
+  </RepeatingLsOuter>
 );
 
 export default RepeatingLs;

--- a/content/webapp/pages/newsletter.js
+++ b/content/webapp/pages/newsletter.js
@@ -26,6 +26,7 @@ export class NewsletterPage extends Component<Props> {
         description={
           'Sign up for news and information from Wellcome Collection'
         }
+        hideNewsletterPromo={true}
         url={{ pathname: `/newsletter` }}
         jsonLd={{ '@type': 'WebPage' }}
         openGraphType={'website'}


### PR DESCRIPTION
Updating the newsletter promo copy and design.

I don't think the pure css option is feasible with the Ls as they appear in the design, but an svg mask still allows us to change the foreground/background colours without having to upload a different image per colour option.

Also, removing the newsletter promo from the /newsletter page because it links to the page itself and could definitely cause confusion.

[Caniuse data for css mask](https://caniuse.com/#search=mask) – basically not supported in any Internet Explorer, but is almost everywhere else. I didn't think the pattern not displaying in IE would be a serious issue, because the content is still there.

__Most browsers__
<img width="1041" alt="Screenshot 2019-09-16 at 15 24 01" src="https://user-images.githubusercontent.com/1394592/64966664-1f66c180-d897-11e9-9c75-4a84dc0db715.png">

__IE__
<img width="963" alt="Screenshot 2019-09-16 at 15 23 39" src="https://user-images.githubusercontent.com/1394592/64966694-2b528380-d897-11e9-9d62-b8ee9cb4c086.png">
