### PR TITLE
Use pseudo element for status dot and hide from screenreaders

### DIFF
--- a/common/views/components/Dot/Dot.js
+++ b/common/views/components/Dot/Dot.js
@@ -1,15 +1,23 @@
 // @flow
+import styled from 'styled-components';
+
+const DotEl = styled.span.attrs({
+  'aria-hidden': true,
+})`
+  display: inline-block;
+  font-size: 0.7em;
+
+  &:before {
+    content: '⬤';
+  }
+`;
 
 type Props = {|
   color: string,
 |};
 
 function Dot({ color }: Props) {
-  return (
-    <span className={`font-${color}`} style={{ fontSize: '0.7em' }}>
-      &#11044;
-    </span>
-  );
+  return <DotEl className={`font-${color}`} />;
 }
 
 export default Dot;

--- a/common/views/components/Dot/Dot.js
+++ b/common/views/components/Dot/Dot.js
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 const DotEl = styled.span.attrs({
   'aria-hidden': true,
 })`
-  display: inline-block;
   font-size: 0.7em;
 
   &:before {


### PR DESCRIPTION
When we changed the status indicator dot from an svg to an ascii character, pa11y started to care about the colour contrast (because it is being treated as text).

The dot isn't meaningful as text – this PR adds an `aria-hidden` attribute to make sure screenreaders ignore it.

Also, moving the dot within the `content` of a `:before` pseudo element prevents it from being considered for contrast-ratio testing by pa11y (passing locally).