### PR TITLE
Take image search results out of grid

### DIFF
--- a/catalogue/webapp/components/ImageCard/ImageCard.js
+++ b/catalogue/webapp/components/ImageCard/ImageCard.js
@@ -1,10 +1,13 @@
 // @flow
 import NextLink from 'next/link';
-import { useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { trackEvent } from '@weco/common/utils/ga';
 import type { Props as ImageProps } from '@weco/common/views/components/Image/Image';
 import Image from '@weco/common/views/components/Image/Image';
+import Space from '@weco/common/views/components/styled/Space';
 import { workLink } from '@weco/common/services/catalogue/routes';
+import styled from 'styled-components';
+import { AppContext } from '@weco/common/views/components/AppContext/AppContext';
 
 type Props = {|
   id: string,
@@ -12,9 +15,33 @@ type Props = {|
   onClick: (event: SyntheticEvent<HTMLAnchorElement>) => void,
 |};
 
+const ImageWrap = styled(Space).attrs({
+  h: { size: 'l', properties: ['margin-right'] },
+  v: { size: 'l', properties: ['margin-bottom'] },
+})`
+  height: 25vw;
+  max-height: 300px;
+
+  ${props => props.theme.media.medium`
+    height: 20vw;
+  `}
+
+  ${props => props.theme.media.large`
+    height: 15vw;
+  `}
+
+  ${props => props.theme.media.xlarge`
+    height: 10vw;
+  `}
+
+  img {
+    height: 100%;
+    width: auto;
+  }
+`;
+
 const ImageCard = ({ id, image, onClick }: Props) => {
-  const [isEnhanced, setIsEnhanced] = useState(false);
-  useEffect(() => setIsEnhanced(true), []);
+  const { isEnhanced } = useContext(AppContext);
 
   return (
     <NextLink {...workLink({ id })}>
@@ -31,16 +58,9 @@ const ImageCard = ({ id, image, onClick }: Props) => {
         id={id}
         title={isEnhanced ? 'Open modal window' : null}
       >
-        <div
-          className={`promo__image-container promo__image-container--constrained`}
-        >
-          <Image
-            {...image}
-            lazyload={true}
-            sizesQueries={`(min-width: 1340px) 178px, (min-width: 960px) calc(25vw - 52px), (min-width: 600px) calc(33.24vw - 43px), calc(50vw - 27px)`}
-            defaultSize={180}
-          />
-        </div>
+        <ImageWrap>
+          <Image {...image} />
+        </ImageWrap>
       </a>
     </NextLink>
   );

--- a/catalogue/webapp/components/ImageSearchResults/ImageSearchResults.js
+++ b/catalogue/webapp/components/ImageSearchResults/ImageSearchResults.js
@@ -1,0 +1,66 @@
+// @flow
+
+import { useState } from 'react';
+import ExpandedImage from '../ExpandedImage/ExpandedImage';
+import ImageCard from '../ImageCard/ImageCard';
+import { trackSearchResultSelected } from '@weco/common/views/components/Tracker/Tracker';
+import { type CatalogueResultsList } from '@weco/common/model/catalogue';
+import { type CatalogueApiProps } from '@weco/common/services/catalogue/api';
+
+type Props = {|
+  works: CatalogueResultsList,
+  apiProps: CatalogueApiProps,
+|};
+
+const ImageSearchResults = ({ works, apiProps }: Props) => {
+  const [expandedImageId, setExpandedImageId] = useState('');
+
+  return (
+    <div className={'flex flex--wrap'}>
+      {works.results.map((result, i) => (
+        <div key={result.id}>
+          <div
+            onClick={() => {
+              trackSearchResultSelected(apiProps, {
+                id: result.id,
+                position: i,
+                resultWorkType: result.workType.label,
+                resultLanguage: result.language && result.language.label,
+                resultIdentifiers: result.identifiers.map(
+                  identifier => identifier.value
+                ),
+                resultSubjects: result.subjects.map(subject => subject.label),
+              });
+            }}
+          >
+            <ImageCard
+              id={result.id}
+              image={{
+                contentUrl: result.thumbnail
+                  ? result.thumbnail.url
+                  : 'https://via.placeholder.com/1600x900?text=%20',
+                width: 300,
+                height: 300,
+                alt: result.title,
+                tasl: null,
+              }}
+              onClick={event => {
+                event.preventDefault();
+                setExpandedImageId(result.id);
+              }}
+            />
+            {expandedImageId === result.id && (
+              <ExpandedImage
+                title={result.title}
+                id={result.id}
+                setExpandedImageId={setExpandedImageId}
+              />
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ImageSearchResults;

--- a/catalogue/webapp/components/ImageSearchResults/ImageSearchResults.js
+++ b/catalogue/webapp/components/ImageSearchResults/ImageSearchResults.js
@@ -6,6 +6,7 @@ import ImageCard from '../ImageCard/ImageCard';
 import { trackSearchResultSelected } from '@weco/common/views/components/Tracker/Tracker';
 import { type CatalogueResultsList } from '@weco/common/model/catalogue';
 import { type CatalogueApiProps } from '@weco/common/services/catalogue/api';
+import { transparentGif } from '@weco/common/utils/backgrounds';
 
 type Props = {|
   works: CatalogueResultsList,
@@ -38,7 +39,7 @@ const ImageSearchResults = ({ works, apiProps }: Props) => {
               image={{
                 contentUrl: result.thumbnail
                   ? result.thumbnail.url
-                  : 'https://via.placeholder.com/1600x900?text=%20',
+                  : transparentGif,
                 width: 300,
                 height: 300,
                 alt: result.title,

--- a/catalogue/webapp/components/WorkSearchResults/WorkSearchResults.js
+++ b/catalogue/webapp/components/WorkSearchResults/WorkSearchResults.js
@@ -1,0 +1,69 @@
+// @flow
+
+import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
+import RelevanceRater from '@weco/common/views/components/RelevanceRater/RelevanceRater';
+import { trackSearchResultSelected } from '@weco/common/views/components/Tracker/Tracker';
+import WorkCard from '../WorkCard/WorkCard';
+import OptIn from '@weco/common/views/components/OptIn/OptIn';
+import { grid, classNames } from '@weco/common/utils/classnames';
+import { type CatalogueResultsList } from '@weco/common/model/catalogue';
+import { type CatalogueApiProps } from '@weco/common/services/catalogue/api';
+import { type WorksRouteProps } from '@weco/common/services/catalogue/routes';
+
+type Props = {|
+  works: CatalogueResultsList,
+  worksRouteProps: WorksRouteProps,
+  apiProps: CatalogueApiProps,
+|};
+
+const WorkSearchResults = ({ works, worksRouteProps, apiProps }: Props) => {
+  const { query, workType, page } = worksRouteProps;
+
+  return (
+    <div className={'grid'}>
+      <div
+        className={classNames({
+          [grid({ s: 12, m: 8, l: 6, xl: 6 })]: true,
+        })}
+      >
+        <OptIn />
+      </div>
+      {works.results.map((result, i) => (
+        <div key={result.id} className={grid({ s: 12, m: 12, l: 12, xl: 12 })}>
+          <div
+            onClick={() => {
+              trackSearchResultSelected(apiProps, {
+                id: result.id,
+                position: i,
+                resultWorkType: result.workType.label,
+                resultLanguage: result.language && result.language.label,
+                resultIdentifiers: result.identifiers.map(
+                  identifier => identifier.value
+                ),
+                resultSubjects: result.subjects.map(subject => subject.label),
+              });
+            }}
+          >
+            <WorkCard work={result} />
+          </div>
+          <TogglesContext.Consumer>
+            {({ relevanceRating }) =>
+              relevanceRating && (
+                <RelevanceRater
+                  id={result.id}
+                  position={i}
+                  query={query}
+                  page={page}
+                  workType={workType}
+                  apiProps={apiProps}
+                />
+              )
+            }
+          </TogglesContext.Consumer>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default WorkSearchResults;

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -89,9 +89,6 @@ const Works = ({
   }, []);
 
   const isImageSearch = worksRouteProps.search === 'images';
-  const resultsGrid = isImageSearch
-    ? { s: 6, m: 4, l: 3, xl: 2 }
-    : { s: 12, m: 12, l: 12, xl: 12 };
 
   if (works && works.type === 'Error') {
     return (
@@ -247,7 +244,7 @@ const Works = ({
               style={{ opacity: loading ? 0 : 1 }}
             >
               <div className="container">
-                <div className="grid">
+                <div className={isImageSearch ? 'flex flex--wrap' : 'grid'}>
                   {isImageSearch ? null : (
                     <div
                       className={classNames({
@@ -260,9 +257,13 @@ const Works = ({
                   {works.results.map((result, i) => (
                     <div
                       key={result.id}
-                      className={classNames({
-                        [grid(resultsGrid)]: true,
-                      })}
+                      className={
+                        isImageSearch
+                          ? null
+                          : classNames({
+                              [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
+                            })
+                      }
                     >
                       <div
                         onClick={() => {
@@ -440,7 +441,7 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   const worksOrError = shouldGetWorks
     ? await getWorks({
         params: apiProps,
-        pageSize: isImageSearch ? 24 : undefined,
+        pageSize: isImageSearch ? 100 : undefined,
       })
     : null;
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -352,10 +352,10 @@ Works.getInitialProps = async (ctx: Context): Promise<Props> => {
   );
 
   const shouldGetWorks = !!(params.query && params.query !== '');
+  // TODO: increase pageSize to 100 when `isImageSearch` (but only if `isEnhanced`)
   const worksOrError = shouldGetWorks
     ? await getWorks({
         params: apiProps,
-        pageSize: isImageSearch ? 100 : undefined,
       })
     : null;
 

--- a/catalogue/webapp/pages/works.js
+++ b/catalogue/webapp/pages/works.js
@@ -22,22 +22,15 @@ import {
   worksRouteToApiUrl,
   worksRouteToApiUrlWithDefaults,
 } from '@weco/common/services/catalogue/api';
-import TogglesContext from '@weco/common/views/components/TogglesContext/TogglesContext';
-import RelevanceRater from '@weco/common/views/components/RelevanceRater/RelevanceRater';
 import Space from '@weco/common/views/components/styled/Space';
-import ExpandedImage from '../components/ExpandedImage/ExpandedImage';
-import ImageCard from '../components/ImageCard/ImageCard';
 import StaticWorksContent from '../components/StaticWorksContent/StaticWorksContent';
 import SearchForm from '../components/SearchForm/SearchForm';
 import { getWorks } from '../services/catalogue/works';
-import WorkCard from '../components/WorkCard/WorkCard';
-import {
-  trackSearchResultSelected,
-  trackSearch,
-} from '@weco/common/views/components/Tracker/Tracker';
-import OptIn from '@weco/common/views/components/OptIn/OptIn';
+import { trackSearch } from '@weco/common/views/components/Tracker/Tracker';
 import cookies from 'next-cookies';
 import useSavedSearchState from '@weco/common/hooks/useSavedSearchState';
+import WorkSearchResults from '../components/WorkSearchResults/WorkSearchResults';
+import ImageSearchResults from '../components/ImageSearchResults/ImageSearchResults';
 
 type Props = {|
   works: ?CatalogueResultsList | CatalogueApiError,
@@ -59,12 +52,10 @@ const Works = ({
 
   const {
     query,
-    workType,
     page,
     productionDatesFrom,
     productionDatesTo,
   } = worksRouteProps;
-  const [expandedImageId, setExpandedImageId] = useState('');
 
   useEffect(() => {
     trackSearch(apiProps, {
@@ -244,92 +235,15 @@ const Works = ({
               style={{ opacity: loading ? 0 : 1 }}
             >
               <div className="container">
-                <div className={isImageSearch ? 'flex flex--wrap' : 'grid'}>
-                  {isImageSearch ? null : (
-                    <div
-                      className={classNames({
-                        [grid({ s: 12, m: 8, l: 6, xl: 6 })]: true,
-                      })}
-                    >
-                      <OptIn />
-                    </div>
-                  )}
-                  {works.results.map((result, i) => (
-                    <div
-                      key={result.id}
-                      className={
-                        isImageSearch
-                          ? null
-                          : classNames({
-                              [grid({ s: 12, m: 12, l: 12, xl: 12 })]: true,
-                            })
-                      }
-                    >
-                      <div
-                        onClick={() => {
-                          trackSearchResultSelected(apiProps, {
-                            id: result.id,
-                            position: i,
-                            resultWorkType: result.workType.label,
-                            resultLanguage:
-                              result.language && result.language.label,
-                            resultIdentifiers: result.identifiers.map(
-                              identifier => identifier.value
-                            ),
-                            resultSubjects: result.subjects.map(
-                              subject => subject.label
-                            ),
-                          });
-                        }}
-                      >
-                        {isImageSearch ? (
-                          <>
-                            <ImageCard
-                              id={result.id}
-                              image={{
-                                contentUrl: result.thumbnail
-                                  ? result.thumbnail.url
-                                  : 'https://via.placeholder.com/1600x900?text=%20',
-                                width: 300,
-                                height: 300,
-                                alt: result.title,
-                                tasl: null,
-                              }}
-                              onClick={event => {
-                                event.preventDefault();
-                                setExpandedImageId(result.id);
-                              }}
-                            />
-                            {expandedImageId === result.id && (
-                              <ExpandedImage
-                                title={result.title}
-                                id={result.id}
-                                setExpandedImageId={setExpandedImageId}
-                              />
-                            )}
-                          </>
-                        ) : (
-                          <WorkCard work={result} />
-                        )}
-                      </div>
-                      <TogglesContext.Consumer>
-                        {({ relevanceRating }) =>
-                          relevanceRating &&
-                          !isImageSearch && (
-                            <RelevanceRater
-                              id={result.id}
-                              position={i}
-                              query={query}
-                              page={page}
-                              workType={workType}
-                              apiProps={apiProps}
-                            />
-                          )
-                        }
-                      </TogglesContext.Consumer>
-                    </div>
-                  ))}
-                </div>
+                {isImageSearch ? (
+                  <ImageSearchResults works={works} apiProps={apiProps} />
+                ) : (
+                  <WorkSearchResults
+                    works={works}
+                    worksRouteProps={worksRouteProps}
+                    apiProps={apiProps}
+                  />
+                )}
               </div>
 
               <Space


### PR DESCRIPTION
Closes #5079 

## Who is this for?
People who want to search by image only

## What is it doing for them?
Gives them more images to look at on a page (100), no longer confined to a grid.

![image](https://user-images.githubusercontent.com/1394592/74335911-20901200-4d95-11ea-89ed-b4157cc71092.png)


