### PR TITLE
fix spacing in opening times

### DIFF
--- a/common/views/components/Footer/Footer.js
+++ b/common/views/components/Footer/Footer.js
@@ -114,7 +114,10 @@ const Footer = ({
               {`Opening times:`}
             </Space>
             <TopBorderBox>
-              <Space v={{ size: 'l', properties: ['padding-top'] }}>
+              <Space
+                className={'flex'}
+                v={{ size: 'l', properties: ['padding-top'] }}
+              >
                 <Space
                   as="span"
                   h={{ size: 'm', properties: ['margin-right'] }}


### PR DESCRIPTION
Fixes the spacing between the clock icon and text

Before:
<img width="464" alt="Screenshot 2019-10-17 at 13 16 58" src="https://user-images.githubusercontent.com/6051896/67008065-a4d0d200-f0e0-11e9-99ea-3487f240753f.png">

After: 
<img width="454" alt="Screenshot 2019-10-17 at 13 16 40" src="https://user-images.githubusercontent.com/6051896/67008070-a7cbc280-f0e0-11e9-8985-d4fb5d7cd79a.png">

