### PR TITLE
Status indicator fixes

### DIFF
--- a/common/icons/svgs/status_indicator.svg
+++ b/common/icons/svgs/status_indicator.svg
@@ -1,1 +1,0 @@
-<svg viewBox="0 0 26 26"><circle cx="13" cy="13" r="10"/></svg>

--- a/common/views/components/Dot/Dot.js
+++ b/common/views/components/Dot/Dot.js
@@ -1,0 +1,15 @@
+// @flow
+
+type Props = {|
+  color: string,
+|};
+
+function Dot({ color }: Props) {
+  return (
+    <span className={`font-${color}`} style={{ fontSize: '0.7em' }}>
+      &#11044;
+    </span>
+  );
+}
+
+export default Dot;

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -106,7 +106,7 @@ const EventPromo = ({
           )}
 
           {!isPast && fullyBooked && (
-            <div className={`${font('hnl', 5)} flex flex--v-center`}>
+            <div className={`${font('hnl', 6)} flex flex--v-center`}>
               <Space
                 as="span"
                 h={{ size: 's', properties: ['margin-right'] }}

--- a/common/views/components/EventPromo/EventPromo.js
+++ b/common/views/components/EventPromo/EventPromo.js
@@ -3,7 +3,7 @@ import { font, classNames } from '../../../utils/classnames';
 import { trackEvent } from '../../../utils/ga';
 import { UiImage } from '../Images/Images';
 import LabelsList from '../LabelsList/LabelsList';
-import Icon from '../Icon/Icon';
+import Dot from '../Dot/Dot';
 import EventDateRange from '../EventDateRange/EventDateRange';
 import { type UiEvent, isEventFullyBooked } from '../../../model/events';
 import Moment from 'moment';
@@ -106,19 +106,19 @@ const EventPromo = ({
           )}
 
           {!isPast && fullyBooked && (
-            <div className={`${font('hnl', 6)} flex flex--v-center`}>
+            <Space
+              v={{ size: 'm', properties: ['margin-top'] }}
+              className={`${font('hnl', 5)} flex flex--v-center`}
+            >
               <Space
                 as="span"
-                h={{ size: 's', properties: ['margin-right'] }}
+                h={{ size: 'xs', properties: ['margin-right'] }}
                 className={`flex flex--v-center`}
               >
-                <Icon
-                  name="statusIndicator"
-                  extraClasses={'icon--red icon--match-text'}
-                />
+                <Dot color={'red'} />
               </Space>
               Fully booked
-            </div>
+            </Space>
           )}
           {!isPast && event.scheduleLength > 0 && (
             <p className={`${font('hnm', 5)} no-padding no-margin`}>
@@ -136,13 +136,10 @@ const EventPromo = ({
             <div className={`${font('hnl', 5)} flex flex--v-center`}>
               <Space
                 as="span"
-                h={{ size: 's', properties: ['margin-right'] }}
+                h={{ size: 'xs', properties: ['margin-right'] }}
                 className={`flex flex--v-center`}
               >
-                <Icon
-                  name="statusIndicator"
-                  extraClasses={'icon--marble icon--match-text'}
-                />
+                <Dot color={'marble'} />
               </Space>
               Past
             </div>

--- a/common/views/components/FeaturedCard/FeaturedCard.js
+++ b/common/views/components/FeaturedCard/FeaturedCard.js
@@ -149,7 +149,11 @@ const FeaturedCardExhibitionBody = ({
         {exhibition.title}
       </h2>
       {!exhibition.statusOverride && exhibition.start && exhibition.end && (
-        <p className={`${font('hnl', 5)} no-margin no-padding`}>
+        <Space
+          as="p"
+          v={{ size: 'm', properties: ['margin-bottom'] }}
+          className={`${font('hnl', 4)} no-margin no-padding`}
+        >
           <>
             <time dateTime={exhibition.start}>
               {formatDate(exhibition.start)}
@@ -157,7 +161,7 @@ const FeaturedCardExhibitionBody = ({
             —{/* $FlowFixMe */}
             <time dateTime={exhibition.end}>{formatDate(exhibition.end)}</time>
           </>
-        </p>
+        </Space>
       )}
       <StatusIndicator
         start={exhibition.start}

--- a/common/views/components/StatusIndicator/StatusIndicator.js
+++ b/common/views/components/StatusIndicator/StatusIndicator.js
@@ -1,8 +1,8 @@
 // @flow
 import { font } from '../../../utils/classnames';
 import { formatDateRangeWithMessage } from '../../../utils/format-date';
-import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
+import Dot from '../Dot/Dot';
 
 type Props = {|
   start: Date,
@@ -15,16 +15,13 @@ const StatusIndicator = ({ start, end, statusOverride }: Props) => {
     ? { color: 'marble', text: statusOverride }
     : formatDateRangeWithMessage({ start, end });
   return (
-    <span className={`flex flex--v-center ${font('hnl', 6)}`}>
+    <span className={`flex flex--v-center ${font('hnl', 5)}`}>
       <Space
         as="span"
-        h={{ size: 's', properties: ['margin-right'] }}
+        h={{ size: 'xs', properties: ['margin-right'] }}
         className={`flex flex--v-center`}
       >
-        <Icon
-          name="statusIndicator"
-          extraClasses={`icon--match-text icon--${color}`}
-        />
+        <Dot color={color} />
       </Space>
       <span>{text}</span>
     </span>

--- a/content/webapp/pages/event.js
+++ b/content/webapp/pages/event.js
@@ -8,7 +8,7 @@ import ContentPage from '@weco/common/views/components/ContentPage/ContentPage';
 import Body from '@weco/common/views/components/Body/Body';
 import Contributors from '@weco/common/views/components/Contributors/Contributors';
 import EventSchedule from '@weco/common/views/components/EventSchedule/EventSchedule';
-import Icon from '@weco/common/views/components/Icon/Icon';
+import Dot from '@weco/common/views/components/Dot/Dot';
 import Button from '@weco/common/views/components/Buttons/Button/Button';
 import EventbriteButton from '@weco/common/views/components/EventbriteButton/EventbriteButton';
 import Message from '@weco/common/views/components/Message/Message';
@@ -47,16 +47,13 @@ type State = {|
 function EventStatus(text, color) {
   return (
     <div className="flex">
-      <div className={`${font('hnm', 6)} flex flex--v-center`}>
+      <div className={`${font('hnm', 5)} flex flex--v-center`}>
         <Space
           as="span"
-          h={{ size: 's', properties: ['margin-right'] }}
+          h={{ size: 'xs', properties: ['margin-right'] }}
           className={`flex flex--v-center`}
         >
-          <Icon
-            name="statusIndicator"
-            extraClasses={`icon--match-text icon--${color}`}
-          />
+          <Dot color={color} />
         </Space>
         {text}
       </div>


### PR DESCRIPTION
@GarethOrmerod has pointed out a handful of visual bugs with the cards regarding spacing, typography, and the status indicator dot.

The svg that we're currently using as the dot is vertically centered with CSS, but the position of the type within the box that the letters are drawn (which is specific to the cut of the font) affects whether this _appears_ vertically centered. This became apparent when we put Helvetica regular behind a toggle, at which point the status indicator dots end up looking mis-aligned.

Using the [black large circle ascii character](http://www.amp-what.com/unicode/search/black%20large%20circle) solves this problem.

