### PR TITLE
Make pewter a shade darker (addresses contrast issues)

### DIFF
--- a/cardigan/config/colors.js
+++ b/cardigan/config/colors.js
@@ -12,7 +12,7 @@ const colors = {
   cream: '#f0ede3',
   green: '#007868',
   charcoal: '#323232',
-  pewter: '#717171',
+  pewter: '#6b6b6b',
   silver: '#8f8f8f',
   marble: '#bcbab5',
   pumice: '#d9d6ce',

--- a/common/styles/utilities/compiled_variables/_colors.scss
+++ b/common/styles/utilities/compiled_variables/_colors.scss
@@ -12,7 +12,7 @@ $colors: (
   'cream': #f0ede3,
   'green': #007868,
   'charcoal': #323232,
-  'pewter': #717171,
+  'pewter': #6b6b6b,
   'silver': #8f8f8f,
   'marble': #bcbab5,
   'pumice': #d9d6ce,


### PR DESCRIPTION
At @GarethOrmerod's suggestion, changing the `pewter` colour to be a fraction darker allows it to have an acceptable contrast in more situations.