### PR TITLE
Move async function out of memoised component

### DIFF
--- a/common/views/components/IIIFViewer/parts/MainViewer.js
+++ b/common/views/components/IIIFViewer/parts/MainViewer.js
@@ -43,14 +43,11 @@ const ItemRenderer = memo(({ style, index, data }) => {
     mainViewerRef,
     setActiveIndex,
     setIsLoading,
+    ocrText,
   } = data;
-  const [ocrText, setOcrText] = useState('');
   const [mainLoaded, setMainLoaded] = useState(false);
   const [thumbLoaded, setThumbLoaded] = useState(false);
   const currentCanvas = canvases[index];
-  getCanvasOcr(currentCanvas).then(text => {
-    text && setOcrText(text);
-  });
   const mainImageService = {
     '@id': currentCanvas ? currentCanvas.images[0].resource.service['@id'] : '',
   };
@@ -159,6 +156,7 @@ const MainViewer = ({
   const [isProgrammaticScroll, setIsProgrammaticScroll] = useState(false);
   const [newScrollOffset, setNewScrollOffset] = useState(0);
   const [firstRender, setFirstRender] = useState(true);
+  const [ocrText, setOcrText] = useState('');
   const firstRenderRef = useRef(firstRender);
   firstRenderRef.current = firstRender;
   const scrollVelocity = useScrollVelocity(newScrollOffset);
@@ -201,6 +199,8 @@ const MainViewer = ({
     }
   }
 
+  getCanvasOcr(canvases[canvasIndex]).then(t => setOcrText(t || ''));
+
   return (
     <FixedSizeList
       style={{ width: `${itemHeight}px`, margin: '0 auto' }}
@@ -215,6 +215,7 @@ const MainViewer = ({
         rotatedImages,
         setActiveIndex,
         setIsLoading,
+        ocrText,
       }}
       itemSize={itemHeight}
       onItemsRendered={debounceHandleOnItemsRendered.current}


### PR DESCRIPTION
We're seeing the following error inside the MainViewer component:

`Can't perform a React state update on an unmounted component.`

The `ItemRenderer` is a `React.Memo` component and as such should be completely described by reference to its `props` (i.e. it shouldn't have any side-effects).

This PR moves the asynchronous `getOcrText` function into the parent, and passes the resolved `ocrText` in as `data`, which solves the problem.