### PR TITLE
encode URL params to API

### DIFF
--- a/catalogue/webapp/services/catalogue/works.js
+++ b/catalogue/webapp/services/catalogue/works.js
@@ -50,7 +50,7 @@ export async function getWorks({
 }: GetWorksProps): Promise<CatalogueResultsList | CatalogueApiError> {
   const filterQueryString = Object.keys(removeEmptyProps(params)).map(key => {
     const val = params[key];
-    return `${key}=${val}`;
+    return `${key}=${encodeURIComponent(val)}`;
   });
   const url =
     `${rootUris[env]}/v2/works?include=${worksIncludes.join(',')}` +


### PR DESCRIPTION
The API expects URLs to be encoded.
This help with that.