### PR TITLE
add withNotes queryType search A/B

### DIFF
--- a/cache/edge_lambdas/toggler.js
+++ b/cache/edge_lambdas/toggler.js
@@ -4,8 +4,8 @@
 // {
 //   id: 'outro',
 //   title: 'Outro',
-//   range: [0, 50] // 50% chance, this is [inclusive, exclusive)
-//   range: [50, 100] // 50% chance, this is [inclusive, exclusive)
+//   range: [0, 50], // 50% chance, this is [inclusive, exclusive)
+//   range: [50, 100], // 50% chance, this is [inclusive, exclusive)
 //   shouldRun: (request, range) => {
 //     return request.uri.match(/^\/articles\/*/);
 //   }
@@ -14,26 +14,10 @@
 // This is mutable for testing
 let tests = [
   {
-    id: 'searchCandidateQueryMsm',
-    title: 'Search candidate query: Minimum should match',
-    range: [0, 25],
-    shouldRun: request => {
-      return request.uri.match(/^\/works\/*/);
-    },
-  },
-  {
-    id: 'searchCandidateQueryBoost',
-    title: 'Search candidate query: Boost',
-    range: [25, 50],
-    shouldRun: request => {
-      return request.uri.match(/^\/works\/*/);
-    },
-  },
-  {
-    id: 'searchCandidateQueryMsmBoost',
-    title: 'Search candidate query: Minimum should match with boost',
-    range: [50, 75],
-    shouldRun: request => {
+    id: 'searchWithNotes',
+    title: 'Search note fields in the catalogue',
+    range: [50, 100],
+    shouldRun: (request, range) => {
       return request.uri.match(/^\/works\/*/);
     },
   },

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -453,12 +453,18 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const params = searchParamsDeserialiser(ctx.query);
   const filters = apiSearchParamsSerialiser(params);
   const shouldGetWorks = query && query !== '';
+  const { searchWithNotes } = ctx.query.toggles;
+
+  const toggledFilters = {
+    ...filters,
+    _queryType: searchWithNotes ? 'withNotes' : undefined,
+  };
 
   const worksOrError = shouldGetWorks
     ? await getWorks({
         query,
         page: filters.page,
-        filters,
+        filters: toggledFilters,
       })
     : null;
 

--- a/common/koa-middleware/withToggles.js
+++ b/common/koa-middleware/withToggles.js
@@ -23,8 +23,8 @@ const parseCookies = function(req) {
 
   return req.headers.cookie.split(';').map(cookieString => {
     const keyVal = cookieString.split('=');
-    const key = keyVal[0].trim();
-    const value = keyVal[1].trim();
+    const key = keyVal[0] && keyVal[0].trim();
+    const value = keyVal[1] && keyVal[1].trim();
 
     return { key, value };
   });


### PR DESCRIPTION
We have the new _queryType that includes searching the notes fields.

We'll need to get the success criteria up (or are we just interested in seeing what it does) <= Ping @harrisonpim.