### PR TITLE
[DO NOT MERGE] only incase of emergency - remove queryType test

### DIFF
--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -428,7 +428,7 @@ const IMAGES_LOCATION_TYPE = 'iiif-image';
 Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const params = searchParamsDeserialiser(ctx.query);
   const {
-    searchInEnglishWithContributors,
+    // searchInEnglishWithContributors,
     unfilteredSearchResults,
   } = ctx.query.toggles;
 
@@ -444,9 +444,9 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
 
   const toggledFilters = {
     ...filters,
-    _queryType: searchInEnglishWithContributors
-      ? 'InEnglishWithContributors'
-      : undefined,
+    // _queryType: searchInEnglishWithContributors
+    //   ? 'InEnglishWithContributors'
+    //   : undefined,
   };
 
   const shouldGetWorks = filters.query && filters.query !== '';


### PR DESCRIPTION
Only merge this if we know everything has exploded with the new [`queryType` test](https://github.com/wellcometrust/catalogue/pull/331).

[Once it's built in circle](https://circleci.com/gh/wellcometrust/workflows/wellcomecollection.org/tree/master) - make sure you are logged into AWS and run `yarn deployCatalogue` from the root of the repo.

If we want to roll back the API - change the SSM parameter for the image to 760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/api:45979b2dd8503aa571357c145ec2527bbfa3c1dc and redeploy.
