### PR TITLE
Filter drawer into Cardigan

### DIFF
--- a/cardigan/stories/components/FilterDrawer.js
+++ b/cardigan/stories/components/FilterDrawer.js
@@ -4,6 +4,15 @@ import Readme from '../../../common/views/components/FilterDrawer/README.md';
 
 const stories = storiesOf('Components', module);
 
-stories.add('FilterDrawer', () => <FilterDrawer />, {
-  readme: { sidebar: Readme },
-});
+stories.add(
+  'FilterDrawer',
+  () => (
+    <div>
+      <FilterDrawer />
+      below
+    </div>
+  ),
+  {
+    readme: { sidebar: Readme },
+  }
+);

--- a/cardigan/stories/components/FilterDrawer.js
+++ b/cardigan/stories/components/FilterDrawer.js
@@ -9,7 +9,9 @@ stories.add(
   () => (
     <div>
       <FilterDrawer />
-      below
+      <p style={{ marginTop: '20px' }}>
+        Dummy content to demo drawer height animation change
+      </p>
     </div>
   ),
   {

--- a/cardigan/stories/components/FilterDrawer.js
+++ b/cardigan/stories/components/FilterDrawer.js
@@ -1,0 +1,9 @@
+import { storiesOf } from '@storybook/react';
+import FilterDrawer from '../../../common/views/components/FilterDrawer/FilterDrawer';
+import Readme from '../../../common/views/components/FilterDrawer/README.md';
+
+const stories = storiesOf('Components', module);
+
+stories.add('FilterDrawer', () => <FilterDrawer />, {
+  readme: { sidebar: Readme },
+});

--- a/common/services/data/facility-promos.js
+++ b/common/services/data/facility-promos.js
@@ -1,0 +1,125 @@
+import type { Promo } from '../model/promo';
+import type { EventPromo } from '../model/events';
+
+export const readingRoomPromo: Promo = {
+  type: 'promo',
+  contentType: 'place',
+  title: 'Reading Room',
+  url: 'https://wellcomecollection.org/pages/Wvlk4yAAAB8A3ufp',
+  metaIcon: 'clock',
+  metaText: 'Open during gallery hours',
+  description:
+    'Drop in to find inspiration and indulge your curiosity. It’s a gallery, a social space, and a place to unwind.',
+  image: {
+    type: 'picture',
+    contentUrl:
+      'https://s3-eu-west-1.amazonaws.com/static.wellcomecollection.org/daily-promo-images/reading-room.png',
+    width: 408,
+    height: 229,
+    alt: '',
+  },
+};
+
+export const cafePromo: Promo = {
+  type: 'promo',
+  id: 'cafePromo',
+  contentType: 'place',
+  title: 'Café',
+  url: 'https://wellcomecollection.org/pages/Wvl1wiAAADMJ3zNe',
+  description:
+    'Join us for a quick cup of coffee and a pastry, afternoon tea, or a light meal with a glass of wine.',
+  image: {
+    type: 'picture',
+    contentUrl:
+      'https://prismic-io.s3.amazonaws.com/wellcomecollection%2F767a5fc5-7095-4772-a22b-275b38e4bd4d_cafe.png',
+    width: 408,
+    height: 229,
+    alt: '',
+  },
+};
+
+export const libraryPromo: Promo = {
+  type: 'promo',
+  id: 'libraryPromo',
+  contentType: 'place',
+  title: 'Library',
+  url: 'https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Smm',
+  description:
+    'Visit our free library for the study of the social and cultural contexts of health and medicine.',
+  metaIcon: 'member_card',
+  metaText: 'Membership not required',
+  image: {
+    type: 'picture',
+    contentUrl:
+      'https://s3-eu-west-1.amazonaws.com/static.wellcomecollection.org/daily-promo-images/wellcome-library.png',
+    width: 408,
+    height: 229,
+    alt: '',
+  },
+};
+
+export const restaurantPromo: Promo = {
+  type: 'promo',
+  id: 'restaurantPromo',
+  contentType: 'place',
+  title: 'Restaurant',
+  url: 'https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Snk',
+  description: 'Enjoy delicious lunches, drinks and afternoon tea on level 2.',
+  image: {
+    type: 'picture',
+    contentUrl:
+      'https://prismic-io.s3.amazonaws.com/wellcomecollection%2Fc2475694-73e3-4309-ba6d-100a25fe6864_restaurant.png',
+    width: 408,
+    height: 229,
+    alt: '',
+  },
+};
+
+export const shopPromo: Promo = {
+  type: 'promo',
+  id: 'shopPromo',
+  contentType: 'place',
+  title: 'Shop',
+  url: 'https://wellcomecollection.org/pages/WwgaIh8AAB8AGhC_',
+  description: 'Come and browse a selection of our quirky gifts and books.',
+  image: {
+    type: 'picture',
+    contentUrl:
+      'https://prismic-io.s3.amazonaws.com/wellcomecollection%2Fb9feb700-cb89-47cc-be19-75b37adc2061_shop.png',
+    width: 408,
+    height: 229,
+    alt: '',
+  },
+};
+
+export const dailyTourPromo: EventPromo = {
+  id: 'tours',
+  title: 'Daily Guided Tours and Discussions',
+  url: 'https://wellcomecollection.org/pages/Wuw19yIAAK1Z3Sma',
+  start: null,
+  end: null,
+  isMultiDate: false,
+  isFullyBooked: false,
+  hasNotFullyBookedTimes: false,
+  description: null,
+  series: [],
+  schedule: [],
+  dateString: 'Tuesday–Sunday',
+  timeString: '11:30, 14:30 and 15:30',
+  format: {
+    id: 'WmYRpCQAACUAn-Ap',
+    title: 'Gallery tour',
+    shortName: null,
+    description: null,
+  },
+  bookingType: null,
+  interpretations: [],
+  image: {
+    type: 'picture',
+    contentUrl:
+      'https://wellcomecollection.cdn.prismic.io/wellcomecollection/7657f9e9-0733-444d-b1b2-6ae0bafa0ff9_c7c94c39161dcfe15d9abd8b40256ea2b40f52b9_c0139861.jpg',
+    width: 2996,
+    height: 2000,
+    alt: '',
+  },
+};

--- a/common/services/data/licenses.js
+++ b/common/services/data/licenses.js
@@ -1,0 +1,60 @@
+// @flow
+export default {
+  'copyright-not-cleared': {
+    text: 'Copyright not cleared',
+    humanReadableText: [
+      'Copyright for this work has not been cleared. You are responsible for identifying the rights owner to seek permission to use this work.',
+    ],
+  },
+  PDM: {
+    url: 'https://creativecommons.org/publicdomain/mark/1.0/',
+    text: 'Public Domain',
+    icons: ['cc_pdm'],
+    humanReadableText: [
+      'You can use this work for any purpose without restriction under copyright law.',
+      'Public Domain Mark (PDM) terms and conditions <a href="https://creativecommons.org/publicdomain/mark/1.0">https://creativecommons.org/publicdomain/mark/1.0</a>',
+    ],
+  },
+  'CC-0': {
+    url: 'https://creativecommons.org/publicdomain/zero/1.0/',
+    text: 'CC0',
+    icons: ['cc_zero'],
+    description: 'Free to use for any purpose',
+    humanReadableText: [
+      'You can use this work for any purpose without restriction under copyright law.',
+      'Creative Commons Zero (CC0) terms and conditions <a href="https://creativecommons.org/publicdomain/zero/1.0">https://creativecommons.org/publicdomain/zero/1.0</a>',
+    ],
+  },
+  'CC-BY': {
+    url: 'https://creativecommons.org/licenses/by/4.0/',
+    text: 'CC BY',
+    icons: ['cc', 'cc_by'],
+    description: 'Free to use with attribution',
+    humanReadableText: [
+      'You can use this work for any purpose, including commercial uses, without restriction under copyright law. You should also provide attribution to the original work, source and licence.',
+      'Creative Commons Attribution (CC BY 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by/4.0">https://creativecommons.org/licenses/by/4.0</a>',
+    ],
+  },
+  'CC-BY-NC': {
+    url: 'https://creativecommons.org/licenses/by-nc/4.0/',
+    text: 'CC BY-NC',
+    icons: ['cc', 'cc_by', 'cc_nc'],
+    description: 'Free to use with attribution for non-commercial purposes',
+    humanReadableText: [
+      'You can use this work for any purpose, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.',
+      'Creative Commons Attribution Non-Commercial (CC BY-NC 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc/4.0">https://creativecommons.org/licenses/by-nc/4.0</a>',
+    ],
+  },
+  'CC-BY-NC-ND': {
+    url: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+    text: 'CC BY-NC-ND',
+    icons: ['cc', 'cc_by', 'cc_nc', 'cc_nd'],
+    description:
+      'Free to use with attribution for non-commercial purposes. No modifications permitted.',
+    humanReadableText: [
+      'You can copy and distribute this work, as long as it is not primarily intended for or directed to commercial advantage or monetary compensation. You should also provide attribution to the original work, source and licence.',
+      'If you make any modifications to or derivatives of the work, it may not be distributed.',
+      'Creative Commons Attribution Non-Commercial No-Derivatives (CC BY-NC-ND 4.0) terms and conditions <a href="https://creativecommons.org/licenses/by-nc-nd/4.0/">https://creativecommons.org/licenses/by-nc-nd/4.0/</a>',
+    ],
+  },
+};

--- a/common/services/data/series.js
+++ b/common/services/data/series.js
@@ -1,0 +1,177 @@
+// @flow
+export function getPositionInSeries(tags: {}): ?number {
+  const chapterString = 'chapter';
+  const chapterTag = Object.keys(tags).find(tag =>
+    tag.toLowerCase().startsWith(chapterString)
+  );
+
+  return chapterTag
+    ? parseInt(chapterTag.slice(chapterString.length), 10)
+    : null;
+}
+
+export function getSeriesColor(seriesUrl: string): ?string {
+  const lookup = {
+    'electric-sublime': 'turquoise',
+    'the-outsiders': 'orange',
+  };
+  return lookup[seriesUrl];
+}
+
+export function getSeriesCommissionedLength(seriesUrl: string): ?number {
+  const lookup = {
+    'electric-sublime': 6,
+    'the-outsiders': 6,
+  };
+  return lookup[seriesUrl];
+}
+
+export const series = [
+  {
+    url: 'body-squabbles',
+    name: 'Body Squabbles',
+    items: [
+      {
+        contentType: 'comic',
+        headline: 'Demodicid Navigation',
+        url: '',
+      },
+    ],
+  },
+  {
+    url: 'the-outsiders',
+    name: 'The Outsiders',
+    commissionedLength: getSeriesCommissionedLength('the-outsiders'),
+    color: 'orange',
+    items: [
+      {
+        contentType: 'article',
+        headline: 'The stranger who started an epidemic',
+        // url: 'the-stranger',
+        url: '',
+        description: '',
+        datePublished: new Date('2017-06-15'),
+      },
+      {
+        contentType: 'article',
+        headline: 'The tradesman who confronted the pestilence',
+        // url: 'outsiders-the-tradesman',
+        url: '',
+        description: '',
+        datePublished: new Date('2017-06-22'),
+      },
+      {
+        contentType: 'article',
+        headline: 'The cook who became a pariah',
+        // url: 'outsiders-the-cook',
+        url: '',
+        description: '',
+        datePublished: new Date('2017-06-29'),
+      },
+      {
+        contentType: 'article',
+        headline: 'The colonist who faced the blue terror',
+        // url: 'outsiders-the-colonist',
+        url: '',
+        description: '',
+        datePublished: new Date('2017-07-06'),
+      },
+      {
+        contentType: 'article',
+        headline: 'The child whose town rejected vaccines',
+        // url: 'outsiders-the-child',
+        url: '',
+        description: '',
+        datePublished: new Date('2017-07-13'),
+      },
+      {
+        contentType: 'article',
+        headline: 'The prostitute whose pox inspired feminists',
+        // url: 'outsiders-the-prostitute',
+        url: '',
+        description: '',
+        datePublished: new Date('2017-07-20'),
+      },
+    ],
+  },
+  {
+    url: 'electric-sublime',
+    name: 'Electric Sublime',
+    commissionedLength: getSeriesCommissionedLength('electric-sublime'),
+    color: 'turquoise',
+    items: [
+      {
+        contentType: 'article',
+        headline: 'Thunderbolts and lightning',
+        // url: 'thunder-bolts-and-ligtning',
+        url: '',
+        description: '',
+        datePublished: new Date('2017-03-30'),
+      },
+      {
+        contentType: 'article',
+        headline: 'Eels and feels',
+        // url: 'eels-and-feels',
+        url: '',
+        description: '',
+        datePublished: new Date('6 April 2017'),
+      },
+      {
+        contentType: 'article',
+        headline: 'Charged bodies',
+        // url: 'charged-bodies',
+        url: '',
+        description: '',
+        datePublished: new Date('13 April 2017'),
+      },
+      {
+        contentType: 'article',
+        headline: 'The current that kills',
+        // url: 'the-current-that-kills',
+        url: '',
+        description: '',
+        datePublished: new Date('20 April 2017'),
+      },
+      {
+        contentType: 'article',
+        headline: 'Dazzling luxury',
+        // url: 'dazzling-luxury',
+        url: '',
+        description: '',
+        datePublished: new Date('27 April 2017'),
+      },
+      {
+        contentType: 'article',
+        headline: 'Titans in the landscape',
+        // url: 'titans-in-the-landscape',
+        url: '',
+        description: '',
+        datePublished: new Date('4 May 2017'),
+      },
+    ],
+  },
+];
+
+export const collectorsPromo = {
+  modifiers: ['standalone'],
+  url:
+    'http://digitalstories.wellcomecollection.org/pathways/2-the-collectors/',
+  title: 'The Collectors',
+  description: 'Searchers, secrets and the power of curiosity.',
+  image: {
+    contentUrl:
+      'https://wellcomecollection.files.wordpress.com/2017/03/the-collectors-promo.jpg',
+    width: 1600,
+    height: 900,
+  },
+  positionInSeries: 1,
+  series: [
+    {
+      color: 'turquoise',
+      commissionedLength: 1,
+      items: {
+        size: 1,
+      },
+    },
+  ],
+};

--- a/common/views/components/FilterDrawer/FilterDrawer.js
+++ b/common/views/components/FilterDrawer/FilterDrawer.js
@@ -190,54 +190,61 @@ function FilterDrawer() {
           id="filter-section-0"
           isActive={activeFilterSection === 0}
         >
-          one
+          <Space v={{ size: 'l', properties: ['padding-top'] }}>
+            <h2 className="h2">One</h2>
+            <p>
+              Unde illum soluta expedita laboriosam facilis incidunt sapiente
+              molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
+              dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
+              provident dicta voluptates pariatur cumque.
+            </p>
+          </Space>
         </FilterSection>
         <FilterSection
           id="filter-section-1"
           isActive={activeFilterSection === 1}
         >
-          <p>
-            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
-            dignissimos optio architecto aut nihil eos nulla, dolores aspernatur
-            quis dolorem ad obcaecati ea excepturi earum et est at. Tempora,
-            esse.
-          </p>
-          <p>
-            Unde illum soluta expedita laboriosam facilis incidunt sapiente
-            molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
-            dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
-            provident dicta voluptates pariatur cumque.
-          </p>
-          <p>
-            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
-            dignissimos optio architecto aut nihil eos nulla, dolores aspernatur
-            quis dolorem ad obcaecati ea excepturi earum et est at. Tempora,
-            esse.
-          </p>
-          <p>
-            Unde illum soluta expedita laboriosam facilis incidunt sapiente
-            molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
-            dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
-            provident dicta voluptates pariatur cumque.
-          </p>
-          <p>
-            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
-            dignissimos optio architecto aut nihil eos nulla, dolores aspernatur
-            quis dolorem ad obcaecati ea excepturi earum et est at. Tempora,
-            esse.
-          </p>
-          <p>
-            Unde illum soluta expedita laboriosam facilis incidunt sapiente
-            molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
-            dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
-            provident dicta voluptates pariatur cumque.
-          </p>
+          <Space v={{ size: 'l', properties: ['padding-top'] }}>
+            <h2 className="h2">Two</h2>
+            <p>
+              Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+              dignissimos optio architecto aut nihil eos nulla, dolores
+              aspernatur quis dolorem ad obcaecati ea excepturi earum et est at.
+              Tempora, esse.
+            </p>
+            <p>
+              Unde illum soluta expedita laboriosam facilis incidunt sapiente
+              molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
+              dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
+              provident dicta voluptates pariatur cumque.
+            </p>
+            <p>
+              Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+              dignissimos optio architecto aut nihil eos nulla, dolores
+              aspernatur quis dolorem ad obcaecati ea excepturi earum et est at.
+              Tempora, esse.
+            </p>
+          </Space>
         </FilterSection>
         <FilterSection
           id="filter-section-2"
           isActive={activeFilterSection === 2}
         >
-          three
+          <Space v={{ size: 'l', properties: ['padding-top'] }}>
+            <h2 className="h2">Three</h2>
+            <p>
+              Unde illum soluta expedita laboriosam facilis incidunt sapiente
+              molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
+              dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
+              provident dicta voluptates pariatur cumque.
+            </p>
+            <p>
+              Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+              dignissimos optio architecto aut nihil eos nulla, dolores
+              aspernatur quis dolorem ad obcaecati ea excepturi earum et est at.
+              Tempora, esse.
+            </p>
+          </Space>
         </FilterSection>
       </FiltersContainer>
     </FilterDrawerEl>

--- a/common/views/components/FilterDrawer/FilterDrawer.js
+++ b/common/views/components/FilterDrawer/FilterDrawer.js
@@ -1,5 +1,6 @@
 // @flow
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import debounce from 'lodash.debounce';
 import styled from 'styled-components';
 import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
@@ -48,7 +49,7 @@ const FilterBarAnchor = styled(Space).attrs({
   }),
 })`
   text-decoration: none;
-  transition: background 250ms ease;
+  transition: background 300ms ease;
 
   &:hover,
   &:focus {
@@ -67,7 +68,7 @@ const FiltersContainer = styled.div.attrs({
     relative: true,
   }),
 })`
-  transition: height 250ms ease;
+  transition: height 300ms ease;
   overflow: hidden;
   height: ${props => props.height}px;
 `;
@@ -76,11 +77,10 @@ const FilterSection = styled.div.attrs(props => ({
   className: classNames({
     absolute: true,
   }),
-  // hidden: !props.isActive,
 }))`
   top: 0;
   left: 0;
-  transition: opacity 250ms ease;
+  transition: opacity 300ms ease;
   opacity: ${props => (props.isActive ? 1 : 0)};
 `;
 
@@ -89,10 +89,29 @@ function FilterDrawer() {
   const [activeFilterSection, setActiveFilterSection] = useState(null);
   const [filtersContainerHeight, setFiltersContainerHeight] = useState(0);
 
-  function updateFiltersContainerHeight(sectionIndex) {
+  function handleResize() {
+    setFiltersContainerHeight(getSectionHeight(activeFilterSection));
+  }
+
+  const debounceHandleResize = debounce(handleResize, 500);
+
+  useEffect(() => {
+    window.addEventListener('resize', debounceHandleResize);
+
+    return () => {
+      window.removeEventListener('resize', debounceHandleResize);
+    };
+  }, [activeFilterSection]);
+
+  function getSectionHeight(sectionIndex) {
     const el = filtersContainerRef && filtersContainerRef.current;
     const newSection = el && el.children[sectionIndex];
-    const height = newSection && newSection.getBoundingClientRect().height;
+
+    return (newSection && newSection.getBoundingClientRect().height) || 0;
+  }
+
+  function updateFiltersContainerHeight(sectionIndex) {
+    const height = getSectionHeight(sectionIndex);
 
     setFiltersContainerHeight(
       activeFilterSection === sectionIndex ? 0 : height
@@ -147,7 +166,20 @@ function FilterDrawer() {
         height={filtersContainerHeight}
       >
         <FilterSection isActive={activeFilterSection === 0}>one</FilterSection>
-        <FilterSection isActive={activeFilterSection === 1}>two</FilterSection>
+        <FilterSection isActive={activeFilterSection === 1}>
+          <p>
+            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+            dignissimos optio architecto aut nihil eos nulla, dolores aspernatur
+            quis dolorem ad obcaecati ea excepturi earum et est at. Tempora,
+            esse.
+          </p>
+          <p>
+            Unde illum soluta expedita laboriosam facilis incidunt sapiente
+            molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
+            dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
+            provident dicta voluptates pariatur cumque.
+          </p>
+        </FilterSection>
         <FilterSection isActive={activeFilterSection === 2}>
           three
         </FilterSection>

--- a/common/views/components/FilterDrawer/FilterDrawer.js
+++ b/common/views/components/FilterDrawer/FilterDrawer.js
@@ -68,20 +68,21 @@ const FiltersContainer = styled.div.attrs({
     relative: true,
   }),
 })`
-  transition: height 300ms ease;
-  overflow: hidden;
-  height: ${props => props.height}px;
+  .enhanced & {
+    transition: height 300ms ease;
+    overflow: hidden;
+    height: ${props => props.height}px;
+  }
 `;
 
-const FilterSection = styled.div.attrs(props => ({
-  className: classNames({
-    absolute: true,
-  }),
-}))`
-  top: 0;
-  left: 0;
-  transition: opacity 300ms ease;
-  opacity: ${props => (props.isActive ? 1 : 0)};
+const FilterSection = styled.div`
+  .enhanced & {
+    top: 0;
+    left: 0;
+    transition: opacity 300ms ease;
+    opacity: ${props => (props.isActive ? 1 : 0)};
+    position: absolute;
+  }
 `;
 
 function FilterDrawer() {
@@ -138,7 +139,13 @@ function FilterDrawer() {
             'is-active': activeFilterSection === 0,
           })}
         >
-          <FilterBarAnchor onClick={() => updateActiveFilterSection(0)}>
+          <FilterBarAnchor
+            href="#filter-section-0"
+            onClick={event => {
+              event.preventDefault();
+              updateActiveFilterSection(0);
+            }}
+          >
             one
           </FilterBarAnchor>
         </FilterBarLi>
@@ -147,7 +154,13 @@ function FilterDrawer() {
             'is-active': activeFilterSection === 1,
           })}
         >
-          <FilterBarAnchor onClick={() => updateActiveFilterSection(1)}>
+          <FilterBarAnchor
+            href="#filter-section-1"
+            onClick={event => {
+              event.preventDefault();
+              updateActiveFilterSection(1);
+            }}
+          >
             two
           </FilterBarAnchor>
         </FilterBarLi>
@@ -156,7 +169,13 @@ function FilterDrawer() {
             'is-active': activeFilterSection === 2,
           })}
         >
-          <FilterBarAnchor onClick={() => updateActiveFilterSection(2)}>
+          <FilterBarAnchor
+            href="#filter-section-2"
+            onClick={event => {
+              event.preventDefault();
+              updateActiveFilterSection(2);
+            }}
+          >
             three
           </FilterBarAnchor>
         </FilterBarLi>
@@ -165,8 +184,40 @@ function FilterDrawer() {
         ref={filtersContainerRef}
         height={filtersContainerHeight}
       >
-        <FilterSection isActive={activeFilterSection === 0}>one</FilterSection>
-        <FilterSection isActive={activeFilterSection === 1}>
+        <FilterSection
+          id="filter-section-0"
+          isActive={activeFilterSection === 0}
+        >
+          one
+        </FilterSection>
+        <FilterSection
+          id="filter-section-1"
+          isActive={activeFilterSection === 1}
+        >
+          <p>
+            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+            dignissimos optio architecto aut nihil eos nulla, dolores aspernatur
+            quis dolorem ad obcaecati ea excepturi earum et est at. Tempora,
+            esse.
+          </p>
+          <p>
+            Unde illum soluta expedita laboriosam facilis incidunt sapiente
+            molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
+            dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
+            provident dicta voluptates pariatur cumque.
+          </p>
+          <p>
+            Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+            dignissimos optio architecto aut nihil eos nulla, dolores aspernatur
+            quis dolorem ad obcaecati ea excepturi earum et est at. Tempora,
+            esse.
+          </p>
+          <p>
+            Unde illum soluta expedita laboriosam facilis incidunt sapiente
+            molestiae, totam perspiciatis odit, nobis a? Aliquam, illum quae
+            dolor tempore mollitia in voluptatibus consequuntur ut dignissimos
+            provident dicta voluptates pariatur cumque.
+          </p>
           <p>
             Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
             dignissimos optio architecto aut nihil eos nulla, dolores aspernatur
@@ -180,7 +231,10 @@ function FilterDrawer() {
             provident dicta voluptates pariatur cumque.
           </p>
         </FilterSection>
-        <FilterSection isActive={activeFilterSection === 2}>
+        <FilterSection
+          id="filter-section-2"
+          isActive={activeFilterSection === 2}
+        >
           three
         </FilterSection>
       </FiltersContainer>

--- a/common/views/components/FilterDrawer/FilterDrawer.js
+++ b/common/views/components/FilterDrawer/FilterDrawer.js
@@ -1,7 +1,14 @@
 // @flow
+import { useState, useRef } from 'react';
 import styled from 'styled-components';
 import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
+
+const FilterDrawerEl = styled.div.attrs({
+  className: classNames({
+    FilterDrawerEl: true,
+  }),
+})``;
 
 const FilterBarUl = styled.ul.attrs({
   className: classNames({
@@ -41,6 +48,7 @@ const FilterBarAnchor = styled(Space).attrs({
   }),
 })`
   text-decoration: none;
+  transition: background 250ms ease;
 
   &:hover,
   &:focus {
@@ -54,21 +62,97 @@ const FilterBarAnchor = styled(Space).attrs({
   }
 `;
 
+const FiltersContainer = styled.div.attrs({
+  className: classNames({
+    relative: true,
+  }),
+})`
+  transition: height 250ms ease;
+  overflow: hidden;
+  height: ${props => props.height}px;
+`;
+
+const FilterSection = styled.div.attrs(props => ({
+  className: classNames({
+    absolute: true,
+  }),
+  // hidden: !props.isActive,
+}))`
+  top: 0;
+  left: 0;
+  transition: opacity 250ms ease;
+  opacity: ${props => (props.isActive ? 1 : 0)};
+`;
+
 function FilterDrawer() {
+  const filtersContainerRef = useRef(null);
+  const [activeFilterSection, setActiveFilterSection] = useState(null);
+  const [filtersContainerHeight, setFiltersContainerHeight] = useState(0);
+
+  function updateFiltersContainerHeight(sectionIndex) {
+    const el = filtersContainerRef && filtersContainerRef.current;
+    const newSection = el && el.children[sectionIndex];
+    const height = newSection && newSection.getBoundingClientRect().height;
+
+    setFiltersContainerHeight(
+      activeFilterSection === sectionIndex ? 0 : height
+    );
+  }
+
+  function updateActiveFilterSection(sectionIndex) {
+    updateFiltersContainerHeight(sectionIndex);
+
+    setActiveFilterSection(
+      activeFilterSection === sectionIndex ? null : sectionIndex
+    );
+  }
+
   return (
-    <>
+    <FilterDrawerEl
+      className={classNames({
+        'is-open': activeFilterSection !== null,
+      })}
+    >
       <FilterBarUl>
-        <FilterBarLi className="is-active">
-          <FilterBarAnchor href="#">one</FilterBarAnchor>
+        <FilterBarLi
+          className={classNames({
+            'is-active': activeFilterSection === 0,
+          })}
+        >
+          <FilterBarAnchor onClick={() => updateActiveFilterSection(0)}>
+            one
+          </FilterBarAnchor>
         </FilterBarLi>
-        <FilterBarLi>
-          <FilterBarAnchor href="#">two</FilterBarAnchor>
+        <FilterBarLi
+          className={classNames({
+            'is-active': activeFilterSection === 1,
+          })}
+        >
+          <FilterBarAnchor onClick={() => updateActiveFilterSection(1)}>
+            two
+          </FilterBarAnchor>
         </FilterBarLi>
-        <FilterBarLi>
-          <FilterBarAnchor href="#">three</FilterBarAnchor>
+        <FilterBarLi
+          className={classNames({
+            'is-active': activeFilterSection === 2,
+          })}
+        >
+          <FilterBarAnchor onClick={() => updateActiveFilterSection(2)}>
+            three
+          </FilterBarAnchor>
         </FilterBarLi>
       </FilterBarUl>
-    </>
+      <FiltersContainer
+        ref={filtersContainerRef}
+        height={filtersContainerHeight}
+      >
+        <FilterSection isActive={activeFilterSection === 0}>one</FilterSection>
+        <FilterSection isActive={activeFilterSection === 1}>two</FilterSection>
+        <FilterSection isActive={activeFilterSection === 2}>
+          three
+        </FilterSection>
+      </FiltersContainer>
+    </FilterDrawerEl>
   );
 }
 

--- a/common/views/components/FilterDrawer/FilterDrawer.js
+++ b/common/views/components/FilterDrawer/FilterDrawer.js
@@ -1,0 +1,75 @@
+// @flow
+import styled from 'styled-components';
+import { classNames } from '../../../utils/classnames';
+import Space from '../styled/Space';
+
+const FilterBarUl = styled.ul.attrs({
+  className: classNames({
+    'bg-cream plain-list no-margin no-padding flex-inline': true,
+  }),
+})``;
+
+const FilterBarLi = styled.li.attrs({
+  className: classNames({
+    FilterBarLi: true,
+    relative: true,
+  }),
+})`
+  &:after {
+    content: '';
+    position: absolute;
+    right: -1px;
+    bottom: 3px;
+    top: 3px;
+    width: 1px;
+    background: ${props => props.theme.colors.pumice};
+  }
+
+  &.is-active:after,
+  &:hover:after,
+  &:last-child:after {
+    display: none;
+  }
+`;
+
+const FilterBarAnchor = styled(Space).attrs({
+  as: 'a',
+  v: { size: 's', properties: ['padding-top', 'padding-bottom'] },
+  h: { size: 'xl', properties: ['padding-left', 'padding-right'] },
+  className: classNames({
+    'inline-block font-pewter border-bottom-width-3 border-color-transparent': true,
+  }),
+})`
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    background: rgba(255, 255, 255, 0.6);
+  }
+
+  .FilterBarLi.is-active & {
+    background: rgba(255, 255, 255, 0.6);
+    border-bottom-color: ${props => props.theme.colors.yellow};
+    color: ${props => props.theme.colors.black};
+  }
+`;
+
+function FilterDrawer() {
+  return (
+    <>
+      <FilterBarUl>
+        <FilterBarLi className="is-active">
+          <FilterBarAnchor href="#">one</FilterBarAnchor>
+        </FilterBarLi>
+        <FilterBarLi>
+          <FilterBarAnchor href="#">two</FilterBarAnchor>
+        </FilterBarLi>
+        <FilterBarLi>
+          <FilterBarAnchor href="#">three</FilterBarAnchor>
+        </FilterBarLi>
+      </FilterBarUl>
+    </>
+  );
+}
+
+export default FilterDrawer;

--- a/common/views/components/FilterDrawer/FilterDrawer.js
+++ b/common/views/components/FilterDrawer/FilterDrawer.js
@@ -79,7 +79,7 @@ const FilterSection = styled.div`
   .enhanced & {
     top: 0;
     left: 0;
-    transition: opacity 300ms ease;
+    transition: opacity 500ms 300ms ease;
     opacity: ${props => (props.isActive ? 1 : 0)};
     position: absolute;
   }

--- a/common/views/components/FilterDrawer/FilterDrawer.js
+++ b/common/views/components/FilterDrawer/FilterDrawer.js
@@ -75,7 +75,9 @@ const FiltersContainer = styled.div.attrs({
   }
 `;
 
-const FilterSection = styled.div`
+const FilterSection = styled.div.attrs(props => ({
+  'aria-hidden': !props.isActive,
+}))`
   .enhanced & {
     top: 0;
     left: 0;

--- a/common/views/components/FilterDrawer/README.md
+++ b/common/views/components/FilterDrawer/README.md
@@ -1,0 +1,3 @@
+## Purpose
+
+Present different filters in an animated drawer.


### PR DESCRIPTION
Adding the markup, styles and UI interaction/animation for the filters container on /works, with a demo in Cardigan.

I imagine a fair bit will change when we hook up real content, but felt like it made sense to get this in sooner rather than later.

Using `aria-hidden` to hide the zero-opacity elements from screenreaders – this allows the elements to remain visible while they crossfade (the `hidden` attribute has the effect of hiding them visually straight-away, which was no good, and this way felt better than listening for `transitionend` events to apply e.g. `display: none`).

Also includes a debounced resize handler that will update the height of the drawer in line with the active section's new height after the resize.

With JavaScript disabled, all sections will be visible, and the links in the bar at the top will act as in-page links to the appropriate section.

![filter-drawer](https://user-images.githubusercontent.com/1394592/65311118-9a75f380-db87-11e9-9461-2d3acb41489c.gif)
