### PR TITLE
deprecate TLS < 1.2

### DIFF
--- a/cache/cloudfront_dev.tf
+++ b/cache/cloudfront_dev.tf
@@ -8,7 +8,7 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
       origin_protocol_policy = "https-only"
       http_port              = "80"
       https_port             = "443"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
@@ -113,7 +113,7 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
   viewer_certificate {
     acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
+    minimum_protocol_version = "TLSv1.2"
   }
 
   restrictions {

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -18,7 +18,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
       origin_protocol_policy = "https-only"
       http_port              = "80"
       https_port             = "443"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
@@ -173,7 +173,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   viewer_certificate {
     acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
+    minimum_protocol_version = "TLSv1.2"
   }
 
   restrictions {

--- a/preview/terraform/cloudfront.tf
+++ b/preview/terraform/cloudfront.tf
@@ -13,12 +13,12 @@ resource "aws_cloudfront_distribution" "preview" {
       origin_protocol_policy = "https-only"
       http_port              = "80"
       https_port             = "443"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
-  enabled             = true
-  is_ipv6_enabled     = true
+  enabled         = true
+  is_ipv6_enabled = true
 
   aliases = ["preview.wellcomecollection.org"]
 
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "preview" {
   viewer_certificate {
     acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
+    minimum_protocol_version = "TLSv1.2"
   }
 
   restrictions {

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -7,7 +7,7 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "http-only"
-      origin_ssl_protocols   = ["TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
   viewer_certificate {
     acm_certificate_arn      = "${var.acm_certificate_arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1"
+    minimum_protocol_version = "TLSv1.2"
   }
 
   restrictions {


### PR DESCRIPTION
## Who is this for?
People who 💘 👮‍♀ 

https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-03.html
https://caniuse.com/#feat=tls1-2

## What is it doing for them?
Removing the old insecure ways of connecting to wc.org