### PR TITLE
Don't drop-cap chevrons

### DIFF
--- a/common/services/prismic/html-serialisers.js
+++ b/common/services/prismic/html-serialisers.js
@@ -20,12 +20,15 @@ export const dropCapSerializer: HtmlSerializer = (
   i
 ) => {
   if (type === Elements.paragraph && i === 0) {
-    const firstLetter = children[0].charAt(0);
-    const restOfLetters = [...children[0].substr(1), ...children.slice(1)];
+    const characters = children[0];
+    const firstCharacter = characters.charAt(0);
+    const restOfCharacters = [...characters.substr(1), ...children.slice(1)];
 
-    return `<p><span class="drop-cap">${firstLetter}</span>${restOfLetters.join(
-      ''
-    )}</p>`;
+    return firstCharacter === '<'
+      ? `<p>${children.join('')}</p>`
+      : `<p><span class="drop-cap">${firstCharacter}</span>${restOfCharacters.join(
+          ''
+        )}</p>`;
   }
   return defaultSerializer(type, element, content, children, i);
 };


### PR DESCRIPTION
We don't want to add drop-cap styling to the start of html tags (`<`) if they're the first character in a paragraph.

__Before__
<img width="842" alt="Screenshot 2019-12-02 at 11 38 14" src="https://user-images.githubusercontent.com/1394592/69956722-a6bbec80-14f8-11ea-9a02-329722fac7f1.png">
__After__
<img width="799" alt="Screenshot 2019-12-02 at 11 38 24" src="https://user-images.githubusercontent.com/1394592/69956725-ab80a080-14f8-11ea-986c-a659e350c8e9.png">

We _could_ be cleverer and add the styling to the first character within the tag, but this seems most straightforward solution (and I'd be surprised if the content team would even want the first character of the example in the screenshot drop-capped).
