### PR TITLE
account for empty humanReadableText on licenses

### DIFF
--- a/catalogue/webapp/components/Download/ViewerDownload.js
+++ b/catalogue/webapp/components/Download/ViewerDownload.js
@@ -182,10 +182,12 @@ const Download = ({
         {licenseInfo && (
           <SpacingComponent>
             <div ref={downloadText}>
-              <WorkDetailsText
-                title="License information"
-                text={licenseInfo.humanReadableText}
-              />
+              {licenseInfo.humanReadableText.length > 0 && (
+                <WorkDetailsText
+                  title="License information"
+                  text={licenseInfo.humanReadableText}
+                />
+              )}
               <WorkDetailsText
                 title="Credit"
                 text={[

--- a/catalogue/webapp/components/WorkDetails/WorkDetails.js
+++ b/catalogue/webapp/components/WorkDetails/WorkDetails.js
@@ -348,10 +348,12 @@ const WorkDetails = ({
         {licenseInfo && (
           <WorkDetailsSection headingText="License information">
             <div id="licenseInformation">
-              <WorkDetailsText
-                title="License information"
-                text={licenseInfo.humanReadableText}
-              />
+              {licenseInfo.humanReadableText.length > 0 && (
+                <WorkDetailsText
+                  title="License information"
+                  text={licenseInfo.humanReadableText}
+                />
+              )}
               <WorkDetailsText
                 title="Credit"
                 text={[

--- a/catalogue/webapp/pages/download.js
+++ b/catalogue/webapp/pages/download.js
@@ -110,10 +110,12 @@ const DownloadPage = ({ workId, sierraId, manifest, work }: Props) => {
           {licenseInfo && (
             <SpacingComponent>
               <div id="licenseInformation">
-                <WorkDetailsText
-                  title="License information"
-                  text={licenseInfo.humanReadableText}
-                />
+                {licenseInfo.humanReadableText.length > 0 && (
+                  <WorkDetailsText
+                    title="License information"
+                    text={licenseInfo.humanReadableText}
+                  />
+                )}
                 <WorkDetailsText
                   title="Credit"
                   text={[


### PR DESCRIPTION
I thought about moving it into the `WorkDetailsText` component, but that felt like the component would be dealing with data management as well as rendering so left it in the components that were aware of the data model.

Assuming `humanReadableText` might become something else when being returned from the API anywho.