### PR TITLE
use specific includes for works search

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -6,13 +6,7 @@ import { type Work } from '@weco/common/model/work';
 import { classNames, font } from '@weco/common/utils/classnames';
 import Icon from '@weco/common/views/components/Icon/Icon';
 import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
-import {
-  getPhysicalLocations,
-  getDigitalLocations,
-  getProductionDates,
-  getWorkTypeIcon,
-} from '@weco/common/utils/works';
+import { getProductionDates, getWorkTypeIcon } from '@weco/common/utils/works';
 import { trackEvent } from '@weco/common/utils/ga';
 import {
   workUrl,
@@ -64,8 +58,6 @@ const Preview: ComponentType<SpaceComponentProps> = styled(Space).attrs(() => ({
 `;
 
 const WorkCard = ({ work, params }: Props) => {
-  const digitalLocations = getDigitalLocations(work);
-  const physicalLocations = getPhysicalLocations(work);
   const productionDates = getProductionDates(work);
   const workTypeIcon = getWorkTypeIcon(work);
   return (
@@ -181,34 +173,6 @@ const WorkCard = ({ work, params }: Props) => {
               </Preview>
             )}
           </Container>
-
-          <TogglesContext.Consumer>
-            {({ showWorkLocations }) =>
-              showWorkLocations &&
-              (digitalLocations.length > 0 || physicalLocations.length > 0) && (
-                <Space v={{ size: 'm', properties: ['margin-top'] }}>
-                  <LinkLabels
-                    heading={'See it'}
-                    icon={'eye'}
-                    items={[
-                      digitalLocations.length > 0
-                        ? {
-                            text: 'Online',
-                            url: null,
-                          }
-                        : null,
-                      physicalLocations.length > 0
-                        ? {
-                            text: 'Wellcome library',
-                            url: null,
-                          }
-                        : null,
-                    ].filter(Boolean)}
-                  />
-                </Space>
-              )
-            }
-          </TogglesContext.Consumer>
         </Space>
       </NextLink>
     </div>

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -27,7 +27,9 @@ type GetWorkProps = {|
   ...Enviable,
 |};
 
-const includes = [
+const worksIncludes = ['identifiers', 'production', 'contributors'];
+
+const workIncludes = [
   'identifiers',
   'items',
   'subjects',
@@ -46,7 +48,7 @@ export async function getWorks({
     return `${key}=${val}`;
   });
   const url =
-    `${rootUris[env]}/v2/works?include=${includes.join(',')}` +
+    `${rootUris[env]}/v2/works?include=${worksIncludes.join(',')}` +
     `&pageSize=25` +
     (filterQueryString.length > 0 ? `&${filterQueryString.join('&')}` : '');
   try {
@@ -69,7 +71,9 @@ export async function getWork({
   id,
   env = 'prod',
 }: GetWorkProps): Promise<Work | CatalogueApiError | CatalogueApiRedirect> {
-  const url = `${rootUris[env]}/v2/works/${id}?include=${includes.join(',')}`;
+  const url = `${rootUris[env]}/v2/works/${id}?include=${workIncludes.join(
+    ','
+  )}`;
   const res = await fetch(url, { redirect: 'manual' });
 
   // When records from Miro have been merged with Sierra data, we redirect the

--- a/common/views/components/WorkHeader/WorkHeader.js
+++ b/common/views/components/WorkHeader/WorkHeader.js
@@ -1,16 +1,10 @@
 // @flow
 import { type Work } from '../../../model/work';
 import { font, classNames, grid } from '../../../utils/classnames';
-import {
-  getDigitalLocations,
-  getPhysicalLocations,
-  getProductionDates,
-  getWorkTypeIcon,
-} from '../../../utils/works';
+import { getProductionDates, getWorkTypeIcon } from '../../../utils/works';
 import Icon from '../Icon/Icon';
 import SpacingComponent from '../SpacingComponent/SpacingComponent';
 import LinkLabels from '../LinkLabels/LinkLabels';
-import TogglesContext from '../TogglesContext/TogglesContext';
 import Space from '../styled/Space';
 import Number from '@weco/common/views/components/Number/Number';
 
@@ -20,8 +14,6 @@ type Props = {|
 |};
 
 const WorkHeader = ({ work, childManifestsCount = 0 }: Props) => {
-  const digitalLocations = getDigitalLocations(work);
-  const physicalLocations = getPhysicalLocations(work);
   const productionDates = getProductionDates(work);
   const workTypeIcon = getWorkTypeIcon(work);
   return (
@@ -95,33 +87,7 @@ const WorkHeader = ({ work, childManifestsCount = 0 }: Props) => {
             )}
           </Space>
         )}
-        <TogglesContext.Consumer>
-          {toggles =>
-            toggles.showWorkLocations &&
-            (digitalLocations.length > 0 || physicalLocations.length > 0) && (
-              <Space v={{ size: 'm', properties: ['margin-top'] }}>
-                <LinkLabels
-                  heading={'See it'}
-                  icon={'eye'}
-                  items={[
-                    digitalLocations.length > 0
-                      ? {
-                          text: 'Online',
-                          url: null,
-                        }
-                      : null,
-                    physicalLocations.length > 0
-                      ? {
-                          text: 'Wellcome library',
-                          url: null,
-                        }
-                      : null,
-                  ].filter(Boolean)}
-                />
-              </Space>
-            )
-          }
-        </TogglesContext.Consumer>
+
         {childManifestsCount > 0 && (
           <Space v={{ size: 'm', properties: ['margin-top'] }}>
             <p

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -15,13 +15,6 @@ module.exports = {
         'Uses api.stage for requests to the API to view data that we are testing.',
     },
     {
-      id: 'showWorkLocations',
-      title: 'Show the locations of a work in the header',
-      defaultValue: false,
-      description:
-        'These can be either physical or digital locations. We need to do a little bt of work figuring out what all the codes mean to get the messaging right.',
-    },
-    {
       id: 'unfilteredSearchResults',
       title:
         'Return all posible results from the catalogue API, without filtering by type or location',


### PR DESCRIPTION
Pushes each search down by about 20kb to 34kb (query=botany).

Removes the location toggle as we'll be changing how that works, we shouldn't have to dig through the items to get the information.