### PR TITLE
Only give image a default background if it isn't being given one elsewhere

### DIFF
--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -78,7 +78,9 @@ const Img = ({
       height={height}
       className={classNames({
         image: true,
-        'bg-charcoal font-white': true,
+        'bg-charcoal font-white': Boolean(
+          extraClasses && !extraClasses.match(/bg-/)
+        ),
         'lazy-image lazyload': lazyload,
         'cursor-zoom-in': Boolean(zoomable),
         [`promo__image-mask ${clipPathClass || ''}`]: clipPathClass,


### PR DESCRIPTION
We were giving `Image` a default `bg-charcoal`, but the `ImagePlaceholder` provides its own background colour (which was being overridden). This doesn't feel great, but I think it's a toss-up between something like this, or the addition of another prop?