### PR TITLE
Zoom image position

### DIFF
--- a/common/views/components/Header/Header.js
+++ b/common/views/components/Header/Header.js
@@ -3,6 +3,8 @@ import { withToggler } from '../../hocs/withToggler';
 import { font, classNames } from '../../../utils/classnames';
 import WellcomeCollectionBlack from '../../../icons/wellcome_collection_black';
 
+export const navHeight = 85;
+
 const links = [
   {
     href: '/visit-us',
@@ -44,7 +46,7 @@ const Header = withToggler(({ siteSection, toggle, isActive }: Props) => (
       'header--is-burger-open': isActive,
     })}
     style={{
-      height: '85px',
+      height: `${navHeight}px`,
     }}
   >
     <span className="visually-hidden">reset focus</span>

--- a/common/views/components/ViewerTopBar/ViewerTopBar.js
+++ b/common/views/components/ViewerTopBar/ViewerTopBar.js
@@ -18,7 +18,7 @@ import Space from '@weco/common/views/components/styled/Space';
 
 const TopBar = styled.div`
   position: relative;
-  z-index: 3;
+  z-index: 4;
   background: ${props => lighten(0.14, props.theme.colors.viewerBlack)};
   color: ${props => props.theme.colors.white};
   .title {

--- a/common/views/components/ViewerTopBar/ViewerTopBar.js
+++ b/common/views/components/ViewerTopBar/ViewerTopBar.js
@@ -18,7 +18,7 @@ import Space from '@weco/common/views/components/styled/Space';
 
 const TopBar = styled.div`
   position: relative;
-  z-index: 4;
+  z-index: 3;
   background: ${props => lighten(0.14, props.theme.colors.viewerBlack)};
   color: ${props => props.theme.colors.white};
   .title {

--- a/common/views/components/ZoomedImage/ZoomedImage.js
+++ b/common/views/components/ZoomedImage/ZoomedImage.js
@@ -7,10 +7,8 @@ import { trackEvent } from '@weco/common/utils/ga';
 import Raven from 'raven-js';
 import Control from '@weco/common/views/components/Buttons/Control/Control';
 import Space from '@weco/common/views/components/styled/Space';
-import {
-  headerHeight,
-  topBarHeight,
-} from '@weco/common/views/components/IIIFViewer/IIIFViewer';
+import { topBarHeight } from '@weco/common/views/components/IIIFViewer/IIIFViewer';
+import { navHeight } from '@weco/common/views/components/Header/Header';
 
 const ZoomedImageContainer = styled.div`
   position: fixed;
@@ -24,9 +22,9 @@ const ZoomedImageContainer = styled.div`
     height: ${props =>
       props.isFullscreen
         ? `calc(100vh - ${topBarHeight}px)`
-        : `calc(100vh - ${headerHeight}px)`};
+        : `calc(100vh - ${navHeight}px)`};
     top: ${props =>
-      props.isFullscreen ? `${topBarHeight}px` : `${headerHeight}px`};
+      props.isFullscreen ? `${topBarHeight}px` : `${navHeight}px`};
   }
 `;
 


### PR DESCRIPTION
Places ZoomedImage over the ViewerTopBar instead of under it, so users have to dismiss zoom before interacting with the links in the ViewerTopBar

Before:
![Screenshot 2020-01-24 at 13 45 13](https://user-images.githubusercontent.com/6051896/73073954-694c5d80-3eb0-11ea-9b8e-8a34b8353b7d.png)

After:
![Screenshot 2020-01-24 at 13 44 39](https://user-images.githubusercontent.com/6051896/73073965-6f423e80-3eb0-11ea-9309-ab2d73f8ac44.png)
