### PR TITLE
update viewer certificate with correct TLS enum

### DIFF
--- a/cache/cloudfront_dev.tf
+++ b/cache/cloudfront_dev.tf
@@ -113,7 +113,7 @@ resource "aws_cloudfront_distribution" "devcache_wellcomecollection_org" {
   viewer_certificate {
     acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2"
+    minimum_protocol_version = "TLSv1.2_2018"
   }
 
   restrictions {

--- a/cache/cloudfront_prod.tf
+++ b/cache/cloudfront_prod.tf
@@ -173,7 +173,7 @@ resource "aws_cloudfront_distribution" "wellcomecollection_org" {
   viewer_certificate {
     acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2"
+    minimum_protocol_version = "TLSv1.2_2018"
   }
 
   restrictions {

--- a/preview/terraform/cloudfront.tf
+++ b/preview/terraform/cloudfront.tf
@@ -45,7 +45,7 @@ resource "aws_cloudfront_distribution" "preview" {
   viewer_certificate {
     acm_certificate_arn      = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2"
+    minimum_protocol_version = "TLSv1.2_2018"
   }
 
   restrictions {

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
   viewer_certificate {
     acm_certificate_arn      = "${var.acm_certificate_arn}"
     ssl_support_method       = "sni-only"
-    minimum_protocol_version = "TLSv1.2"
+    minimum_protocol_version = "TLSv1.2_2018"
   }
 
   restrictions {


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-viewercertificate.html#cfn-cloudfront-distribution-viewercertificate-minimumprotocolversion