### PR TITLE
Test for RadioNodeList to stop IE breaking

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -24,7 +24,8 @@ function inputValue(input: ?HTMLElement): ?string {
     input &&
     (input instanceof window.HTMLInputElement ||
       input instanceof window.HTMLSelectElement ||
-      input instanceof window.RadioNodeList)
+      (window.RadioNodeList && input instanceof window.RadioNodeList) ||
+      (!window.RadioNodeList && input instanceof window.HTMLCollection))
   ) {
     return input.value;
   }


### PR DESCRIPTION
## Who is this for?
IE11 users

## What is it doing for them?
Allows the search form to be sumitted – `RadioNodeList` isn't defined in IE11, so checking if the `input` is an `instanceof` it was killing IE. If `RadioNodeList` isn't defined, we check for `HTMLCollection` instead.