### PR TITLE
Update image-similarity.js with renamed palette-similarity API

### DIFF
--- a/catalogue/webapp/services/image-similarity.js
+++ b/catalogue/webapp/services/image-similarity.js
@@ -5,7 +5,7 @@ type SimilarityMeasure = 'palette' | 'feature';
 
 const ROOT_URL = 'https://labs.wellcomecollection.org';
 const SIMILARITY_MEASURE: { [key: SimilarityMeasure]: string } = {
-  palette: 'palette-api',
+  palette: 'palette-similarity',
   feature: 'feature-similarity',
 };
 


### PR DESCRIPTION
## Who is this for?
anyone who wants to see images with similar colour palettes 🎨 

## What is it doing for them?
pointing them to the correct name of the API