### PR TITLE
Add useIsKeyboard hook to determine when to show visual focus

### DIFF
--- a/common/hooks/useIsKeyboard.js
+++ b/common/hooks/useIsKeyboard.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const useIsKeyboard = () => {
+  const [isKeyboard, setIsKeyboard] = useState(true);
+
+  function setIsKeyboardTrue() {
+    setIsKeyboard(true);
+  }
+
+  function setIsKeyboardFalse(event) {
+    setIsKeyboard(false);
+  }
+
+  useEffect(() => {
+    document.addEventListener('mousedown', setIsKeyboardFalse);
+    document.addEventListener('keydown', setIsKeyboardTrue);
+
+    return () => {
+      document.removeEventListener('keydown', setIsKeyboardTrue);
+      document.removeEventListener('mousedown', setIsKeyboardFalse);
+    };
+  });
+
+  return isKeyboard;
+};
+
+export default useIsKeyboard;

--- a/common/views/components/Checkbox/Checkbox.js
+++ b/common/views/components/Checkbox/Checkbox.js
@@ -4,6 +4,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { classNames } from '../../../utils/classnames';
 import Space from '../styled/Space';
+import useIsKeyboard from '../../../hooks/useIsKeyboard';
 
 const CheckboxLabel = styled.label.attrs({
   className: classNames({
@@ -52,16 +53,7 @@ const CheckboxInput = styled.input.attrs({
   }
 
   &:focus ~ ${CheckboxBox} {
-    border-color: ${props => props.theme.colors.black};
-  }
-
-  ~ span {
-    color: ${props => props.theme.colors.pewter};
-  }
-
-  &:focus ~ span,
-  &:checked ~ span {
-    color: ${props => props.theme.colors.black};
+    border-color: ${props => !props.hideFocus && props.theme.colors.black};
   }
 `;
 
@@ -75,9 +67,11 @@ type CheckboxProps = {|
 |};
 
 function Checkbox({ id, text, ...inputProps }: CheckboxProps) {
+  const isKeyboard = useIsKeyboard();
+
   return (
     <CheckboxLabel htmlFor={id}>
-      <CheckboxInput id={id} {...inputProps} />
+      <CheckboxInput id={id} {...inputProps} hideFocus={!isKeyboard} />
       <CheckboxBox />
       <Space as="span" h={{ size: 'xs', properties: ['margin-left'] }}>
         {text}


### PR DESCRIPTION
Closes #4983

Currently, when you open the format filters by clicking the format button, the first checkbox has a black border and the rest have grey borders.

This is because the first checkbox has keyboard focus at that point.

This is potentially confusing, making all bar the first input appear disabled.

Knowledge of what has keyboard focus is only beneficial to a user if they're using the keyboard to navigate, and this PR introduces a hook that tracks just that, applying/removing visible focus styles accordingly.

Also updates the checkbox label colour to black to further reduce the potential for is-this-disabled confusion. 

__before__
![image](https://user-images.githubusercontent.com/1394592/73002840-89bae000-3dfc-11ea-8d8a-6f1dbc5dc186.png)

__after__
![image](https://user-images.githubusercontent.com/1394592/73002743-6859f400-3dfc-11ea-8f90-ce4d1f834c43.png)
