### PR TITLE
redirect lowercase article URL to proper case

### DIFF
--- a/cache/edge_lambdas/redirects.js
+++ b/cache/edge_lambdas/redirects.js
@@ -160,4 +160,5 @@ module.exports = {
   '/installations/W-K6iBUAAJqYxKMi': '/exhibitions/XFximBAAAPkAioW_',
   '/installations/WqwC1iAAAB8AJgFB': '/exhibitions/XFximBAAAPkAioWn',
   '/installations/Wrynhx8AAAjk9XX-': '/exhibitions/XFximBAAAPkAioW1',
+  '/articles/xksu0xiaadlrl4-h': '/articles/XKsU0xIAADlrL4-h',
 };


### PR DESCRIPTION
Alice W found loads of logs of people leaving on the lowercase version, so it must be shared somewhere in the lowercase.