### PR TITLE
Treat all query string parameters equally

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -453,15 +453,12 @@ const Works = ({ works, searchParams }: Props) => {
 };
 
 Works.getInitialProps = async (ctx: Context): Promise<Props> => {
-  const query = ctx.query.query;
   const params = searchParamsDeserialiser(ctx.query);
   const filters = apiSearchParamsSerialiser(params);
-  const shouldGetWorks = query && query !== '';
+  const shouldGetWorks = filters.query && filters.query !== '';
 
   const worksOrError = shouldGetWorks
     ? await getWorks({
-        query,
-        page: filters.page,
         filters,
       })
     : null;

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -18,8 +18,6 @@ type Enviable = {|
 |};
 
 type GetWorksProps = {|
-  query: string,
-  page: number,
   filters: Object,
   ...Enviable,
 |};
@@ -39,8 +37,6 @@ const includes = [
 ];
 
 export async function getWorks({
-  query,
-  page,
   filters,
   env = 'prod',
 }: GetWorksProps): Promise<CatalogueResultsList | CatalogueApiError> {
@@ -51,10 +47,7 @@ export async function getWorks({
   const url =
     `${rootUris[env]}/v2/works?include=${includes.join(',')}` +
     `&pageSize=25` +
-    (filterQueryString.length > 0 ? `&${filterQueryString.join('&')}` : '') +
-    (query ? `&query=${encodeURIComponent(query)}` : '') +
-    (page ? `&page=${page}` : '');
-
+    (filterQueryString.length > 0 ? `&${filterQueryString.join('&')}` : '');
   try {
     const res = await fetch(url);
     const json = await res.json();


### PR DESCRIPTION
Now we have [`query` and `page` in the `apiSerialisers`](https://github.com/wellcometrust/wellcomecollection.org/blob/4697006fe1610db1f37dfb41fcc2cac8cb643ccc/common/services/catalogue/search-params.js#L71-L72), they're being added twice in the query string to the API.

This doesn't affect the end result, but made me wonder, is there a good reason to treat them differently from any of the other query string parameters, or does this simplification make sense?