### PR TITLE
OPL stands for Open Parliament License not Open Publication License

### DIFF
--- a/common/utils/get-license-info.js
+++ b/common/utils/get-license-info.js
@@ -95,8 +95,9 @@ export const licenseMap = {
     humanReadableText: [],
   },
   opl: {
-    url: 'http://opencontent.org/openpub/',
-    text: 'Open Publication License',
+    url:
+      'https://www.parliament.uk/site-information/copyright-parliament/open-parliament-licence/',
+    text: 'Open Parliament License',
     icons: [],
     humanReadableText: [],
   },


### PR DESCRIPTION
Corresponding catalogue PR https://github.com/wellcometrust/catalogue/pull/403