### PR TITLE
Image urls

### DIFF
--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -81,20 +81,26 @@ function wordPressImageTemplate(baseUrl: string) {
     template.expand(Object.assign({}, defaultOpts, opts));
 }
 
-type iiifTemplateOpts = {|
-  imagePath: string,
+type IiifUriOpts = {
+  region?: string,
   size?: string,
-  format?: 'jpg' | 'png',
-|};
+  rotation?: number,
+  quality?: string,
+  format?: string,
+};
 
-function iiifTemplate(baseUrl: string) {
-  const templateString = `${baseUrl}{imagePath}/full/{size}/0/default.{format}`;
+export function iiifImageTemplate(infoJsonLocation: string) {
+  const baseUrl = infoJsonLocation.replace('/info.json', '');
+  const templateString = `${baseUrl}/{region}/{size}/{rotation}/{quality}.{format}`;
   const defaultOpts = {
+    region: 'full',
     size: 'full',
+    rotation: 0,
+    quality: 'default',
     format: 'jpg',
   };
   const template = urlTemplate.parse(templateString);
-  return (opts: iiifTemplateOpts) =>
+  return (opts: IiifUriOpts) =>
     template.expand(Object.assign({}, defaultOpts, opts));
 }
 
@@ -156,11 +162,10 @@ export function convertImageUri(
       const iiifRoot = imageMap[imageSrc].iiifRoot;
 
       const params = {
-        imagePath,
         size: requiredSize === 'full' ? 'full' : `${requiredSize},`,
         format: determineFinalFormat(originalUri),
       };
-      return iiifTemplate(iiifRoot)(params);
+      return iiifImageTemplate(`${iiifRoot}${imagePath}`)(params);
     } else {
       if (imageSrc === 'wordpress') {
         return wordPressImageTemplate(originalUri)({ width: requiredSize });
@@ -169,29 +174,6 @@ export function convertImageUri(
       }
     }
   }
-}
-
-type IiifUriOpts = {
-  region?: string,
-  size?: string,
-  rotation?: number,
-  quality?: string,
-  format?: string,
-};
-
-export function iiifImageTemplate(infoJsonLocation: string) {
-  const baseUrl = infoJsonLocation.replace('/info.json', '');
-  const templateString = `${baseUrl}/{region}/{size}/{rotation}/{quality}.{format}`;
-  const defaultOpts = {
-    region: 'full',
-    size: 'full',
-    rotation: 0,
-    quality: 'default',
-    format: 'jpg',
-  };
-  const template = urlTemplate.parse(templateString);
-  return (opts: IiifUriOpts) =>
-    template.expand(Object.assign({}, defaultOpts, opts));
 }
 
 export function convertIiifUriToInfoUri(originalUriPath: string) {

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -6,6 +6,9 @@ const imageMap = {
     root: 'https://wellcomecollection.files.wordpress.com/',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/wordpress:',
   },
+  prismicImgix: {
+    root: 'https://images.prismic.io/wellcomecollection/',
+  },
   prismic: {
     cdnRoot: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/',
     root: 'https://prismic-io.s3.amazonaws.com/wellcomecollection/',

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -66,17 +66,6 @@ function convertPathToIiifUri(originalUriPath, iiifRoot, size) {
   }/0/default.${format}`;
 }
 
-export function convertIiifUriToInfoUri(originalUriPath: string) {
-  const match = originalUriPath.match(
-    /^https:\/\/iiif\.wellcomecollection\.org\/image\/(.+?\.[a-z]{3})/
-  );
-  if (match && match[0]) {
-    return `${match[0]}/info.json`;
-  } else {
-    return `${originalUriPath}/info.json`;
-  }
-}
-
 export function convertImageUri(
   originalUri: string,
   requiredSize: number | 'full'
@@ -117,6 +106,7 @@ type IiifUriOpts = {
   quality?: string,
   format?: string,
 };
+
 export function iiifImageTemplate(infoJsonLocation: string) {
   const baseUrl = infoJsonLocation.replace('/info.json', '');
   const templateString = `${baseUrl}/{region}/{size}/{rotation}/{quality}.{format}`;
@@ -130,4 +120,15 @@ export function iiifImageTemplate(infoJsonLocation: string) {
   const template = urlTemplate.parse(templateString);
   return (opts: IiifUriOpts) =>
     template.expand(Object.assign({}, defaultOpts, opts));
+}
+
+export function convertIiifUriToInfoUri(originalUriPath: string) {
+  const match = originalUriPath.match(
+    /^https:\/\/iiif\.wellcomecollection\.org\/image\/(.+?\.[a-z]{3})/
+  );
+  if (match && match[0]) {
+    return `${match[0]}/info.json`;
+  } else {
+    return `${originalUriPath}/info.json`;
+  }
 }

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -67,8 +67,18 @@ function prismicImageTemplate(baseUrl: string) {
   };
 }
 
-function convertPathToWordpressUri(originalUriPath, size) {
-  return originalUriPath + `?w=${size}`;
+type wordpressUriOpts = {|
+  width?: number | 'full',
+|};
+
+function wordPressImageTemplate(baseUrl: string) {
+  const templateString = `${baseUrl}?w={width}`;
+  const defaultOpts = {
+    width: 'full',
+  };
+  const template = urlTemplate.parse(templateString);
+  return (opts: wordpressUriOpts) =>
+    template.expand(Object.assign({}, defaultOpts, opts));
 }
 
 function convertPathToIiifUri(originalUriPath, iiifRoot, size) {
@@ -142,7 +152,7 @@ export function convertImageUri(
       return convertPathToIiifUri(imagePath, iiifRoot, requiredSize);
     } else {
       if (imageSrc === 'wordpress') {
-        return convertPathToWordpressUri(originalUri, requiredSize);
+        return wordPressImageTemplate(originalUri)({ width: requiredSize });
       } else {
         return originalUri;
       }

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -43,11 +43,11 @@ function determineSrc(url: string): string {
 }
 
 function determineIfGif(originalUriPath) {
-  return originalUriPath.slice(-4) === '.gif';
+  return originalUriPath.includes('.gif');
 }
 
 function determineFinalFormat(originalUriPath) {
-  if (originalUriPath.slice(-4) === '.png') {
+  if (originalUriPath.includes('.png')) {
     return 'png';
   } else {
     return 'jpg';

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -10,8 +10,7 @@ const imageMap = {
     root: 'https://images.prismic.io/wellcomecollection/',
   },
   prismic: {
-    cdnRoot: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/',
-    root: 'https://prismic-io.s3.amazonaws.com/wellcomecollection/',
+    root: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/prismic:',
   },
   miro: {
@@ -28,10 +27,7 @@ const imageMap = {
 function determineSrc(url: string): string {
   if (url.startsWith(imageMap.wordpress.root)) {
     return 'wordpress';
-  } else if (
-    url.startsWith(imageMap.prismic.root) ||
-    url.startsWith(imageMap.prismic.cdnRoot)
-  ) {
+  } else if (url.startsWith(imageMap.prismic.root)) {
     return 'prismic';
   } else if (url.startsWith(imageMap.prismicImgix.root)) {
     return 'prismicImgix';

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -67,7 +67,7 @@ function prismicImageTemplate(baseUrl: string) {
   };
 }
 
-type wordpressUriOpts = {|
+type WordpressUriOpts = {|
   width?: number | 'full',
 |};
 
@@ -77,17 +77,17 @@ function wordPressImageTemplate(baseUrl: string) {
     width: 'full',
   };
   const template = urlTemplate.parse(templateString);
-  return (opts: wordpressUriOpts) =>
+  return (opts: WordpressUriOpts) =>
     template.expand(Object.assign({}, defaultOpts, opts));
 }
 
-type IiifUriOpts = {
+type IiifUriOpts = {|
   region?: string,
   size?: string,
   rotation?: number,
   quality?: string,
   format?: string,
-};
+|};
 
 export function iiifImageTemplate(infoJsonLocation: string) {
   const baseUrl = infoJsonLocation.replace('/info.json', '');

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -5,25 +5,20 @@ const imageMap = {
   wordpress: {
     root: 'https://wellcomecollection.files.wordpress.com/',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/wordpress:',
-    iiifOriginRoot:
-      'https://iiif-origin.wellcomecollection.org/image/wordpress:',
   },
   prismic: {
     cdnRoot: 'https://wellcomecollection.cdn.prismic.io/wellcomecollection/',
     root: 'https://prismic-io.s3.amazonaws.com/wellcomecollection/',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/prismic:',
-    iiifOriginRoot: 'https://iiif-origin.wellcomecollection.org/image/prismic:',
   },
   miro: {
     root: 'https://s3-eu-west-1.amazonaws.com/miro-images-public/',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/',
-    iiifOriginRoot: 'https://iiif-origin.wellcomecollection.org/image/',
   },
   iiif: {
     // sometimes we already have the iiif url, but we may want to convert it to use the origin
     root: 'https://iiif.wellcomecollection.org/image/',
     iiifRoot: 'https://iiif.wellcomecollection.org/image/',
-    iiifOriginRoot: 'https://iiif-origin.wellcomecollection.org/image/',
   },
 };
 
@@ -81,8 +76,7 @@ export function convertIiifUriToInfoUri(originalUriPath: string) {
 
 export function convertImageUri(
   originalUri: string,
-  requiredSize: number | 'full',
-  useIiifOrigin: boolean = false
+  requiredSize: number | 'full'
 ): string {
   const imageSrc = determineSrc(originalUri);
   const isGif = determineIfGif(originalUri);
@@ -100,9 +94,7 @@ export function convertImageUri(
           ? originalUri.split(imageMap[imageSrc].root)[1]
           : // $FlowFixMe
             originalUri.split(imageMap[imageSrc].cdnRoot)[1];
-      const iiifRoot = useIiifOrigin
-        ? imageMap[imageSrc].iiifOriginRoot
-        : imageMap[imageSrc].iiifRoot;
+      const iiifRoot = imageMap[imageSrc].iiifRoot;
 
       return convertPathToIiifUri(imagePath, iiifRoot, requiredSize);
     } else {

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -52,17 +52,17 @@ function determineFinalFormat(originalUriPath) {
   }
 }
 
-type prismicUriOpts = {
+type PrismicUriOpts = {|
   auto?: string,
   rect?: string,
   w?: number | 'full',
   h?: number,
-};
+|};
 
 function prismicImageTemplate(baseUrl: string) {
   const templateString = `${baseUrl}?auto={auto}&rect={rect}&w={w}&h={h}`;
   const template = urlTemplate.parse(templateString);
-  return (opts: prismicUriOpts) => {
+  return (opts: PrismicUriOpts) => {
     return template.expand(opts);
   };
 }

--- a/common/utils/convert-image-uri.js
+++ b/common/utils/convert-image-uri.js
@@ -116,10 +116,9 @@ function prismicTemplateParts(
   originalUri: string,
   requiredSize: number | 'full'
 ) {
-  const uriParts = originalUri.split('?');
-  const base = uriParts[0];
-  const queryString = uriParts[1];
-  const urlParams = queryString && new URLSearchParams(`?${queryString}`);
+  const url = new URL(originalUri);
+  const base = `${url.origin}${url.pathname}`;
+  const urlParams = url.searchParams;
   const width = urlParams && urlParams.get('w');
   const height = urlParams && urlParams.get('h');
   const params =

--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -38,7 +38,7 @@ const Image = (props: Props) => {
       <img width='${props.width}'
         height='${props.height || ''}'
         class='${classes}'
-        src='${convertImageUri(props.contentUrl, 640, false)}'
+        src='${convertImageUri(props.contentUrl, 640)}'
         alt='${props.alt || ''}' />`,
         }}
       />
@@ -84,9 +84,9 @@ const Img = ({
         [`promo__image-mask ${clipPathClass || ''}`]: clipPathClass,
         [`${extraClasses || ''}`]: Boolean(extraClasses),
       })}
-      src={convertImageUri(contentUrl, defaultSize, false)}
+      src={convertImageUri(contentUrl, defaultSize)}
       data-srcset={sizes.map(size => {
-        return `${convertImageUri(contentUrl, size, false)} ${size}w`;
+        return `${convertImageUri(contentUrl, size)} ${size}w`;
       })}
       sizes={sizesQueries}
       data-copyright={copyright}

--- a/common/views/components/Images/Images.js
+++ b/common/views/components/Images/Images.js
@@ -96,7 +96,7 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
           <img width='${width}'
             height='${height || ''}'
             class='image image--noscript bg-charcoal font-white'
-            src=${convertImageUri(contentUrl, 640, false)}
+            src=${convertImageUri(contentUrl, 640)}
             alt='${alt || ''}' />`,
           }}
         />
@@ -115,9 +115,9 @@ export class UiImage extends Component<UiImageProps, UiImageState> {
             image: true,
             [extraClasses || '']: true,
           })}
-          src={convertImageUri(contentUrl, 30, false)}
+          src={convertImageUri(contentUrl, 30)}
           data-srcset={imageSizes(width).map(size => {
-            return `${convertImageUri(contentUrl, size, false)} ${size}w`;
+            return `${convertImageUri(contentUrl, size)} ${size}w`;
           })}
           sizes={sizesQueries}
           alt={alt || ''}

--- a/common/views/components/Picture/Picture.js
+++ b/common/views/components/Picture/Picture.js
@@ -30,7 +30,7 @@ const Picture = ({ images, extraClasses, isFull = false }: Props) => {
                 srcSet={sizes.map(size => {
                   return (
                     image.contentUrl &&
-                    `${convertImageUri(image.contentUrl, size, false)} ${size}w`
+                    `${convertImageUri(image.contentUrl, size)} ${size}w`
                   );
                 })}
               />
@@ -41,7 +41,7 @@ const Picture = ({ images, extraClasses, isFull = false }: Props) => {
         {lastImage && lastImage.contentUrl && lastImage.width && (
           <img
             className="image block"
-            src={convertImageUri(lastImage.contentUrl, lastImage.width, false)}
+            src={convertImageUri(lastImage.contentUrl, lastImage.width)}
             alt={lastImage.alt || ''}
           />
         )}
@@ -82,7 +82,7 @@ export const PictureFromImages = ({
                 data-srcset={sizes.map(size => {
                   return (
                     image.contentUrl &&
-                    `${convertImageUri(image.contentUrl, size, false)} ${size}w`
+                    `${convertImageUri(image.contentUrl, size)} ${size}w`
                   );
                 })}
               />
@@ -95,11 +95,7 @@ export const PictureFromImages = ({
             height={lastImage.height}
             width={lastImage.width}
             className="image lazy-image lazyload"
-            data-src={convertImageUri(
-              lastImage.contentUrl,
-              lastImage.width,
-              false
-            )}
+            data-src={convertImageUri(lastImage.contentUrl, lastImage.width)}
             alt={lastImage.alt || ''}
           />
         )}

--- a/common/views/components/WorkEmbed/WorkEmbed.js
+++ b/common/views/components/WorkEmbed/WorkEmbed.js
@@ -21,7 +21,7 @@ const WorkEmbed = ({ work }: Props) => {
   const iiifImage = iiifImageTemplate(iiifInfoUrl);
   const imageUrl = iiifImage({ size: '800,' });
   const imageInfoUrl = convertIiifUriToInfoUri(
-    convertImageUri(imageUrl, 'full', false)
+    convertImageUri(imageUrl, 'full')
   );
 
   return (


### PR DESCRIPTION
Prepares for Prismic switching on its imgix service.

Using the imgix service has page weight improvements:

Before:
![story_before](https://user-images.githubusercontent.com/6051896/66995841-8f9b7980-f0c7-11e9-9424-ffc0c4729e90.jpg)
After:
![story_after](https://user-images.githubusercontent.com/6051896/66995860-9629f100-f0c7-11e9-9b45-037d947e5d1f.jpg)
