### PR TITLE
Display the correct date for events, based on the month they are grouped in

### DIFF
--- a/common/views/components/CardGrid/CardGrid.js
+++ b/common/views/components/CardGrid/CardGrid.js
@@ -13,6 +13,7 @@ import { type UiEvent } from '../../../model/events';
 import { type Book } from '../../../model/books';
 import { type Article } from '../../../model/articles';
 import Space from '../styled/Space';
+import type Moment from 'moment';
 
 // TODO: This should be MultiContent
 type ContentTypes = UiEvent | UiExhibition | Book | Article;
@@ -23,6 +24,7 @@ type Props = {|
   itemsPerRow: number,
   itemsHaveTransparentBackground?: boolean,
   links?: Link[],
+  fromDate?: Moment,
 |};
 
 const CardGrid = ({
@@ -31,6 +33,7 @@ const CardGrid = ({
   itemsPerRow,
   itemsHaveTransparentBackground = false,
   links,
+  fromDate,
 }: Props) => {
   const gridColumns = itemsPerRow === 4 ? 3 : 4;
 
@@ -71,7 +74,7 @@ const CardGrid = ({
                 />
               )}
               {item.id !== 'tours' && item.type === 'events' && (
-                <EventPromo event={item} position={i} />
+                <EventPromo event={item} position={i} fromDate={fromDate} />
               )}
               {item.type === 'articles' && (
                 <StoryPromo

--- a/common/views/components/EventsByMonth/EventsByMonth.js
+++ b/common/views/components/EventsByMonth/EventsByMonth.js
@@ -194,6 +194,7 @@ class EventsByMonth extends Component<Props, State> {
               items={eventsInMonths[month.id].concat(dailyTourPromo)}
               itemsPerRow={3}
               links={links}
+              fromDate={london(month.id)}
             />
           </div>
         ))}


### PR DESCRIPTION
Noticed that multi date event promos were displaying their next available date, regardless of the month they were grouped into. This makes them display the next available date for the month.

Before:
![before](https://user-images.githubusercontent.com/6051896/67217245-50995b00-f41c-11e9-95b3-cf75a30bf7fd.jpg)
After:
![after](https://user-images.githubusercontent.com/6051896/67217258-53944b80-f41c-11e9-92b3-f8a4b8118ed6.jpg)



