### PR TITLE
remove errant label on 'Where to find it' section of work details

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -306,18 +306,12 @@ const WorkDetails = ({
               <WorkDetailsSection headingText="Where to find it">
                 {stacksRequestService && (
                   <div className={`${font('hnl', 5)}`}>
-                    <h3 className={`${font('hnm', 5)} no-margin`}>
-                      In the library
-                    </h3>
-                    <div className={`${font('hnl', 5)}`}>
-                      <WorkItemsStatus work={work} />
-                    </div>
+                    <WorkItemsStatus work={work} />
                   </div>
                 )}
 
                 {(encoreLink || iiifPresentationRepository) && (
                   <WorkDetailsText
-                    title={'Online'}
                     text={[
                       encoreLink &&
                         `<a href="${encoreLink}">Wellcome library</a>`,

--- a/catalogue/webapp/components/WorkItemsStatus/WorkItemsStatus.js
+++ b/catalogue/webapp/components/WorkItemsStatus/WorkItemsStatus.js
@@ -144,10 +144,17 @@ const WorkItemsStatus = ({ work }: Props) => {
                 properties: ['margin-bottom'],
               }}
             >
-              <p>
+              <p className="no-margin">
                 {item.location.label}: {item.status.label}
               </p>
-              <ItemRequestButton item={item} workId={work.id} />
+              <Space
+                v={{
+                  size: 's',
+                  properties: ['margin-top'],
+                }}
+              >
+                <ItemRequestButton item={item} workId={work.id} />
+              </Space>
             </Space>
           </Fragment>
         ))}


### PR DESCRIPTION
## Before
<img width="728" alt="Screenshot 2019-12-06 at 15 59 20" src="https://user-images.githubusercontent.com/31692/70336636-6b475800-1841-11ea-85af-b8358fd1364c.png">


## After
<img width="685" alt="Screenshot 2019-12-06 at 15 58 02" src="https://user-images.githubusercontent.com/31692/70336645-6f737580-1841-11ea-8db4-400ec9c4c6d0.png">

Probably needs some labelling, but removing the bug for now.