### PR TITLE
add serialisers for links

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -17,7 +17,6 @@ import { worksUrl } from '@weco/common/services/catalogue/urls';
 import {
   apiSearchParamsSerialiser,
   searchParamsDeserialiser,
-  defaultItemsLocationsLocationType,
   type SearchParams,
 } from '@weco/common/services/catalogue/search-params';
 import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
@@ -218,7 +217,7 @@ const Works = ({ works, searchParams }: Props) => {
                         text: 'All',
                         link: worksUrl({
                           ...searchParams,
-                          page: 1,
+                          page: null,
                           workType: unfilteredSearchResults ? [] : null,
                           itemsLocationsLocationType: unfilteredSearchResults
                             ? []
@@ -235,8 +234,8 @@ const Works = ({ works, searchParams }: Props) => {
                             workType: t.materialTypes.map(m => m.letter),
                             itemsLocationsLocationType: unfilteredSearchResults
                               ? []
-                              : defaultItemsLocationsLocationType,
-                            page: 1,
+                              : null,
+                            page: null,
                           }),
                           selected:
                             !!workType &&
@@ -434,6 +433,7 @@ const Works = ({ works, searchParams }: Props) => {
 Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const params = searchParamsDeserialiser(ctx.query);
   const filters = apiSearchParamsSerialiser(params);
+
   const shouldGetWorks = filters.query && filters.query !== '';
   const { searchUsingAndOperator } = ctx.query.toggles;
 

--- a/common/services/catalogue/search-params.js
+++ b/common/services/catalogue/search-params.js
@@ -10,6 +10,7 @@ import {
   nullableCsvDeserialiser,
   stringSerialiser,
   numberWithDefaultSerialiser,
+  numberSerialiser,
   nullableCsvSerialiser,
   nullableStringSerialiser,
   csvWithDefaultSerialiser,
@@ -20,7 +21,7 @@ import {
 
 export type SearchParams = {|
   query: string,
-  page: number,
+  page: ?number,
   workType: ?(string[]),
   itemsLocationsLocationType: ?(string[]),
   sort: ?string,
@@ -59,6 +60,19 @@ const deserialisers: SearchParamsDeserialisers = {
   _queryType: nullableStringDeserialiser,
 };
 
+const serialisers: SearchParamsDeserialisers = {
+  query: stringSerialiser,
+  page: numberSerialiser,
+  workType: nullableCsvSerialiser,
+  itemsLocationsLocationType: nullableCsvSerialiser,
+  sort: nullableStringSerialiser,
+  sortOrder: nullableStringSerialiser,
+  aggregations: nullableCsvSerialiser,
+  productionDatesFrom: nullableStringSerialiser,
+  productionDatesTo: nullableStringSerialiser,
+  _queryType: nullableStringSerialiser,
+};
+
 const apiSerialisers: ApiSearchParamsSerialisers = {
   query: stringSerialiser,
   page: numberWithDefaultSerialiser(1),
@@ -73,6 +87,11 @@ const apiSerialisers: ApiSearchParamsSerialisers = {
   productionDatesTo: nullableDateStringSerialiser,
   _queryType: nullableStringSerialiser,
 };
+
+export const searchParamsSerialiser = buildSerialiser(
+  serialisers,
+  propToQueryStringMapping
+);
 
 export const searchParamsDeserialiser = buildDeserialiser(
   deserialisers,

--- a/common/services/catalogue/urls.js
+++ b/common/services/catalogue/urls.js
@@ -1,6 +1,6 @@
 // @flow
 import { type NextLinkType } from '@weco/common/model/next-link-type';
-import { type SearchParams } from './search-params';
+import { type SearchParams, searchParamsSerialiser } from './search-params';
 import { removeEmptyProps } from '../../utils/json';
 
 export type WorksUrlProps = SearchParams;
@@ -30,7 +30,7 @@ export function workUrl({ id, ...searchParams }: WorkUrlProps): NextLinkType {
       pathname: `/work`,
       query: removeEmptyProps({
         id,
-        ...searchParams,
+        ...searchParamsSerialiser(searchParams),
       }),
     },
     as: {
@@ -44,13 +44,13 @@ export function worksUrl(searchParams: WorksUrlProps): NextLinkType {
     href: {
       pathname: `/works`,
       query: removeEmptyProps({
-        ...searchParams,
+        ...searchParamsSerialiser(searchParams),
       }),
     },
     as: {
       pathname: `/works`,
       query: removeEmptyProps({
-        ...searchParams,
+        ...searchParamsSerialiser(searchParams),
       }),
     },
   };
@@ -76,7 +76,7 @@ export function itemUrl({
           sierraId: sierraId,
           langCode: langCode,
           isOverview: isOverview,
-          ...{ ...searchParams, page: 1 },
+          ...{ ...searchParamsSerialiser(searchParams), page: 1 },
         }),
       },
     },

--- a/common/views/components/RelevanceRater/RelevanceRater.js
+++ b/common/views/components/RelevanceRater/RelevanceRater.js
@@ -7,7 +7,7 @@ type Props = {|
   position: number,
   id: string,
   query: string,
-  page: number,
+  page: ?number,
   workType: ?(string[]),
   _queryType: ?string,
 |};
@@ -33,7 +33,7 @@ const RelevanceRater = ({
             position,
             rating: value,
             query,
-            page,
+            page: page || 1,
             workType,
             _queryType,
           });


### PR DESCRIPTION
My bad.

Things like string arrays serialise to `prop=val&prop=val2` in normal next land, we need to hijack that and make it a CSV.