### PR TITLE
filter aggregations from API by defaultWorkTypes

### DIFF
--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -84,13 +84,17 @@ export async function getWorkTypeAggregations({
     `${rootUris[env]}/v2/works?include=${workIncludes.join(
       ','
     )}&aggregations=workType` +
-    (unfilteredSearchResults ? '' : `&workType=${defaultWorkTypes.join(',')}`) +
     (filterQueryString.length > 0 ? `&${filterQueryString.join('&')}` : '');
-
   const res = await fetch(url);
   const json = await res.json();
-
-  return json.aggregations.workType.buckets;
+  const workTypeBuckets = unfilteredSearchResults
+    ? json.aggregations.workType.buckets
+    : json.aggregations.workType.buckets.filter(bucket => {
+        return Boolean(
+          defaultWorkTypes.find(defaultType => bucket.data.id === defaultType)
+        );
+      });
+  return workTypeBuckets;
 }
 
 export async function getWork({

--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -90,9 +90,7 @@ export async function getWorkTypeAggregations({
   const workTypeBuckets = unfilteredSearchResults
     ? json.aggregations.workType.buckets
     : json.aggregations.workType.buckets.filter(bucket => {
-        return Boolean(
-          defaultWorkTypes.find(defaultType => bucket.data.id === defaultType)
-        );
+        return defaultWorkTypes.includes(bucket.data.id);
       });
   return workTypeBuckets;
 }


### PR DESCRIPTION
A change to the API wellcometrust/catalogue#321 means that all workType aggregations are now available in the UI
<img width="392" alt="Screenshot 2020-01-09 at 14 34 53" src="https://user-images.githubusercontent.com/6051896/72076805-10949680-32ee-11ea-8546-69f20cb6fc1b.png">

This means users can access works we're not ready to cope with yet on the front end, and can cause errors.

This PR filters the aggregations returned from the API by the defaults we have set in the project, so this doesn't occur. We'll be working to remove this defaults soon.