### PR TITLE
reinstate beta bar

### DIFF
--- a/catalogue/webapp/pages/item.js
+++ b/catalogue/webapp/pages/item.js
@@ -177,6 +177,7 @@ const ItemPage = ({
       hideNewsletterPromo={true}
       hideFooter={true}
       fixHeader={true}
+      hideInfoBar={true}
     >
       {audio && (
         <Layout12>

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -15,25 +15,18 @@ import {
 } from '@weco/common/utils/works';
 import { itemUrl } from '@weco/common/services/catalogue/urls';
 import { clientSideSearchParams } from '@weco/common/services/catalogue/search-params';
-
 import { iiifImageTemplate } from '@weco/common/utils/convert-image-uri';
 import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayout/CataloguePageLayout';
-import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
 import { workLd } from '@weco/common/utils/json-ld';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
 import BackToResults from '@weco/common/views/components/BackToResults/BackToResults';
 import WorkHeader from '@weco/common/views/components/WorkHeader/WorkHeader';
-import BetaBar from '@weco/common/views/components/BetaBar/BetaBar';
-import Layout12 from '@weco/common/views/components/Layout12/Layout12';
-
 import WorkDetails from '../components/WorkDetails/WorkDetails';
 import SearchForm from '../components/SearchForm/SearchForm';
 import ManifestContext from '@weco/common/views/components/ManifestContext/ManifestContext';
 import { getWork } from '../services/catalogue/works';
 import IIIFPresentationPreview from '@weco/common/views/components/IIIFPresentationPreview/IIIFPresentationPreview';
 import IIIFImagePreview from '@weco/common/views/components/IIIFImagePreview/IIIFImagePreview';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
-import MessageBar from '@weco/common/views/components/MessageBar/MessageBar';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import WobblyRow from '@weco/common/views/components/WobblyRow/WobblyRow';
 import Space from '@weco/common/views/components/styled/Space';
@@ -135,29 +128,6 @@ export const WorkPage = ({ work }: Props) => {
       imageAltText={work.title}
       hideNewsletterPromo={true}
     >
-      <InfoBanner
-        text={[
-          {
-            type: 'paragraph',
-            text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
-            spans: [],
-          },
-        ]}
-        cookieName="WC_wellcomeImagesRedirect"
-      />
-
-      <Layout12>
-        <TogglesContext.Consumer>
-          {({ useStageApi }) =>
-            useStageApi && (
-              <MessageBar tagText="Dev alert">
-                You are using the stage catalogue API - data mileage may vary!
-              </MessageBar>
-            )
-          }
-        </TogglesContext.Consumer>
-        <BetaBar />
-      </Layout12>
       <div className="container">
         <div className="grid">
           <div

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -10,7 +10,6 @@ import {
 import { font, grid, classNames } from '@weco/common/utils/classnames';
 import convertUrlToString from '@weco/common/utils/convert-url-to-string';
 import CataloguePageLayout from '@weco/common/views/components/CataloguePageLayout/CataloguePageLayout';
-import InfoBanner from '@weco/common/views/components/InfoBanner/InfoBanner';
 import Paginator from '@weco/common/views/components/Paginator/Paginator';
 import ErrorPage from '@weco/common/views/components/ErrorPage/ErrorPage';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
@@ -27,12 +26,12 @@ import {
   SearchEventNames,
 } from '@weco/common/views/components/Tracker/Tracker';
 import RelevanceRater from '@weco/common/views/components/RelevanceRater/RelevanceRater';
+import Space from '@weco/common/views/components/styled/Space';
+import TabNav from '@weco/common/views/components/TabNav/TabNav';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
 import WorkCard from '../components/WorkCard/WorkCard';
-import Space from '@weco/common/views/components/styled/Space';
-import TabNav from '@weco/common/views/components/TabNav/TabNav';
 
 type Props = {|
   works: ?CatalogueResultsList | CatalogueApiError,
@@ -161,17 +160,6 @@ const Works = ({ works, searchParams }: Props) => {
         imageUrl={null}
         imageAltText={null}
       >
-        <InfoBanner
-          text={[
-            {
-              type: 'paragraph',
-              text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
-              spans: [],
-            },
-          ]}
-          cookieName="WC_wellcomeImagesRedirect"
-        />
-
         <Space
           v={{
             size: 'l',

--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.js
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.js
@@ -1,11 +1,56 @@
 // @flow
-import PageLayout, { type Props } from '../PageLayout/PageLayout';
+import PageLayout, {
+  type Props as PageLayoutProps,
+} from '../PageLayout/PageLayout';
+import InfoBanner from '../InfoBanner/InfoBanner';
+import MessageBar from '../MessageBar/MessageBar';
+import TogglesContext from '../TogglesContext/TogglesContext';
+import Layout12 from '../Layout12/Layout12';
+import BetaBar from '../BetaBar/BetaBar';
 import { TrackerScript } from '../Tracker/Tracker';
 
-const CataloguePageLayout = (props: Props) => (
-  <>
-    <TrackerScript />
-    <PageLayout {...props} />
-  </>
-);
+type Props = {|
+  ...PageLayoutProps,
+  hideInfoBar?: boolean,
+|};
+
+const CataloguePageLayout = (props: Props) => {
+  const { children, hideInfoBar, ...extraProps } = props;
+  return (
+    <>
+      <TrackerScript />
+      <PageLayout {...extraProps}>
+        {hideInfoBar === false && (
+          <>
+            <InfoBanner
+              text={[
+                {
+                  type: 'paragraph',
+                  text: `Coming from Wellcome Images? All freely available images have now been moved to the Wellcome Collection website. Here we're working to improve data quality, search relevance and tools to help you use these images more easily`,
+                  spans: [],
+                },
+              ]}
+              cookieName="WC_wellcomeImagesRedirect"
+            />
+
+            <Layout12>
+              <TogglesContext.Consumer>
+                {({ useStageApi }) =>
+                  useStageApi && (
+                    <MessageBar tagText="Dev alert">
+                      You are using the stage catalogue API - data mileage may
+                      vary!
+                    </MessageBar>
+                  )
+                }
+              </TogglesContext.Consumer>
+              <BetaBar />
+            </Layout12>
+          </>
+        )}
+        {children}
+      </PageLayout>
+    </>
+  );
+};
 export default CataloguePageLayout;

--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.js
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.js
@@ -20,7 +20,7 @@ const CataloguePageLayout = (props: Props) => {
     <>
       <TrackerScript />
       <PageLayout {...extraProps}>
-        {hideInfoBar === false && (
+        {hideInfoBar !== true && (
           <>
             <InfoBanner
               text={[


### PR DESCRIPTION
![Screenshot 2019-09-30 at 15 15 32](https://user-images.githubusercontent.com/31692/65886958-29a7b600-e395-11e9-9120-0c4d6fc97eb4.png)

Fixes #4761 

We could probably abstract it further by having a `<WorksPageLayout />` which extends `<CataloguePageLayout />` which extends `<PageLayout />` and then have an `<ItemPageLayout />` so we stop using all the `hideThisThing` logic, but seems over kill.