### PR TITLE
Remove beige background from search area (prep for filter drawer)

### DIFF
--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -158,47 +158,36 @@ export const WorkPage = ({ work }: Props) => {
         </TogglesContext.Consumer>
         <BetaBar />
       </Layout12>
-
-      <Space
-        v={{
-          size: 'l',
-          properties: ['padding-top'],
-        }}
-        className={classNames({
-          'bg-cream': true,
-        })}
-      >
-        <div className="container">
-          <div className="grid">
-            <div
-              className={classNames({
-                [grid({ s: 12, m: 10, l: 8, xl: 8 })]: true,
-              })}
-            >
-              <SearchForm
-                ariaDescribedBy="search-form-description"
-                compact={true}
-                shouldShowFilters={false}
-                searchParams={searchParams}
-              />
-            </div>
-          </div>
-
-          <div className="grid">
-            <Space
-              v={{
-                size: 's',
-                properties: ['padding-top', 'padding-bottom'],
-              }}
-              className={classNames({
-                [grid({ s: 12 })]: true,
-              })}
-            >
-              <BackToResults />
-            </Space>
+      <div className="container">
+        <div className="grid">
+          <div
+            className={classNames({
+              [grid({ s: 12, m: 10, l: 8, xl: 8 })]: true,
+            })}
+          >
+            <SearchForm
+              ariaDescribedBy="search-form-description"
+              compact={true}
+              shouldShowFilters={false}
+              searchParams={searchParams}
+            />
           </div>
         </div>
-      </Space>
+
+        <div className="grid">
+          <Space
+            v={{
+              size: 's',
+              properties: ['padding-top', 'padding-bottom'],
+            }}
+            className={classNames({
+              [grid({ s: 12 })]: true,
+            })}
+          >
+            <BackToResults />
+          </Space>
+        </div>
+      </div>
 
       <Space
         v={{

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -177,7 +177,7 @@ const Works = ({ works, searchParams }: Props) => {
             size: 'l',
             properties: ['padding-top', 'padding-bottom'],
           }}
-          className={classNames(['row bg-cream'])}
+          className={classNames(['row'])}
         >
           <div className="container">
             <div className="grid">


### PR DESCRIPTION
Getting rid of the cream background behind the search area on `/works` and `/works/:id` in line with the new visual design for the filter drawer.

![image](https://user-images.githubusercontent.com/1394592/65685334-9fd8af80-e059-11e9-9e9e-a0ad44e75bde.png)
