### PR TITLE
Don't show loading indicator within viewer

### DIFF
--- a/common/views/components/LoadingIndicator/LoadingIndicator.js
+++ b/common/views/components/LoadingIndicator/LoadingIndicator.js
@@ -34,7 +34,11 @@ const LoadingIndicatorWrapper = styled.div.attrs({
 `;
 
 const LoadingIndicator = () => {
-  function handleRouteChangeStart() {
+  function handleRouteChangeStart(pathName) {
+    const isViewer = pathName.match(/canvas=/);
+
+    if (isViewer) return;
+
     NProgress.start();
   }
 


### PR DESCRIPTION
☝️ 

Is there a nicer way to do this?