### PR TITLE
bump up the pageSize of prismic request

### DIFF
--- a/common/services/prismic/events.js
+++ b/common/services/prismic/events.js
@@ -300,7 +300,10 @@ export async function getEvent(
       .filter(Boolean);
     const eventScheduleDocs =
       scheduleIds.length > 0 &&
-      (await getTypeByIds(req, ['events'], scheduleIds, { fetchLinks }));
+      (await getTypeByIds(req, ['events'], scheduleIds, {
+        fetchLinks,
+        pageSize: 40,
+      }));
     const event = parseEventDoc(document, eventScheduleDocs || null);
 
     return event;


### PR DESCRIPTION
This event https://wellcomecollection.org/events/XagmOxAAACIAo0v8 has an event missing from its schedule.

This is because the prismic request to get the scheduled events, is limited to the default of 20 items per response. This bumps that up, so all the attached schedule events are returned.