### PR TITLE
Make sure documentElement is tall enough when back button clicked

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -108,6 +108,31 @@ function openingHoursToOpeningHoursSpecification(openingHours: OpeningHours) {
   };
 }
 
+function makeSurePageIsTallEnough() {
+  const pageHeightCache = [];
+  const html = document.querySelector('html');
+
+  Router.events.on('routeChangeStart', () => {
+    document &&
+      document.documentElement &&
+      pageHeightCache.push(document.documentElement.offsetHeight);
+  });
+
+  Router.events.on('routeChangeComplete', () => {
+    if (html) {
+      html.style.height = 'initial';
+    }
+  });
+
+  Router.beforePopState(() => {
+    if (html) {
+      html.style.height = `${pageHeightCache.pop()}px`;
+    }
+
+    return true;
+  });
+}
+
 export default class WecoApp extends App {
   static async getInitialProps({ Component, router, ctx }: AppInitialProps) {
     // Caching things from the server request to be available to the client
@@ -170,6 +195,8 @@ export default class WecoApp extends App {
   }
 
   componentDidMount() {
+    makeSurePageIsTallEnough();
+
     if (document.documentElement) {
       document.documentElement.classList.add('enhanced');
     }


### PR DESCRIPTION
We push the heights of pages into a cache as a result of Next `Router` events, then temporarily set the html to the last height in the cache (and pop it off the cache) on `Router.beforePopState`, so that if the page we're navigating to is taller than the one we've come from when we click the back button, there'll be enough space that we can scroll to the correct position.

Fixes #4289

