### PR TITLE
Rename Captioned icon

### DIFF
--- a/common/icons/components/Captioned.js
+++ b/common/icons/components/Captioned.js
@@ -1,4 +1,4 @@
-const SvgClosedCaptioning = props => (
+const Captioned = props => (
   <svg viewBox="0 0 24 24" {...props}>
     <g className="icon__shape" fillRule="nonzero">
       <path d="M20 2.18H4.1a4 4 0 0 0-4 4v12a4 4 0 0 0 4 4H20a4 4 0 0 0 4-4v-12a4 4 0 0 0-4-4zm2 16a2 2 0 0 1-2 2H4.1a2 2 0 0 1-2-2v-12a2 2 0 0 1 2-2H20a2 2 0 0 1 2 2v12z" />
@@ -7,4 +7,4 @@ const SvgClosedCaptioning = props => (
   </svg>
 );
 
-export default SvgClosedCaptioning;
+export default Captioned;

--- a/common/icons/index.js
+++ b/common/icons/index.js
@@ -25,7 +25,7 @@ import chevron from './components/Chevron';
 import citation from './components/Citation';
 import clear from './components/Clear';
 import clock from './components/Clock';
-import closedCaptioning from './components/ClosedCaptioning';
+import captioned from './components/Captioned';
 import code from './components/Code';
 import comments from './components/Comments';
 import cookies from './components/Cookies';
@@ -136,7 +136,7 @@ export {
   citation,
   clear,
   clock,
-  closedCaptioning,
+  captioned,
   code,
   comments,
   cookies,


### PR DESCRIPTION
Closes #4878.

We camelize the interpretation title in order to get the icon svg. The interpretation is 'Captioned', so this PR renames `closedCaptioning` to `captioned` in order for the icon to display.

![image](https://user-images.githubusercontent.com/1394592/69538591-947f0300-0f7a-11ea-9885-bde8cea9fcd0.png)
