### PR TITLE
Make checkbox filters work in IE11

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -32,10 +32,16 @@ function inputValue(input: ?HTMLElement): ?string {
 }
 
 function nodeListValueToArray(input: ?HTMLElement): ?(HTMLInputElement[]) {
-  if (input && input instanceof window.HTMLInputElement) {
+  if (!input) return;
+
+  if (input instanceof window.HTMLInputElement) {
     return [input];
   }
-  if (input && input instanceof window.NodeList) {
+
+  if (
+    input instanceof window.NodeList ||
+    input instanceof window.HTMLCollection // IE11 reports checkboxes as HTMLCollections
+  ) {
     return Array.from(input);
   }
 }

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -84,6 +84,7 @@ const SearchFiltersDesktop = ({
             <>
               <Space as="span" h={{ size: 'm', properties: ['margin-right'] }}>
                 <NumberInput
+                  name="production.dates.from"
                   label="From"
                   min="0"
                   max="9999"
@@ -95,6 +96,7 @@ const SearchFiltersDesktop = ({
                 />
               </Space>
               <NumberInput
+                name="production.dates.to"
                 label="to"
                 min="0"
                 max="9999"


### PR DESCRIPTION
☝️ 

Addresses part of #4989

- The check marks aren't centred, but they do now work.
- The dates now work

![image](https://user-images.githubusercontent.com/1394592/72163168-3b005580-33bb-11ea-8af0-1bcb6355fd91.png)

