### PR TITLE
show all active filters

### DIFF
--- a/common/services/data/workTypeAggregations.js
+++ b/common/services/data/workTypeAggregations.js
@@ -1,0 +1,117 @@
+export const allWorkTypes = [
+  {
+    data: { id: 'a', label: 'Books', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'q', label: 'Digital Images', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'x', label: 'E-manuscripts, Asian', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'l', label: 'Ephemera', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'e', label: 'Maps', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'k', label: 'Pictures', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'w', label: 'Student dissertations', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'r', label: '3-D Objects', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'm', label: 'CD-Roms', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'v', label: 'E-books', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 's', label: 'E-sound', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'd', label: 'Journals', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'p', label: 'Mixed materials', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'i', label: 'Sound', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'g', label: 'Videorecordings', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'h', label: 'Archives and manuscripts', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'n', label: 'Cinefilm', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'j', label: 'E-journals', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'f', label: 'E-videos', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'b', label: 'Manuscripts, Asian', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'c', label: 'Music', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'u', label: 'Standing order', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'z', label: 'Web sites', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+];

--- a/common/views/components/FilterDrawerRefine/FilterDrawerRefine.js
+++ b/common/views/components/FilterDrawerRefine/FilterDrawerRefine.js
@@ -11,98 +11,121 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import { type SearchParams } from '@weco/common/services/catalogue/search-params';
 import { type CatalogueAggregationBucket } from '@weco/common/model/catalogue';
 
-const possibleWorktypes = [
+const allWorkTypes = [
   {
-    id: 'a',
-    label: 'Books',
+    data: { id: 'a', label: 'Books', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'q',
-    label: 'Digital Images',
+    data: { id: 'q', label: 'Digital Images', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'x',
-    label: 'E-manuscripts, Asian',
+    data: { id: 'x', label: 'E-manuscripts, Asian', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'l',
-    label: 'Ephemera',
+    data: { id: 'l', label: 'Ephemera', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'e',
-    label: 'Maps',
+    data: { id: 'e', label: 'Maps', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'k',
-    label: 'Pictures',
+    data: { id: 'k', label: 'Pictures', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'w',
-    label: 'Student dissertations',
+    data: { id: 'w', label: 'Student dissertations', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'r',
-    label: '3-D Objects',
+    data: { id: 'r', label: '3-D Objects', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'm',
-    label: 'CD-Roms',
+    data: { id: 'm', label: 'CD-Roms', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'v',
-    label: 'E-books',
+    data: { id: 'v', label: 'E-books', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 's',
-    label: 'E-sound',
+    data: { id: 's', label: 'E-sound', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'd',
-    label: 'Journals',
+    data: { id: 'd', label: 'Journals', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'p',
-    label: 'Mixed materials',
+    data: { id: 'p', label: 'Mixed materials', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'i',
-    label: 'Sound',
+    data: { id: 'i', label: 'Sound', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'g',
-    label: 'Videorecordings',
+    data: { id: 'g', label: 'Videorecordings', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'h',
-    label: 'Archives and manuscripts',
+    data: { id: 'h', label: 'Archives and manuscripts', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'n',
-    label: 'Cinefilm',
+    data: { id: 'n', label: 'Cinefilm', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'j',
-    label: 'E-journals',
+    data: { id: 'j', label: 'E-journals', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'f',
-    label: 'E-videos',
+    data: { id: 'f', label: 'E-videos', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'b',
-    label: 'Manuscripts, Asian',
+    data: { id: 'b', label: 'Manuscripts, Asian', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'c',
-    label: 'Music',
+    data: { id: 'c', label: 'Music', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'u',
-    label: 'Standing order',
+    data: { id: 'u', label: 'Standing order', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
   {
-    id: 'z',
-    label: 'Web sites',
+    data: { id: 'z', label: 'Web sites', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
   },
 ];
 
@@ -147,9 +170,26 @@ const FilterDrawerRefine = ({
   changeHandler,
 }: Props) => {
   const workTypeInUrlArray = searchParams.workType || [];
-  const { productionDatesFrom, productionDatesTo, workType } = searchParams;
+  const { productionDatesFrom, productionDatesTo } = searchParams;
   const [inputDateFrom, setInputDateFrom] = useState(productionDatesFrom);
   const [inputDateTo, setInputDateTo] = useState(productionDatesTo);
+  const workTypeFilters = allWorkTypes
+    .map(workType => {
+      const matchingWorkTypeAggregation = workTypeAggregations.find(
+        ({ data }) => workType.data.id === data.id
+      );
+      const matchingAppliedWorkType = workTypeInUrlArray.find(
+        id => workType.data.id === id
+      );
+      if (matchingWorkTypeAggregation) {
+        return matchingWorkTypeAggregation;
+      } else if (matchingAppliedWorkType) {
+        return workType;
+      } else {
+        return null;
+      }
+    })
+    .filter(Boolean);
 
   useEffect(() => {
     if (productionDatesFrom !== inputDateFrom) {
@@ -213,33 +253,34 @@ const FilterDrawerRefine = ({
     },
   ];
 
-  if (workTypeAggregations.length > 0) {
+  if (workTypeFilters.length > 0) {
     filterDrawerItems.push({
       title: 'Formats',
       component: (
         <Space v={{ size: 'l', properties: ['margin-top'] }}>
-          {workTypeAggregations &&
-            workTypeAggregations.map(type => (
+          {workTypeFilters.map(workType => {
+            return (
               <Space
-                key={type.data.id}
+                key={workType.data.id}
                 as="span"
                 h={{ size: 'm', properties: ['margin-right'] }}
               >
                 <Checkbox
-                  id={type.data.id}
-                  text={`${type.data.label} (${type.count})`}
-                  value={type.data.id}
+                  id={workType.data.id}
+                  text={`${workType.data.label} (${workType.count})`}
+                  value={workType.data.id}
                   name={`workType`}
                   checked={
                     workTypeInUrlArray &&
-                    workTypeInUrlArray.includes(type.data.id)
+                    workTypeInUrlArray.includes(workType.data.id)
                   }
                   onChange={event => {
                     changeHandler();
                   }}
                 />
               </Space>
-            ))}
+            );
+          })}
         </Space>
       ),
     });
@@ -306,26 +347,30 @@ const FilterDrawerRefine = ({
                   </a>
                 </NextLink>
               )}
-              {possibleWorktypes.map(possibleWorkType => (
-                <Fragment key={possibleWorkType.id}>
-                  {workType && workType.includes(possibleWorkType.id) && (
+
+              {workTypeInUrlArray.map(id => {
+                const workTypeObject = workTypeFilters.find(({ data }) => {
+                  return data.id === id;
+                });
+                return (
+                  <Fragment key={id}>
                     <NextLink
-                      key={possibleWorkType.id}
+                      key={workTypeObject.data.id}
                       {...worksUrl({
                         ...searchParams,
                         workType: searchParams.workType.filter(
-                          w => w !== possibleWorkType.id
+                          w => w !== workTypeObject.data.id
                         ),
                         page: 1,
                       })}
                     >
                       <a>
-                        <CancelFilter text={possibleWorkType.label} />
+                        <CancelFilter text={workTypeObject.data.label} />
                       </a>
                     </NextLink>
-                  )}
-                </Fragment>
-              ))}
+                  </Fragment>
+                );
+              })}
               <NextLink
                 passHref
                 {...worksUrl({

--- a/common/views/components/FilterDrawerRefine/FilterDrawerRefine.js
+++ b/common/views/components/FilterDrawerRefine/FilterDrawerRefine.js
@@ -11,6 +11,101 @@ import Divider from '@weco/common/views/components/Divider/Divider';
 import { type SearchParams } from '@weco/common/services/catalogue/search-params';
 import { type CatalogueAggregationBucket } from '@weco/common/model/catalogue';
 
+const possibleWorktypes = [
+  {
+    id: 'a',
+    label: 'Books',
+  },
+  {
+    id: 'q',
+    label: 'Digital Images',
+  },
+  {
+    id: 'x',
+    label: 'E-manuscripts, Asian',
+  },
+  {
+    id: 'l',
+    label: 'Ephemera',
+  },
+  {
+    id: 'e',
+    label: 'Maps',
+  },
+  {
+    id: 'k',
+    label: 'Pictures',
+  },
+  {
+    id: 'w',
+    label: 'Student dissertations',
+  },
+  {
+    id: 'r',
+    label: '3-D Objects',
+  },
+  {
+    id: 'm',
+    label: 'CD-Roms',
+  },
+  {
+    id: 'v',
+    label: 'E-books',
+  },
+  {
+    id: 's',
+    label: 'E-sound',
+  },
+  {
+    id: 'd',
+    label: 'Journals',
+  },
+  {
+    id: 'p',
+    label: 'Mixed materials',
+  },
+  {
+    id: 'i',
+    label: 'Sound',
+  },
+  {
+    id: 'g',
+    label: 'Videorecordings',
+  },
+  {
+    id: 'h',
+    label: 'Archives and manuscripts',
+  },
+  {
+    id: 'n',
+    label: 'Cinefilm',
+  },
+  {
+    id: 'j',
+    label: 'E-journals',
+  },
+  {
+    id: 'f',
+    label: 'E-videos',
+  },
+  {
+    id: 'b',
+    label: 'Manuscripts, Asian',
+  },
+  {
+    id: 'c',
+    label: 'Music',
+  },
+  {
+    id: 'u',
+    label: 'Standing order',
+  },
+  {
+    id: 'z',
+    label: 'Web sites',
+  },
+];
+
 function CancelFilter({ text }: { text: string }) {
   return (
     <Space
@@ -211,21 +306,21 @@ const FilterDrawerRefine = ({
                   </a>
                 </NextLink>
               )}
-              {workTypeAggregations.map(({ data }) => (
-                <Fragment key={data.id}>
-                  {workType && workType.includes(data.id) && (
+              {possibleWorktypes.map(possibleWorkType => (
+                <Fragment key={possibleWorkType.id}>
+                  {workType && workType.includes(possibleWorkType.id) && (
                     <NextLink
-                      key={data.id}
+                      key={possibleWorkType.id}
                       {...worksUrl({
                         ...searchParams,
                         workType: searchParams.workType.filter(
-                          w => w !== data.id
+                          w => w !== possibleWorkType.id
                         ),
                         page: 1,
                       })}
                     >
                       <a>
-                        <CancelFilter text={data.label} />
+                        <CancelFilter text={possibleWorkType.label} />
                       </a>
                     </NextLink>
                   )}

--- a/common/views/components/FilterDrawerRefine/FilterDrawerRefine.js
+++ b/common/views/components/FilterDrawerRefine/FilterDrawerRefine.js
@@ -10,124 +10,7 @@ import Checkbox from '@weco/common/views/components/Checkbox/Checkbox';
 import Divider from '@weco/common/views/components/Divider/Divider';
 import { type SearchParams } from '@weco/common/services/catalogue/search-params';
 import { type CatalogueAggregationBucket } from '@weco/common/model/catalogue';
-
-const allWorkTypes = [
-  {
-    data: { id: 'a', label: 'Books', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'q', label: 'Digital Images', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'x', label: 'E-manuscripts, Asian', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'l', label: 'Ephemera', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'e', label: 'Maps', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'k', label: 'Pictures', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'w', label: 'Student dissertations', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'r', label: '3-D Objects', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'm', label: 'CD-Roms', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'v', label: 'E-books', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 's', label: 'E-sound', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'd', label: 'Journals', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'p', label: 'Mixed materials', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'i', label: 'Sound', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'g', label: 'Videorecordings', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'h', label: 'Archives and manuscripts', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'n', label: 'Cinefilm', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'j', label: 'E-journals', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'f', label: 'E-videos', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'b', label: 'Manuscripts, Asian', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'c', label: 'Music', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'u', label: 'Standing order', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-  {
-    data: { id: 'z', label: 'Web sites', type: 'WorkType' },
-    count: 0,
-    type: 'AggregationBucket',
-  },
-];
+import { allWorkTypes } from '@weco/common/services/data/workTypeAggregations';
 
 function CancelFilter({ text }: { text: string }) {
   return (
@@ -173,6 +56,11 @@ const FilterDrawerRefine = ({
   const { productionDatesFrom, productionDatesTo } = searchParams;
   const [inputDateFrom, setInputDateFrom] = useState(productionDatesFrom);
   const [inputDateTo, setInputDateTo] = useState(productionDatesTo);
+  // We want to display all currently applied worktypes to the user within the filter drop down
+  // This may include worktypes that have no aggregations for the given search
+  // We therefore go through all possible worktypes,
+  // if they have a matching aggregation from the API response we use that
+  // If they aren't included in the API response, but are one of the applied filters,// then we still include it with a count of 0.
   const workTypeFilters = allWorkTypes
     .map(workType => {
       const matchingWorkTypeAggregation = workTypeAggregations.find(


### PR DESCRIPTION
Because we are relying on the workType aggregations from the API to display active filters, they sometimes don't appear in the UI, which is confusing for the user.

Here we're filtering by a work type of pictures(k), which in combination with the productionDatesFrom, returns no results:

![url](https://user-images.githubusercontent.com/6051896/69542175-c85e2680-0f82-11ea-9570-54b94518a709.png)

However, we're only telling the user that the date filter is active (since the pictures workType is not part of the aggregations returned by the API for this query combination - as there aren't any)
![Screenshot 2019-11-25 at 12 48 00](https://user-images.githubusercontent.com/6051896/69542281-06f3e100-0f83-11ea-9b46-6df3d8b8fade.png)

This PR fixes that:
![a](https://user-images.githubusercontent.com/6051896/69542452-6520c400-0f83-11ea-9ad3-ee954d59a684.png)


Downside is needing to keep a list of the workTypes in code.


