### PR TITLE
Amend space around h2 and h3 within .spaced-text blocks

### DIFF
--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -215,18 +215,29 @@ hr {
 
 .spaced-text {
   p,
-  ul {
+  ul,
+  h2,
+  h3 {
     margin-bottom: 0;
   }
 
   // All elements with a preceding sibling get margin-top
   // https://alistapart.com/article/axiomatic-css-and-lobotomized-owls
   * + * {
-    margin-top: 1.6em;
+    margin-top: 1.5em;
   }
 
   // …but not as much margin-top for list items
   li + li {
     margin-top: 0.3em;
+  }
+
+  // …and paragraphs after headings have a specific margin-top too
+  h2 + p {
+    margin-top: 1.2em;
+  }
+
+  h3 + p {
+    margin-top: 0.4em;
   }
 }

--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -224,7 +224,7 @@ hr {
   // All elements with a preceding sibling get margin-top
   // https://alistapart.com/article/axiomatic-css-and-lobotomized-owls
   * + * {
-    margin-top: 1.5em;
+    margin-top: 1.55em;
   }
 
   // …but not as much margin-top for list items
@@ -238,6 +238,6 @@ hr {
   }
 
   h3 + p {
-    margin-top: 0.4em;
+    margin-top: 0.3em;
   }
 }


### PR DESCRIPTION
Closes #4860

I think this is the minimum required change to the `.spaced-text` to align systematically with what @GarethOrmerod has specified.

`margin-top`s at desktop:
`p+p` = `*+*` = `1.55em` = `31px`
`h2+p` = `1.2em` = `24px`
`h3+p` = `0.3em` = `6px`

Using `em` means margins will scale proportionally with the type at the smaller breakpoints.

![image](https://user-images.githubusercontent.com/1394592/69653157-ab9d1e00-106a-11ea-93ae-2c3e6b543895.png)



