### PR TITLE
Fix "Where to find it" link

### DIFF
--- a/common/utils/works.js
+++ b/common/utils/works.js
@@ -160,7 +160,7 @@ export function getAudio(iiifManifest: IIIFManifest) {
 }
 
 export function getEncoreLink(sierraId: string): string {
-  return `http://search.wellcomelibrary.org/iii/encore/record/C__R${sierraId.substr(
+  return `http://encore.wellcomelibrary.org/iii/encore/record/C__R${sierraId.substr(
     0,
     sierraId.length - 1
   )}`;


### PR DESCRIPTION
Fixes the link from the catalogue to the old library site, currently this link is broken as it requires users to sign in. 

<img width="521" alt="wtfi" src="https://user-images.githubusercontent.com/953792/74347385-ed577e00-4da8-11ea-8ef4-1c804183c599.png">

Linking to the `encore.wellcomelibrary.org` subdomain avoids this.
