### PR TITLE
add basic similarity panel

### DIFF
--- a/catalogue/webapp/components/PaletteSimilarityBox/PaletteSimilarityBox.js
+++ b/catalogue/webapp/components/PaletteSimilarityBox/PaletteSimilarityBox.js
@@ -1,0 +1,63 @@
+// @flow
+import { type Work } from '@weco/common/model/work';
+import { useState, useEffect } from 'react';
+import fetch from 'isomorphic-unfetch';
+
+type Props = {|
+  work: Work,
+|};
+
+const PaletteSimilarityBox = ({ work }: Props) => {
+  const [similar, setSimilar] = useState();
+
+  const miroNumber = (
+    work.identifiers.find(
+      identifier => identifier.identifierType.id === 'miro-image-number'
+    ) || {}
+  ).value;
+
+  async function getSimilar(id) {
+    const resp = await fetch(
+      `https://labs.wellcomecollection.org/palette-api/by_image_id?image_id=${id}&n=5`
+    );
+    const similar = await resp.json();
+    setSimilar(similar);
+  }
+
+  useEffect(() => {
+    if (miroNumber) {
+      getSimilar(miroNumber);
+    }
+  }, []);
+
+  return similar ? (
+    <div>
+      <div className="flex">
+        {similar.neighbours.map(neighbour => {
+          return (
+            <div
+              style={{
+                flex: '1 1 auto',
+                marginRight: '5px',
+              }}
+              key={neighbour.uri}
+            >
+              {/* Woohoo, is this hacky, but we need it as we only have the miro image */}
+              <a
+                href={`https://wellcomeimages.org/redirect?query=${neighbour.id}`}
+              >
+                <img
+                  src={`${neighbour.uri}`}
+                  alt=""
+                  style={{ maxWidth: '100%', width: 'auto' }}
+                />
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  ) : null;
+};
+
+export default PaletteSimilarityBox;

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -23,9 +23,11 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import CopyUrl from '@weco/common/views/components/CopyUrl/CopyUrl';
 import MetaUnit from '@weco/common/views/components/MetaUnit/MetaUnit';
 import Layout12 from '@weco/common/views/components/Layout12/Layout12';
-import Download from '../Download/Download';
 import Space from '@weco/common/views/components/styled/Space';
 import { clientSideSearchParams } from '@weco/common/services/catalogue/search-params';
+
+import Download from '../Download/Download';
+import PaletteSimilarityBox from '../PaletteSimilarityBox/PaletteSimilarityBox';
 
 type WorkDetailsSectionProps = {|
   headingText?: string,
@@ -78,6 +80,7 @@ type Props = {|
   iiifPresentationManifest: ?IIIFManifest,
   encoreLink: ?string,
   childManifestsCount?: number,
+  showImagesWithSimilarPalette?: boolean,
 |};
 
 const WorkDetails = ({
@@ -86,6 +89,7 @@ const WorkDetails = ({
   iiifPresentationManifest,
   encoreLink,
   childManifestsCount,
+  showImagesWithSimilarPalette,
 }: Props) => {
   const params = clientSideSearchParams();
   const iiifImageLocation = getLocationType(work, 'iiif-image');
@@ -359,6 +363,15 @@ const WorkDetails = ({
       </WorkDetailsSection>
     );
   }
+
+  if (showImagesWithSimilarPalette) {
+    WorkDetailsSections.push(
+      <WorkDetailsSection headingText="Images with a similar palette">
+        <PaletteSimilarityBox work={work} />
+      </WorkDetailsSection>
+    );
+  }
+
   WorkDetailsSections.push(
     <WorkDetailsSection>
       <div className="flex flex--v-center">

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -29,6 +29,7 @@ import IIIFPresentationPreview from '@weco/common/views/components/IIIFPresentat
 import IIIFImagePreview from '@weco/common/views/components/IIIFImagePreview/IIIFImagePreview';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import WobblyRow from '@weco/common/views/components/WobblyRow/WobblyRow';
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {|
@@ -158,7 +159,6 @@ export const WorkPage = ({ work }: Props) => {
           </Space>
         </div>
       </div>
-
       <Space
         v={{
           size: 'xl',
@@ -174,7 +174,6 @@ export const WorkPage = ({ work }: Props) => {
           </div>
         </div>
       </Space>
-
       {firstChildManifest && (
         <ManifestContext.Provider value={firstChildManifest}>
           <SpacingComponent>
@@ -197,7 +196,6 @@ export const WorkPage = ({ work }: Props) => {
           </SpacingComponent>
         </ManifestContext.Provider>
       )}
-
       <ManifestContext.Provider value={iiifPresentationManifest}>
         {!firstChildManifest &&
           sierraIdFromPresentationManifestUrl &&
@@ -216,7 +214,6 @@ export const WorkPage = ({ work }: Props) => {
             />
           )}
       </ManifestContext.Provider>
-
       {iiifImageLocationUrl && (
         <WobblyRow>
           <IIIFImagePreview
@@ -235,14 +232,18 @@ export const WorkPage = ({ work }: Props) => {
           />
         </WobblyRow>
       )}
-
-      <WorkDetails
-        work={work}
-        sierraId={sierraIdFromPresentationManifestUrl}
-        iiifPresentationManifest={iiifPresentationManifest}
-        encoreLink={encoreLink}
-        childManifestsCount={childManifestsCount}
-      />
+      <TogglesContext.Consumer>
+        {({ showImagesWithSimilarPalette }) => (
+          <WorkDetails
+            showImagesWithSimilarPalette={showImagesWithSimilarPalette}
+            work={work}
+            sierraId={sierraIdFromPresentationManifestUrl}
+            iiifPresentationManifest={iiifPresentationManifest}
+            encoreLink={encoreLink}
+            childManifestsCount={childManifestsCount}
+          />
+        )}
+      </TogglesContext.Consumer>
     </CataloguePageLayout>
   );
 };

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -42,5 +42,12 @@ module.exports = {
       description:
         'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
+    {
+      id: 'showImagesWithSimilarPalette',
+      title: 'Show images with similar palette in the work details section',
+      defaultValue: false,
+      description:
+        'If the work has a Miro image, we can show images with similar a palette.',
+    },
   ],
 };


### PR DESCRIPTION
Add a basic component connecting to the palette API.
This is giving us a chance to see what shape the API should be in, and what we're missing.

- [X] Will be behind a toggle.


## Original 👇 
![Screenshot 2019-09-30 at 18 13 32](https://user-images.githubusercontent.com/31692/65900504-0e957000-e3ae-11e9-9873-841265f26caa.png)

## Images 👇 
![Screenshot 2019-09-30 at 18 10 07](https://user-images.githubusercontent.com/31692/65900438-ec035700-e3ad-11e9-846c-14e9eb35dd7f.png)

