### PR TITLE
be more precise about how the parsers work

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -50,11 +50,15 @@ const Works = ({ works, searchParams }: Props) => {
   } = searchParams;
 
   function trackOnRouteChange() {
-    trackSearch();
+    trackSearch({
+      totalResults: works && works.totalResults ? works.totalResults : null,
+    });
   }
 
   useEffect(() => {
-    trackSearch();
+    trackSearch({
+      totalResults: works && works.totalResults ? works.totalResults : null,
+    });
     Router.events.on('routeChangeComplete', trackOnRouteChange);
     return () => {
       Router.events.off('routeChangeComplete', trackOnRouteChange);

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -17,7 +17,6 @@ import { worksUrl } from '@weco/common/services/catalogue/urls';
 import {
   apiSearchParamsSerialiser,
   searchParamsDeserialiser,
-  defaultWorkTypes,
   defaultItemsLocationsLocationType,
   type SearchParams,
 } from '@weco/common/services/catalogue/search-params';
@@ -216,19 +215,12 @@ const Works = ({ works, searchParams }: Props) => {
                         link: worksUrl({
                           ...searchParams,
                           page: 1,
-                          workType: unfilteredSearchResults
-                            ? []
-                            : defaultWorkTypes,
+                          workType: unfilteredSearchResults ? [] : null,
                           itemsLocationsLocationType: unfilteredSearchResults
                             ? []
-                            : defaultItemsLocationsLocationType,
+                            : null,
                         }),
-                        selected:
-                          !!workType &&
-                          arraysEqual(
-                            unfilteredSearchResults ? [] : defaultWorkTypes,
-                            workType
-                          ),
+                        selected: workType === null,
                       },
                     ].concat(
                       workTypes.map(t => {

--- a/catalogue/webapp/test/search-params.test.js
+++ b/catalogue/webapp/test/search-params.test.js
@@ -1,12 +1,12 @@
 import {
   searchParamsDeserialiser,
-  searchParamsSerialiser,
+  apiSearchParamsSerialiser,
 } from '@weco/common/services/catalogue/search-params';
 
 // @flow
 
 describe('deserialises', () => {
-  it('should deserialise with defaults for missing keys', () => {
+  it('should deserialise URLs', () => {
     const params = searchParamsDeserialiser(
       {
         'production.dates.from': '1900',
@@ -24,21 +24,21 @@ describe('deserialises', () => {
     expect(params.productionDatesFrom).toBe('1900');
 
     // nullable string
-    expect(params.productionDatesTo).toBe(null);
+    expect(params.productionDatesTo).toStrictEqual(null);
 
-    // array with defaults
-    expect(params.workType).toStrictEqual(['a', 'k', 'q', 'v', 'f', 's']);
+    // nullable CSV
+    expect(params.workType).toStrictEqual(null);
 
     // not in keys => undefined
     expect(params.shakeTheRoom).toBe(undefined);
   });
 
-  it('should serialise removing default values', () => {
-    const params = searchParamsSerialiser({
+  it('should serialise with default values', () => {
+    const params = apiSearchParamsSerialiser({
       query: '',
       workType: null,
-      page: 1,
-      itemsLocationsLocationType: ['iiif-image', 'iiif-presentation'],
+      page: null,
+      itemsLocationsLocationType: null,
       aggregations: [],
     });
 
@@ -46,13 +46,15 @@ describe('deserialises', () => {
     expect(params.query).toBeNull();
 
     // number exclusion
-    expect(params.page).toBeNull();
+    expect(params.page).toBe('1');
 
     // array that's empty
     expect(params.aggregations).toBeNull();
 
-    // array serialisation with alternative param name and defaults
-    expect(params['items.locations.locationType']).toBe(null);
+    // array with defaults
+    expect(params['items.locations.locationType']).toBe(
+      'iiif-image,iiif-presentation'
+    );
 
     // array with defaults
     expect(params.workType).toBe('a,k,q,v,f,s');

--- a/common/services/catalogue/params.js
+++ b/common/services/catalogue/params.js
@@ -17,8 +17,13 @@ export type QueryStringParameterMapping = { [string]: string };
 const stringDeserialiser: Deserialiser<string> = input => input || '';
 const numberDeserialiser: Deserialiser<number> = input =>
   input ? parseInt(input) : 1;
+const nullableNumberDeserialiser: Deserialiser<number> = input =>
+  input ? parseInt(input) : null;
 const csvDeserialiser: Deserialiser<?(string[])> = input => {
   return input ? input.split(',') : [];
+};
+const nullableCsvDeserialiser: Deserialiser<?(string[])> = input => {
+  return input ? input.split(',') : null;
 };
 const nullableStringDeserialiser: Deserialiser<?string> = input => input;
 const booleanDeserialiser: Deserialiser<boolean> = input => input === 'true';
@@ -31,7 +36,12 @@ const stringSerialiser: Serialiser<string> = input =>
   input === '' ? null : input;
 const numberSerialiser: Serialiser<number> = input =>
   input === 1 || !input ? null : input.toString();
+const numberWithDefaultSerialiser: SerializerWithDefaults<number> = (
+  defaults: number
+) => input => (input === 1 || !input ? defaults.toString() : input.toString());
 const csvSerialiser: Serialiser<?(string[])> = input =>
+  input && input.length > 0 ? input.join(',') : '';
+const nullableCsvSerialiser: Serialiser<?(string[])> = input =>
   input && input.length > 0 ? input.join(',') : null;
 const nullableStringSerialiser: Serialiser<?string> = input => input;
 const booleanSerialiser: Serialiser<boolean> = input =>
@@ -58,14 +68,15 @@ function buildDeserialiser<T>(
   return (obj: Object): T => {
     const keys = Object.keys(deserialisers);
     const searchParams = keys.reduce((acc, key) => {
-      const input = key in obj ? obj[key] : null;
       const urlParam = queryStringParameterMapping[key]
         ? queryStringParameterMapping[key]
         : key;
 
+      const input = urlParam in obj ? obj[urlParam] : null;
+
       return {
         ...acc,
-        [urlParam]: deserialisers[key](input, key),
+        [key]: deserialisers[key](input, key),
       };
     }, {});
 
@@ -108,10 +119,14 @@ export {
   csvWithDefaultDeserialiser,
   stringSerialiser,
   numberSerialiser,
+  nullableNumberDeserialiser,
+  numberWithDefaultSerialiser,
   csvSerialiser,
+  nullableCsvSerialiser,
   nullableStringSerialiser,
   booleanSerialiser,
   csvWithDefaultSerialiser,
+  nullableCsvDeserialiser,
   nullableDateStringSerialiser,
   buildDeserialiser,
   buildSerialiser,

--- a/common/services/catalogue/search-params.js
+++ b/common/services/catalogue/search-params.js
@@ -5,13 +5,12 @@ import {
   type Deserialisers,
   type QueryStringParameterMapping,
   stringDeserialiser,
-  numberDeserialiser,
-  csvDeserialiser,
+  nullableNumberDeserialiser,
   nullableStringDeserialiser,
-  csvWithDefaultDeserialiser,
+  nullableCsvDeserialiser,
   stringSerialiser,
-  numberSerialiser,
-  csvSerialiser,
+  numberWithDefaultSerialiser,
+  nullableCsvSerialiser,
   nullableStringSerialiser,
   csvWithDefaultSerialiser,
   nullableDateStringSerialiser,
@@ -32,7 +31,7 @@ export type SearchParams = {|
   _queryType: ?string,
 |};
 
-type SearchParamsSerialisers = Serialisers<SearchParams>;
+type ApiSearchParamsSerialisers = Serialisers<SearchParams>;
 type SearchParamsDeserialisers = Deserialisers<SearchParams>;
 
 export const defaultWorkTypes = ['a', 'k', 'q', 'v', 'f', 's'];
@@ -47,57 +46,36 @@ const propToQueryStringMapping: QueryStringParameterMapping = {
   productionDatesTo: 'production.dates.to',
 };
 
-const queryStringToPropMapping: QueryStringParameterMapping = Object.entries(
-  propToQueryStringMapping
-  // $FlowFixMe
-).reduce((obj, [key, value]) => ({ ...obj, [value]: key }), {});
-
 const deserialisers: SearchParamsDeserialisers = {
   query: stringDeserialiser,
-  page: numberDeserialiser,
-  workType: csvWithDefaultDeserialiser(defaultWorkTypes),
-  [`items.locations.locationType`]: csvWithDefaultDeserialiser(
-    defaultItemsLocationsLocationType
-  ),
+  page: nullableNumberDeserialiser,
+  workType: nullableCsvDeserialiser,
+  itemsLocationsLocationType: nullableCsvDeserialiser,
   sort: nullableStringDeserialiser,
   sortOrder: nullableStringDeserialiser,
-  aggregations: csvDeserialiser,
-  [`production.dates.from`]: nullableStringDeserialiser,
-  [`production.dates.to`]: nullableStringDeserialiser,
+  aggregations: nullableCsvDeserialiser,
+  productionDatesFrom: nullableStringDeserialiser,
+  productionDatesTo: nullableStringDeserialiser,
   _queryType: nullableStringDeserialiser,
 };
 
-const apiSerialisers: SearchParamsSerialisers = {
+const apiSerialisers: ApiSearchParamsSerialisers = {
   query: stringSerialiser,
-  page: numberSerialiser,
-  workType: csvWithDefaultSerialiser([]),
-  itemsLocationsLocationType: csvWithDefaultSerialiser([]),
+  page: numberWithDefaultSerialiser(1),
+  workType: csvWithDefaultSerialiser(defaultWorkTypes),
+  itemsLocationsLocationType: csvWithDefaultSerialiser(
+    defaultItemsLocationsLocationType
+  ),
   sort: nullableStringSerialiser,
   sortOrder: nullableStringSerialiser,
-  aggregations: csvSerialiser,
+  aggregations: nullableCsvSerialiser,
   productionDatesFrom: nullableDateStringSerialiser,
   productionDatesTo: nullableDateStringSerialiser,
   _queryType: nullableStringSerialiser,
 };
 
-// We do a few things differently this side, including havein UI params
-// And also not showing certain filters when they are actually applied e.g. workType
-const serialisers: SearchParamsSerialisers = {
-  ...apiSerialisers,
-  workType: csvWithDefaultSerialiser(defaultWorkTypes),
-  itemsLocationsLocationType: csvWithDefaultSerialiser(
-    defaultItemsLocationsLocationType
-  ),
-  productionDatesFrom: nullableStringSerialiser,
-  productionDatesTo: nullableStringSerialiser,
-};
-
 export const searchParamsDeserialiser = buildDeserialiser(
   deserialisers,
-  queryStringToPropMapping
-);
-export const searchParamsSerialiser = buildSerialiser(
-  serialisers,
   propToQueryStringMapping
 );
 

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -1,6 +1,6 @@
 // @flow
 import { type NextLinkType } from '@weco/common/model/next-link-type';
-import { type SearchParams, searchParamsSerialiser } from './search-params';
+import { type SearchParams } from './search-params';
 import { removeEmptyProps } from '../../utils/json';
 
 export type WorksUrlProps = SearchParams;
@@ -30,7 +30,7 @@ export function workUrl({ id, ...searchParams }: WorkUrlProps): NextLinkType {
       pathname: `/work`,
       query: removeEmptyProps({
         id,
-        ...searchParamsSerialiser(searchParams),
+        ...searchParams,
       }),
     },
     as: {
@@ -44,13 +44,13 @@ export function worksUrl(searchParams: WorksUrlProps): NextLinkType {
     href: {
       pathname: `/works`,
       query: removeEmptyProps({
-        ...searchParamsSerialiser(searchParams),
+        ...searchParams,
       }),
     },
     as: {
       pathname: `/works`,
       query: removeEmptyProps({
-        ...searchParamsSerialiser(searchParams),
+        ...searchParams,
       }),
     },
   };
@@ -76,7 +76,7 @@ export function itemUrl({
           sierraId: sierraId,
           langCode: langCode,
           isOverview: isOverview,
-          ...searchParamsSerialiser({ ...searchParams, page: 1 }),
+          ...{ ...searchParams, page: 1 },
         }),
       },
     },

--- a/common/views/components/Tracker/Tracker.js
+++ b/common/views/components/Tracker/Tracker.js
@@ -1,6 +1,10 @@
 // @flow
 import { useEffect } from 'react';
 import Router from 'next/router';
+import {
+  searchParamsDeserialiser,
+  apiSearchParamsSerialiser,
+} from '../../../services/catalogue/search-params';
 
 type RelevanceRatingData = {|
   position: number,
@@ -30,7 +34,8 @@ const trackSearchResultSelected = (data: SearchResultSelectedData) => {
   track('Search result selected', 'search_relevance_implicit', data);
 };
 
-const trackSearch = () => {
+type SearchData = {| totalResults: ?number |};
+const trackSearch = (data: SearchData) => {
   const query = Router.query.query;
   if (query && query !== '') {
     track('Search', 'search_relevance_implicit');
@@ -45,9 +50,9 @@ const track = (
   serviceName: ServiceName,
   data: ?TrackingEventData
 ) => {
-  const query = {
-    ...Router.query,
-  };
+  const query = apiSearchParamsSerialiser(
+    searchParamsDeserialiser(Router.query)
+  );
   // These are from the global contex, we should probably not be storing them on the query
   delete query.toggles;
   delete query.globalAlert;


### PR DESCRIPTION
- Deserialisers replicate _exactly_ what we get from the URL. The only addition is to add number and array parsers. The site then reacts with that.
- We then use an API deserialiser if we receive a `null` for any value with a default, we use the default.

Feels a bit more close to what we were talking about.