### PR TITLE
add auth redirector to works

### DIFF
--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -38,6 +38,7 @@ module.exports = app
         }
 
         ctx.status = 303;
+        ctx.cookies.set('WC_auth_redirect', null);
         ctx.redirect(`${originalPathname}?${originalSearchParams.toString()}`);
         return;
       }

--- a/catalogue/webapp/app.js
+++ b/catalogue/webapp/app.js
@@ -20,6 +20,31 @@ module.exports = app
     // server cached values
     server.use(middleware);
 
+    // Used for redirecting from cognito to actual works pages
+    router.get('/works/auth-code', async (ctx, next) => {
+      const authRedirect = ctx.cookies.get('WC_auth_redirect');
+
+      if (authRedirect) {
+        const originalPathnameAndSearch = authRedirect.split('?');
+        const originalPathname = originalPathnameAndSearch[0];
+        const originalSearchParams = new URLSearchParams(
+          originalPathnameAndSearch[1]
+        );
+        const requestSearchParams = new URLSearchParams(ctx.request.search);
+        const code = requestSearchParams.get('code');
+
+        if (code) {
+          originalSearchParams.set('code', code);
+        }
+
+        ctx.status = 303;
+        ctx.redirect(`${originalPathname}?${originalSearchParams.toString()}`);
+        return;
+      }
+
+      return next();
+    });
+
     // Next routing
     route('/oembed/works/:id', '/embed', router, app);
     route('/works/progress', '/progress', router, app);


### PR DESCRIPTION
## Who is this for?
People who might want hijack cognito redirection

## What is it doing for them?
Allows us to:
* Set redirect URL
* Send off to cognito URL with redirect = `https://wc.org/works`
* Redirect that redirect to `https://wc.org/works/where/you/actually/want`