### PR TITLE
Bump header z-index to make sure it's above everything

### DIFF
--- a/common/styles/components/_header.scss
+++ b/common/styles/components/_header.scss
@@ -130,7 +130,7 @@ $tweakpoints: (
     top: 0;
     left: 0;
     right: 0;
-    z-index: 3;
+    z-index: 10;
   }
 }
 


### PR DESCRIPTION
Fixes #4603

This issue is now preventing the menu from being usable on works.

![image](https://user-images.githubusercontent.com/1394592/73174365-73b06680-40ff-11ea-813b-aab156d328be.png)
