### PR TITLE
Prevent tabbing inside dialog when it first renders

### DIFF
--- a/common/views/components/PopupDialog/PopupDialog.js
+++ b/common/views/components/PopupDialog/PopupDialog.js
@@ -158,6 +158,10 @@ const PopupDialog = ({ children, openButtonText, cta }: Props) => {
   }, []);
 
   useEffect(() => {
+    setTabbable(false);
+  }, [dialogWindowRef.current]);
+
+  useEffect(() => {
     isActiveRef.current = isActive;
 
     window.document.addEventListener('click', handleBodyClick);


### PR DESCRIPTION
Fixes an a11y issue where you can't tab away from the `PopupDialog` button (doubly bad since it's the first thing on the page).