### PR TITLE
Swap Helvetica medium for bold behind toggle

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -425,8 +425,20 @@ export default class WecoApp extends App {
                                   font-style: normal;
                                 }
 
+                                @font-face {
+                                  font-family: 'Helvetica Neue Medium Web';
+                                  src: local('Helvetica Neue Bold'),
+                                    local('HelveticaNeue-Bold'),
+                                    url('https://i.wellcomecollection.org/assets/fonts/455d1f57-1462-4536-aefa-c13f0a67bbbe.woff2') format('woff2'),
+                                    url('https://i.wellcomecollection.org/assets/fonts/fd5c4818-7809-4a21-a48d-a0dc15aa47b8.woff') format('woff');
+                                  font-weight: normal;
+                                  font-style: normal;
+                                }
+
+
                                 body,
-                                .font-hnl {
+                                .font-hnl,
+                                .font-hnm {
                                   letter-spacing: normal;
                                 }
                               `,


### PR DESCRIPTION
☝️ 

__before__ (body is `light` and part of is `medium`)
<img width="305" alt="Screenshot 2019-10-25 at 16 52 10" src="https://user-images.githubusercontent.com/1394592/67585941-6f635e80-f748-11e9-989f-08afda1c6700.png">

__after__ (body is `regular` and part of is `bold`)
<img width="303" alt="Screenshot 2019-10-25 at 16 51 32" src="https://user-images.githubusercontent.com/1394592/67586014-9326a480-f748-11e9-998b-c0d9b8b3f192.png">

