### PR TITLE
Bake space into component instead of passing it in children

### DIFF
--- a/cardigan/stories/components/PopupDialog.js
+++ b/cardigan/stories/components/PopupDialog.js
@@ -2,7 +2,6 @@ import { storiesOf } from '@storybook/react';
 import { classNames, font } from '../../../common/utils/classnames';
 import PopupDialog from '../../../common/views/components/PopupDialog/PopupDialog';
 import Readme from '../../../common/views/components/PopupDialog/README.md';
-import Space from '../../../common/views/components/styled/Space';
 
 const stories = storiesOf('Components', module);
 
@@ -12,29 +11,21 @@ const PopupDialogExample = () => {
       openButtonText="Got 5 minutes?"
       cta={{ url: '#', text: 'Take the survey' }}
     >
-      <Space
-        h={{
-          size: 'm',
-          properties: ['padding-right'],
-          overrides: { small: 4, medium: 4, large: 4 },
-        }}
+      <h2
+        className={classNames({
+          [font('wb', 6, { small: 5, medium: 5, large: 5 })]: true,
+        })}
       >
-        <h2
-          className={classNames({
-            [font('wb', 6, { small: 5, medium: 5, large: 5 })]: true,
-          })}
-        >
-          Help us improve our website
-        </h2>
-        <p
-          className={classNames({
-            [font('hnl', 5, { medium: 2, large: 2 })]: true,
-          })}
-        >
-          We&apos;d like to know more about how you use Wellcome
-          Collection&apos;s website.
-        </p>
-      </Space>
+        Help us improve our website
+      </h2>
+      <p
+        className={classNames({
+          [font('hnl', 5, { medium: 2, large: 2 })]: true,
+        })}
+      >
+        We&apos;d like to know more about how you use Wellcome Collection&apos;s
+        website.
+      </p>
     </PopupDialog>
   );
 };

--- a/common/views/components/PopupDialog/PopupDialog.js
+++ b/common/views/components/PopupDialog/PopupDialog.js
@@ -278,7 +278,15 @@ const PopupDialog = ({ children, openButtonText, cta }: Props) => {
               extraClasses="icon--purple"
             />
           </PopupDialogClose>
-          {children}
+          <Space
+            h={{
+              size: 'm',
+              properties: ['padding-right'],
+              overrides: { small: 4, medium: 4, large: 4 },
+            }}
+          >
+            {children}
+          </Space>
           <PopupDialogCTA
             href={cta.url}
             ref={ctaRef}


### PR DESCRIPTION
☝️ this space deserves to be part of the `PopupDialog` instead of being passed in every time by the `children`.