### PR TITLE
Make input focus borders black

### DIFF
--- a/common/views/components/NumberInput/NumberInput.js
+++ b/common/views/components/NumberInput/NumberInput.js
@@ -9,6 +9,7 @@ const StyledInput: ComponentType<SpaceComponentProps> = styled(Space).attrs({
   outline: none;
   border: 1px solid ${props => props.theme.colors.pumice};
   padding: 12px;
+  border-radius: 3px;
 
   /* removes up and down arrows webkit adds to number inputs on desktop */
   &::-webkit-inner-spin-button,
@@ -18,7 +19,7 @@ const StyledInput: ComponentType<SpaceComponentProps> = styled(Space).attrs({
   }
 
   &:focus {
-    border: 2px solid ${props => props.theme.colors.yellow};
+    border: 2px solid ${props => props.theme.colors.black};
     padding: 11px;
   }
 `;

--- a/common/views/components/TextInput/TextInput.js
+++ b/common/views/components/TextInput/TextInput.js
@@ -26,7 +26,7 @@ const StyledInput: ComponentType<SpaceComponentProps> = styled(Space).attrs({
 
   &:focus {
     outline: 0;
-    border: 2px solid ${props => props.theme.colors.yellow};
+    border: 2px solid ${props => props.theme.colors.black};
   }
 
   &::-ms-clear {


### PR DESCRIPTION
☝️ 

![input_focus](https://user-images.githubusercontent.com/1394592/71019774-dc64f600-20f2-11ea-8db9-3eb43a78036d.gif)

(Aligning with Zeplin where focus states are tending towards having black borders).