### PR TITLE
Use Web Auth client_id

### DIFF
--- a/catalogue/webapp/components/Auth/Auth.js
+++ b/catalogue/webapp/components/Auth/Auth.js
@@ -9,7 +9,7 @@ import base64url from 'base64url';
 const authDomain = 'https://id.wellcomecollection.org';
 const authParams = {
   response_type: 'code',
-  client_id: '5n4vt54rjsg6t691c5b5kiacdv',
+  client_id: '4sl9v9v3i72fs66i0kpgqent8b',
   scope: ['openid'].join(' '),
 };
 


### PR DESCRIPTION
## Who is this for?

Folk who want to use the requesting service.

## What is it doing for them?

Making it work.

The application needs an effective way to differentiate between the development and production keys. Having the production key in code means that the prod version will work but the dev version won't (which is better).