### PR TITLE
add sound (i) and videorecordings (g) to defaultWorkTypes

### DIFF
--- a/catalogue/webapp/test/search-params.test.js
+++ b/catalogue/webapp/test/search-params.test.js
@@ -57,6 +57,6 @@ describe('deserialises', () => {
     );
 
     // array with defaults
-    expect(params.workType).toBe('a,k,q');
+    expect(params.workType).toBe('a,k,q,i,g');
   });
 });

--- a/common/services/catalogue/search-params.js
+++ b/common/services/catalogue/search-params.js
@@ -36,7 +36,7 @@ export type SearchParams = {|
 type ApiSearchParamsSerialisers = Serialisers<SearchParams>;
 type SearchParamsDeserialisers = Deserialisers<SearchParams>;
 
-export const defaultWorkTypes = ['a', 'k', 'q'];
+export const defaultWorkTypes = ['a', 'k', 'q', 'i', 'g'];
 export const defaultItemsLocationsLocationType = [
   'iiif-image',
   'iiif-presentation',


### PR DESCRIPTION
Looks like these were accidentally removed
