### PR TITLE
Don't show cancel filter link if there aren't any results

### DIFF
--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -185,93 +185,100 @@ const SearchFiltersDesktop = ({
       <Space v={{ size: 'l', properties: ['margin-top'] }} className="tokens">
         {(productionDatesFrom ||
           productionDatesTo ||
-          workTypeInUrlArray.length > 0) && (
-          <div className={classNames({ [font('hnl', 5)]: true })}>
-            <Space
-              v={{
-                size: 'l',
-                properties: ['margin-top', 'margin-bottom'],
-              }}
-            >
-              <h2 className="inline">
-                <Space
-                  as="span"
-                  h={{
-                    size: 'm',
-                    properties: ['margin-right'],
-                  }}
-                >
-                  Active filters:
-                </Space>
-              </h2>
-              {productionDatesFrom && (
-                <NextLink
-                  passHref
-                  {...worksUrl({
-                    ...searchParams,
-                    page: 1,
-                    productionDatesFrom: null,
-                  })}
-                >
-                  <a>
-                    <CancelFilter text={`From ${productionDatesFrom}`} />
-                  </a>
-                </NextLink>
-              )}
-              {productionDatesTo && (
-                <NextLink
-                  passHref
-                  {...worksUrl({
-                    ...searchParams,
-                    page: 1,
-                    productionDatesTo: null,
-                  })}
-                >
-                  <a>
-                    <CancelFilter text={`To ${productionDatesTo}`} />
-                  </a>
-                </NextLink>
-              )}
-
-              {workTypeInUrlArray.map(id => {
-                const workTypeObject = workTypeFilters.find(({ data }) => {
-                  return data.id === id;
-                });
-                return (
+          workTypeInUrlArray.length > 0) &&
+          workTypeFilters.length > 0 && (
+            <div className={classNames({ [font('hnl', 5)]: true })}>
+              <Space
+                v={{
+                  size: 'l',
+                  properties: ['margin-top', 'margin-bottom'],
+                }}
+              >
+                <h2 className="inline">
+                  <Space
+                    as="span"
+                    h={{
+                      size: 'm',
+                      properties: ['margin-right'],
+                    }}
+                  >
+                    Active filters:
+                  </Space>
+                </h2>
+                {productionDatesFrom && (
                   <NextLink
-                    key={id}
+                    passHref
                     {...worksUrl({
                       ...searchParams,
-                      workType: searchParams.workType.filter(
-                        w => w !== workTypeObject.data.id
-                      ),
                       page: 1,
+                      productionDatesFrom: null,
                     })}
                   >
                     <a>
-                      <CancelFilter text={workTypeObject.data.label} />
+                      <CancelFilter text={`From ${productionDatesFrom}`} />
                     </a>
                   </NextLink>
-                );
-              })}
-              <NextLink
-                passHref
-                {...worksUrl({
-                  ...searchParams,
-                  workType: null,
-                  page: 1,
-                  productionDatesFrom: null,
-                  productionDatesTo: null,
-                  itemsLocationsLocationType: null,
+                )}
+                {productionDatesTo && (
+                  <NextLink
+                    passHref
+                    {...worksUrl({
+                      ...searchParams,
+                      page: 1,
+                      productionDatesTo: null,
+                    })}
+                  >
+                    <a>
+                      <CancelFilter text={`To ${productionDatesTo}`} />
+                    </a>
+                  </NextLink>
+                )}
+
+                {workTypeInUrlArray.map(id => {
+                  const workTypeObject = workTypeFilters.find(({ data }) => {
+                    return data.id === id;
+                  });
+
+                  return (
+                    workTypeObject && (
+                      <NextLink
+                        key={id}
+                        {...worksUrl({
+                          ...searchParams,
+                          workType: searchParams.workType.filter(
+                            w => w !== workTypeObject.data.id
+                          ),
+                          page: 1,
+                        })}
+                      >
+                        <a>
+                          <CancelFilter text={workTypeObject.data.label} />
+                        </a>
+                      </NextLink>
+                    )
+                  );
                 })}
-              >
-                <a>
-                  <CancelFilter text={'Clear all'} />
-                </a>
-              </NextLink>
-            </Space>
-          </div>
-        )}
+
+                {workTypeFilters.length > 0 && (
+                  <NextLink
+                    passHref
+                    {...worksUrl({
+                      ...searchParams,
+                      workType: null,
+                      page: 1,
+                      productionDatesFrom: null,
+                      productionDatesTo: null,
+                      itemsLocationsLocationType: null,
+                    })}
+                  >
+                    <a>
+                      <CancelFilter text={'Clear all'} />
+                    </a>
+                  </NextLink>
+                )}
+              </Space>
+            </div>
+          )}
       </Space>
     </>
   );


### PR DESCRIPTION
This fixes a 500 we're seeing if there are zero results.

__UX issue for consideration__
If we do a search from `/works` then apply a `workType` filter, any subsequent searches will also have that filter applied. But only if the search returns at least one result. I.e. if one of the subsequent searches doesn't return results, the search scope is then broadened back out to all `workType`s (which might not be immediately apparent to the user).