### PR TITLE
Handle zero count aggregation buckets

### DIFF
--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -122,9 +122,8 @@ const SearchFiltersDesktop = ({
               })}
             >
               {workTypeFilters.map(workType => {
-                const isChecked =
-                  workTypeInUrlArray &&
-                  workTypeInUrlArray.includes(workType.data.id);
+                const isChecked = workTypeInUrlArray.includes(workType.data.id);
+
                 return (
                   (workType.count > 0 || isChecked) && (
                     <li key={workType.data.id}>

--- a/common/views/components/SearchFilters/SearchFiltersDesktop.js
+++ b/common/views/components/SearchFilters/SearchFiltersDesktop.js
@@ -52,6 +52,9 @@ const SearchFiltersDesktop = ({
   productionDatesTo,
   workTypeInUrlArray,
 }: SearchFiltersSharedProps) => {
+  const showWorkTypeFilters =
+    workTypeFilters.some(f => f.count > 0) || workTypeInUrlArray.length > 0;
+
   return (
     <>
       <Space
@@ -111,7 +114,7 @@ const SearchFiltersDesktop = ({
           </DropdownButton>
         </Space>
 
-        {workTypeFilters.length > 0 && (
+        {showWorkTypeFilters && (
           <DropdownButton label={'Formats'}>
             <ul
               className={classNames({
@@ -119,22 +122,22 @@ const SearchFiltersDesktop = ({
               })}
             >
               {workTypeFilters.map(workType => {
+                const isChecked =
+                  workTypeInUrlArray &&
+                  workTypeInUrlArray.includes(workType.data.id);
                 return (
-                  <li key={workType.data.id}>
-                    <Checkbox
-                      id={workType.data.id}
-                      text={`${workType.data.label} (${workType.count})`}
-                      value={workType.data.id}
-                      name={`workType`}
-                      checked={
-                        workTypeInUrlArray &&
-                        workTypeInUrlArray.includes(workType.data.id)
-                      }
-                      onChange={event => {
-                        changeHandler();
-                      }}
-                    />
-                  </li>
+                  (workType.count > 0 || isChecked) && (
+                    <li key={workType.data.id}>
+                      <Checkbox
+                        id={workType.data.id}
+                        text={`${workType.data.label} (${workType.count})`}
+                        value={workType.data.id}
+                        name={`workType`}
+                        checked={isChecked}
+                        onChange={changeHandler}
+                      />
+                    </li>
+                  )
                 );
               })}
             </ul>

--- a/common/views/components/SearchFilters/SearchFiltersMobile.js
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.js
@@ -267,9 +267,10 @@ const SearchFiltersMobile = ({
                     })}
                   >
                     {workTypeFilters.map(workType => {
-                      const isChecked =
-                        workTypeInUrlArray &&
-                        workTypeInUrlArray.includes(workType.data.id);
+                      const isChecked = workTypeInUrlArray.includes(
+                        workType.data.id
+                      );
+
                       return (
                         (workType.count > 0 || isChecked) && (
                           <Space

--- a/common/views/components/SearchFilters/SearchFiltersMobile.js
+++ b/common/views/components/SearchFilters/SearchFiltersMobile.js
@@ -199,6 +199,9 @@ const SearchFiltersMobile = ({
       closeFiltersButtonRef.current.focus();
   }
 
+  const showWorkTypeFilters =
+    workTypeFilters.some(f => f.count > 0) || workTypeInUrlArray.length > 0;
+
   return (
     <Space v={{ size: 'l', properties: ['margin-top', 'margin-bottom'] }}>
       <OpenFiltersButton
@@ -255,7 +258,7 @@ const SearchFiltersMobile = ({
                   }}
                 />
               </FilterSection>
-              {workTypeFilters.length > 0 && (
+              {showWorkTypeFilters && (
                 <FilterSection>
                   <h3 className="h3">Formats</h3>
                   <ul
@@ -264,26 +267,26 @@ const SearchFiltersMobile = ({
                     })}
                   >
                     {workTypeFilters.map(workType => {
+                      const isChecked =
+                        workTypeInUrlArray &&
+                        workTypeInUrlArray.includes(workType.data.id);
                       return (
-                        <Space
-                          as="li"
-                          v={{ size: 'l', properties: ['margin-bottom'] }}
-                          key={`mobile-${workType.data.id}`}
-                        >
-                          <Checkbox
-                            id={`mobile-${workType.data.id}`}
-                            text={`${workType.data.label} (${workType.count})`}
-                            value={workType.data.id}
-                            name={`workType`}
-                            checked={
-                              workTypeInUrlArray &&
-                              workTypeInUrlArray.includes(workType.data.id)
-                            }
-                            onChange={event => {
-                              changeHandler();
-                            }}
-                          />
-                        </Space>
+                        (workType.count > 0 || isChecked) && (
+                          <Space
+                            as="li"
+                            v={{ size: 'l', properties: ['margin-bottom'] }}
+                            key={`mobile-${workType.data.id}`}
+                          >
+                            <Checkbox
+                              id={`mobile-${workType.data.id}`}
+                              text={`${workType.data.label} (${workType.count})`}
+                              value={workType.data.id}
+                              name={`workType`}
+                              checked={isChecked}
+                              onChange={changeHandler}
+                            />
+                          </Space>
+                        )
                       );
                     })}
                   </ul>


### PR DESCRIPTION
__Don't merge – needs wellcometrust/catalogue#391 to be deployed__

When the above PR makes it into the API, we will see all workType filters in the dropdown, even when they have an aggregation count of `0`.

This PR will hide those zero-count filters unless they have already been selected.