### PR TITLE
add digitised filter for whole catalogue search

### DIFF
--- a/catalogue/webapp/components/SearchForm/SearchForm.js
+++ b/catalogue/webapp/components/SearchForm/SearchForm.js
@@ -144,6 +144,14 @@ const SearchForm = ({
     const sort =
       sortOrder === 'asc' || sortOrder === 'desc' ? 'production.dates' : null;
     const search = inputValue(form['search']);
+
+    const itemsLocationsLocationType =
+      form['items.locations.locationType'] instanceof window.HTMLInputElement
+        ? form['items.locations.locationType'].checked
+          ? form['items.locations.locationType'].value.split(',')
+          : null
+        : null;
+
     const link = url({
       ...searchParams,
       query: inputQuery,
@@ -154,6 +162,7 @@ const SearchForm = ({
       sortOrder,
       sort,
       search,
+      itemsLocationsLocationType,
     });
     return Router.push(link.href, link.as);
   }

--- a/common/views/components/SearchFilters/SearchFilters.js
+++ b/common/views/components/SearchFilters/SearchFilters.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import {
   type SearchParams,
   defaultWorkTypes,
@@ -7,6 +7,7 @@ import { type CatalogueAggregationBucket } from '@weco/common/model/catalogue';
 import SearchFiltersDesktop from '@weco/common/views/components/SearchFilters/SearchFiltersDesktop';
 import SearchFiltersMobile from '@weco/common/views/components/SearchFilters/SearchFiltersMobile';
 import theme from '@weco/common/views/themes/default';
+import TogglesContext from '../TogglesContext/TogglesContext';
 
 type Props = {|
   searchForm: React.Ref<typeof HTMLFormElement>,
@@ -39,11 +40,13 @@ const SearchFilters = ({
   const [isMobile, setIsMobile] = useState(false);
   const [inputDateFrom, setInputDateFrom] = useState(productionDatesFrom);
   const [inputDateTo, setInputDateTo] = useState(productionDatesTo);
+  const { unfilteredSearchResults } = useContext(TogglesContext);
 
-  const allowedWorkTypeAggregations = defaultWorkTypes;
-  const workTypeFilters = workTypeAggregations.filter(agg =>
-    allowedWorkTypeAggregations.includes(agg.data.id)
-  );
+  const workTypeFilters = unfilteredSearchResults
+    ? workTypeAggregations
+    : workTypeAggregations.filter(agg =>
+        defaultWorkTypes.includes(agg.data.id)
+      );
 
   useEffect(() => {
     function updateIsMobile() {

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -9,6 +9,7 @@ import NumberInput from '@weco/common/views/components/NumberInput/NumberInput';
 import Checkbox from '@weco/common/views/components/Checkbox/Checkbox';
 import NextLink from 'next/link';
 import { type SearchFiltersSharedProps } from './SearchFilters';
+import TogglesContext from '../TogglesContext/TogglesContext';
 
 const CancelFilter = ({ text }: { text: string }) => {
   return (
@@ -109,6 +110,7 @@ const SearchFiltersDesktop = ({
             </>
           </DropdownButton>
         </Space>
+
         {workTypeFilters.length > 0 && (
           <DropdownButton label={'Formats'}>
             <ul
@@ -138,7 +140,48 @@ const SearchFiltersDesktop = ({
             </ul>
           </DropdownButton>
         )}
+
+        <TogglesContext.Consumer>
+          {({ unfilteredSearchResults }) =>
+            unfilteredSearchResults && (
+              <Space
+                h={{ size: 's', properties: ['margin-left'] }}
+                v={{ size: 'xs', properties: ['margin-top'] }}
+              >
+                <div className="flex">
+                  <Checkbox
+                    id="digitised"
+                    text={`Digitised`}
+                    value={'iiif-image,iiif-presentation'}
+                    name={`items.locations.locationType`}
+                    checked={
+                      (searchParams.itemsLocationsLocationType || []).join(
+                        ','
+                      ) === 'iiif-image,iiif-presentation'
+                    }
+                    onChange={event => {
+                      changeHandler();
+                    }}
+                  />
+                  <Space
+                    h={{ size: 's', properties: ['margin-left'] }}
+                    v={{ size: 's', properties: ['margin-top'] }}
+                  >
+                    <Icon
+                      name="info2"
+                      extraClasses="pointer"
+                      title={
+                        'Currently includes works with a IIIF Image or IIIF presentation manifest'
+                      }
+                    />
+                  </Space>
+                </div>
+              </Space>
+            )
+          }
+        </TogglesContext.Consumer>
       </Space>
+
       <Space v={{ size: 'l', properties: ['margin-top'] }} className="tokens">
         {(productionDatesFrom ||
           productionDatesTo ||

--- a/toggles/webapp/toggles.js
+++ b/toggles/webapp/toggles.js
@@ -2,9 +2,9 @@ module.exports = {
   toggles: [
     {
       id: 'unfilteredSearchResults',
-      title: 'Search the entire catalogue',
+      title: 'Complete catalogue search',
       defaultValue: false,
-      description: 'Search the entire catalogue without any filters',
+      description: 'Search the complete catalogue without any filters',
     },
     {
       id: 'stacksRequestService',


### PR DESCRIPTION
## Who is this for?
Internal researchers using the complete catalogue search that want to swap between things that have been digitised or not.

Behind a the complete catalogue search toggle.

## What is it doing for them?
This adds the filter to works that have a `iiif-image` or `iiif-presentation` `locationType.id`.

We're working on making it better, but for internal people, this i useful and fine for now.

![Screenshot 2020-01-15 at 13 12 03](https://user-images.githubusercontent.com/31692/72436778-3233c900-3799-11ea-947c-7752d23c9c3a.png)

This was a little more fiddly than I would have liked - the way we're doing the form and filters could probably be simplified. I haven't added a mobile filter as internally we use desktops mostly.
