### PR TITLE
Add tracking to open/close PopupDialog events

### DIFF
--- a/common/views/components/PopupDialog/PopupDialog.js
+++ b/common/views/components/PopupDialog/PopupDialog.js
@@ -151,6 +151,10 @@ const PopupDialog = ({ children, openButtonText, cta }: Props) => {
     if (dialog && isActiveRef.current && !dialog.contains(event.target)) {
       setIsActive(false);
       openDialogRef && openDialogRef.current && openDialogRef.current.focus();
+      trackEvent({
+        category: 'PopupDialog',
+        action: 'close dialog',
+      });
     }
   }
 
@@ -158,6 +162,10 @@ const PopupDialog = ({ children, openButtonText, cta }: Props) => {
     if (event.keyCode === 27 && isActiveRef.current) {
       setIsActive(false);
       openDialogRef && openDialogRef.current && openDialogRef.current.focus();
+      trackEvent({
+        category: 'PopupDialog',
+        action: 'close dialog',
+      });
     }
   }
 

--- a/common/views/components/PopupDialog/PopupDialog.js
+++ b/common/views/components/PopupDialog/PopupDialog.js
@@ -6,6 +6,7 @@ import { type Link } from '../../../model/link';
 import Icon from '../Icon/Icon';
 import Space from '../styled/Space';
 import { classNames, font } from '../../../utils/classnames';
+import { trackEvent } from '../../../utils/ga';
 
 const PopupDialogOpen = styled(Space).attrs(props => ({
   'aria-hidden': props.isActive ? 'true' : 'false',
@@ -203,6 +204,11 @@ const PopupDialog = ({ children, openButtonText, cta }: Props) => {
             closeDialogRef &&
               closeDialogRef.current &&
               closeDialogRef.current.focus();
+
+            trackEvent({
+              category: 'PopupDialog',
+              action: 'open dialog',
+            });
           }}
         >
           <Space h={{ size: 's', properties: ['margin-right'] }}>
@@ -221,6 +227,11 @@ const PopupDialog = ({ children, openButtonText, cta }: Props) => {
               openDialogRef &&
                 openDialogRef.current &&
                 openDialogRef.current.focus();
+
+              trackEvent({
+                category: 'PopupDialog',
+                action: 'close dialog',
+              });
             }}
           >
             <Icon


### PR DESCRIPTION
Adding tracking events to the `PopupDialog` for the opening and closing of the dialog box (i.e. clicking the button to launch the dialog, and clicking the close button/pressing escape/clicking `body` outside dialog when the dialog is open).
