### PR TITLE
Tidy toggles and add search with scoring tiers

### DIFF
--- a/cache/edge_lambdas/toggler.js
+++ b/cache/edge_lambdas/toggler.js
@@ -14,19 +14,11 @@
 // This is mutable for testing
 let tests = [
   {
-    id: 'searchUsingAndOperator',
-    title: 'Search using AND as the default operator',
-    range: [50, 100],
+    id: 'searchUsingScoringTiers',
+    title: 'Search the API with a scoring tiered approach',
+    range: [0, 100],
     shouldRun: (request, range) => {
       return request.uri.match(/^\/works\/*/);
-    },
-  },
-  {
-    id: 'newsletterPromoUpdate',
-    title: 'New design for NewsletterPromo component',
-    range: [0, 50],
-    shouldRun(request) {
-      return !request.uri.match(/^\/works\/.*/);
     },
   },
 ];

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -40,8 +40,6 @@ type Props = {|
   iiifPresentationManifest: ?IIIFManifest,
   encoreLink: ?string,
   childManifestsCount?: number,
-  showImagesWithSimilarPalette?: boolean,
-  showAdditionalCatalogueData?: boolean,
 |};
 
 const WorkDetails = ({
@@ -50,8 +48,6 @@ const WorkDetails = ({
   iiifPresentationManifest,
   encoreLink,
   childManifestsCount,
-  showImagesWithSimilarPalette,
-  showAdditionalCatalogueData,
 }: Props) => {
   const duration =
     work.duration && moment.utc(work.duration).format('HH:mm:ss');
@@ -173,7 +169,7 @@ const WorkDetails = ({
           )}
 
         <WorkDetailsSection headingText="About this work">
-          {showAdditionalCatalogueData && work.alternativeTitles.length > 0 && (
+          {work.alternativeTitles.length > 0 && (
             <WorkDetailsText
               title="Also known as"
               text={work.alternativeTitles}
@@ -211,7 +207,7 @@ const WorkDetails = ({
             />
           )}
 
-          {showAdditionalCatalogueData && work.edition && (
+          {work.edition && (
             <WorkDetailsText title="Edition" text={[work.edition]} />
           )}
 
@@ -222,18 +218,15 @@ const WorkDetails = ({
             />
           )}
 
-          {showAdditionalCatalogueData && duration && (
-            <WorkDetailsText title="Duration" text={[duration]} />
-          )}
+          {duration && <WorkDetailsText title="Duration" text={[duration]} />}
 
-          {showAdditionalCatalogueData &&
-            work.notes.map(note => (
-              <WorkDetailsText
-                key={note.noteType.label}
-                title={note.noteType.label}
-                text={note.contents}
-              />
-            ))}
+          {work.notes.map(note => (
+            <WorkDetailsText
+              key={note.noteType.label}
+              title={note.noteType.label}
+              text={note.contents}
+            />
+          ))}
 
           {work.genres.length > 0 && (
             <WorkDetailsTags
@@ -281,18 +274,20 @@ const WorkDetails = ({
         {(encoreLink || iiifPresentationRepository) && (
           <WorkDetailsSection headingText="Where to find it">
             <TogglesContext.Consumer>
-              {({ stacksRequestService }) => (
-                <>
-                  <div className={`${font('hnl', 5)}`}>
-                    <h3 className={`${font('hnm', 5)} no-margin`}>
-                      In the library
-                    </h3>
+              {({ stacksRequestService }) =>
+                stacksRequestService && (
+                  <>
                     <div className={`${font('hnl', 5)}`}>
-                      <WorkItemsStatus work={work} />
+                      <h3 className={`${font('hnm', 5)} no-margin`}>
+                        In the library
+                      </h3>
+                      <div className={`${font('hnl', 5)}`}>
+                        <WorkItemsStatus work={work} />
+                      </div>
                     </div>
-                  </div>
-                </>
-              )}
+                  </>
+                )
+              }
             </TogglesContext.Consumer>
 
             <WorkDetailsText
@@ -324,7 +319,7 @@ const WorkDetails = ({
               />
             </div>
           </SpacingComponent>
-          {showAdditionalCatalogueData && work.citeAs && (
+          {work.citeAs && (
             <WorkDetailsText title="Reference number" text={[work.citeAs]} />
           )}
         </WorkDetailsSection>

--- a/catalogue/webapp/pages/work.js
+++ b/catalogue/webapp/pages/work.js
@@ -29,7 +29,6 @@ import IIIFPresentationPreview from '@weco/common/views/components/IIIFPresentat
 import IIIFImagePreview from '@weco/common/views/components/IIIFImagePreview/IIIFImagePreview';
 import SpacingComponent from '@weco/common/views/components/SpacingComponent/SpacingComponent';
 import WobblyRow from '@weco/common/views/components/WobblyRow/WobblyRow';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
 import Space from '@weco/common/views/components/styled/Space';
 
 type Props = {|
@@ -229,19 +228,14 @@ export const WorkPage = ({ work }: Props) => {
           />
         </WobblyRow>
       )}
-      <TogglesContext.Consumer>
-        {({ showImagesWithSimilarPalette, showAdditionalCatalogueData }) => (
-          <WorkDetails
-            showImagesWithSimilarPalette={showImagesWithSimilarPalette}
-            showAdditionalCatalogueData={showAdditionalCatalogueData}
-            work={work}
-            sierraId={sierraIdFromPresentationManifestUrl}
-            iiifPresentationManifest={iiifPresentationManifest}
-            encoreLink={encoreLink}
-            childManifestsCount={childManifestsCount}
-          />
-        )}
-      </TogglesContext.Consumer>
+
+      <WorkDetails
+        work={work}
+        sierraId={sierraIdFromPresentationManifestUrl}
+        iiifPresentationManifest={iiifPresentationManifest}
+        encoreLink={encoreLink}
+        childManifestsCount={childManifestsCount}
+      />
     </CataloguePageLayout>
   );
 };
@@ -250,11 +244,9 @@ WorkPage.getInitialProps = async (
   ctx
 ): Promise<Props | CatalogueApiRedirect> => {
   const { id } = ctx.query;
-  const { useStageApi } = ctx.query.toggles;
 
   const workOrError = await getWork({
     id,
-    env: useStageApi ? 'stage' : 'prod',
   });
 
   if (workOrError && workOrError.type === 'Redirect') {

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -379,14 +379,17 @@ const Works = ({
 
 Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const params = searchParamsDeserialiser(ctx.query);
-  const { searchUsingAndOperator, unfilteredSearchResults } = ctx.query.toggles;
+  const {
+    searchUsingScoringTiers,
+    unfilteredSearchResults,
+  } = ctx.query.toggles;
   const filters = unfilteredSearchResults
     ? unfilteredApiSearchParamsSerialiser(params)
     : apiSearchParamsSerialiser(params);
 
   const toggledFilters = {
     ...filters,
-    _queryType: searchUsingAndOperator ? 'usingAnd' : undefined,
+    _queryType: searchUsingScoringTiers ? 'ScoringTiers' : undefined,
   };
 
   const shouldGetWorks = filters.query && filters.query !== '';

--- a/common/views/components/CataloguePageLayout/CataloguePageLayout.js
+++ b/common/views/components/CataloguePageLayout/CataloguePageLayout.js
@@ -3,8 +3,6 @@ import PageLayout, {
   type Props as PageLayoutProps,
 } from '../PageLayout/PageLayout';
 import InfoBanner from '../InfoBanner/InfoBanner';
-import MessageBar from '../MessageBar/MessageBar';
-import TogglesContext from '../TogglesContext/TogglesContext';
 import Layout12 from '../Layout12/Layout12';
 import BetaBar from '../BetaBar/BetaBar';
 
@@ -32,16 +30,6 @@ const CataloguePageLayout = (props: Props) => {
             />
 
             <Layout12>
-              <TogglesContext.Consumer>
-                {({ useStageApi }) =>
-                  useStageApi && (
-                    <MessageBar tagText="Dev alert">
-                      You are using the stage catalogue API - data mileage may
-                      vary!
-                    </MessageBar>
-                  )
-                }
-              </TogglesContext.Consumer>
               <BetaBar />
             </Layout12>
           </>

--- a/dash/webapp/pages/toggles.js
+++ b/dash/webapp/pages/toggles.js
@@ -37,18 +37,12 @@ function setCookie(name, value) {
 
 const abTests = [
   {
-    id: 'searchUsingAndOperator',
-    title: 'Search using AND as the default operator',
+    id: 'searchUsingScoringTiers',
+    title: 'Search the API with a scoring tiered approach',
+    range: [0, 100],
     defaultValue: false,
-    range: [50, 100],
-    description: '',
-  },
-  {
-    id: 'newsletterPromoUpdate',
-    title: 'New design for NewsletterPromo component',
-    defaultValue: false,
-    description: '',
-    range: [0, 50],
+    description:
+      'This enables high accuracy on things like titles, and high recal from things like descriptions.',
   },
 ];
 const IndexPage = () => {
@@ -229,7 +223,6 @@ const IndexPage = () => {
                     });
                   }}
                   style={{
-                    // $FlowFixMe
                     opacity: toggleStates[toggle.id] === true ? 1 : 0.5,
                   }}
                 >
@@ -244,7 +237,6 @@ const IndexPage = () => {
                     });
                   }}
                   style={{
-                    // $FlowFixMe
                     opacity: toggleStates[toggle.id] === false ? 1 : 0.5,
                   }}
                 >

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -1,62 +1,6 @@
 module.exports = {
   toggles: [
     {
-      id: 'relevanceRating',
-      title: `Search relevance rating`,
-      defaultValue: false,
-      description:
-        'Allow people rate the relevance or results on the search results page.',
-    },
-    {
-      id: 'useStageApi',
-      title: `Use the staging API`,
-      defaultValue: false,
-      description:
-        'Uses api.stage for requests to the API to view data that we are testing.',
-    },
-    {
-      id: 'unfilteredSearchResults',
-      title:
-        'Return all posible results from the catalogue API, without filtering by type or location',
-      defaultValue: false,
-      description: 'Shows all possible search results from the catalogue API',
-    },
-    {
-      id: 'refineFiltersPrototype',
-      title: 'Display the Refine filters prototype',
-      defaultValue: false,
-      description:
-        'Shows filters on the works search pages. Geared towards refinement.',
-    },
-    {
-      id: 'helveticaRegular',
-      title: 'Helvetica regular',
-      defaultValue: false,
-      description:
-        'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
-    },
-    {
-      id: 'showImagesWithSimilarPalette',
-      title: 'Show images with similar palette in the work details section',
-      defaultValue: false,
-      description:
-        'If the work has a Miro image, we can show images with similar a palette.',
-    },
-    {
-      id: 'showAdditionalCatalogueData',
-      title: 'Show the latest Sierra data additions to the API',
-      defaultValue: false,
-      description:
-        'Displays the latest data additions, that have been added to the API, on the work page.',
-    },
-    {
-      id: 'showLocationsAndStatuses',
-      title: 'Show physical locations and statuses of work items',
-      defaultValue: false,
-      description:
-        "Shows the physical locations and statuses of a work's items where available",
-    },
-    {
       id: 'enableImageSearch',
       title: 'Enable the images-only search on /images',
       defaultValue: false,
@@ -68,6 +12,20 @@ module.exports = {
       title: 'Items status and requesting',
       defaultValue: false,
       description: 'Get the status of items and request them from the stacks',
+    },
+    {
+      id: 'unfilteredSearchResults',
+      title:
+        'Return all posible results from the catalogue API, without filtering by type or location',
+      defaultValue: false,
+      description: 'Shows all possible search results from the catalogue API',
+    },
+    {
+      id: 'helveticaRegular',
+      title: 'Helvetica regular',
+      defaultValue: false,
+      description:
+        'Displays body copy in Helvetica regular (where it is currently Helvetica light)',
     },
   ],
 };


### PR DESCRIPTION
There's a few things in here.
Normally I wouldn't do it like this, but it seems things were backing up.

* New metadata on works from API
* Search using AND and scoring tiers
* remove palette toggle as it's now in the image search
* Put the `WorkItemsStatus` behind the toggle as it's broken
* Remove staging API as it's not useful
* other toggles tidy up
