### PR TITLE
Fix preview

### DIFF
--- a/common/koa-middleware/withCachedValues.js
+++ b/common/koa-middleware/withCachedValues.js
@@ -3,16 +3,18 @@ const compose = require('koa-compose');
 const withGlobalAlert = require('./withGlobalAlert');
 const withOpeningtimes = require('./withOpeningTimes');
 const withToggles = require('./withToggles');
+const withPrismicPreviewStatus = require('./withPrismicPreviewStatus');
 
 const withCachedValues = compose([
   withGlobalAlert,
   withOpeningtimes,
   withToggles,
+  withPrismicPreviewStatus,
 ]);
 
 async function route(path, page, router, app, extraParams = {}) {
   router.get(path, async ctx => {
-    const { toggles, globalAlert, openingTimes } = ctx;
+    const { toggles, globalAlert, openingTimes, isPreview } = ctx;
     const params = ctx.params;
     const query = ctx.query;
 
@@ -20,6 +22,7 @@ async function route(path, page, router, app, extraParams = {}) {
       toggles,
       globalAlert,
       openingTimes,
+      isPreview,
       ...params,
       ...query,
       ...extraParams,
@@ -31,12 +34,13 @@ async function route(path, page, router, app, extraParams = {}) {
 function handleAllRoute(handle) {
   return async function(ctx) {
     const parsedUrl = parse(ctx.request.url, true);
-    const { toggles, globalAlert, openingTimes } = ctx;
+    const { toggles, globalAlert, openingTimes, isPreview } = ctx;
     const query = {
       ...parsedUrl.query,
       toggles,
       globalAlert,
       openingTimes,
+      isPreview,
     };
     const url = {
       ...parsedUrl,

--- a/common/koa-middleware/withPrismicPreviewStatus.js
+++ b/common/koa-middleware/withPrismicPreviewStatus.js
@@ -1,0 +1,9 @@
+function withPrismicPreviewStatus(ctx, next) {
+  // for previews on localhost we use /preview to determine whether the 'isPreview' cookie should be set
+  // this kinda works for live too, but not for shared preview links, as they never hit /preview
+  // we therefore look for the subdomain .preview to determine if it's a preview
+  ctx.isPreview = Boolean(ctx.request.host.startsWith('preview.'));
+  return next();
+}
+
+module.exports = withPrismicPreviewStatus;

--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -23,7 +23,10 @@ periodicallyUpdatePrismic();
 
 export function isPreview(req: ?Request): boolean {
   const cookies = req && new Cookies(req);
-  return cookies ? Boolean(cookies.get('isPreview')) : false;
+  return cookies
+    ? Boolean(cookies.get('isPreview')) ||
+        Boolean(cookies.get(Prismic.previewCookie))
+    : false;
 }
 
 export async function getPrismicApi(req: ?Request) {

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -27,6 +27,7 @@ const isClient = !isServer;
 let toggles;
 let openingTimes;
 let globalAlert;
+let isPreview;
 let engagement;
 let previouslyAccruedTimeOnSpaPage = 0;
 let accruedHiddenTimeOnPage = 0;
@@ -111,10 +112,12 @@ export default class WecoApp extends App {
     toggles = isServer ? router.query.toggles : toggles;
     openingTimes = isServer ? router.query.openingTimes : openingTimes;
     globalAlert = isServer ? router.query.globalAlert : globalAlert;
+    isPreview = isServer ? router.query.isPreview : isPreview;
 
     let pageProps = {};
     if (Component.getInitialProps) {
       ctx.query.toggles = toggles;
+      ctx.query.isPreview = isPreview;
       pageProps = await Component.getInitialProps(ctx);
 
       // If we override the statusCode from getInitialProps, make sure we
@@ -129,6 +132,7 @@ export default class WecoApp extends App {
       toggles,
       openingTimes,
       globalAlert,
+      isPreview,
     };
   }
 
@@ -142,6 +146,9 @@ export default class WecoApp extends App {
     }
     if (isClient && !globalAlert) {
       globalAlert = props.globalAlert;
+    }
+    if (isClient && !isPreview) {
+      isPreview = props.isPreview;
     }
     super(props);
   }
@@ -233,8 +240,7 @@ export default class WecoApp extends App {
     })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
 
     // Prismic preview and validation warnings
-    const isPreview = document.cookie.match('isPreview=true');
-    if (isPreview) {
+    if (isPreview || document.cookie.match('isPreview=true')) {
       window.prismic = {
         endpoint: 'https://wellcomecollection.prismic.io/api/v2',
       };


### PR DESCRIPTION
Make shared Prismic preview links work

We were relying on hitting /preview to set a cookie which in turn determined whether or not to load the Prismic javascript. Shared links never hit /preview so now also if the subdomain is preview.
