### PR TITLE
add extra properties to search result selected

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -333,6 +333,15 @@ const Works = ({ works, searchParams }: Props) => {
                               page,
                               workType,
                               _queryType,
+                              resultWorkType: result.workType.label,
+                              resultLanguage:
+                                result.language && result.language.label,
+                              resultIdentifiers: result.identifiers.map(
+                                identifier => identifier.value
+                              ),
+                              resultSubjects: result.subjects.map(
+                                subject => subject.label
+                              ),
                             },
                           };
                           trackSearch(event);

--- a/common/views/components/Tracker/Tracker.js
+++ b/common/views/components/Tracker/Tracker.js
@@ -24,6 +24,10 @@ type SearchResultEventData = {|
   page: number,
   workType: ?(string[]),
   _queryType: ?string,
+  resultWorkType: string,
+  resultLanguage: ?string,
+  resultIdentifiers: string[],
+  resultSubjects: string[],
 |};
 
 type SearchData = SearchEventData | SearchResultEventData;


### PR DESCRIPTION
Ref: https://github.com/wellcometrust/wellcomecollection.org/issues/4341

Adds the properties to the search result that has been selected.

It treats everything as a string, or a list of strings to not pollute the ES index too heavily. I have added a suggestion to the issue if we'd like more structured querying.