### PR TITLE
Remove letter-spacing

### DIFF
--- a/common/styles/base/_typography.scss
+++ b/common/styles/base/_typography.scss
@@ -46,7 +46,6 @@ $font-sizes-at-breakpoints: (
 %font-hnl,
 .font-hnl {
   font-weight: normal;
-  letter-spacing: 0.02em;
 }
 
 %font-hnm,

--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -475,13 +475,6 @@ export default class WecoApp extends App {
                                   font-weight: normal;
                                   font-style: normal;
                                 }
-
-
-                                body,
-                                .font-hnl,
-                                .font-hnm {
-                                  letter-spacing: normal;
-                                }
                               `,
                             }}
                           />


### PR DESCRIPTION
☝️ 

Getting rid of the blanket `0.02em` letter-spacing for Helvetica to optimise readability.