### PR TITLE
Font overrides ii

### DIFF
--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -91,14 +91,23 @@ $font-sizes-at-breakpoints: (
       %font-size-#{$font-size-key},
       .font-size-#{$font-size-key} {
         font-size: $font-size-value;
-        line-height: 1.5;
       }
     }
   }
 }
 
 @each $font-breakpoint-key, $font-breakpoint-value in $font-sizes-at-breakpoints {
-  @include respond-to($font-breakpoint-key) {
+  $breakpoint-upper: null;
+
+  @if $font-breakpoint-key == 'small' {
+    $breakpoint-upper: 'medium';
+  } @else if $font-breakpoint-key == 'medium' {
+    $breakpoint-upper: 'large';
+  } @else {
+    $breakpoint-upper: 'xlarge';
+  }
+
+  @include respond-between($font-breakpoint-key, $breakpoint-upper) {
     @each $font-sizes-all-key, $font-sizes-all-value in $font-sizes-all {
       .font-size-override-#{$font-breakpoint-key}-#{$font-sizes-all-key} {
         font-size: $font-sizes-all-value;
@@ -117,6 +126,7 @@ body {
   @extend %font-hnl;
   @extend %font-size-4;
 
+  line-height: 1.5;
   color: color('black');
 
   font-variant-ligatures: no-common-ligatures;

--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -103,14 +103,22 @@ $font-sizes-at-breakpoints: (
     $breakpoint-upper: 'medium';
   } @else if $font-breakpoint-key == 'medium' {
     $breakpoint-upper: 'large';
-  } @else {
-    $breakpoint-upper: 'xlarge';
   }
 
-  @include respond-between($font-breakpoint-key, $breakpoint-upper) {
-    @each $font-sizes-all-key, $font-sizes-all-value in $font-sizes-all {
-      .font-size-override-#{$font-breakpoint-key}-#{$font-sizes-all-key} {
-        font-size: $font-sizes-all-value;
+  @if $font-breakpoint-key == 'small' or $font-breakpoint-key == 'medium' {
+    @include respond-between($font-breakpoint-key, $breakpoint-upper) {
+      @each $font-sizes-all-key, $font-sizes-all-value in $font-sizes-all {
+        .font-size-override-#{$font-breakpoint-key}-#{$font-sizes-all-key} {
+          font-size: $font-sizes-all-value;
+        }
+      }
+    }
+  } @else if $font-breakpoint-key == 'large' {
+    @include respond-to($font-breakpoint-key) {
+      @each $font-sizes-all-key, $font-sizes-all-value in $font-sizes-all {
+        .font-size-override-#{$font-breakpoint-key}-#{$font-sizes-all-key} {
+          font-size: $font-sizes-all-value;
+        }
       }
     }
   }

--- a/common/utils/classnames.js
+++ b/common/utils/classnames.js
@@ -34,20 +34,26 @@ export function cssGrid(sizes: SizeMap): string {
 
 type FontFamily = 'hnl' | 'hnm' | 'wb' | 'lr';
 type FontSize = 1 | 2 | 3 | 4 | 5 | 6;
-export function font(family: FontFamily, size: FontSize) {
-  return `font-${family} font-size-${size}`;
-}
-
 type FontSizeAll = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 type FontSizeOverrides = {|
-  small: FontSizeAll,
-  medium: FontSizeAll,
-  large: FontSizeAll,
+  small?: FontSizeAll,
+  medium?: FontSizeAll,
+  large?: FontSizeAll,
 |};
-export function fontSizeOverrides(overrides: FontSizeOverrides) {
-  return Object.keys(overrides).reduce((acc, key) => {
-    return acc.concat(` font-size-override-${key}-${overrides[key]}`);
-  }, '');
+
+export function font(
+  family: FontFamily,
+  size: FontSize,
+  overrides?: FontSizeOverrides
+) {
+  const overrideClasses =
+    overrides &&
+    Object.keys(overrides).reduce((acc, key) => {
+      return overrides[key]
+        ? acc.concat(` font-size-override-${key}-${overrides[key]}`)
+        : '';
+    }, '');
+  return `font-${family} font-size-${size} ${overrideClasses || ''}`;
 }
 
 type ClassNames = string[] | { [string]: boolean };

--- a/common/views/components/FeaturedText/FeaturedText.js
+++ b/common/views/components/FeaturedText/FeaturedText.js
@@ -1,13 +1,13 @@
-import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
-import type { HtmlSerialiser } from '../../../services/prismic/html-serialisers';
-
 // @flow
+
+import PrismicHtmlBlock from '../PrismicHtmlBlock/PrismicHtmlBlock';
+import { type HTMLString } from '../../../services/prismic/types';
+import { type HtmlSerializer } from '../../../services/prismic/html-serialisers';
 import { font, classNames } from '../../../utils/classnames';
-import type { HTMLString } from '../../../services/prismic/types';
 
 type Props = {|
   html: HTMLString,
-  htmlSerialiser?: HtmlSerialiser,
+  htmlSerialiser?: HtmlSerializer,
 |};
 
 const FeaturedText = ({ html, htmlSerialiser }: Props) => (


### PR DESCRIPTION
When we override a font-size at a breakpoint, we want the override to target _only_ that breakpoint. I think this is an appropriate use of `respond-between`, because we don't want a e.g. `small` override to mobile-first percolate up to the `medium` breakpoint.
 