### PR TITLE
Move 'location of original'notes to 'where to find it' section

### DIFF
--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -114,6 +114,10 @@ const WorkDetails = ({
   const encoreLink =
     shouldDisplayEncoreLink && sierraWorkId && getEncoreLink(sierraWorkId);
 
+  const locationOfWork = work.notes.find(
+    note => note.noteType.id === 'location-of-original'
+  );
+
   return (
     <Space
       v={{
@@ -294,35 +298,32 @@ const WorkDetails = ({
           </WorkDetailsSection>
         )}
 
-        {[work.notes.find(note => note.noteType.id === 'location-of-original')]
-          .filter(Boolean)
-          .map(note => (
-            <WorkDetailsSection
-              headingText="Where to find it"
-              key={note.noteType.label}
-            >
+        {(locationOfWork || encoreLink) && (
+          <WorkDetailsSection headingText="Where to find it">
+            {locationOfWork && (
               <WorkDetailsText
-                title={note.noteType.label}
-                text={note.contents}
+                title={locationOfWork.noteType.label}
+                text={locationOfWork.contents}
               />
+            )}
 
-              {encoreLink && (
-                <WorkDetailsText
-                  text={[`<a href="${encoreLink}">Wellcome library</a>`]}
-                />
-              )}
+            {encoreLink && (
+              <WorkDetailsText
+                text={[`<a href="${encoreLink}">Wellcome library</a>`]}
+              />
+            )}
 
-              <TogglesContext.Consumer>
-                {({ stacksRequestService }) =>
-                  stacksRequestService && (
-                    <div className={`${font('hnl', 5)}`}>
-                      <WorkItemsStatus work={work} />
-                    </div>
-                  )
-                }
-              </TogglesContext.Consumer>
-            </WorkDetailsSection>
-          ))}
+            <TogglesContext.Consumer>
+              {({ stacksRequestService }) =>
+                stacksRequestService && (
+                  <div className={`${font('hnl', 5)}`}>
+                    <WorkItemsStatus work={work} />
+                  </div>
+                )
+              }
+            </TogglesContext.Consumer>
+          </WorkDetailsSection>
+        )}
 
         <WorkDetailsSection headingText="Identifiers">
           {isbnIdentifiers.length > 0 && (

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -8,6 +8,8 @@ import {
   getDownloadOptionsFromImageUrl,
   getLocationOfType,
   getIIIFPresentationLocation,
+  getWorkIdentifiersWith,
+  getEncoreLink,
 } from '@weco/common/utils/works';
 import {
   getIIIFPresentationLicenceInfo,
@@ -97,6 +99,20 @@ const WorkDetails = ({
   const sierraIdFromPresentationManifestUrl =
     iiifPresentationLocation &&
     (iiifPresentationLocation.url.match(/iiif\/(.*)\/manifest/) || [])[1];
+
+  const sierraWorkIds = getWorkIdentifiersWith(work, {
+    identifierId: 'sierra-system-number',
+  });
+
+  const sierraWorkId = sierraWorkIds.length >= 1 ? sierraWorkIds[0] : null;
+
+  // We do not wish to display a link to the old library site if the new site
+  // provides a digital representation of that work
+  const shouldDisplayEncoreLink = !(
+    sierraIdFromPresentationManifestUrl === sierraWorkId
+  );
+  const encoreLink =
+    shouldDisplayEncoreLink && sierraWorkId && getEncoreLink(sierraWorkId);
 
   return (
     <Space
@@ -289,6 +305,13 @@ const WorkDetails = ({
                 title={note.noteType.label}
                 text={note.contents}
               />
+
+              {encoreLink && (
+                <WorkDetailsText
+                  text={[`<a href="${encoreLink}">Wellcome library</a>`]}
+                />
+              )}
+
               <TogglesContext.Consumer>
                 {({ stacksRequestService }) =>
                   stacksRequestService && (


### PR DESCRIPTION
Fixes #4925

## Who is this for?
People who like de-duped 'location of the original' information.

## What is it doing for them?
De-duping the 'location of the original' information, and moving the version from the newer data to the appropriate ('where to find it') section of the page.

<img width="1263" alt="Screenshot 2019-12-11 at 15 38 58" src="https://user-images.githubusercontent.com/1394592/70636036-cce63880-1c2c-11ea-8777-ba5d364ec396.png">

(sparkles are for illustrative purposes only)
