### PR TITLE
return 500 if getInitialProps throws an error

### DIFF
--- a/common/views/pages/_app.js
+++ b/common/views/pages/_app.js
@@ -148,7 +148,14 @@ export default class WecoApp extends App {
     if (Component.getInitialProps) {
       ctx.query.toggles = toggles;
       ctx.query.isPreview = isPreview;
-      pageProps = await Component.getInitialProps(ctx);
+
+      // If the getInitialProps fails, we should propegate this failure through to the repsonse.
+      try {
+        pageProps = await Component.getInitialProps(ctx);
+      } catch (error) {
+        pageProps.statusCode = 500;
+        pageProps.error = error;
+      }
 
       // If we override the statusCode from getInitialProps, make sure we
       // set that on the server response too

--- a/content/webapp/pages/articles.js
+++ b/content/webapp/pages/articles.js
@@ -5,7 +5,6 @@ import type {
   PaginatedResults,
   PrismicApiError,
 } from '@weco/common/services/prismic/types';
-import { Component } from 'react';
 import { getArticles } from '@weco/common/services/prismic/articles';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
 import { articleLd } from '@weco/common/utils/json-ld';
@@ -19,60 +18,55 @@ type Props = {|
 
 const pageDescription =
   'Our words and pictures explore the connections between science, medicine, life and art. Dive into one no matter where in the world you are.';
-export class ArticlesPage extends Component<Props> {
-  static getInitialProps = async (
-    ctx: Context
-  ): Promise<?Props | PrismicApiError> => {
-    const { page = 1 } = ctx.query;
-    const articles = await getArticles(ctx.req, { page });
-    if (articles && articles.results.length > 0) {
-      return {
-        articles,
-      };
-    } else {
-      return { statusCode: 404 };
-    }
+
+const ArticlesPage = ({ articles }: Props) => {
+  const firstArticle = articles.results[0];
+
+  return (
+    <PageLayout
+      title={'Articles'}
+      description={pageDescription}
+      url={{ pathname: `/articles` }}
+      jsonLd={articles.results.map(articleLd)}
+      openGraphType={'website'}
+      siteSection={'stories'}
+      imageUrl={
+        firstArticle &&
+        firstArticle.image &&
+        convertImageUri(firstArticle.image.contentUrl, 800)
+      }
+      imageAltText={
+        firstArticle && firstArticle.image && firstArticle.image.alt
+      }
+    >
+      <SpacingSection>
+        <LayoutPaginatedResults
+          showFreeAdmissionMessage={false}
+          title={'Articles'}
+          description={[
+            {
+              type: 'paragraph',
+              text: pageDescription,
+              spans: [],
+            },
+          ]}
+          paginatedResults={articles}
+          paginationRoot={'articles'}
+        />
+      </SpacingSection>
+    </PageLayout>
+  );
+};
+
+ArticlesPage.getInitialProps = async (
+  ctx: Context
+): Promise<?Props | PrismicApiError> => {
+  const { page = 1 } = ctx.query;
+  const articles = await getArticles(ctx.req, { page });
+
+  return {
+    articles,
   };
-
-  render() {
-    const { articles } = this.props;
-    const firstArticle = articles.results[0];
-
-    return (
-      <PageLayout
-        title={'Articles'}
-        description={pageDescription}
-        url={{ pathname: `/articles` }}
-        jsonLd={articles.results.map(articleLd)}
-        openGraphType={'website'}
-        siteSection={'stories'}
-        imageUrl={
-          firstArticle &&
-          firstArticle.image &&
-          convertImageUri(firstArticle.image.contentUrl, 800)
-        }
-        imageAltText={
-          firstArticle && firstArticle.image && firstArticle.image.alt
-        }
-      >
-        <SpacingSection>
-          <LayoutPaginatedResults
-            showFreeAdmissionMessage={false}
-            title={'Articles'}
-            description={[
-              {
-                type: 'paragraph',
-                text: pageDescription,
-                spans: [],
-              },
-            ]}
-            paginatedResults={articles}
-            paginationRoot={'articles'}
-          />
-        </SpacingSection>
-      </PageLayout>
-    );
-  }
-}
+};
 
 export default ArticlesPage;


### PR DESCRIPTION
## Who is this for?
People not wanting to see error pages and rather get stale cache pages

## What is it doing for them?
Makes sure the status code propagates down to the response level.

The `_app` page is probably a really good place to start looking at testing as:
* It needs a lot of work as it's composed of lots of hangover from nunjucks days
* Moving it to typescript means it will have to be refractored with type properly
* If something is wrong here, the whole app borks.

