### PR TITLE
move s3 websites to tf0.12

### DIFF
--- a/assets/terraform/terraform.tf
+++ b/assets/terraform/terraform.tf
@@ -12,7 +12,7 @@ provider "aws" {
   version = "~> 2.0"
   region  = "eu-west-1"
   assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
@@ -21,7 +21,7 @@ provider "aws" {
   region  = "us-east-1"
   alias   = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 

--- a/assets/terraform/terraform.tf
+++ b/assets/terraform/terraform.tf
@@ -1,6 +1,4 @@
 terraform {
-  required_version = ">= 0.11"
-
   backend "s3" {
     key            = "build-state/client.tfstate"
     dynamodb_table = "terraform-locktable"
@@ -11,30 +9,37 @@ terraform {
 }
 
 provider "aws" {
-  version = "~> 2.2"
+  version = "~> 2.0"
   region  = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+  }
 }
 
 provider "aws" {
-  version = "~> 2.2"
+  version = "~> 2.0"
   region  = "us-east-1"
   alias   = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+  }
 }
 
 provider "template" {
-  version = "~> 2.0"
+  version = "~> 2.1"
 }
 
 data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
   domain   = "wellcomecollection.org"
 }
 
 module "static" {
   source              = "../../terraform-modules/https_s3_website"
   website_uri         = "i.wellcomecollection.org"
-  acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
+  acm_certificate_arn = data.aws_acm_certificate.wellcomecollection_ssl_cert.arn
   min_ttl             = 86400
   default_ttl         = 86400
   max_ttl             = 86400
 }
+

--- a/assets/terraform/versions.tf
+++ b/assets/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/cardigan/terraform/terraform.tf
+++ b/cardigan/terraform/terraform.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_version = ">= 0.11"
+
+  backend "s3" {
+    key            = "build-state/cardigan.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+    bucket         = "wellcomecollection-infra"
+    role_arn       = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.0"
+  region  = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}
+
+provider "aws" {
+  version = "~> 2.1"
+  region  = "us-east-1"
+  alias   = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
+  }
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
+data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
+  provider = aws.us-east-1
+  domain   = "wellcomecollection.org"
+}
+
+module "cardigan" {
+  source              = "../../terraform-modules/https_s3_website"
+  website_uri         = "cardigan.wellcomecollection.org"
+  acm_certificate_arn = data.aws_acm_certificate.wellcomecollection_ssl_cert.arn
+}
+

--- a/dash/terraform/terraform.tf
+++ b/dash/terraform/terraform.tf
@@ -34,12 +34,13 @@ provider "template" {
 }
 
 data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
   domain   = "wellcomecollection.org"
 }
 
 module "dash" {
   source              = "../../terraform-modules/https_s3_website"
   website_uri         = "dash.wellcomecollection.org"
-  acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
+  acm_certificate_arn = data.aws_acm_certificate.wellcomecollection_ssl_cert.arn
 }
+

--- a/dash/terraform/versions.tf
+++ b/dash/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/static/terraform/terraform.tf
+++ b/static/terraform/terraform.tf
@@ -1,32 +1,41 @@
 terraform {
-  required_version = ">= 0.9"
-
   backend "s3" {
     key            = "build-state/static.tfstate"
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
+    role_arn       = "arn:aws:iam::130871440101:role/experience-admin"
+  }
+}
+
+provider "template" {
+  version = "~> 2.1"
+}
+
+provider "aws" {
+  version = "~> 2.0"
+  region  = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
   }
 }
 
 provider "aws" {
-  version = "~> 1.0"
-  region  = "eu-west-1"
-}
-
-provider "aws" {
-  version = "~> 1.0"
+  version = "~> 2.0"
   region  = "us-east-1"
   alias   = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+  }
 }
 
 data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
   domain   = "wellcomecollection.org"
 }
 
 module "static" {
-  source = "../../terraform-modules/https_s3_website"
-  website_uri = "static.wellcomecollection.org"
-  acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
+  source              = "../../terraform-modules/https_s3_website"
+  website_uri         = "static.wellcomecollection.org"
+  acm_certificate_arn = data.aws_acm_certificate.wellcomecollection_ssl_cert.arn
 }

--- a/static/terraform/terraform.tf
+++ b/static/terraform/terraform.tf
@@ -4,7 +4,7 @@ terraform {
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
-    role_arn       = "arn:aws:iam::130871440101:role/experience-admin"
+    role_arn       = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
@@ -16,7 +16,7 @@ provider "aws" {
   version = "~> 2.0"
   region  = "eu-west-1"
   assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
@@ -25,7 +25,7 @@ provider "aws" {
   region  = "us-east-1"
   alias   = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 

--- a/static/terraform/versions.tf
+++ b/static/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/terraform-modules/https_s3_website/cloudfront.tf
+++ b/terraform-modules/https_s3_website/cloudfront.tf
@@ -1,7 +1,11 @@
+locals {
+  s3_origin_id = "S3-${var.website_uri}"
+}
+
 resource "aws_cloudfront_distribution" "https_s3_website" {
   origin {
-    domain_name = "${aws_s3_bucket.website_bucket.website_endpoint}"
-    origin_id   = "S3-${var.website_uri}"
+    domain_name = aws_s3_bucket.website_bucket.website_endpoint
+    origin_id   = local.s3_origin_id
 
     custom_origin_config {
       http_port              = 80
@@ -14,17 +18,17 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
   enabled             = true
   default_root_object = "index.html"
   is_ipv6_enabled     = true
-  aliases             = ["${var.website_uri}"]
+  aliases             = [var.website_uri]
 
   default_cache_behavior {
     allowed_methods        = ["HEAD", "GET", "OPTIONS"]
     cached_methods         = ["HEAD", "GET", "OPTIONS"]
     viewer_protocol_policy = "redirect-to-https"
-    target_origin_id       = "S3-${var.website_uri}"
+    target_origin_id       = local.s3_origin_id
     compress               = true
-    min_ttl                = "${var.min_ttl}"
-    default_ttl            = "${var.default_ttl}"
-    max_ttl                = "${var.max_ttl}"
+    min_ttl                = var.min_ttl
+    default_ttl            = var.default_ttl
+    max_ttl                = var.max_ttl
 
     forwarded_values {
       query_string = false
@@ -44,7 +48,7 @@ resource "aws_cloudfront_distribution" "https_s3_website" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = "${var.acm_certificate_arn}"
+    acm_certificate_arn      = var.acm_certificate_arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2018"
   }

--- a/terraform-modules/https_s3_website/s3.tf
+++ b/terraform-modules/https_s3_website/s3.tf
@@ -1,15 +1,15 @@
 data "template_file" "website_policy" {
-  template = "${file("${path.module}/s3-website-policy.json")}"
+  template = file("${path.module}/s3-website-policy.json")
 
-  vars {
-    website_uri = "${var.website_uri}"
+  vars = {
+    website_uri = var.website_uri
   }
 }
 
 resource "aws_s3_bucket" "website_bucket" {
-  bucket = "${var.website_uri}"
+  bucket = var.website_uri
   acl    = "public-read"
-  policy = "${data.template_file.website_policy.rendered}"
+  policy = data.template_file.website_policy.rendered
 
   website {
     index_document = "index.html"

--- a/toggles/terraform/terraform.tf
+++ b/toggles/terraform/terraform.tf
@@ -6,18 +6,25 @@ terraform {
     dynamodb_table = "terraform-locktable"
     region         = "eu-west-1"
     bucket         = "wellcomecollection-infra"
+    role_arn       = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
 provider "aws" {
-  version = "~> 2.1"
+  version = "~> 2.0"
   region  = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+  }
 }
 
 provider "aws" {
   version = "~> 2.1"
   region  = "us-east-1"
   alias   = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+  }
 }
 
 provider "template" {
@@ -25,12 +32,13 @@ provider "template" {
 }
 
 data "aws_acm_certificate" "wellcomecollection_ssl_cert" {
-  provider = "aws.us-east-1"
+  provider = aws.us-east-1
   domain   = "wellcomecollection.org"
 }
 
 module "static" {
   source              = "../../terraform-modules/https_s3_website"
   website_uri         = "toggles.wellcomecollection.org"
-  acm_certificate_arn = "${data.aws_acm_certificate.wellcomecollection_ssl_cert.arn}"
+  acm_certificate_arn = data.aws_acm_certificate.wellcomecollection_ssl_cert.arn
 }
+

--- a/toggles/terraform/terraform.tf
+++ b/toggles/terraform/terraform.tf
@@ -14,7 +14,7 @@ provider "aws" {
   version = "~> 2.0"
   region  = "eu-west-1"
   assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 
@@ -23,7 +23,7 @@ provider "aws" {
   region  = "us-east-1"
   alias   = "us-east-1"
   assume_role {
-    role_arn = "arn:aws:iam::130871440101:role/experience-admin"
+    role_arn = "arn:aws:iam::130871440101:role/experience-developer"
   }
 }
 

--- a/toggles/terraform/versions.tf
+++ b/toggles/terraform/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Ref #5070 

It does mean that we are using two versions of terraform.
This will hopefully not be for long.

How I get around this is alias `tf => terraform0.12` and leave `terraform => terraform0.11`.