### PR TITLE
Catch errors fetching Prismic

### DIFF
--- a/common/services/prismic/api.js
+++ b/common/services/prismic/api.js
@@ -20,7 +20,6 @@ function periodicallyUpdatePrismic() {
     try {
       memoizedPrismic = await Prismic.getApi(apiUri);
     } catch (error) {
-      // TODO: maybe remove once we've established the error(s)
       Raven.captureException(new Error(`Prismic error: ${error}`));
     }
   }, oneMinute);
@@ -37,21 +36,11 @@ export function isPreview(req: ?Request): boolean {
 
 export async function getPrismicApi(req: ?Request) {
   if (req && isPreview(req)) {
-    try {
-      const api = await Prismic.getApi(apiUri, { req });
-      return api;
-    } catch (error) {
-      // TODO: maybe remove once we've established the error(s)
-      Raven.captureException(new Error(`Prismic error: ${error}`));
-    }
+    const api = await Prismic.getApi(apiUri, { req });
+    return api;
   } else {
     if (!memoizedPrismic) {
-      try {
-        memoizedPrismic = await Prismic.getApi(apiUri);
-      } catch (error) {
-        // TODO: maybe remove once we've established the error(s)
-        Raven.captureException(new Error(`Prismic error: ${error}`));
-      }
+      memoizedPrismic = await Prismic.getApi(apiUri);
     }
     return memoizedPrismic;
   }


### PR DESCRIPTION
We've seen quite a few more errors in Sentry recently most likely coming from our fetching Prismic every minute (which is currently not wrapped in a `try catch`).

This PR will report the _actual_ error to Sentry so that we can act on it if there's anything we could do (instead of 'uncaught error in Promise').

If it transpires the problem lies solely with Prismic, we can 1. let them know and 2. stop pushing the errors through to Sentry (where they're threatening to soak up our quota).