### PR TITLE
add search by and op test to toggler dash

### DIFF
--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -37,6 +37,13 @@ function setCookie(name, value) {
 
 const abTests = [
   {
+    id: 'searchUsingAndOperator',
+    title: 'Search using AND as the default operator',
+    defaultValue: false,
+    range: [50, 100],
+    description: '',
+  },
+  {
     id: 'newsletterPromoUpdate',
     title: 'New design for NewsletterPromo component',
     defaultValue: false,


### PR DESCRIPTION
Forgot to add this.

@jamieparkinson this is an annoying step - I'll make some docs for it.

What would be nicer is if we could find a way for the edge lambda to serve off another path / subdomain and this webapp just consumes that...