### PR TITLE
Work card thumbnails

### DIFF
--- a/catalogue/webapp/components/WorkCard/WorkCard.js
+++ b/catalogue/webapp/components/WorkCard/WorkCard.js
@@ -9,9 +9,8 @@ import LinkLabels from '@weco/common/views/components/LinkLabels/LinkLabels';
 import { getProductionDates, getWorkTypeIcon } from '@weco/common/utils/works';
 import { trackEvent } from '@weco/common/utils/ga';
 import { workLink } from '@weco/common/services/catalogue/routes';
-import IIIFResponsiveImage from '@weco/common/views/components/IIIFResponsiveImage/IIIFResponsiveImage';
+import Image from '@weco/common/views/components/Image/Image';
 import { convertImageUri } from '@weco/common/utils/convert-image-uri';
-import { imageSizes } from '@weco/common/utils/image-sizes';
 import Space, {
   type SpaceComponentProps,
 } from '@weco/common/views/components/styled/Space';
@@ -155,24 +154,13 @@ const WorkCard = ({ work }: Props) => {
             !isPdfThumbnail(work.thumbnail) &&
             ['k', 'q'].includes(work.workType.id) && ( // Only show thumbnails for 'Pictures' and 'Digital Images' for now
                 <Preview h={{ size: 'm', properties: ['margin-left'] }}>
-                  <IIIFResponsiveImage
-                    width={178}
-                    src={convertImageUri(work.thumbnail.url, 178)}
-                    srcSet={imageSizes(2048)
-                      .map(width => {
-                        return `${convertImageUri(
-                          work.thumbnail.url,
-                          width
-                        )} ${width}w`;
-                      })
-                      .join(',')}
-                    sizes={`178px`}
+                  <Image
+                    defaultSize={178}
                     alt={''}
-                    lang={null}
-                    extraClasses={classNames({
-                      'h-center': true,
-                    })}
-                    isLazy={true}
+                    contentUrl={convertImageUri(work.thumbnail.url, 178)}
+                    tasl={null}
+                    srcsetRequired={false}
+                    style={{ margin: 'auto' }}
                   />
                 </Preview>
               )}

--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -3,7 +3,6 @@ import type { Tasl } from '../../../model/tasl';
 import { classNames } from '../../../utils/classnames';
 import { convertImageUri } from '../../../utils/convert-image-uri';
 import { imageSizes, supportedSizes } from '../../../utils/image-sizes';
-import { Fragment } from 'react';
 import type { ImageType } from '../../../model/image';
 
 export type Props = {|
@@ -12,7 +11,6 @@ export type Props = {|
   alt: string,
   tasl: ?Tasl,
   height?: number,
-  clipPathClass?: ?string,
   caption?: string,
   lazyload?: boolean,
   sizesQueries?: string,
@@ -31,7 +29,7 @@ const Image = (props: Props) => {
     [`${props.extraClasses || ''}`]: Boolean(props.extraClasses),
   });
   return (
-    <Fragment>
+    <>
       <noscript
         dangerouslySetInnerHTML={{
           __html: `
@@ -42,16 +40,8 @@ const Image = (props: Props) => {
         alt='${props.alt || ''}' />`,
         }}
       />
-
-      {props.clipPathClass ? (
-        <Fragment>
-          <Img {...props} clipPathClass={null} />
-          <Img {...props} />
-        </Fragment>
-      ) : (
-        <Img {...props} />
-      )}
-    </Fragment>
+      <Img {...props} />
+    </>
   );
 };
 
@@ -59,8 +49,6 @@ const Img = ({
   width,
   height,
   contentUrl,
-  clipPathClass,
-  caption,
   copyright,
   lazyload = true,
   sizesQueries = '100vw',
@@ -81,7 +69,6 @@ const Img = ({
         'bg-charcoal font-white': true,
         'lazy-image lazyload': lazyload,
         'cursor-zoom-in': Boolean(zoomable),
-        [`promo__image-mask ${clipPathClass || ''}`]: clipPathClass,
         [`${extraClasses || ''}`]: Boolean(extraClasses),
       })}
       src={convertImageUri(contentUrl, defaultSize)}

--- a/common/views/components/Image/Image.js
+++ b/common/views/components/Image/Image.js
@@ -21,6 +21,7 @@ export type Props = {|
   extraClasses?: string,
   crops?: {| [string]: ImageType |},
   style?: { [string]: any }, // TODO: find flowtype for this
+  srcsetRequired?: boolean,
 |};
 
 const Image = (props: Props) => {
@@ -58,6 +59,7 @@ const Img = ({
   zoomable,
   extraClasses,
   style,
+  srcsetRequired = true,
 }: Props) => {
   const sizes = width !== undefined ? imageSizes(width) : supportedSizes;
   return (
@@ -72,10 +74,14 @@ const Img = ({
         [`${extraClasses || ''}`]: Boolean(extraClasses),
       })}
       src={convertImageUri(contentUrl, defaultSize)}
-      data-srcset={sizes.map(size => {
-        return `${convertImageUri(contentUrl, size)} ${size}w`;
-      })}
-      sizes={sizesQueries}
+      data-srcset={
+        srcsetRequired
+          ? sizes.map(size => {
+              return `${convertImageUri(contentUrl, size)} ${size}w`;
+            })
+          : null
+      }
+      sizes={srcsetRequired ? sizesQueries : null}
       data-copyright={copyright}
       onClick={clickHandler}
       alt={alt || ''}


### PR DESCRIPTION
References #4339

Fixes the issue of book thumbnails appearing tiny under certain conditions:

Before:
![Screenshot 2020-02-07 at 13 00 23](https://user-images.githubusercontent.com/6051896/74031650-fa8bfb80-49a9-11ea-97db-c01151c5c158.png)

After: 
![Screenshot 2020-02-07 at 12 59 36](https://user-images.githubusercontent.com/6051896/74031658-fd86ec00-49a9-11ea-9cbb-6ecf0c3074e8.png)
