### PR TITLE
Fix toggles page downloading when loaded from server

### DIFF
--- a/dash/terraform/terraform.tf
+++ b/dash/terraform/terraform.tf
@@ -6,18 +6,27 @@ terraform {
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
+    role_arn       = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
 provider "aws" {
   version = "~> 2.2"
   region  = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
 }
 
 provider "aws" {
   version = "~> 2.2"
   region  = "us-east-1"
   alias   = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
 }
 
 provider "template" {

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -1,7 +1,14 @@
 resource "aws_cloudfront_distribution" "https_s3_website" {
   origin {
-    domain_name = "${var.website_uri}.s3.amazonaws.com"
+    domain_name = "${aws_s3_bucket.website_bucket.website_endpoint}"
     origin_id   = "S3-${var.website_uri}"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+    }
   }
 
   enabled             = true


### PR DESCRIPTION
It's irritating that we can't link directly to dash.wellcomecollection.org/toggles/ - the reason for this is that, despite setting the S3 bucket up as a website, the CloudFront origin that we use is that of the "plain" bucket, and that server does not perform URL rewrites to serve `/blah/index.html` when `/blah/` is accessed.

Next.js's export relies on a directory structure full of `index.html`s, hence the issue, and it's OK when direct linking as in this case it loads the new page via an XHR request.
