### PR TITLE
Better aggregation data

### DIFF
--- a/common/services/data/work-type-aggregations.js
+++ b/common/services/data/work-type-aggregations.js
@@ -1,0 +1,117 @@
+export default [
+  {
+    data: { id: 'a', label: 'Books', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'q', label: 'Digital Images', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'x', label: 'E-manuscripts, Asian', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'l', label: 'Ephemera', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'e', label: 'Maps', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'k', label: 'Pictures', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'w', label: 'Student dissertations', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'r', label: '3-D Objects', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'm', label: 'CD-Roms', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'v', label: 'E-books', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 's', label: 'E-sound', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'd', label: 'Journals', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'p', label: 'Mixed materials', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'i', label: 'Sound', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'g', label: 'Videorecordings', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'h', label: 'Archives and manuscripts', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'n', label: 'Cinefilm', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'j', label: 'E-journals', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'f', label: 'E-videos', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'b', label: 'Manuscripts, Asian', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'c', label: 'Music', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'u', label: 'Standing order', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+  {
+    data: { id: 'z', label: 'Web sites', type: 'WorkType' },
+    count: 0,
+    type: 'AggregationBucket',
+  },
+];

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -185,100 +185,97 @@ const SearchFiltersDesktop = ({
       <Space v={{ size: 'l', properties: ['margin-top'] }} className="tokens">
         {(productionDatesFrom ||
           productionDatesTo ||
-          workTypeInUrlArray.length > 0) &&
-          workTypeFilters.length > 0 && (
-            <div className={classNames({ [font('hnl', 5)]: true })}>
-              <Space
-                v={{
-                  size: 'l',
-                  properties: ['margin-top', 'margin-bottom'],
-                }}
-              >
-                <h2 className="inline">
-                  <Space
-                    as="span"
-                    h={{
-                      size: 'm',
-                      properties: ['margin-right'],
-                    }}
-                  >
-                    Active filters:
-                  </Space>
-                </h2>
-                {productionDatesFrom && (
+          workTypeInUrlArray.length > 0) && (
+          <div className={classNames({ [font('hnl', 5)]: true })}>
+            <Space
+              v={{
+                size: 'l',
+                properties: ['margin-top', 'margin-bottom'],
+              }}
+            >
+              <h2 className="inline">
+                <Space
+                  as="span"
+                  h={{
+                    size: 'm',
+                    properties: ['margin-right'],
+                  }}
+                >
+                  Active filters:
+                </Space>
+              </h2>
+              {productionDatesFrom && (
+                <NextLink
+                  passHref
+                  {...worksUrl({
+                    ...searchParams,
+                    page: 1,
+                    productionDatesFrom: null,
+                  })}
+                >
+                  <a>
+                    <CancelFilter text={`From ${productionDatesFrom}`} />
+                  </a>
+                </NextLink>
+              )}
+              {productionDatesTo && (
+                <NextLink
+                  passHref
+                  {...worksUrl({
+                    ...searchParams,
+                    page: 1,
+                    productionDatesTo: null,
+                  })}
+                >
+                  <a>
+                    <CancelFilter text={`To ${productionDatesTo}`} />
+                  </a>
+                </NextLink>
+              )}
+
+              {workTypeInUrlArray.map(id => {
+                const workTypeObject = workTypeFilters.find(({ data }) => {
+                  return data.id === id;
+                });
+
+                return (
                   <NextLink
-                    passHref
+                    key={id}
                     {...worksUrl({
                       ...searchParams,
+                      workType: searchParams.workType.filter(
+                        w => w !== workTypeObject.data.id
+                      ),
                       page: 1,
-                      productionDatesFrom: null,
                     })}
                   >
                     <a>
-                      <CancelFilter text={`From ${productionDatesFrom}`} />
+                      <CancelFilter text={workTypeObject.data.label} />
                     </a>
                   </NextLink>
-                )}
-                {productionDatesTo && (
-                  <NextLink
-                    passHref
-                    {...worksUrl({
-                      ...searchParams,
-                      page: 1,
-                      productionDatesTo: null,
-                    })}
-                  >
-                    <a>
-                      <CancelFilter text={`To ${productionDatesTo}`} />
-                    </a>
-                  </NextLink>
-                )}
+                );
+              })}
 
-                {workTypeInUrlArray.map(id => {
-                  const workTypeObject = workTypeFilters.find(({ data }) => {
-                    return data.id === id;
-                  });
-
-                  return (
-                    workTypeObject && (
-                      <NextLink
-                        key={id}
-                        {...worksUrl({
-                          ...searchParams,
-                          workType: searchParams.workType.filter(
-                            w => w !== workTypeObject.data.id
-                          ),
-                          page: 1,
-                        })}
-                      >
-                        <a>
-                          <CancelFilter text={workTypeObject.data.label} />
-                        </a>
-                      </NextLink>
-                    )
-                  );
-                })}
-
-                {workTypeFilters.length > 0 && (
-                  <NextLink
-                    passHref
-                    {...worksUrl({
-                      ...searchParams,
-                      workType: null,
-                      page: 1,
-                      productionDatesFrom: null,
-                      productionDatesTo: null,
-                      itemsLocationsLocationType: null,
-                    })}
-                  >
-                    <a>
-                      <CancelFilter text={'Clear all'} />
-                    </a>
-                  </NextLink>
-                )}
-              </Space>
-            </div>
-          )}
+              {workTypeFilters.length > 0 && (
+                <NextLink
+                  passHref
+                  {...worksUrl({
+                    ...searchParams,
+                    workType: null,
+                    page: 1,
+                    productionDatesFrom: null,
+                    productionDatesTo: null,
+                    itemsLocationsLocationType: null,
+                  })}
+                >
+                  <a>
+                    <CancelFilter text={'Clear all'} />
+                  </a>
+                </NextLink>
+              )}
+            </Space>
+          </div>
+        )}
       </Space>
     </>
   );


### PR DESCRIPTION
Reintroducing an `allAppliedFilters` object so that we can show users the filter(s) they have applied at the point when no results are returned.

Would it be better to get all the workTypes from the API? e.g. could a call with the aggregations query parameter set always return all possible workTypes, and not just those with a count greater than zero?

Or maybe a middleware that hits the base `/works` URL with the aggregations query parameter which will be guaranteed to return all the workTypes that are in the API?
