### PR TITLE
Do newsletter signup error handling better

### DIFF
--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -168,8 +168,8 @@ const NewsletterPromo = () => {
           );
         } else {
           try {
-            const { contact, ...anonymisedData } = json;
-            const errorData = JSON.stringify(anonymisedData);
+            const { contact, ...anonymousData } = json;
+            const errorData = JSON.stringify(anonymousData);
 
             Raven.captureException(
               new Error(`Newsletter signup error: ${errorData}`)

--- a/common/views/components/NewsletterPromo/NewsletterPromo.js
+++ b/common/views/components/NewsletterPromo/NewsletterPromo.js
@@ -150,6 +150,7 @@ const NewsletterPromo = () => {
 
     switch (status) {
       case 'ContactChallenged':
+      case 'ContactAdded':
       case 'PendingOptIn':
       case 'Subscribed':
         setIsSuccess(true);
@@ -161,16 +162,23 @@ const NewsletterPromo = () => {
       default:
         setIsError(true);
 
-        try {
-          const errorJson = JSON.stringify(json);
+        if (status) {
+          Raven.captureException(
+            new Error(`Newsletter signup error: ${status}`)
+          );
+        } else {
+          try {
+            const { contact, ...anonymisedData } = json;
+            const errorData = JSON.stringify(anonymisedData);
 
-          Raven.captureException(
-            new Error(`Newsletter signup error: ${errorJson}`)
-          );
-        } catch (error) {
-          Raven.captureException(
-            new Error(`Newsletter signup error: ${error}`)
-          );
+            Raven.captureException(
+              new Error(`Newsletter signup error: ${errorData}`)
+            );
+          } catch (error) {
+            Raven.captureException(
+              new Error(`Newsletter signup error: ${error}`)
+            );
+          }
         }
     }
 


### PR DESCRIPTION
Adding a supported `case` to the newsletter signup (based on an error message sent to Sentry).

Also anonymising any error data we do send to Sentry.
